### PR TITLE
feat(datasets): datasets list and detail with version selection

### DIFF
--- a/backend/db/clickhouse/migrations/008_add_is_evaluation.sql
+++ b/backend/db/clickhouse/migrations/008_add_is_evaluation.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- Explicit classification flag for offline-evaluation traces/spans.
+--
+-- This is deliberately NOT folded into `environment`. `environment` is a
+-- user-namespace value (the SDK's TRACEROOT_ENVIRONMENT deployment tag: production,
+-- staging, ...) and must not double as an internal control flag: a customer who
+-- legitimately names their environment "evaluation" would otherwise have their real
+-- traces treated as eval runs and hidden, and an eval run in a project that DOES set
+-- TRACEROOT_ENVIRONMENT would go unclassified. The two concepts are orthogonal and
+-- get one column each.
+--
+-- UInt8 rather than Nullable(UInt8): "unknown" and "not an evaluation" are the same
+-- thing for every consumer, and a non-null default keeps the read-side predicate a
+-- plain `is_evaluation = 0` with no NULL handling.
+ALTER TABLE spans  ADD COLUMN IF NOT EXISTS is_evaluation UInt8 DEFAULT 0;
+ALTER TABLE traces ADD COLUMN IF NOT EXISTS is_evaluation UInt8 DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE spans  DROP COLUMN IF EXISTS is_evaluation;
+ALTER TABLE traces DROP COLUMN IF EXISTS is_evaluation;

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+
+type RouteParams = { params: Promise<{ projectId: string }> };
+
+// GET — read-only scorer registry, aggregated from the scores reported on this
+// project's runs: distinct (name, version) with usage count and error rate.
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const scores = await prisma.score.findMany({
+    where: { projectId },
+    select: { scorerName: true, scorerVersion: true, error: true },
+  });
+
+  const byKey = new Map<
+    string,
+    { name: string; version: string; total: number; errored: number }
+  >();
+  for (const s of scores) {
+    const key = `${s.scorerName}@${s.scorerVersion}`;
+    const entry = byKey.get(key) ?? {
+      name: s.scorerName,
+      version: s.scorerVersion,
+      total: 0,
+      errored: 0,
+    };
+    entry.total += 1;
+    if (s.error) entry.errored += 1;
+    byKey.set(key, entry);
+  }
+
+  const data = [...byKey.values()]
+    .map((e) => ({
+      name: e.name,
+      version: e.version,
+      scoreCount: e.total,
+      errorCount: e.errored,
+      errorRate: e.total > 0 ? e.errored / e.total : 0,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version));
+
+  return successResponse({ data });
+}

--- a/frontend/ui/src/app/globals.css
+++ b/frontend/ui/src/app/globals.css
@@ -69,3 +69,16 @@
 .animate-slide-in-right {
   animation: slideInFromRight 0.3s ease-out;
 }
+
+@keyframes slideInFromLeft {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+.animate-slide-in-left {
+  animation: slideInFromLeft 0.3s ease-out;
+}

--- a/frontend/ui/src/app/projects/[projectId]/datasets/[datasetId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/datasets/[datasetId]/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { DatasetDetailView } from "@/features/evaluations/views/dataset-detail-view";
+
+export default function DatasetDetailPage() {
+  const params = useParams();
+  return (
+    <DatasetDetailView
+      projectId={params.projectId as string}
+      datasetId={params.datasetId as string}
+    />
+  );
+}

--- a/frontend/ui/src/app/projects/[projectId]/datasets/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/datasets/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { DatasetsView } from "@/features/evaluations/views/datasets-view";
+
+export default function DatasetsPage() {
+  const params = useParams();
+  return <DatasetsView projectId={params.projectId as string} />;
+}

--- a/frontend/ui/src/app/projects/[projectId]/evaluations/[runId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/evaluations/[runId]/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { RunDetailView } from "@/features/evaluations/views/run-detail-view";
+
+export default function RunDetailPage() {
+  const params = useParams();
+  return <RunDetailView projectId={params.projectId as string} runId={params.runId as string} />;
+}

--- a/frontend/ui/src/app/projects/[projectId]/evaluations/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/evaluations/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { EvaluationsView } from "@/features/evaluations/views/evaluations-view";
+
+export default function EvaluationsPage() {
+  const params = useParams();
+  return <EvaluationsView projectId={params.projectId as string} />;
+}

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -19,8 +19,6 @@ import {
   Database,
   FlaskConical,
   Ruler,
-  ShieldCheck,
-  Waypoints,
   type LucideIcon,
 } from "lucide-react";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
@@ -60,30 +58,24 @@ interface OfflineEvalNavItem {
 /**
  * Offline Evaluation (design prototype) section.
  *
- * Kept as a data array rather than the hand-written blocks above: six items is
- * past the point where copy-pasted Tooltip/Link blocks stay readable. Mirrors
- * the SettingsTab[] pattern in features/settings/settings-layout.tsx.
+ * Four items, in workflow order: look at what happened, keep the examples worth
+ * rerunning, see how a version did, and check how it was judged. There is no
+ * landing dashboard — the section opens on Traces.
  */
 const OFFLINE_EVAL_NAV: OfflineEvalNavItem[] = [
-  { id: "overview", label: "Overview", icon: Waypoints, href: "" },
   { id: "traces", label: "Traces", icon: Route, href: "/traces" },
   { id: "datasets", label: "Datasets", icon: Database, href: "/datasets" },
   { id: "experiments", label: "Experiments", icon: FlaskConical, href: "/experiments" },
   { id: "scorers", label: "Scorers", icon: Ruler, href: "/scorers" },
-  { id: "ci-gates", label: "CI Gates", icon: ShieldCheck, href: "/ci-gates" },
 ];
 
-/** Marks the offline-eval item matching the current path, longest-prefix first. */
+/** Marks the offline-eval item matching the current path. */
 function activeOfflineEvalId(pathname: string, base: string): string | null {
   if (!pathname.startsWith(base)) return null;
   const rest = pathname.slice(base.length);
-  // "" (overview) must lose to every real fragment, so check it last.
-  const match = OFFLINE_EVAL_NAV.filter((item) => item.href !== "").find((item) =>
-    rest.startsWith(item.href),
-  );
-  if (match) return match.id;
-  // Issue pages hang off the overview conceptually — keep Overview lit there.
-  return "overview";
+  // The bare base redirects to /traces, so treat it as Traces.
+  if (rest === "" || rest === "/") return "traces";
+  return OFFLINE_EVAL_NAV.find((item) => rest.startsWith(item.href))?.id ?? null;
 }
 
 export function Sidebar({ collapsed = false }: SidebarProps) {

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -14,6 +14,14 @@ import {
   Monitor,
   Settings,
   UserRoundSearch,
+  Eye,
+  Route,
+  Database,
+  FlaskConical,
+  Ruler,
+  ShieldCheck,
+  Waypoints,
+  type LucideIcon,
 } from "lucide-react";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -41,6 +49,43 @@ interface SidebarProps {
   collapsed?: boolean;
 }
 
+interface OfflineEvalNavItem {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  /** Path fragment appended to the offline-eval base. Empty string = overview. */
+  href: string;
+}
+
+/**
+ * Offline Evaluation (design prototype) section.
+ *
+ * Kept as a data array rather than the hand-written blocks above: six items is
+ * past the point where copy-pasted Tooltip/Link blocks stay readable. Mirrors
+ * the SettingsTab[] pattern in features/settings/settings-layout.tsx.
+ */
+const OFFLINE_EVAL_NAV: OfflineEvalNavItem[] = [
+  { id: "overview", label: "Overview", icon: Waypoints, href: "" },
+  { id: "traces", label: "Traces", icon: Route, href: "/traces" },
+  { id: "datasets", label: "Datasets", icon: Database, href: "/datasets" },
+  { id: "experiments", label: "Experiments", icon: FlaskConical, href: "/experiments" },
+  { id: "scorers", label: "Scorers", icon: Ruler, href: "/scorers" },
+  { id: "ci-gates", label: "CI Gates", icon: ShieldCheck, href: "/ci-gates" },
+];
+
+/** Marks the offline-eval item matching the current path, longest-prefix first. */
+function activeOfflineEvalId(pathname: string, base: string): string | null {
+  if (!pathname.startsWith(base)) return null;
+  const rest = pathname.slice(base.length);
+  // "" (overview) must lose to every real fragment, so check it last.
+  const match = OFFLINE_EVAL_NAV.filter((item) => item.href !== "").find((item) =>
+    rest.startsWith(item.href),
+  );
+  if (match) return match.id;
+  // Issue pages hang off the overview conceptually — keep Overview lit there.
+  return "overview";
+}
+
 export function Sidebar({ collapsed = false }: SidebarProps) {
   const pathname = usePathname();
   const { data: sessionData } = authClient.useSession();
@@ -60,6 +105,14 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
   // Project/workspace context from the matched dynamic route params
   const projectId = params?.projectId ?? null;
   const workspaceId = params?.workspaceId ?? null;
+
+  // The nav items above match on substrings (pathname.includes("/traces")), so
+  // the nested offline-eval routes would otherwise light up two links at once
+  // (/offline-eval/traces contains "/traces"). Gate the production items on
+  // being outside the prototype rather than loosening their existing checks.
+  const offlineEvalBase = projectId ? `/projects/${projectId}/offline-eval` : null;
+  const inOfflineEval = !!offlineEvalBase && pathname.startsWith(offlineEvalBase);
+  const activeEvalId = offlineEvalBase ? activeOfflineEvalId(pathname, offlineEvalBase) : null;
 
   // Settings target depends on context: project settings inside a project,
   // workspace settings inside a workspace, hidden elsewhere
@@ -145,7 +198,9 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                     className={cn(
                       "flex items-center gap-2 py-2 text-[13px] transition-colors",
                       collapsed ? "justify-center px-2" : "px-3",
-                      pathname.includes("/traces") ? "bg-muted" : "hover:bg-muted/50",
+                      pathname.includes("/traces") && !inOfflineEval
+                        ? "bg-muted"
+                        : "hover:bg-muted/50",
                     )}
                   >
                     <DOMAIN_ICONS.trace className="h-3.5 w-3.5 shrink-0" />
@@ -165,7 +220,9 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                     className={cn(
                       "flex items-center gap-2 py-2 text-[13px] transition-colors",
                       collapsed ? "justify-center px-2" : "px-3",
-                      pathname.includes("/detectors") ? "bg-muted" : "hover:bg-muted/50",
+                      pathname.includes("/detectors") && !inOfflineEval
+                        ? "bg-muted"
+                        : "hover:bg-muted/50",
                     )}
                   >
                     <DOMAIN_ICONS.detector className="h-3.5 w-3.5 shrink-0" />
@@ -185,7 +242,9 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                     className={cn(
                       "flex items-center gap-2 py-2 text-[13px] transition-colors",
                       collapsed ? "justify-center px-2" : "px-3",
-                      pathname.includes("/dashboard") ? "bg-muted" : "hover:bg-muted/50",
+                      pathname.includes("/dashboard") && !inOfflineEval
+                        ? "bg-muted"
+                        : "hover:bg-muted/50",
                     )}
                   >
                     <DOMAIN_ICONS.dashboard className="h-3.5 w-3.5 shrink-0" />
@@ -198,6 +257,41 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                   </TooltipContent>
                 )}
               </Tooltip>
+
+              {/* Offline Evaluation — design prototype */}
+              {collapsed ? (
+                <div className="mx-2 my-1.5 h-px bg-border" aria-hidden />
+              ) : (
+                <p className="px-3 pb-1 pt-3 text-[10px] uppercase tracking-wide text-muted-foreground/70">
+                  Offline Eval
+                </p>
+              )}
+              {OFFLINE_EVAL_NAV.map((item) => {
+                const Icon = item.icon;
+                const isActive = activeEvalId === item.id;
+                return (
+                  <Tooltip key={item.id}>
+                    <TooltipTrigger asChild>
+                      <Link
+                        href={`/projects/${projectId}/offline-eval${item.href}`}
+                        className={cn(
+                          "flex items-center gap-2 py-2 text-[13px] transition-colors",
+                          collapsed ? "justify-center px-2" : "px-3",
+                          isActive ? "bg-muted" : "hover:bg-muted/50",
+                        )}
+                      >
+                        <Icon className="h-3.5 w-3.5 shrink-0" />
+                        {!collapsed && item.label}
+                      </Link>
+                    </TooltipTrigger>
+                    {collapsed && (
+                      <TooltipContent side="right" sideOffset={16}>
+                        {item.label}
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                );
+              })}
             </>
           ) : (
             // Default navigation (Workspaces)

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -65,7 +65,7 @@ interface OfflineEvalNavItem {
 const OFFLINE_EVAL_NAV: OfflineEvalNavItem[] = [
   { id: "traces", label: "Traces", icon: Route, href: "/traces" },
   { id: "datasets", label: "Datasets", icon: Database, href: "/datasets" },
-  { id: "experiments", label: "Experiments", icon: FlaskConical, href: "/experiments" },
+  { id: "evaluations", label: "Evaluations", icon: FlaskConical, href: "/evaluations" },
   { id: "scorers", label: "Scorers", icon: Ruler, href: "/scorers" },
 ];
 

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -16,6 +16,7 @@ import {
   UserRoundSearch,
   Eye,
   Database,
+  FlaskConical,
 } from "lucide-react";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -222,10 +223,26 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                   </TooltipContent>
                 )}
               </Tooltip>
-              {/* No "Evaluations" entry yet: its route (/projects/[projectId]/evaluations)
-                  doesn't ship until the PR that lands the evaluations backend — a
-                  permanent nav item pointing at a 404 would ship to every project
-                  the moment this branch merges. Add it back alongside that PR. */}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Link
+                    href={`/projects/${projectId}/evaluations`}
+                    className={cn(
+                      "flex items-center gap-2 py-2 text-[13px] transition-colors",
+                      collapsed ? "justify-center px-2" : "px-3",
+                      pathname.includes("/evaluations") ? "bg-muted" : "hover:bg-muted/50",
+                    )}
+                  >
+                    <FlaskConical className="h-3.5 w-3.5 shrink-0" />
+                    {!collapsed && "Evaluations"}
+                  </Link>
+                </TooltipTrigger>
+                {collapsed && (
+                  <TooltipContent side="right" sideOffset={16}>
+                    Evaluations
+                  </TooltipContent>
+                )}
+              </Tooltip>
             </>
           ) : (
             // Default navigation (Workspaces)

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -16,7 +16,6 @@ import {
   UserRoundSearch,
   Eye,
   Database,
-  FlaskConical,
 } from "lucide-react";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -208,7 +207,9 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                     className={cn(
                       "flex items-center gap-2 py-2 text-[13px] transition-colors",
                       collapsed ? "justify-center px-2" : "px-3",
-                      pathname.includes("/datasets") ? "bg-muted" : "hover:bg-muted/50",
+                      pathname.startsWith(`/projects/${projectId}/datasets`)
+                        ? "bg-muted"
+                        : "hover:bg-muted/50",
                     )}
                   >
                     <Database className="h-3.5 w-3.5 shrink-0" />
@@ -221,26 +222,10 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                   </TooltipContent>
                 )}
               </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Link
-                    href={`/projects/${projectId}/evaluations`}
-                    className={cn(
-                      "flex items-center gap-2 py-2 text-[13px] transition-colors",
-                      collapsed ? "justify-center px-2" : "px-3",
-                      pathname.includes("/evaluations") ? "bg-muted" : "hover:bg-muted/50",
-                    )}
-                  >
-                    <FlaskConical className="h-3.5 w-3.5 shrink-0" />
-                    {!collapsed && "Evaluations"}
-                  </Link>
-                </TooltipTrigger>
-                {collapsed && (
-                  <TooltipContent side="right" sideOffset={16}>
-                    Evaluations
-                  </TooltipContent>
-                )}
-              </Tooltip>
+              {/* No "Evaluations" entry yet: its route (/projects/[projectId]/evaluations)
+                  doesn't ship until the PR that lands the evaluations backend — a
+                  permanent nav item pointing at a 404 would ship to every project
+                  the moment this branch merges. Add it back alongside that PR. */}
             </>
           ) : (
             // Default navigation (Workspaces)

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -18,7 +18,6 @@ import {
   Route,
   Database,
   FlaskConical,
-  Ruler,
   type LucideIcon,
 } from "lucide-react";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
@@ -58,15 +57,14 @@ interface OfflineEvalNavItem {
 /**
  * Offline Evaluation (design prototype) section.
  *
- * Four items, in workflow order: look at what happened, keep the examples worth
- * rerunning, see how a version did, and check how it was judged. There is no
- * landing dashboard — the section opens on Traces.
+ * Three items, in workflow order: look at what happened, keep the examples worth
+ * rerunning, and see how a version did. Scorers live as a tab on the Evaluations
+ * page, not as their own nav item. The section opens on Traces.
  */
 const OFFLINE_EVAL_NAV: OfflineEvalNavItem[] = [
   { id: "traces", label: "Traces", icon: Route, href: "/traces" },
   { id: "datasets", label: "Datasets", icon: Database, href: "/datasets" },
   { id: "evaluations", label: "Evaluations", icon: FlaskConical, href: "/evaluations" },
-  { id: "scorers", label: "Scorers", icon: Ruler, href: "/scorers" },
 ];
 
 /** Marks the offline-eval item matching the current path. */
@@ -75,6 +73,8 @@ function activeOfflineEvalId(pathname: string, base: string): string | null {
   const rest = pathname.slice(base.length);
   // The bare base redirects to /traces, so treat it as Traces.
   if (rest === "" || rest === "/") return "traces";
+  // Scorers is a tab on the Evaluations page; its route highlights Evaluations.
+  if (rest.startsWith("/scorers")) return "evaluations";
   return OFFLINE_EVAL_NAV.find((item) => rest.startsWith(item.href))?.id ?? null;
 }
 

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -15,10 +15,8 @@ import {
   Settings,
   UserRoundSearch,
   Eye,
-  Route,
   Database,
   FlaskConical,
-  type LucideIcon,
 } from "lucide-react";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -46,38 +44,6 @@ interface SidebarProps {
   collapsed?: boolean;
 }
 
-interface OfflineEvalNavItem {
-  id: string;
-  label: string;
-  icon: LucideIcon;
-  /** Path fragment appended to the offline-eval base. Empty string = overview. */
-  href: string;
-}
-
-/**
- * Offline Evaluation (design prototype) section.
- *
- * Three items, in workflow order: look at what happened, keep the examples worth
- * rerunning, and see how a version did. Scorers live as a tab on the Evaluations
- * page, not as their own nav item. The section opens on Traces.
- */
-const OFFLINE_EVAL_NAV: OfflineEvalNavItem[] = [
-  { id: "traces", label: "Traces", icon: Route, href: "/traces" },
-  { id: "datasets", label: "Datasets", icon: Database, href: "/datasets" },
-  { id: "evaluations", label: "Evaluations", icon: FlaskConical, href: "/evaluations" },
-];
-
-/** Marks the offline-eval item matching the current path. */
-function activeOfflineEvalId(pathname: string, base: string): string | null {
-  if (!pathname.startsWith(base)) return null;
-  const rest = pathname.slice(base.length);
-  // The bare base redirects to /traces, so treat it as Traces.
-  if (rest === "" || rest === "/") return "traces";
-  // Scorers is a tab on the Evaluations page; its route highlights Evaluations.
-  if (rest.startsWith("/scorers")) return "evaluations";
-  return OFFLINE_EVAL_NAV.find((item) => rest.startsWith(item.href))?.id ?? null;
-}
-
 export function Sidebar({ collapsed = false }: SidebarProps) {
   const pathname = usePathname();
   const { data: sessionData } = authClient.useSession();
@@ -97,14 +63,6 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
   // Project/workspace context from the matched dynamic route params
   const projectId = params?.projectId ?? null;
   const workspaceId = params?.workspaceId ?? null;
-
-  // The nav items above match on substrings (pathname.includes("/traces")), so
-  // the nested offline-eval routes would otherwise light up two links at once
-  // (/offline-eval/traces contains "/traces"). Gate the production items on
-  // being outside the prototype rather than loosening their existing checks.
-  const offlineEvalBase = projectId ? `/projects/${projectId}/offline-eval` : null;
-  const inOfflineEval = !!offlineEvalBase && pathname.startsWith(offlineEvalBase);
-  const activeEvalId = offlineEvalBase ? activeOfflineEvalId(pathname, offlineEvalBase) : null;
 
   // Settings target depends on context: project settings inside a project,
   // workspace settings inside a workspace, hidden elsewhere
@@ -190,9 +148,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                     className={cn(
                       "flex items-center gap-2 py-2 text-[13px] transition-colors",
                       collapsed ? "justify-center px-2" : "px-3",
-                      pathname.includes("/traces") && !inOfflineEval
-                        ? "bg-muted"
-                        : "hover:bg-muted/50",
+                      pathname.includes("/traces") ? "bg-muted" : "hover:bg-muted/50",
                     )}
                   >
                     <DOMAIN_ICONS.trace className="h-3.5 w-3.5 shrink-0" />
@@ -212,9 +168,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                     className={cn(
                       "flex items-center gap-2 py-2 text-[13px] transition-colors",
                       collapsed ? "justify-center px-2" : "px-3",
-                      pathname.includes("/detectors") && !inOfflineEval
-                        ? "bg-muted"
-                        : "hover:bg-muted/50",
+                      pathname.includes("/detectors") ? "bg-muted" : "hover:bg-muted/50",
                     )}
                   >
                     <DOMAIN_ICONS.detector className="h-3.5 w-3.5 shrink-0" />
@@ -234,9 +188,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                     className={cn(
                       "flex items-center gap-2 py-2 text-[13px] transition-colors",
                       collapsed ? "justify-center px-2" : "px-3",
-                      pathname.includes("/dashboard") && !inOfflineEval
-                        ? "bg-muted"
-                        : "hover:bg-muted/50",
+                      pathname.includes("/dashboard") ? "bg-muted" : "hover:bg-muted/50",
                     )}
                   >
                     <DOMAIN_ICONS.dashboard className="h-3.5 w-3.5 shrink-0" />
@@ -256,9 +208,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                     className={cn(
                       "flex items-center gap-2 py-2 text-[13px] transition-colors",
                       collapsed ? "justify-center px-2" : "px-3",
-                      pathname.includes("/datasets") && !inOfflineEval
-                        ? "bg-muted"
-                        : "hover:bg-muted/50",
+                      pathname.includes("/datasets") ? "bg-muted" : "hover:bg-muted/50",
                     )}
                   >
                     <Database className="h-3.5 w-3.5 shrink-0" />
@@ -278,9 +228,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                     className={cn(
                       "flex items-center gap-2 py-2 text-[13px] transition-colors",
                       collapsed ? "justify-center px-2" : "px-3",
-                      pathname.includes("/evaluations") && !inOfflineEval
-                        ? "bg-muted"
-                        : "hover:bg-muted/50",
+                      pathname.includes("/evaluations") ? "bg-muted" : "hover:bg-muted/50",
                     )}
                   >
                     <FlaskConical className="h-3.5 w-3.5 shrink-0" />
@@ -293,41 +241,6 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                   </TooltipContent>
                 )}
               </Tooltip>
-
-              {/* Offline Evaluation — design prototype */}
-              {collapsed ? (
-                <div className="mx-2 my-1.5 h-px bg-border" aria-hidden />
-              ) : (
-                <p className="px-3 pb-1 pt-3 text-[10px] uppercase tracking-wide text-muted-foreground/70">
-                  Offline Eval
-                </p>
-              )}
-              {OFFLINE_EVAL_NAV.map((item) => {
-                const Icon = item.icon;
-                const isActive = activeEvalId === item.id;
-                return (
-                  <Tooltip key={item.id}>
-                    <TooltipTrigger asChild>
-                      <Link
-                        href={`/projects/${projectId}/offline-eval${item.href}`}
-                        className={cn(
-                          "flex items-center gap-2 py-2 text-[13px] transition-colors",
-                          collapsed ? "justify-center px-2" : "px-3",
-                          isActive ? "bg-muted" : "hover:bg-muted/50",
-                        )}
-                      >
-                        <Icon className="h-3.5 w-3.5 shrink-0" />
-                        {!collapsed && item.label}
-                      </Link>
-                    </TooltipTrigger>
-                    {collapsed && (
-                      <TooltipContent side="right" sideOffset={16}>
-                        {item.label}
-                      </TooltipContent>
-                    )}
-                  </Tooltip>
-                );
-              })}
             </>
           ) : (
             // Default navigation (Workspaces)

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -249,6 +249,50 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                   </TooltipContent>
                 )}
               </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Link
+                    href={`/projects/${projectId}/datasets`}
+                    className={cn(
+                      "flex items-center gap-2 py-2 text-[13px] transition-colors",
+                      collapsed ? "justify-center px-2" : "px-3",
+                      pathname.includes("/datasets") && !inOfflineEval
+                        ? "bg-muted"
+                        : "hover:bg-muted/50",
+                    )}
+                  >
+                    <Database className="h-3.5 w-3.5 shrink-0" />
+                    {!collapsed && "Datasets"}
+                  </Link>
+                </TooltipTrigger>
+                {collapsed && (
+                  <TooltipContent side="right" sideOffset={16}>
+                    Datasets
+                  </TooltipContent>
+                )}
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Link
+                    href={`/projects/${projectId}/evaluations`}
+                    className={cn(
+                      "flex items-center gap-2 py-2 text-[13px] transition-colors",
+                      collapsed ? "justify-center px-2" : "px-3",
+                      pathname.includes("/evaluations") && !inOfflineEval
+                        ? "bg-muted"
+                        : "hover:bg-muted/50",
+                    )}
+                  >
+                    <FlaskConical className="h-3.5 w-3.5 shrink-0" />
+                    {!collapsed && "Evaluations"}
+                  </Link>
+                </TooltipTrigger>
+                {collapsed && (
+                  <TooltipContent side="right" sideOffset={16}>
+                    Evaluations
+                  </TooltipContent>
+                )}
+              </Tooltip>
 
               {/* Offline Evaluation — design prototype */}
               {collapsed ? (

--- a/frontend/ui/src/components/search-filter-bar.tsx
+++ b/frontend/ui/src/components/search-filter-bar.tsx
@@ -13,12 +13,14 @@ interface SearchFilterBarProps {
   // Optional replacement for the default search input (e.g. a combined
   // search-and-filter input). When provided, the plain input is not rendered.
   searchInput?: React.ReactNode;
-  // Date filter
-  dateFilter: DateFilterOption;
-  customStartDate: Date | null;
-  customEndDate: Date | null;
-  onDateFilterChange: (option: DateFilterOption) => void;
-  onCustomRangeChange: (startDate: Date, endDate: Date) => void;
+  // Date filter — omit all five when the list has no date predicate to apply
+  // one to; a rendered-but-inert filter would falsely read as an applied
+  // constraint. The control simply doesn't render when `dateFilter` is unset.
+  dateFilter?: DateFilterOption;
+  customStartDate?: Date | null;
+  customEndDate?: Date | null;
+  onDateFilterChange?: (option: DateFilterOption) => void;
+  onCustomRangeChange?: (startDate: Date, endDate: Date) => void;
   // Retention gating — options exceeding the window show a lock icon
   retentionDays?: number | null;
   onUpgradeClick?: () => void;
@@ -55,16 +57,18 @@ export function SearchFilterBar({
           </div>
         )}
         {children}
-        <DateFilterSelect
-          className="ml-auto"
-          dateFilter={dateFilter}
-          customStartDate={customStartDate}
-          customEndDate={customEndDate}
-          onDateFilterChange={onDateFilterChange}
-          onCustomRangeChange={onCustomRangeChange}
-          retentionDays={retentionDays}
-          onUpgradeClick={onUpgradeClick}
-        />
+        {dateFilter && onDateFilterChange && onCustomRangeChange && (
+          <DateFilterSelect
+            className="ml-auto"
+            dateFilter={dateFilter}
+            customStartDate={customStartDate ?? null}
+            customEndDate={customEndDate ?? null}
+            onDateFilterChange={onDateFilterChange}
+            onCustomRangeChange={onCustomRangeChange}
+            retentionDays={retentionDays}
+            onUpgradeClick={onUpgradeClick}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/ui/src/components/ui/badge.tsx
+++ b/frontend/ui/src/components/ui/badge.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+// Dense, low-chroma badges to match the existing table/chip language
+// (text-[11px], bg-muted/50 headers). Status hues stay muted on purpose:
+// the workbench uses color to mean something, not to decorate.
+const badgeVariants = cva(
+  "inline-flex items-center gap-1 whitespace-nowrap rounded border px-1.5 py-0.5 text-[11px] font-medium leading-none",
+  {
+    variants: {
+      variant: {
+        default: "border-border bg-muted/60 text-muted-foreground",
+        outline: "border-border bg-transparent text-muted-foreground",
+        foreground: "border-border bg-muted text-foreground",
+        // Semantic — used sparingly, tuned to the same -100/-300 tint scale
+        // as SPAN_KIND_COLORS in features/traces.
+        success:
+          "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300",
+        warning:
+          "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-300",
+        danger:
+          "border-red-300 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/50 dark:text-red-300",
+        info: "border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950/50 dark:text-blue-300",
+        accent:
+          "border-violet-300 bg-violet-50 text-violet-700 dark:border-violet-800 dark:bg-violet-950/50 dark:text-violet-300",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>, VariantProps<typeof badgeVariants> {}
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { badgeVariants };

--- a/frontend/ui/src/components/ui/checkbox.tsx
+++ b/frontend/ui/src/components/ui/checkbox.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Native checkbox styled to the dense table language.
+ *
+ * `@radix-ui/react-checkbox` is not a dependency; the repo already uses raw
+ * <input type="checkbox"> (ModelProvidersTab). Keeping it native also keeps
+ * indeterminate state and label association free.
+ */
+export interface CheckboxProps extends Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "type" | "onChange"
+> {
+  onCheckedChange?: (checked: boolean) => void;
+  /** Renders the mixed state used by "select all" header cells. */
+  indeterminate?: boolean;
+}
+
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  { className, onCheckedChange, indeterminate, ...props },
+  forwardedRef,
+) {
+  const innerRef = React.useRef<HTMLInputElement>(null);
+
+  React.useImperativeHandle(forwardedRef, () => innerRef.current as HTMLInputElement);
+
+  React.useEffect(() => {
+    if (innerRef.current) innerRef.current.indeterminate = !!indeterminate;
+  }, [indeterminate]);
+
+  return (
+    <input
+      ref={innerRef}
+      type="checkbox"
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+      className={cn(
+        "h-3.5 w-3.5 shrink-0 cursor-pointer rounded-sm border-border accent-foreground",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+});

--- a/frontend/ui/src/components/ui/drawer.tsx
+++ b/frontend/ui/src/components/ui/drawer.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Right-anchored drawer for multi-step flows.
+ *
+ * Built on @radix-ui/react-dialog (already a dependency) rather than adding
+ * `vaul`: this reuses Radix's focus trap, scroll lock, and Escape handling.
+ * It differs from ui/dialog.tsx only in placement and sizing, so it lives
+ * beside it instead of overloading DialogContent with a side variant.
+ */
+
+const Drawer = DialogPrimitive.Root;
+const DrawerTrigger = DialogPrimitive.Trigger;
+const DrawerClose = DialogPrimitive.Close;
+const DrawerPortal = DialogPrimitive.Portal;
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/50", className)}
+    {...props}
+  />
+));
+DrawerOverlay.displayName = "DrawerOverlay";
+
+export interface DrawerContentProps extends React.ComponentPropsWithoutRef<
+  typeof DialogPrimitive.Content
+> {
+  /** Tailwind width class for the panel. */
+  width?: string;
+}
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  DrawerContentProps
+>(({ className, children, width = "w-[720px]", ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-y-0 right-0 z-50 flex max-w-[96vw] flex-col border-l bg-background shadow-lg",
+        "focus:outline-none",
+        width,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close
+        className="absolute right-3 top-3 rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+        aria-label="Close"
+      >
+        <X className="h-4 w-4" />
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = "DrawerContent";
+
+const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("shrink-0 border-b border-border px-4 py-3", className)} {...props} />
+);
+DrawerHeader.displayName = "DrawerHeader";
+
+const DrawerBody = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("min-h-0 flex-1 overflow-auto px-4 py-3", className)} {...props} />
+);
+DrawerBody.displayName = "DrawerBody";
+
+const DrawerFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex shrink-0 items-center justify-between gap-2 border-t border-border px-4 py-3",
+      className,
+    )}
+    {...props}
+  />
+);
+DrawerFooter.displayName = "DrawerFooter";
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-[13px] font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DrawerTitle.displayName = "DrawerTitle";
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-[12px] text-muted-foreground", className)}
+    {...props}
+  />
+));
+DrawerDescription.displayName = "DrawerDescription";
+
+export {
+  Drawer,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerHeader,
+  DrawerBody,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/frontend/ui/src/components/ui/expandable-section.tsx
+++ b/frontend/ui/src/components/ui/expandable-section.tsx
@@ -8,6 +8,12 @@ interface ExpandableSectionProps {
   children: React.ReactNode;
   defaultOpen?: boolean;
   onCopy?: () => void;
+  /**
+   * Optional control(s) shown in the header, before the copy button (e.g. a format
+   * switcher). Clicks inside it don't toggle the section. Use non-`<button>` triggers
+   * here — the header is itself a button, so a nested native button is invalid.
+   */
+  headerAction?: React.ReactNode;
 }
 
 /**
@@ -18,6 +24,7 @@ export function ExpandableSection({
   children,
   defaultOpen = true,
   onCopy,
+  headerAction,
 }: ExpandableSectionProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
@@ -35,18 +42,25 @@ export function ExpandableSection({
           )}
           <span className="text-xs font-medium text-foreground">{title}</span>
         </div>
-        {onCopy && (
-          <div
-            onClick={(e) => {
-              e.stopPropagation();
-              onCopy();
-            }}
-            className="p-0.5 text-muted-foreground transition-colors hover:text-foreground"
-            title="Copy"
-          >
-            <Copy className="h-3 w-3" />
-          </div>
-        )}
+        <div className="flex items-center gap-1">
+          {headerAction && (
+            <div onClick={(e) => e.stopPropagation()} className="flex items-center">
+              {headerAction}
+            </div>
+          )}
+          {onCopy && (
+            <div
+              onClick={(e) => {
+                e.stopPropagation();
+                onCopy();
+              }}
+              className="p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+              title="Copy"
+            >
+              <Copy className="h-3 w-3" />
+            </div>
+          )}
+        </div>
       </button>
       {isOpen && <div className="bg-background px-2.5 py-2">{children}</div>}
     </div>

--- a/frontend/ui/src/components/ui/table.tsx
+++ b/frontend/ui/src/components/ui/table.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Thin wrappers over the raw <table> convention already used across
+ * detectors/traces/sessions pages. These carry the same classes that
+ * detector-table-cells.tsx exports as DETECTOR_TH / DETECTOR_TD so a new
+ * table matches the existing ones without re-typing the strings.
+ */
+
+/** Header cell classes — mirrors DETECTOR_TH. */
+export const TH =
+  "h-7 whitespace-nowrap border-r border-border/50 px-3 text-left text-[12px] font-medium text-muted-foreground last:border-r-0";
+
+/** Body cell classes — mirrors DETECTOR_TD. */
+export const TD = "border-r border-border/50 px-3 py-1.5 text-[12px] last:border-r-0";
+
+/** Right-aligned numeric cell (durations, costs, scores). */
+export const TD_NUM = cn(TD, "text-right tabular-nums");
+
+/** Monospace identifier cell. */
+export const TD_ID = cn(TD, "font-mono text-[11px] text-muted-foreground");
+
+export function Table({ className, ...props }: React.TableHTMLAttributes<HTMLTableElement>) {
+  return <table className={cn("w-full border-collapse", className)} {...props} />;
+}
+
+export function THead({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <thead className={cn("sticky top-0 z-10 bg-background", className)} {...props} />;
+}
+
+export function TRHead({ className, ...props }: React.HTMLAttributes<HTMLTableRowElement>) {
+  return <tr className={cn("border-b border-border bg-muted/50", className)} {...props} />;
+}
+
+export function TBody(props: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody {...props} />;
+}
+
+export interface TRProps extends React.HTMLAttributes<HTMLTableRowElement> {
+  selected?: boolean;
+  interactive?: boolean;
+}
+
+export function TR({ className, selected, interactive, ...props }: TRProps) {
+  return (
+    <tr
+      data-selected={selected ? "true" : undefined}
+      className={cn(
+        "border-b border-border/50 transition-colors last:border-0",
+        interactive && "cursor-pointer",
+        selected ? "bg-muted" : interactive && "hover:bg-muted/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function Th({ className, ...props }: React.ThHTMLAttributes<HTMLTableCellElement>) {
+  return <th scope="col" className={cn(TH, className)} {...props} />;
+}
+
+export function Td({ className, ...props }: React.TdHTMLAttributes<HTMLTableCellElement>) {
+  return <td className={cn(TD, className)} {...props} />;
+}
+
+/** Centered empty-state row spanning the whole table. */
+export function TableEmpty({ colSpan, children }: { colSpan: number; children: React.ReactNode }) {
+  return (
+    <tr>
+      <td colSpan={colSpan} className="px-3 py-10 text-center text-[12px] text-muted-foreground">
+        {children}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/ui/src/components/ui/table.tsx
+++ b/frontend/ui/src/components/ui/table.tsx
@@ -42,13 +42,30 @@ export interface TRProps extends React.HTMLAttributes<HTMLTableRowElement> {
   interactive?: boolean;
 }
 
-export function TR({ className, selected, interactive, ...props }: TRProps) {
+export function TR({ className, selected, interactive, onClick, onKeyDown, ...props }: TRProps) {
   return (
     <tr
       data-selected={selected ? "true" : undefined}
+      // Interactive rows are otherwise mouse-only: no way to reach onClick from
+      // the keyboard, and no indication one exists (WCAG 2.1.1). tabIndex + a
+      // role + Enter/Space activation give every consumer of `interactive` the
+      // same keyboard path a real link/button would have, without each one
+      // having to re-implement it.
+      tabIndex={interactive && onClick ? 0 : undefined}
+      role={interactive && onClick ? "button" : undefined}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (interactive && onClick && (e.key === "Enter" || e.key === " ")) {
+          e.preventDefault();
+          onClick(e as unknown as React.MouseEvent<HTMLTableRowElement>);
+        }
+        onKeyDown?.(e);
+      }}
       className={cn(
         "border-b border-border/50 transition-colors last:border-0",
         interactive && "cursor-pointer",
+        interactive &&
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
         selected ? "bg-muted" : interactive && "hover:bg-muted/50",
         className,
       )}

--- a/frontend/ui/src/components/ui/table.tsx
+++ b/frontend/ui/src/components/ui/table.tsx
@@ -55,7 +55,15 @@ export function TR({ className, selected, interactive, onClick, onKeyDown, ...pr
       role={interactive && onClick ? "button" : undefined}
       onClick={onClick}
       onKeyDown={(e) => {
-        if (interactive && onClick && (e.key === "Enter" || e.key === " ")) {
+        // Only the row itself activates row navigation — a keypress on a nested
+        // action (a button/link inside the row) bubbles here, and activating the row
+        // too would fire both the action AND the navigation from one Enter/Space.
+        if (
+          interactive &&
+          onClick &&
+          e.target === e.currentTarget &&
+          (e.key === "Enter" || e.key === " ")
+        ) {
           e.preventDefault();
           onClick(e as unknown as React.MouseEvent<HTMLTableRowElement>);
         }

--- a/frontend/ui/src/components/ui/tabs.tsx
+++ b/frontend/ui/src/components/ui/tabs.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Minimal in-page tabs.
+ *
+ * `@radix-ui/react-tabs` is not a dependency here, and the repo's existing
+ * "tabs" are route-based (settings-layout.tsx). This covers the local-state
+ * case with the roving-tabindex + arrow-key behaviour the ARIA tabs pattern
+ * expects, styled to match the border-b-2 strip in traces/page.tsx.
+ */
+
+interface TabsContextValue {
+  value: string;
+  setValue: (value: string) => void;
+  baseId: string;
+}
+
+const TabsContext = React.createContext<TabsContextValue | null>(null);
+
+function useTabs(component: string): TabsContextValue {
+  const ctx = React.useContext(TabsContext);
+  if (!ctx) throw new Error(`<${component}> must be used inside <Tabs>`);
+  return ctx;
+}
+
+export interface TabsProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function Tabs({ value, defaultValue, onValueChange, className, children }: TabsProps) {
+  const [uncontrolled, setUncontrolled] = React.useState(defaultValue ?? "");
+  const isControlled = value !== undefined;
+  const current = isControlled ? value : uncontrolled;
+  const baseId = React.useId();
+
+  const setValue = React.useCallback(
+    (next: string) => {
+      if (!isControlled) setUncontrolled(next);
+      onValueChange?.(next);
+    },
+    [isControlled, onValueChange],
+  );
+
+  const ctx = React.useMemo(
+    () => ({ value: current, setValue, baseId }),
+    [current, setValue, baseId],
+  );
+
+  return (
+    <TabsContext.Provider value={ctx}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+export function TabsList({
+  className,
+  children,
+  "aria-label": ariaLabel,
+}: {
+  className?: string;
+  children: React.ReactNode;
+  "aria-label"?: string;
+}) {
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  // Arrow keys move between tabs, per the ARIA tabs pattern.
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const keys = ["ArrowLeft", "ArrowRight", "Home", "End"];
+    if (!keys.includes(event.key)) return;
+    const tabs = Array.from(
+      ref.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]:not([disabled])') ?? [],
+    );
+    if (tabs.length === 0) return;
+    const index = tabs.findIndex((tab) => tab === document.activeElement);
+    if (index === -1) return;
+    event.preventDefault();
+    const next =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? tabs.length - 1
+          : event.key === "ArrowLeft"
+            ? (index - 1 + tabs.length) % tabs.length
+            : (index + 1) % tabs.length;
+    tabs[next].focus();
+    tabs[next].click();
+  };
+
+  return (
+    <div
+      ref={ref}
+      role="tablist"
+      aria-label={ariaLabel}
+      onKeyDown={onKeyDown}
+      className={cn("flex items-center gap-1 border-b border-border", className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function TabsTrigger({
+  value,
+  className,
+  children,
+  count,
+  disabled,
+}: {
+  value: string;
+  className?: string;
+  children: React.ReactNode;
+  /** Optional right-aligned count, rendered in the muted chip style. */
+  count?: number;
+  disabled?: boolean;
+}) {
+  const { value: current, setValue, baseId } = useTabs("TabsTrigger");
+  const isActive = current === value;
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      id={`${baseId}-tab-${value}`}
+      aria-selected={isActive}
+      aria-controls={`${baseId}-panel-${value}`}
+      tabIndex={isActive ? 0 : -1}
+      disabled={disabled}
+      onClick={() => setValue(value)}
+      className={cn(
+        "-mb-px flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "disabled:pointer-events-none disabled:opacity-50",
+        isActive
+          ? "border-foreground text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground",
+        className,
+      )}
+    >
+      {children}
+      {count !== undefined && (
+        <span className="rounded bg-muted px-1 text-[11px] tabular-nums text-muted-foreground">
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export function TabsContent({
+  value,
+  className,
+  children,
+}: {
+  value: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const { value: current, baseId } = useTabs("TabsContent");
+  if (current !== value) return null;
+  return (
+    <div
+      role="tabpanel"
+      id={`${baseId}-panel-${value}`}
+      aria-labelledby={`${baseId}-tab-${value}`}
+      tabIndex={0}
+      className={cn("focus-visible:outline-none", className)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/ui/src/components/ui/toast.tsx
+++ b/frontend/ui/src/components/ui/toast.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import * as React from "react";
+import { Check, Info, TriangleAlert, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Small toast system.
+ *
+ * The repo has no toast library and no global mount point — the established
+ * feedback pattern is inline `text-destructive` text tied to a mutation's
+ * error state. Confirmation of a *transient, non-blocking* action (row
+ * duplicated, baseline set) has no existing home, so this adds one without
+ * pulling in `sonner`. Mount <ToastProvider> around the subtree that needs it.
+ */
+
+export type ToastTone = "default" | "success" | "warning";
+
+export interface ToastOptions {
+  title: string;
+  description?: string;
+  tone?: ToastTone;
+  /** Milliseconds before auto-dismiss. */
+  duration?: number;
+}
+
+interface ToastRecord extends ToastOptions {
+  id: number;
+}
+
+interface ToastContextValue {
+  toast: (options: ToastOptions) => void;
+}
+
+const ToastContext = React.createContext<ToastContextValue | null>(null);
+
+export function useToast(): ToastContextValue {
+  const ctx = React.useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used inside <ToastProvider>");
+  return ctx;
+}
+
+const TONE_ICON: Record<ToastTone, React.ComponentType<{ className?: string }>> = {
+  default: Info,
+  success: Check,
+  warning: TriangleAlert,
+};
+
+const TONE_GLYPH: Record<ToastTone, string> = {
+  default: "text-muted-foreground",
+  success: "text-emerald-600 dark:text-emerald-400",
+  warning: "text-amber-600 dark:text-amber-400",
+};
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = React.useState<ToastRecord[]>([]);
+  const nextId = React.useRef(0);
+  const timers = React.useRef(new Map<number, ReturnType<typeof setTimeout>>());
+
+  const dismiss = React.useCallback((id: number) => {
+    setToasts((current) => current.filter((item) => item.id !== id));
+    const timer = timers.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timers.current.delete(id);
+    }
+  }, []);
+
+  const toast = React.useCallback(
+    (options: ToastOptions) => {
+      const id = nextId.current++;
+      setToasts((current) => [...current, { ...options, id }]);
+      const timer = setTimeout(() => dismiss(id), options.duration ?? 4000);
+      timers.current.set(id, timer);
+    },
+    [dismiss],
+  );
+
+  // Clear pending timers if the provider unmounts mid-flight.
+  React.useEffect(() => {
+    const pending = timers.current;
+    return () => {
+      pending.forEach((timer) => clearTimeout(timer));
+      pending.clear();
+    };
+  }, []);
+
+  const value = React.useMemo(() => ({ toast }), [toast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div
+        role="region"
+        aria-label="Notifications"
+        className="pointer-events-none fixed bottom-4 right-4 z-[60] flex w-[340px] flex-col gap-2"
+      >
+        {toasts.map((item) => {
+          const tone = item.tone ?? "default";
+          const Icon = TONE_ICON[tone];
+          return (
+            <div
+              key={item.id}
+              role="status"
+              aria-live="polite"
+              className="pointer-events-auto flex items-start gap-2 rounded-md border border-border bg-popover px-3 py-2 shadow-md"
+            >
+              <Icon className={cn("mt-px h-3.5 w-3.5 shrink-0", TONE_GLYPH[tone])} />
+              <div className="min-w-0 flex-1">
+                <p className="text-[12px] font-medium text-foreground">{item.title}</p>
+                {item.description && (
+                  <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">
+                    {item.description}
+                  </p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => dismiss(item.id)}
+                aria-label="Dismiss notification"
+                className="shrink-0 rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </ToastContext.Provider>
+  );
+}

--- a/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
+++ b/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
@@ -12,10 +12,11 @@ import {
 import { useCreateDataset, useUpdateDataset } from "../hooks";
 
 /**
- * Server-wired New-dataset and Edit-dataset panels, sharing DatasetFormFields
- * and persisting through the real hooks with real toasts. The schema/metadata
- * form cards are illustrative for now (the server persists name + description);
- * kept visible by design.
+ * Server-wired ports of the mock's New-dataset and Edit-dataset panels. Identical
+ * chrome and fields (the shared DatasetFormFields), but persisting through the
+ * real hooks with real toasts instead of the prototype's in-browser stubs. The
+ * schema/metadata form cards are illustrative for now (the server persists name +
+ * description); kept visible to match the approved design.
  */
 
 /** "New dataset" — non-modal right slide-in, same shape as Save as test case. */

--- a/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
+++ b/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
@@ -1,17 +1,9 @@
 "use client";
 
 import * as React from "react";
-import { Check, Copy, Database } from "lucide-react";
+import { Check, Copy, Database, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/toast";
-import {
-  Drawer,
-  DrawerBody,
-  DrawerContent,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-} from "@/components/ui/drawer";
 import {
   DatasetFormFields,
   emptyDatasetForm,
@@ -24,15 +16,9 @@ import { useCreateDataset, useUpdateDataset } from "../hooks";
  * and persisting through the real hooks with real toasts. The schema/metadata
  * form cards are illustrative for now (the server persists name + description);
  * kept visible by design.
- *
- * Both panels are built on the shared `Drawer` (Radix Dialog underneath) rather
- * than a hand-rolled `fixed` overlay, so they get a real focus trap, scroll
- * lock, Escape handling, and `role="dialog"`/`aria-modal` for free — matching
- * `form-kit.tsx`'s `CreateDrawer` and keeping the two panels consistent with
- * each other instead of each reinventing (or half-reinventing) the same thing.
  */
 
-/** "New dataset" — right slide-in drawer, same shape as Save as test case. */
+/** "New dataset" — non-modal right slide-in, same shape as Save as test case. */
 export function NewDatasetPanel({
   projectId,
   open,
@@ -49,6 +35,20 @@ export function NewDatasetPanel({
   React.useEffect(() => {
     if (open) setState(emptyDatasetForm());
   }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onOpenChange(false);
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
 
   const canCreate = state.name.trim() !== "";
   const handleCreate = () => {
@@ -67,38 +67,46 @@ export function NewDatasetPanel({
   };
 
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent width="w-[560px]">
-        <DrawerHeader className="pr-10">
-          <DrawerTitle>New dataset</DrawerTitle>
-        </DrawerHeader>
-        <DrawerBody>
-          <DatasetFormFields state={state} onChange={setState} />
-        </DrawerBody>
-        <DrawerFooter className="justify-end">
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 text-[12px]"
-            onClick={() => onOpenChange(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            size="sm"
-            className="h-7 text-[12px]"
-            onClick={handleCreate}
-            disabled={!canCreate || create.isPending}
-          >
-            {create.isPending ? "Creating…" : "Create dataset"}
-          </Button>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
+      <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
+        <h2 className="text-[13px] font-semibold">New dataset</h2>
+        <button
+          type="button"
+          onClick={() => onOpenChange(false)}
+          aria-label="Close"
+          className="rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <DatasetFormFields state={state} onChange={setState} />
+      </div>
+
+      <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border px-4 py-3">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-[12px]"
+          onClick={() => onOpenChange(false)}
+        >
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          className="h-7 text-[12px]"
+          onClick={handleCreate}
+          disabled={!canCreate || create.isPending}
+        >
+          {create.isPending ? "Creating…" : "Create dataset"}
+        </Button>
+      </div>
+    </div>
   );
 }
 
-/** "Edit dataset" — right slide-in drawer, modelled on the detector edit panel. */
+/** "Edit dataset" — right slide-in, modelled on the detector edit panel. */
 export function DatasetEditPanel({
   projectId,
   dataset,
@@ -139,16 +147,10 @@ export function DatasetEditPanel({
     );
   };
 
-  // Mounted only while editing (see datasets-view.tsx), so it is always "open";
-  // a dismiss of any kind (Escape, overlay click, the drawer's own close button)
-  // routes through onClose the same way Cancel does.
   return (
-    <Drawer open onOpenChange={(next) => !next && onClose()}>
-      <DrawerContent width="w-[560px]">
-        {/* Visually-hidden title for the Radix a11y contract; the visible
-            identity strip below (name + copyable id) is the real header. */}
-        <DrawerTitle className="sr-only">Edit dataset {dataset.name}</DrawerTitle>
-        <div className="flex h-10 flex-shrink-0 items-center gap-2 border-b border-border bg-muted/30 px-4 pr-10">
+    <div className="animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
+      <div className="flex h-10 flex-shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4">
+        <div className="flex min-w-0 items-center gap-2">
           <Database className="h-4 w-4 shrink-0 text-muted-foreground" />
           <span className="text-[13px] font-medium">Dataset</span>
           <span className="truncate text-[13px] text-muted-foreground">{dataset.name}</span>
@@ -162,25 +164,34 @@ export function DatasetEditPanel({
             {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
           </button>
         </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onClose}
+          className="h-7 w-7 p-0"
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
 
-        <DrawerBody>
-          <DatasetFormFields state={state} onChange={setState} />
-        </DrawerBody>
+      <div className="flex-1 overflow-y-auto p-4">
+        <DatasetFormFields state={state} onChange={setState} />
+      </div>
 
-        <DrawerFooter className="justify-end">
-          <Button variant="outline" size="sm" onClick={onClose} className="h-7 text-[12px]">
-            Cancel
-          </Button>
-          <Button
-            size="sm"
-            onClick={handleSave}
-            className="h-7 text-[12px]"
-            disabled={update.isPending}
-          >
-            {update.isPending ? "Saving…" : "Save"}
-          </Button>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+      <div className="flex flex-shrink-0 justify-end gap-2 border-t border-border px-4 py-3">
+        <Button variant="outline" size="sm" onClick={onClose} className="h-7 text-[12px]">
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleSave}
+          className="h-7 text-[12px]"
+          disabled={update.isPending}
+        >
+          {update.isPending ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
+++ b/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
@@ -1,9 +1,17 @@
 "use client";
 
 import * as React from "react";
-import { Check, Copy, Database, X } from "lucide-react";
+import { Check, Copy, Database } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/toast";
+import {
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
 import {
   DatasetFormFields,
   emptyDatasetForm,
@@ -12,14 +20,19 @@ import {
 import { useCreateDataset, useUpdateDataset } from "../hooks";
 
 /**
- * Server-wired ports of the mock's New-dataset and Edit-dataset panels. Identical
- * chrome and fields (the shared DatasetFormFields), but persisting through the
- * real hooks with real toasts instead of the prototype's in-browser stubs. The
- * schema/metadata form cards are illustrative for now (the server persists name +
- * description); kept visible to match the approved design.
+ * Server-wired New-dataset and Edit-dataset panels, sharing DatasetFormFields
+ * and persisting through the real hooks with real toasts. The schema/metadata
+ * form cards are illustrative for now (the server persists name + description);
+ * kept visible by design.
+ *
+ * Both panels are built on the shared `Drawer` (Radix Dialog underneath) rather
+ * than a hand-rolled `fixed` overlay, so they get a real focus trap, scroll
+ * lock, Escape handling, and `role="dialog"`/`aria-modal` for free — matching
+ * `form-kit.tsx`'s `CreateDrawer` and keeping the two panels consistent with
+ * each other instead of each reinventing (or half-reinventing) the same thing.
  */
 
-/** "New dataset" — non-modal right slide-in, same shape as Save as test case. */
+/** "New dataset" — right slide-in drawer, same shape as Save as test case. */
 export function NewDatasetPanel({
   projectId,
   open,
@@ -36,20 +49,6 @@ export function NewDatasetPanel({
   React.useEffect(() => {
     if (open) setState(emptyDatasetForm());
   }, [open]);
-
-  React.useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.stopPropagation();
-        onOpenChange(false);
-      }
-    };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [open, onOpenChange]);
-
-  if (!open) return null;
 
   const canCreate = state.name.trim() !== "";
   const handleCreate = () => {
@@ -68,46 +67,38 @@ export function NewDatasetPanel({
   };
 
   return (
-    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
-      <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
-        <h2 className="text-[13px] font-semibold">New dataset</h2>
-        <button
-          type="button"
-          onClick={() => onOpenChange(false)}
-          aria-label="Close"
-          className="rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
-        >
-          <X className="h-4 w-4" />
-        </button>
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-auto p-4">
-        <DatasetFormFields state={state} onChange={setState} />
-      </div>
-
-      <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border px-4 py-3">
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 text-[12px]"
-          onClick={() => onOpenChange(false)}
-        >
-          Cancel
-        </Button>
-        <Button
-          size="sm"
-          className="h-7 text-[12px]"
-          onClick={handleCreate}
-          disabled={!canCreate || create.isPending}
-        >
-          {create.isPending ? "Creating…" : "Create dataset"}
-        </Button>
-      </div>
-    </div>
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent width="w-[560px]">
+        <DrawerHeader className="pr-10">
+          <DrawerTitle>New dataset</DrawerTitle>
+        </DrawerHeader>
+        <DrawerBody>
+          <DatasetFormFields state={state} onChange={setState} />
+        </DrawerBody>
+        <DrawerFooter className="justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-[12px]"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            className="h-7 text-[12px]"
+            onClick={handleCreate}
+            disabled={!canCreate || create.isPending}
+          >
+            {create.isPending ? "Creating…" : "Create dataset"}
+          </Button>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
   );
 }
 
-/** "Edit dataset" — right slide-in, modelled on the detector edit panel. */
+/** "Edit dataset" — right slide-in drawer, modelled on the detector edit panel. */
 export function DatasetEditPanel({
   projectId,
   dataset,
@@ -148,10 +139,16 @@ export function DatasetEditPanel({
     );
   };
 
+  // Mounted only while editing (see datasets-view.tsx), so it is always "open";
+  // a dismiss of any kind (Escape, overlay click, the drawer's own close button)
+  // routes through onClose the same way Cancel does.
   return (
-    <div className="animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
-      <div className="flex h-10 flex-shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4">
-        <div className="flex min-w-0 items-center gap-2">
+    <Drawer open onOpenChange={(next) => !next && onClose()}>
+      <DrawerContent width="w-[560px]">
+        {/* Visually-hidden title for the Radix a11y contract; the visible
+            identity strip below (name + copyable id) is the real header. */}
+        <DrawerTitle className="sr-only">Edit dataset {dataset.name}</DrawerTitle>
+        <div className="flex h-10 flex-shrink-0 items-center gap-2 border-b border-border bg-muted/30 px-4 pr-10">
           <Database className="h-4 w-4 shrink-0 text-muted-foreground" />
           <span className="text-[13px] font-medium">Dataset</span>
           <span className="truncate text-[13px] text-muted-foreground">{dataset.name}</span>
@@ -165,34 +162,25 @@ export function DatasetEditPanel({
             {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
           </button>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onClose}
-          className="h-7 w-7 p-0"
-          aria-label="Close"
-        >
-          <X className="h-4 w-4" />
-        </Button>
-      </div>
 
-      <div className="flex-1 overflow-y-auto p-4">
-        <DatasetFormFields state={state} onChange={setState} />
-      </div>
+        <DrawerBody>
+          <DatasetFormFields state={state} onChange={setState} />
+        </DrawerBody>
 
-      <div className="flex flex-shrink-0 justify-end gap-2 border-t border-border px-4 py-3">
-        <Button variant="outline" size="sm" onClick={onClose} className="h-7 text-[12px]">
-          Cancel
-        </Button>
-        <Button
-          size="sm"
-          onClick={handleSave}
-          className="h-7 text-[12px]"
-          disabled={update.isPending}
-        >
-          {update.isPending ? "Saving…" : "Save"}
-        </Button>
-      </div>
-    </div>
+        <DrawerFooter className="justify-end">
+          <Button variant="outline" size="sm" onClick={onClose} className="h-7 text-[12px]">
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSave}
+            className="h-7 text-[12px]"
+            disabled={update.isPending}
+          >
+            {update.isPending ? "Saving…" : "Save"}
+          </Button>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
   );
 }

--- a/frontend/ui/src/features/evaluations/components/delete-dataset-dialog.tsx
+++ b/frontend/ui/src/features/evaluations/components/delete-dataset-dialog.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface DeleteDatasetDialogProps {
+  datasetName: string;
+  caseCount: number;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isDeleting?: boolean;
+}
+
+/**
+ * Confirms a dataset delete before it fires. Deleting cascades every version
+ * and test case (irreversible, no undo), and a mis-click on the row's action
+ * menu is otherwise the only thing standing between a dataset and permanent
+ * loss — so this mirrors the detector delete flow's type-to-confirm gate.
+ */
+export function DeleteDatasetDialog({
+  datasetName,
+  caseCount,
+  isOpen,
+  onClose,
+  onConfirm,
+  isDeleting,
+}: DeleteDatasetDialogProps) {
+  const [typed, setTyped] = useState("");
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setTyped("");
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle className="text-[13px] font-semibold">Delete dataset</DialogTitle>
+        </DialogHeader>
+
+        <div className="mt-1 space-y-4">
+          <p className="text-[12px] text-muted-foreground">
+            This deletes <span className="font-medium text-foreground">{datasetName}</span> and all{" "}
+            {caseCount} test case{caseCount === 1 ? "" : "s"} across every version. This action
+            cannot be undone. Type{" "}
+            <span className="font-medium text-foreground">{datasetName}</span> to confirm.
+          </p>
+
+          <Input
+            className="h-8 text-[12px]"
+            placeholder={datasetName}
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            autoFocus
+          />
+
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 text-[12px]"
+              onClick={onClose}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              className="h-7 text-[12px]"
+              disabled={typed !== datasetName || isDeleting}
+              onClick={onConfirm}
+            >
+              {isDeleting ? "Deleting..." : "Delete"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/ui/src/features/evaluations/components/pull-code-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/pull-code-drawer.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import * as React from "react";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
+import { cn } from "@/lib/utils";
+import { HighlightedCode } from "@/features/offline-eval/components/syntax";
+
+type Lang = "python" | "typescript";
+
+/** One thing you can pull, in both languages. Only DATA is pullable. */
+export interface PullOption {
+  id: string;
+  label: string;
+  /** One-line explanation of exactly what this pulls (resolves latest/exact/none). */
+  note?: React.ReactNode;
+  py: string;
+  ts: string;
+}
+
+/**
+ * The shared "pull code" slide-out used on BOTH the dataset and run surfaces, so
+ * pulling data reads as one pattern. You only pull DATA: a dataset (its current
+ * version) or an exact immutable version. An evaluation series or a run id is an
+ * identifier, not runnable — those are never options here.
+ *
+ * When there is more than one option, a small selector switches between them;
+ * Python/TypeScript is always a tab toggle.
+ */
+export function PullCodeDrawer({
+  title,
+  subtitle,
+  options,
+  open,
+  onOpenChange,
+}: {
+  title: string;
+  subtitle?: React.ReactNode;
+  options: PullOption[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [lang, setLang] = React.useState<Lang>("python");
+  const [optionId, setOptionId] = React.useState(options[0]?.id);
+
+  React.useEffect(() => {
+    if (open) setOptionId((prev) => (options.some((o) => o.id === prev) ? prev : options[0]?.id));
+  }, [open, options]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onOpenChange(false);
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+
+  const option = options.find((o) => o.id === optionId) ?? options[0];
+  const code = lang === "python" ? option.py : option.ts;
+
+  return (
+    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
+      <div className="flex shrink-0 items-start justify-between gap-2 border-b border-border px-4 py-3">
+        <div>
+          <h2 className="text-[13px] font-semibold">{title}</h2>
+          {subtitle && (
+            <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">{subtitle}</p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => onOpenChange(false)}
+          aria-label="Close"
+          className="mt-0.5 rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-auto px-4 pb-6 pt-3 text-[12px]">
+        {/* What to pull — only shown when there's a genuine choice. */}
+        {options.length > 1 && (
+          <div className="flex flex-wrap gap-1.5">
+            {options.map((o) => (
+              <Button
+                key={o.id}
+                variant={o.id === option.id ? "default" : "outline"}
+                size="sm"
+                className="h-7 text-[12px]"
+                onClick={() => setOptionId(o.id)}
+              >
+                {o.label}
+              </Button>
+            ))}
+          </div>
+        )}
+
+        {option.note && (
+          <p className="text-[11px] leading-relaxed text-muted-foreground">{option.note}</p>
+        )}
+
+        <div className="overflow-hidden rounded border border-border">
+          <div className="flex items-center justify-between border-b border-border bg-muted/50 px-1.5 py-1">
+            <div className="flex items-center gap-0.5">
+              {(["python", "typescript"] as Lang[]).map((l) => (
+                <button
+                  key={l}
+                  type="button"
+                  onClick={() => setLang(l)}
+                  className={cn(
+                    "rounded px-1.5 py-0.5 text-xs font-medium transition-colors",
+                    lang === l
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {l === "python" ? "Python" : "TypeScript"}
+                </button>
+              ))}
+            </div>
+            <CopyButton
+              value={code}
+              className="h-6 w-6 text-muted-foreground hover:text-foreground"
+              title="Copy"
+            />
+          </div>
+          {/* Self-contained scroll box + pb-6 so the last line clears the scrollbar. */}
+          <HighlightedCode
+            code={code}
+            className="max-h-[55vh] overflow-auto whitespace-pre px-3 pb-6 pt-2.5 font-mono text-[11px] leading-relaxed"
+          />
+        </div>
+      </div>
+
+      <div className="flex shrink-0 items-center justify-between gap-2 border-t border-border px-4 py-3">
+        <span className="text-[11px] text-muted-foreground">Nothing runs from this panel.</span>
+        <Button size="sm" className="h-7 text-[12px]" onClick={() => onOpenChange(false)}>
+          Done
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 /**
  * View-mount ("e2e") smoke for the real, server-backed Datasets + Evaluations
- * pages (Phase 8). The routes sit behind auth and can't be driven over HTTP
+ * pages. The routes sit behind auth and can't be driven over HTTP
  * without a session, and the repo has no browser driver — so mounting the views
  * against a stubbed fetch (server-shaped payloads) is how the browser path is
  * checked, exactly like offline-eval.smoke.test.tsx.
@@ -276,7 +276,7 @@ afterEach(() => cleanup());
 function mount(node: React.ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   // The real /datasets and /evaluations route subtrees mount a ToastProvider;
-  // the faithful views use toasts, so the harness mirrors that wrapping.
+  // the views use toasts, so the harness mirrors that wrapping.
   return render(
     <QueryClientProvider client={qc}>
       <ToastProvider>{node}</ToastProvider>
@@ -333,31 +333,17 @@ describe("real Datasets + Evaluations views render server data", () => {
     expect(screen.getAllByText("total").length).toBeGreaterThan(0);
   });
 
-  it("selecting exactly two runs offers a Compare action", async () => {
-    mount(<EvaluationsView projectId="p1" />);
-    await screen.findByText(/Run #27 ·/);
-    // Only the per-row checkboxes (labels like "Select … #27"), not the select-all header.
-    const boxes = screen
-      .getAllByRole("checkbox")
-      .filter((b) => /^Select .*#\d/.test(b.getAttribute("aria-label") ?? ""));
-    expect(boxes.length).toBe(2);
-    fireEvent.click(boxes[0]);
-    fireEvent.click(boxes[1]);
-    expect(await screen.findByRole("button", { name: /Compare/ })).toBeDefined();
-  });
-
-  it("Scorers tab shows an SDK-defined scorer and its detail is honest about gaps", async () => {
+  it("Scorers tab shows an SDK-defined scorer and opens its read-only detail", async () => {
     mount(<EvaluationsView projectId="p1" />);
     fireEvent.click(await screen.findByRole("button", { name: /Scorers/ }));
-    // Clicking a scorer row opens the detail panel; then assert on it.
+    // Clicking a scorer row opens the read-only, detector-style detail panel.
     fireEvent.click(await screen.findByText("routing-accuracy"));
-    expect(await screen.findByText("Defined in SDK")).toBeDefined();
-    const detail = screen.getByLabelText("Scorer detail");
-    // This fixture reports no definition (no type/model/source), so the detector-style
-    // detail is honest about the gaps but still shows the observed usage + config cards.
-    expect(within(detail).getAllByText("Not provided by SDK").length).toBeGreaterThan(0);
-    expect(within(detail).getByText("Configuration")).toBeDefined();
-    expect(within(detail).getByText("Observed usage")).toBeDefined();
+    const detail = await screen.findByLabelText("Scorer detail");
+    // Detector-style cards; the removed analytics block is gone.
+    expect(within(detail).getByText("Name")).toBeDefined();
+    expect(within(detail).getByText("Pass threshold")).toBeDefined();
+    expect(within(detail).queryByText("Observed usage")).toBeNull();
+    expect(within(detail).queryByText("Configuration")).toBeNull();
     // Scorers are SDK-authored — no create/edit control.
     expect(screen.queryByRole("button", { name: /Create scorer/ })).toBeNull();
   });

--- a/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
@@ -33,8 +33,8 @@ const RUN = {
   candidateVersion: "git:4a91c02",
   environment: "ci",
   status: "completed_with_errors",
-  baselineRunId: null,
-  mainScore: 93.8,
+  baselineRunId: "run0",
+  mainScore: 0.938,
   mainScoreName: "Routing accuracy",
   caseCount: 24,
   scoredCount: 22,
@@ -47,9 +47,46 @@ const RUN = {
   evaluationName: "Billing routing",
   datasetName: "Billing routing",
   datasetVersionLabel: "v12",
-  changeFromBaseline: 22.4,
+  changeFromBaseline: 0.224,
   errorCount: 2,
   baselineComparable: true,
+  elapsedMs: 360000,
+  comparison: {
+    available: true,
+    trustworthy: true,
+    reasons: [],
+    baseline: { runId: "run0", runNumber: 26, candidateVersion: "git:0000000" },
+    mainScore: { candidate: 0.938, baseline: 0.714, delta: 0.224 },
+    caseCounts: {
+      improved: 1,
+      regressed: 0,
+      unchanged: 21,
+      changed: 0,
+      unpaired: 0,
+      not_comparable: 0,
+    },
+    scoreCellCounts: {
+      improved: 1,
+      regressed: 0,
+      unchanged: 21,
+      changed: 0,
+      unpaired: 0,
+      not_comparable: 0,
+    },
+    scorers: [
+      {
+        name: "routing-accuracy",
+        version: "v3",
+        valueType: "numeric",
+        direction: "higher_is_better",
+        candidateMean: 0.938,
+        baselineMean: 0.714,
+        delta: 0.224,
+        pairedCount: 22,
+      },
+    ],
+    duration: { candidateMeanMs: 1500, baselineMeanMs: 1400, deltaMs: 100, pairedCount: 22 },
+  },
 };
 
 const RESULT = {
@@ -83,6 +120,25 @@ const RESULT = {
     },
   ],
   humanScores: [],
+  comparison: {
+    caseChange: "improved",
+    pairing: "paired",
+    mainScore: { candidate: 1, baseline: 0, delta: 1 },
+    scorerCells: [
+      {
+        scorerName: "routing-accuracy",
+        scorerVersion: "v3",
+        valueType: "numeric",
+        direction: "higher_is_better",
+        candidateValue: 1,
+        baselineValue: 0,
+        delta: 1,
+        classification: "improved",
+      },
+    ],
+    regressedCellCount: 0,
+    comparableCellCount: 1,
+  },
 };
 
 function payloadFor(url: string): unknown {
@@ -104,7 +160,7 @@ function payloadFor(url: string): unknown {
             runNumber: 27,
             candidateVersion: "git:4a91c02",
             status: "completed_with_errors",
-            mainScore: 93.8,
+            mainScore: 0.938,
             startedAt: "2026-07-17T10:24:00Z",
             datasetVersionId: "dv1",
           },

--- a/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
@@ -7,7 +7,7 @@
  * checked, exactly like offline-eval.smoke.test.tsx.
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, cleanup, screen } from "@testing-library/react";
+import { render, cleanup, screen, fireEvent, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastProvider } from "@/components/ui/toast";
 
@@ -141,10 +141,47 @@ const RESULT = {
   },
 };
 
+// An older run of the SAME evaluation lineage, distinct candidate, so grouping and
+// latest-only are meaningful in the run-centric table.
+const RUN_OLDER = {
+  ...RUN,
+  id: "run0",
+  runNumber: 26,
+  candidateVersion: "git:0000000",
+  startedAt: "2026-07-16T10:24:00Z",
+  completedAt: "2026-07-16T10:30:00Z",
+  changeFromBaseline: null,
+  baselineRunId: null,
+};
+
 function payloadFor(url: string): unknown {
   if (url.includes("/evaluations/runs/run1")) return { run: RUN, results: [RESULT] };
   if (url.includes("/evaluations/runs"))
-    return { data: [RUN], meta: { page: 0, limit: 50, total: 1 } };
+    return { data: [RUN, RUN_OLDER], meta: { page: 0, limit: 50, total: 2 } };
+  if (url.includes("/evaluations/scorers"))
+    return {
+      data: [
+        {
+          name: "routing-accuracy",
+          version: "v3",
+          scoreCount: 22,
+          errorCount: 0,
+          errorRate: 0,
+          valueType: "numeric",
+          declaredValueType: "numeric",
+          direction: "higher_is_better",
+          threshold: null,
+          numeric: { mean: 0.9, min: 0.5, max: 1, count: 22 },
+          passRate: null,
+          distribution: null,
+          runCount: 2,
+          evaluationCount: 1,
+          lastUsed: "2026-07-17T10:24:00Z",
+          recentErrors: [],
+          source: "SDK",
+        },
+      ],
+    };
   if (url.includes("/evaluations")) {
     return {
       data: [
@@ -258,7 +295,7 @@ describe("real Datasets + Evaluations views render server data", () => {
     expect((await screen.findAllByText("git:4a91c02")).length).toBeGreaterThan(0);
   });
 
-  it("Evaluations shows a detectors-style empty page with a Run evaluation CTA", async () => {
+  it("Evaluations shows an empty state that points at the SDK (no Run evaluation CTA)", async () => {
     global.fetch = vi.fn(async () => ({
       ok: true,
       status: 200,
@@ -266,7 +303,63 @@ describe("real Datasets + Evaluations views render server data", () => {
     })) as unknown as typeof fetch;
     mount(<EvaluationsView projectId="p1" />);
     expect(await screen.findByText(/No evaluation runs yet/)).toBeDefined();
-    expect((await screen.findAllByText("Run evaluation")).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: /Run evaluation/ })).toBeNull();
+  });
+
+  it("run-centric table shows immutable-run identity (Run # + candidate) for both runs", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    expect(await screen.findByText(/Run #27 ·/)).toBeDefined();
+    expect(await screen.findByText(/Run #26 ·/)).toBeDefined();
+  });
+
+  it("Latest only keeps just the newest run of each lineage", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    // Both runs visible first.
+    expect(await screen.findByText("git:0000000")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: /Latest only/ }));
+    // The older run (#26) drops out; the newest (#27) stays.
+    expect(screen.queryByText("git:0000000")).toBeNull();
+    expect(screen.getByText("git:4a91c02")).toBeDefined();
+  });
+
+  it("Group by evaluation collapses runs under a lineage header", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    await screen.findByText(/Run #27 ·/);
+    fireEvent.click(screen.getByRole("button", { name: /Group by evaluation/ }));
+    // Group header shows per-column aggregate totals across the lineage (not the latest
+    // run's values): run count, the averaged main score, and total captions.
+    expect(await screen.findByText(/2 runs/)).toBeDefined();
+    expect(screen.getByText(/93\.8%/)).toBeDefined(); // avg main score across the lineage
+    expect(screen.getAllByText("total").length).toBeGreaterThan(0);
+  });
+
+  it("selecting exactly two runs offers a Compare action", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    await screen.findByText(/Run #27 ·/);
+    // Only the per-row checkboxes (labels like "Select … #27"), not the select-all header.
+    const boxes = screen
+      .getAllByRole("checkbox")
+      .filter((b) => /^Select .*#\d/.test(b.getAttribute("aria-label") ?? ""));
+    expect(boxes.length).toBe(2);
+    fireEvent.click(boxes[0]);
+    fireEvent.click(boxes[1]);
+    expect(await screen.findByRole("button", { name: /Compare/ })).toBeDefined();
+  });
+
+  it("Scorers tab shows an SDK-defined scorer and its detail is honest about gaps", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    fireEvent.click(await screen.findByRole("button", { name: /Scorers/ }));
+    // Clicking a scorer row opens the detail panel; then assert on it.
+    fireEvent.click(await screen.findByText("routing-accuracy"));
+    expect(await screen.findByText("Defined in SDK")).toBeDefined();
+    const detail = screen.getByLabelText("Scorer detail");
+    // This fixture reports no definition (no type/model/source), so the detector-style
+    // detail is honest about the gaps but still shows the observed usage + config cards.
+    expect(within(detail).getAllByText("Not provided by SDK").length).toBeGreaterThan(0);
+    expect(within(detail).getByText("Configuration")).toBeDefined();
+    expect(within(detail).getByText("Observed usage")).toBeDefined();
+    // Scorers are SDK-authored — no create/edit control.
+    expect(screen.queryByRole("button", { name: /Create scorer/ })).toBeNull();
   });
 
   it("Run detail renders the run header and the result row (results-forward)", async () => {

--- a/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
@@ -1,13 +1,13 @@
 // @vitest-environment jsdom
 /**
  * View-mount ("e2e") smoke for the real, server-backed Datasets + Evaluations
- * pages. The routes sit behind auth and can't be driven over HTTP
+ * pages (Phase 8). The routes sit behind auth and can't be driven over HTTP
  * without a session, and the repo has no browser driver — so mounting the views
  * against a stubbed fetch (server-shaped payloads) is how the browser path is
  * checked, exactly like offline-eval.smoke.test.tsx.
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, cleanup, screen, fireEvent, within } from "@testing-library/react";
+import { render, cleanup, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastProvider } from "@/components/ui/toast";
 
@@ -33,8 +33,8 @@ const RUN = {
   candidateVersion: "git:4a91c02",
   environment: "ci",
   status: "completed_with_errors",
-  baselineRunId: "run0",
-  mainScore: 0.938,
+  baselineRunId: null,
+  mainScore: 93.8,
   mainScoreName: "Routing accuracy",
   caseCount: 24,
   scoredCount: 22,
@@ -47,46 +47,9 @@ const RUN = {
   evaluationName: "Billing routing",
   datasetName: "Billing routing",
   datasetVersionLabel: "v12",
-  changeFromBaseline: 0.224,
+  changeFromBaseline: 22.4,
   errorCount: 2,
   baselineComparable: true,
-  elapsedMs: 360000,
-  comparison: {
-    available: true,
-    trustworthy: true,
-    reasons: [],
-    baseline: { runId: "run0", runNumber: 26, candidateVersion: "git:0000000" },
-    mainScore: { candidate: 0.938, baseline: 0.714, delta: 0.224 },
-    caseCounts: {
-      improved: 1,
-      regressed: 0,
-      unchanged: 21,
-      changed: 0,
-      unpaired: 0,
-      not_comparable: 0,
-    },
-    scoreCellCounts: {
-      improved: 1,
-      regressed: 0,
-      unchanged: 21,
-      changed: 0,
-      unpaired: 0,
-      not_comparable: 0,
-    },
-    scorers: [
-      {
-        name: "routing-accuracy",
-        version: "v3",
-        valueType: "numeric",
-        direction: "higher_is_better",
-        candidateMean: 0.938,
-        baselineMean: 0.714,
-        delta: 0.224,
-        pairedCount: 22,
-      },
-    ],
-    duration: { candidateMeanMs: 1500, baselineMeanMs: 1400, deltaMs: 100, pairedCount: 22 },
-  },
 };
 
 const RESULT = {
@@ -120,68 +83,12 @@ const RESULT = {
     },
   ],
   humanScores: [],
-  comparison: {
-    caseChange: "improved",
-    pairing: "paired",
-    mainScore: { candidate: 1, baseline: 0, delta: 1 },
-    scorerCells: [
-      {
-        scorerName: "routing-accuracy",
-        scorerVersion: "v3",
-        valueType: "numeric",
-        direction: "higher_is_better",
-        candidateValue: 1,
-        baselineValue: 0,
-        delta: 1,
-        classification: "improved",
-      },
-    ],
-    regressedCellCount: 0,
-    comparableCellCount: 1,
-  },
-};
-
-// An older run of the SAME evaluation lineage, distinct candidate, so grouping and
-// latest-only are meaningful in the run-centric table.
-const RUN_OLDER = {
-  ...RUN,
-  id: "run0",
-  runNumber: 26,
-  candidateVersion: "git:0000000",
-  startedAt: "2026-07-16T10:24:00Z",
-  completedAt: "2026-07-16T10:30:00Z",
-  changeFromBaseline: null,
-  baselineRunId: null,
 };
 
 function payloadFor(url: string): unknown {
   if (url.includes("/evaluations/runs/run1")) return { run: RUN, results: [RESULT] };
   if (url.includes("/evaluations/runs"))
-    return { data: [RUN, RUN_OLDER], meta: { page: 0, limit: 50, total: 2 } };
-  if (url.includes("/evaluations/scorers"))
-    return {
-      data: [
-        {
-          name: "routing-accuracy",
-          version: "v3",
-          scoreCount: 22,
-          errorCount: 0,
-          errorRate: 0,
-          valueType: "numeric",
-          declaredValueType: "numeric",
-          direction: "higher_is_better",
-          threshold: null,
-          numeric: { mean: 0.9, min: 0.5, max: 1, count: 22 },
-          passRate: null,
-          distribution: null,
-          runCount: 2,
-          evaluationCount: 1,
-          lastUsed: "2026-07-17T10:24:00Z",
-          recentErrors: [],
-          source: "SDK",
-        },
-      ],
-    };
+    return { data: [RUN], meta: { page: 0, limit: 50, total: 1 } };
   if (url.includes("/evaluations")) {
     return {
       data: [
@@ -197,7 +104,7 @@ function payloadFor(url: string): unknown {
             runNumber: 27,
             candidateVersion: "git:4a91c02",
             status: "completed_with_errors",
-            mainScore: 0.938,
+            mainScore: 93.8,
             startedAt: "2026-07-17T10:24:00Z",
             datasetVersionId: "dv1",
           },
@@ -276,7 +183,7 @@ afterEach(() => cleanup());
 function mount(node: React.ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   // The real /datasets and /evaluations route subtrees mount a ToastProvider;
-  // the views use toasts, so the harness mirrors that wrapping.
+  // the faithful views use toasts, so the harness mirrors that wrapping.
   return render(
     <QueryClientProvider client={qc}>
       <ToastProvider>{node}</ToastProvider>
@@ -295,7 +202,7 @@ describe("real Datasets + Evaluations views render server data", () => {
     expect((await screen.findAllByText("git:4a91c02")).length).toBeGreaterThan(0);
   });
 
-  it("Evaluations shows an empty state that points at the SDK (no Run evaluation CTA)", async () => {
+  it("Evaluations shows a detectors-style empty page with a Run evaluation CTA", async () => {
     global.fetch = vi.fn(async () => ({
       ok: true,
       status: 200,
@@ -303,62 +210,7 @@ describe("real Datasets + Evaluations views render server data", () => {
     })) as unknown as typeof fetch;
     mount(<EvaluationsView projectId="p1" />);
     expect(await screen.findByText(/No evaluation runs yet/)).toBeDefined();
-    expect(screen.queryByRole("button", { name: /Run evaluation/ })).toBeNull();
-  });
-
-  it("run-centric table shows immutable-run identity (Run # + candidate) for both runs", async () => {
-    mount(<EvaluationsView projectId="p1" />);
-    expect(await screen.findByText(/Run #27 ·/)).toBeDefined();
-    expect(await screen.findByText(/Run #26 ·/)).toBeDefined();
-  });
-
-  it("Latest only keeps just the newest run of each lineage", async () => {
-    mount(<EvaluationsView projectId="p1" />);
-    // Both runs visible first.
-    expect(await screen.findByText("git:0000000")).toBeDefined();
-    fireEvent.click(screen.getByRole("button", { name: /Latest only/ }));
-    // The older run (#26) drops out; the newest (#27) stays.
-    expect(screen.queryByText("git:0000000")).toBeNull();
-    expect(screen.getByText("git:4a91c02")).toBeDefined();
-  });
-
-  it("Group by evaluation collapses runs under a lineage header", async () => {
-    mount(<EvaluationsView projectId="p1" />);
-    await screen.findByText(/Run #27 ·/);
-    fireEvent.click(screen.getByRole("button", { name: /Group by evaluation/ }));
-    // Group header shows per-column aggregate totals across the lineage (not the latest
-    // run's values): run count, the averaged main score, and total captions.
-    expect(await screen.findByText(/2 runs/)).toBeDefined();
-    expect(screen.getByText(/93\.8%/)).toBeDefined(); // avg main score across the lineage
-    expect(screen.getAllByText("total").length).toBeGreaterThan(0);
-  });
-
-  it("selecting exactly two runs offers a Compare action", async () => {
-    mount(<EvaluationsView projectId="p1" />);
-    await screen.findByText(/Run #27 ·/);
-    // Only the per-row checkboxes (labels like "Select … #27"), not the select-all header.
-    const boxes = screen
-      .getAllByRole("checkbox")
-      .filter((b) => /^Select .*#\d/.test(b.getAttribute("aria-label") ?? ""));
-    expect(boxes.length).toBe(2);
-    fireEvent.click(boxes[0]);
-    fireEvent.click(boxes[1]);
-    expect(await screen.findByRole("button", { name: /Compare/ })).toBeDefined();
-  });
-
-  it("Scorers tab shows an SDK-defined scorer and its detail is honest about gaps", async () => {
-    mount(<EvaluationsView projectId="p1" />);
-    fireEvent.click(await screen.findByRole("button", { name: /Scorers/ }));
-    // Clicking a scorer row opens the detail panel; then assert on it.
-    fireEvent.click(await screen.findByText("routing-accuracy"));
-    const detail = await screen.findByLabelText("Scorer detail");
-    // This fixture reports no definition (no type/model/source), so the detector-style
-    // detail is honest about the gap but still shows the observed usage + config cards.
-    expect(within(detail).getByText(/hasn't reported this scorer/i)).toBeDefined();
-    expect(within(detail).getByText("Configuration")).toBeDefined();
-    expect(within(detail).getByText("Observed usage")).toBeDefined();
-    // Scorers are SDK-authored — no create/edit control.
-    expect(screen.queryByRole("button", { name: /Create scorer/ })).toBeNull();
+    expect((await screen.findAllByText("Run evaluation")).length).toBeGreaterThan(0);
   });
 
   it("Run detail renders the run header and the result row (results-forward)", async () => {

--- a/frontend/ui/src/features/evaluations/hooks.ts
+++ b/frontend/ui/src/features/evaluations/hooks.ts
@@ -10,6 +10,7 @@ import type {
   EvaluationRow,
   RunRow,
   RunDetailResponse,
+  CompareRunsResponse,
   EvalResultStatus,
   ScoreRow,
 } from "./types";
@@ -63,12 +64,14 @@ export function useDatasets(
   });
 }
 
-export function useDataset(projectId: string, datasetId: string) {
+export function useDataset(projectId: string, datasetId: string, versionId?: string | null) {
+  const qs = versionId ? `?version_id=${encodeURIComponent(versionId)}` : "";
   return useQuery({
-    queryKey: ["datasets", "detail", projectId, datasetId],
+    queryKey: ["datasets", "detail", projectId, datasetId, versionId ?? null],
     queryFn: () =>
-      getJson<DatasetDetailResponse>(`/api/projects/${projectId}/datasets/${datasetId}`),
+      getJson<DatasetDetailResponse>(`/api/projects/${projectId}/datasets/${datasetId}${qs}`),
     enabled: !!projectId && !!datasetId,
+    placeholderData: (prev) => prev,
   });
 }
 
@@ -129,7 +132,11 @@ export function useSaveTestCase(projectId: string, datasetId: string) {
         "POST",
         input,
       ),
-    onSuccess: () => void qc.invalidateQueries({ queryKey: ["datasets"] }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["datasets"] });
+      // Refresh the trace's span→dataset chips so a just-saved span is marked.
+      void qc.invalidateQueries({ queryKey: ["evaluations", "trace-test-cases"] });
+    },
   });
 }
 
@@ -151,6 +158,30 @@ export function useUpdateTestCase(projectId: string, datasetId: string) {
         args.patch,
       ),
     onSuccess: () => void qc.invalidateQueries({ queryKey: ["datasets"] }),
+  });
+}
+
+export interface TestCaseRunRow {
+  resultId: string;
+  runId: string;
+  runNumber: number;
+  candidateVersion: string;
+  evaluationName: string;
+  ranAt: string;
+  score: number | null;
+  status: string;
+  change: "improved" | "regressed" | "unchanged" | null;
+}
+
+/** Every evaluation run that measured a given test case (newest first). */
+export function useTestCaseRuns(projectId: string, datasetId: string, testCaseId: string | null) {
+  return useQuery({
+    queryKey: ["datasets", projectId, datasetId, "test-case-runs", testCaseId],
+    queryFn: () =>
+      getJson<{ data: TestCaseRunRow[] }>(
+        `/api/projects/${projectId}/datasets/${datasetId}/test-cases/${testCaseId}/runs`,
+      ),
+    enabled: !!projectId && !!datasetId && !!testCaseId,
   });
 }
 
@@ -183,6 +214,7 @@ export function useEvaluationRuns(
   if (query.status) params.set("status", query.status);
   if (query.search_query) params.set("search_query", query.search_query);
   if (query.page !== undefined) params.set("page", String(query.page));
+  if (query.limit !== undefined) params.set("limit", String(query.limit));
   const qs = params.toString();
   return useQuery({
     queryKey: [
@@ -194,6 +226,7 @@ export function useEvaluationRuns(
       query.status ?? null,
       query.search_query ?? null,
       query.page ?? 0,
+      query.limit ?? null,
     ],
     queryFn: () =>
       getJson<{ data: RunRow[]; meta: Meta }>(
@@ -210,6 +243,24 @@ export function useEvaluationRun(projectId: string, runId: string) {
     queryFn: () =>
       getJson<RunDetailResponse>(`/api/projects/${projectId}/evaluations/runs/${runId}`),
     enabled: !!projectId && !!runId,
+  });
+}
+
+/** Compare two arbitrary runs (candidate vs baseline) of the same evaluation. */
+export function useCompareRuns(
+  projectId: string,
+  candidateId: string | null,
+  baselineId: string | null,
+) {
+  return useQuery({
+    queryKey: ["evaluations", "compare", projectId, candidateId, baselineId],
+    queryFn: () =>
+      getJson<CompareRunsResponse>(
+        `/api/projects/${projectId}/evaluations/compare?candidate=${encodeURIComponent(
+          candidateId!,
+        )}&baseline=${encodeURIComponent(baselineId!)}`,
+      ),
+    enabled: !!projectId && !!candidateId && !!baselineId && candidateId !== baselineId,
   });
 }
 
@@ -262,12 +313,101 @@ export function useTraceEvaluationResults(projectId: string, traceId: string) {
   });
 }
 
+export interface TraceTestCaseRow {
+  testCaseId: string;
+  datasetId: string;
+  datasetName: string;
+  sourceSpanId: string | null;
+  review: string;
+  datasetVersionLabel: string;
+  datasetUpdatedAt: string;
+  caseCount: number;
+}
+
+/**
+ * Dataset test cases captured from a given trace, keyed by source span. Powers
+ * the "In <dataset>" chip that marks a span already saved as a test case.
+ */
+export function useTraceTestCases(projectId: string, traceId: string) {
+  return useQuery({
+    queryKey: ["evaluations", "trace-test-cases", projectId, traceId],
+    queryFn: () =>
+      getJson<{ data: TraceTestCaseRow[] }>(
+        `/api/projects/${projectId}/traces/${traceId}/test-cases`,
+      ),
+    enabled: !!projectId && !!traceId,
+    // Warmed when the trace opens (see the traces page) and reused as spans are
+    // selected, so the "Dataset:" chip appears without a per-span round trip.
+    staleTime: 60_000,
+  });
+}
+
+/** Delete one or more evaluation runs (cascades their results + scores). */
+export function useDeleteRuns(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (runIds: string[]) =>
+      Promise.all(
+        runIds.map((id) =>
+          sendJson<{ deleted: boolean }>(
+            `/api/projects/${projectId}/evaluations/runs/${id}`,
+            "DELETE",
+            undefined,
+          ),
+        ),
+      ),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["evaluations", "runs"] }),
+  });
+}
+
 export interface ScorerRegistryRow {
   name: string;
   version: string;
   scoreCount: number;
   errorCount: number;
   errorRate: number;
+  /** Inferred from which value column the scores populate. */
+  valueType: "numeric" | "boolean" | "categorical" | "mixed" | "unknown";
+  /** Declared metadata from the run's scorers JSON (when the SDK sends it). */
+  declaredValueType: "numeric" | "boolean" | "categorical" | null;
+  direction: "higher_is_better" | "lower_is_better" | "none" | null;
+  threshold: number | null;
+  /** Numeric summary over successfully-scored numeric values (else null). */
+  numeric: { mean: number; min: number; max: number; count: number } | null;
+  /** Fraction of scores marked passed (else null when the scorer sets no `passed`). */
+  passRate: number | null;
+  /** Boolean (true/false) or categorical value counts, most-common first. */
+  distribution: Array<{ label: string; count: number }> | null;
+  runCount: number;
+  evaluationCount: number;
+  lastUsed: string | null;
+  recentErrors: Array<{ message: string; at: string }>;
+  /** Always "SDK": the catalog only shows what the SDK reported. */
+  source: "SDK";
+  // SDK-reported scorer DEFINITION (offline-eval/sdk-ask/scorer-definition-reporting.md).
+  // Every field is optional — absent → "Not provided by SDK", never inferred.
+  scorerType: "llm_judge" | "code" | null;
+  outputType: "score" | "classification" | null;
+  description: string | null;
+  metadata: unknown | null;
+  model: string | null;
+  messages: Array<{ role: string; content: string }> | null;
+  language: "python" | "typescript" | null;
+  sourceCode: string | null;
+}
+
+/** One scorer family (all versions of a name) + a family-level usage summary. */
+export interface ScorerFamilyResponse {
+  name: string;
+  versions: ScorerRegistryRow[];
+  usage: {
+    runCount: number;
+    evaluationCount: number;
+    scoreCount: number;
+    errorCount: number;
+    lastUsed: string | null;
+  };
+  source: "SDK";
 }
 
 /** Read-only scorer registry, aggregated from reported runs. */
@@ -277,5 +417,17 @@ export function useScorers(projectId: string) {
     queryFn: () =>
       getJson<{ data: ScorerRegistryRow[] }>(`/api/projects/${projectId}/evaluations/scorers`),
     enabled: !!projectId,
+  });
+}
+
+/** One scorer family (its versions + usage), for the scorer detail. */
+export function useScorer(projectId: string, name: string | null) {
+  return useQuery({
+    queryKey: ["evaluations", "scorer", projectId, name],
+    queryFn: () =>
+      getJson<ScorerFamilyResponse>(
+        `/api/projects/${projectId}/evaluations/scorers/${encodeURIComponent(name!)}`,
+      ),
+    enabled: !!projectId && !!name,
   });
 }

--- a/frontend/ui/src/features/evaluations/hooks.ts
+++ b/frontend/ui/src/features/evaluations/hooks.ts
@@ -10,8 +10,6 @@ import type {
   EvaluationRow,
   RunRow,
   RunDetailResponse,
-  EvalResultStatus,
-  ScoreRow,
 } from "./types";
 
 interface Meta {
@@ -63,14 +61,12 @@ export function useDatasets(
   });
 }
 
-export function useDataset(projectId: string, datasetId: string, versionId?: string | null) {
-  const qs = versionId ? `?version_id=${encodeURIComponent(versionId)}` : "";
+export function useDataset(projectId: string, datasetId: string) {
   return useQuery({
-    queryKey: ["datasets", "detail", projectId, datasetId, versionId ?? null],
+    queryKey: ["datasets", "detail", projectId, datasetId],
     queryFn: () =>
-      getJson<DatasetDetailResponse>(`/api/projects/${projectId}/datasets/${datasetId}${qs}`),
+      getJson<DatasetDetailResponse>(`/api/projects/${projectId}/datasets/${datasetId}`),
     enabled: !!projectId && !!datasetId,
-    placeholderData: (prev) => prev,
   });
 }
 
@@ -131,11 +127,7 @@ export function useSaveTestCase(projectId: string, datasetId: string) {
         "POST",
         input,
       ),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ["datasets"] });
-      // Refresh the trace's span→dataset chips so a just-saved span is marked.
-      void qc.invalidateQueries({ queryKey: ["evaluations", "trace-test-cases"] });
-    },
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["datasets"] }),
   });
 }
 
@@ -157,30 +149,6 @@ export function useUpdateTestCase(projectId: string, datasetId: string) {
         args.patch,
       ),
     onSuccess: () => void qc.invalidateQueries({ queryKey: ["datasets"] }),
-  });
-}
-
-export interface TestCaseRunRow {
-  resultId: string;
-  runId: string;
-  runNumber: number;
-  candidateVersion: string;
-  evaluationName: string;
-  ranAt: string;
-  score: number | null;
-  status: string;
-  change: "improved" | "regressed" | "unchanged" | null;
-}
-
-/** Every evaluation run that measured a given test case (newest first). */
-export function useTestCaseRuns(projectId: string, datasetId: string, testCaseId: string | null) {
-  return useQuery({
-    queryKey: ["datasets", projectId, datasetId, "test-case-runs", testCaseId],
-    queryFn: () =>
-      getJson<{ data: TestCaseRunRow[] }>(
-        `/api/projects/${projectId}/datasets/${datasetId}/test-cases/${testCaseId}/runs`,
-      ),
-    enabled: !!projectId && !!datasetId && !!testCaseId,
   });
 }
 
@@ -213,7 +181,6 @@ export function useEvaluationRuns(
   if (query.status) params.set("status", query.status);
   if (query.search_query) params.set("search_query", query.search_query);
   if (query.page !== undefined) params.set("page", String(query.page));
-  if (query.limit !== undefined) params.set("limit", String(query.limit));
   const qs = params.toString();
   return useQuery({
     queryKey: [
@@ -225,7 +192,6 @@ export function useEvaluationRuns(
       query.status ?? null,
       query.search_query ?? null,
       query.page ?? 0,
-      query.limit ?? null,
     ],
     queryFn: () =>
       getJson<{ data: RunRow[]; meta: Meta }>(
@@ -260,83 +226,5 @@ export function useCreateHumanScore(projectId: string, resultId: string) {
         input,
       ),
     onSuccess: () => void qc.invalidateQueries({ queryKey: ["evaluations", "run"] }),
-  });
-}
-
-export interface TraceEvaluationResultRow {
-  id: string;
-  runId: string;
-  testCaseId: string;
-  traceId: string | null;
-  status: EvalResultStatus;
-  mainScore: number | null;
-  scores: ScoreRow[];
-  run: {
-    id: string;
-    runNumber: number;
-    candidateVersion: string;
-    datasetId: string;
-    datasetVersionId: string;
-    evaluation: { id: string; name: string };
-    datasetVersion: { label: string };
-  };
-}
-
-/** Evaluation results a trace produced — the trace -> evaluation-run link. */
-export function useTraceEvaluationResults(projectId: string, traceId: string) {
-  return useQuery({
-    queryKey: ["evaluations", "trace-results", projectId, traceId],
-    queryFn: () =>
-      getJson<{ data: TraceEvaluationResultRow[] }>(
-        `/api/projects/${projectId}/traces/${traceId}/evaluation-results`,
-      ),
-    enabled: !!projectId && !!traceId,
-  });
-}
-
-export interface TraceTestCaseRow {
-  testCaseId: string;
-  datasetId: string;
-  datasetName: string;
-  sourceSpanId: string | null;
-  review: string;
-  datasetVersionLabel: string;
-  datasetUpdatedAt: string;
-  caseCount: number;
-}
-
-/**
- * Dataset test cases captured from a given trace, keyed by source span. Powers
- * the "In <dataset>" chip that marks a span already saved as a test case.
- */
-export function useTraceTestCases(projectId: string, traceId: string) {
-  return useQuery({
-    queryKey: ["evaluations", "trace-test-cases", projectId, traceId],
-    queryFn: () =>
-      getJson<{ data: TraceTestCaseRow[] }>(
-        `/api/projects/${projectId}/traces/${traceId}/test-cases`,
-      ),
-    enabled: !!projectId && !!traceId,
-    // Warmed when the trace opens (see the traces page) and reused as spans are
-    // selected, so the "Dataset:" chip appears without a per-span round trip.
-    staleTime: 60_000,
-  });
-}
-
-export interface ScorerRegistryRow {
-  name: string;
-  version: string;
-  scoreCount: number;
-  errorCount: number;
-  errorRate: number;
-}
-
-/** Read-only scorer registry, aggregated from reported runs. */
-export function useScorers(projectId: string) {
-  return useQuery({
-    queryKey: ["evaluations", "scorers", projectId],
-    queryFn: () =>
-      getJson<{ data: ScorerRegistryRow[] }>(`/api/projects/${projectId}/evaluations/scorers`),
-    enabled: !!projectId,
   });
 }

--- a/frontend/ui/src/features/evaluations/hooks.ts
+++ b/frontend/ui/src/features/evaluations/hooks.ts
@@ -10,6 +10,8 @@ import type {
   EvaluationRow,
   RunRow,
   RunDetailResponse,
+  EvalResultStatus,
+  ScoreRow,
 } from "./types";
 
 interface Meta {
@@ -226,5 +228,54 @@ export function useCreateHumanScore(projectId: string, resultId: string) {
         input,
       ),
     onSuccess: () => void qc.invalidateQueries({ queryKey: ["evaluations", "run"] }),
+  });
+}
+
+export interface TraceEvaluationResultRow {
+  id: string;
+  runId: string;
+  testCaseId: string;
+  traceId: string | null;
+  status: EvalResultStatus;
+  mainScore: number | null;
+  scores: ScoreRow[];
+  run: {
+    id: string;
+    runNumber: number;
+    candidateVersion: string;
+    datasetId: string;
+    datasetVersionId: string;
+    evaluation: { id: string; name: string };
+    datasetVersion: { label: string };
+  };
+}
+
+/** Evaluation results a trace produced — the trace -> evaluation-run link. */
+export function useTraceEvaluationResults(projectId: string, traceId: string) {
+  return useQuery({
+    queryKey: ["evaluations", "trace-results", projectId, traceId],
+    queryFn: () =>
+      getJson<{ data: TraceEvaluationResultRow[] }>(
+        `/api/projects/${projectId}/traces/${traceId}/evaluation-results`,
+      ),
+    enabled: !!projectId && !!traceId,
+  });
+}
+
+export interface ScorerRegistryRow {
+  name: string;
+  version: string;
+  scoreCount: number;
+  errorCount: number;
+  errorRate: number;
+}
+
+/** Read-only scorer registry, aggregated from reported runs. */
+export function useScorers(projectId: string) {
+  return useQuery({
+    queryKey: ["evaluations", "scorers", projectId],
+    queryFn: () =>
+      getJson<{ data: ScorerRegistryRow[] }>(`/api/projects/${projectId}/evaluations/scorers`),
+    enabled: !!projectId,
   });
 }

--- a/frontend/ui/src/features/evaluations/run-detail-trace.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/run-detail-trace.smoke.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+/**
+ * Result → real trace behavior (Phase F). Opening a result should:
+ *  - open the REAL ingested trace directly when it's available (no synthetic override),
+ *  - show a pending state while the trace is still ingesting,
+ *  - fall back to a clearly-labeled reconstructed trace when none was emitted.
+ *
+ * TraceViewerPanel is stubbed to a prop recorder (it's a heavy component) and the
+ * real-trace probe (useTrace) is controllable, so we assert the branch, not the panel.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@/components/ui/toast";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1", runId: "run1" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/projects/p1/evaluations",
+}));
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+
+// Controllable real-trace probe (shares TraceViewerPanel's cache key in real code).
+const traceState: { data: unknown; isFetching: boolean; refetch: () => void } = {
+  data: undefined,
+  isFetching: false,
+  refetch: vi.fn(),
+};
+vi.mock("@/features/traces/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/traces/hooks")>();
+  return { ...actual, useTrace: () => traceState };
+});
+
+// Record TraceViewerPanel props instead of mounting the real (heavy) panel.
+let lastPanel: { traceId?: string; override?: boolean } = {};
+vi.mock("@/features/traces/components", () => ({
+  TraceViewerPanel: (props: {
+    traceId: string;
+    traceOverride?: unknown;
+    spanExtraTags?: () => React.ReactNode;
+  }) => {
+    lastPanel = { traceId: props.traceId, override: !!props.traceOverride };
+    return (
+      <div data-testid="trace-panel" data-traceid={props.traceId}>
+        {props.spanExtraTags?.()}
+      </div>
+    );
+  },
+}));
+
+import { RunDetailView } from "./views/run-detail-view";
+
+const RUN = {
+  id: "run1",
+  evaluationId: "eval1",
+  datasetId: "ds1",
+  datasetVersionId: "dv1",
+  runNumber: 27,
+  candidateVersion: "git:4a91c02",
+  environment: "evaluation",
+  status: "completed",
+  baselineRunId: null,
+  mainScore: 90,
+  mainScoreName: "Routing accuracy",
+  caseCount: 1,
+  scoredCount: 1,
+  taskErrorCount: 0,
+  scorerErrorCount: 0,
+  scorers: [{ name: "routing-accuracy", version: "v3" }],
+  model: null,
+  startedAt: "2026-07-17T10:24:00Z",
+  completedAt: "2026-07-17T10:30:00Z",
+  evaluationName: "Billing routing",
+  datasetName: "Billing routing",
+  datasetVersionLabel: "v12",
+  changeFromBaseline: null,
+  errorCount: 0,
+  baselineComparable: true,
+};
+
+function makeResult(traceId: string | null) {
+  return {
+    id: "res1",
+    runId: "run1",
+    evaluationId: "eval1",
+    testCaseId: "case-1",
+    traceId,
+    input: "I was charged twice for my July invoice",
+    expectedOutput: "billing",
+    candidateOutput: "billing",
+    baselineOutput: null,
+    status: "passed",
+    mainScore: 1,
+    change: null,
+    taskError: null,
+    durationMs: 2400,
+    cost: 0.012,
+    createTime: "2026-07-17T10:24:00Z",
+    scores: [],
+    humanScores: [],
+  };
+}
+
+function stubFetch(result: ReturnType<typeof makeResult>) {
+  global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+    const u = String(url);
+    const body = u.includes("/evaluations/runs/run1")
+      ? { run: RUN, results: [result] }
+      : { data: [], meta: { page: 0, limit: 50, total: 0 } };
+    return { ok: true, status: 200, json: async () => body } as Response;
+  }) as unknown as typeof fetch;
+}
+
+function mount() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ToastProvider>
+        <RunDetailView projectId="p1" runId="run1" />
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+async function openResult() {
+  const cell = await screen.findByText(/charged twice/);
+  fireEvent.click(cell);
+}
+
+beforeEach(() => {
+  lastPanel = {};
+  traceState.data = undefined;
+  traceState.isFetching = false;
+});
+afterEach(() => cleanup());
+
+describe("result → real trace", () => {
+  it("opens the REAL trace directly (no synthetic override) when it is available", async () => {
+    traceState.data = { trace_id: "tr_1", spans: [] };
+    stubFetch(makeResult("tr_1"));
+    mount();
+    await openResult();
+    expect(await screen.findByTestId("trace-panel")).toBeDefined();
+    expect(lastPanel.traceId).toBe("tr_1");
+    expect(lastPanel.override).toBe(false); // real trace, not a reconstruction
+  });
+
+  it("shows a pending state while a reported trace is still ingesting", async () => {
+    traceState.data = undefined; // reported traceId but not yet ingested
+    stubFetch(makeResult("tr_1"));
+    mount();
+    await openResult();
+    expect(await screen.findByText(/still being ingested/i)).toBeDefined();
+    expect(screen.queryByTestId("trace-panel")).toBeNull();
+  });
+
+  it("falls back to a clearly-labeled reconstructed trace when none was emitted", async () => {
+    stubFetch(makeResult(null)); // no trace id → fully-local result
+    mount();
+    await openResult();
+    expect(await screen.findByTestId("trace-panel")).toBeDefined();
+    expect(lastPanel.override).toBe(true); // synthetic override
+    expect(screen.getByText(/Reconstructed/)).toBeDefined();
+  });
+});

--- a/frontend/ui/src/features/evaluations/run-detail-trace.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/run-detail-trace.smoke.test.tsx
@@ -22,9 +22,10 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
 
 // Controllable real-trace probe (shares TraceViewerPanel's cache key in real code).
-const traceState: { data: unknown; isFetching: boolean; refetch: () => void } = {
+const traceState: { data: unknown; isFetching: boolean; isError: boolean; refetch: () => void } = {
   data: undefined,
   isFetching: false,
+  isError: false,
   refetch: vi.fn(),
 };
 vi.mock("@/features/traces/hooks", async (importOriginal) => {
@@ -61,7 +62,7 @@ const RUN = {
   environment: "evaluation",
   status: "completed",
   baselineRunId: null,
-  mainScore: 90,
+  mainScore: 0.9,
   mainScoreName: "Routing accuracy",
   caseCount: 1,
   scoredCount: 1,
@@ -76,7 +77,33 @@ const RUN = {
   datasetVersionLabel: "v12",
   changeFromBaseline: null,
   errorCount: 0,
-  baselineComparable: true,
+  baselineComparable: false,
+  elapsedMs: 360000,
+  comparison: {
+    available: false,
+    trustworthy: false,
+    reasons: ["no_baseline"],
+    baseline: null,
+    mainScore: { candidate: 0.9, baseline: null, delta: null },
+    caseCounts: {
+      improved: 0,
+      regressed: 0,
+      unchanged: 0,
+      changed: 0,
+      unpaired: 1,
+      not_comparable: 0,
+    },
+    scoreCellCounts: {
+      improved: 0,
+      regressed: 0,
+      unchanged: 0,
+      changed: 0,
+      unpaired: 0,
+      not_comparable: 0,
+    },
+    scorers: [],
+    duration: { candidateMeanMs: null, baselineMeanMs: null, deltaMs: null, pairedCount: 0 },
+  },
 };
 
 function makeResult(traceId: string | null) {
@@ -99,6 +126,14 @@ function makeResult(traceId: string | null) {
     createTime: "2026-07-17T10:24:00Z",
     scores: [],
     humanScores: [],
+    comparison: {
+      caseChange: "unpaired",
+      pairing: "candidate_only",
+      mainScore: { candidate: 1, baseline: null, delta: null },
+      scorerCells: [],
+      regressedCellCount: 0,
+      comparableCellCount: 0,
+    },
   };
 }
 
@@ -132,6 +167,7 @@ beforeEach(() => {
   lastPanel = {};
   traceState.data = undefined;
   traceState.isFetching = false;
+  traceState.isError = false;
 });
 afterEach(() => cleanup());
 
@@ -146,13 +182,25 @@ describe("result → real trace", () => {
     expect(lastPanel.override).toBe(false); // real trace, not a reconstruction
   });
 
-  it("shows a pending state while a reported trace is still ingesting", async () => {
-    traceState.data = undefined; // reported traceId but not yet ingested
+  it("shows a pending state when a reported trace hasn't been ingested (404)", async () => {
+    traceState.data = undefined;
+    traceState.isError = true; // fetch failed → not ingested yet
     stubFetch(makeResult("tr_1"));
     mount();
     await openResult();
     expect(await screen.findByText(/still being ingested/i)).toBeDefined();
     expect(screen.queryByTestId("trace-panel")).toBeNull();
+  });
+
+  it("keeps the real trace panel (loading) rather than the pending panel while fetching", async () => {
+    traceState.data = undefined; // still loading, no error
+    stubFetch(makeResult("tr_1"));
+    mount();
+    await openResult();
+    // The real panel stays mounted (shows its own loading) — no pending swap/remount.
+    expect(await screen.findByTestId("trace-panel")).toBeDefined();
+    expect(lastPanel.override).toBe(false);
+    expect(screen.queryByText(/still being ingested/i)).toBeNull();
   });
 
   it("falls back to a clearly-labeled reconstructed trace when none was emitted", async () => {

--- a/frontend/ui/src/features/evaluations/run-evaluation-drawer.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/run-evaluation-drawer.smoke.test.tsx
@@ -1,0 +1,289 @@
+// @vitest-environment jsdom
+/**
+ * Component smoke for the two evaluation drawers that no view mounts today:
+ * "Copy starter code" (RunEvaluationDrawer) and the server-wired
+ * TestCaseReviewDrawer. Both are rendered directly against a stubbed fetch, the
+ * same way the view smokes do it.
+ */
+import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@/components/ui/toast";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/projects/p1/evaluations",
+}));
+
+import { RunEvaluationDrawer } from "./components/run-evaluation-drawer";
+import { TestCaseReviewDrawer } from "@/features/offline-eval/components";
+
+const DATASETS = [
+  {
+    id: "ds_billing",
+    projectId: "p1",
+    name: "Billing routing",
+    description: null,
+    currentVersionId: "dsv_12",
+    createTime: "2026-07-16T00:00:00Z",
+    updateTime: "2026-07-17T00:00:00Z",
+    caseCount: 8,
+    versionCount: 3,
+  },
+  {
+    id: "ds_refunds",
+    projectId: "p1",
+    name: "Refund routing",
+    description: null,
+    currentVersionId: "dsv_3",
+    createTime: "2026-07-16T00:00:00Z",
+    updateTime: "2026-07-17T00:00:00Z",
+    caseCount: 4,
+    versionCount: 1,
+  },
+];
+
+let datasets = DATASETS;
+
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  window.HTMLElement.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+});
+
+beforeEach(() => {
+  datasets = DATASETS;
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ data: datasets, meta: { page: 0, limit: 200, total: datasets.length } }),
+  })) as unknown as typeof fetch;
+});
+afterEach(() => cleanup());
+
+function mount(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ToastProvider>{node}</ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/** The drawer body, so snippet assertions read its text as one string. */
+function panel() {
+  return screen.getByText("Copy starter code").closest("div.fixed") as HTMLElement;
+}
+
+/**
+ * Mounts the drawer closed, lets the dataset list resolve, then opens it — the
+ * real sequence. The default dataset is chosen by the open transition, so a
+ * drawer that is already open on its very first render has nothing to pick yet.
+ */
+async function openDrawer(props: { datasetId?: string } = {}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const onOpenChange = vi.fn();
+  const ui = (open: boolean) => (
+    <QueryClientProvider client={qc}>
+      <ToastProvider>
+        <RunEvaluationDrawer
+          projectId="p1"
+          open={open}
+          onOpenChange={onOpenChange}
+          datasetId={props.datasetId}
+        />
+      </ToastProvider>
+    </QueryClientProvider>
+  );
+  const view = render(ui(false));
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  view.rerender(ui(true));
+  await screen.findByText("Copy starter code");
+  return { onOpenChange };
+}
+
+describe("RunEvaluationDrawer", () => {
+  it("renders nothing while closed", () => {
+    mount(<RunEvaluationDrawer projectId="p1" open={false} onOpenChange={vi.fn()} />);
+    expect(screen.queryByText("Copy starter code")).toBeNull();
+  });
+
+  it("defaults to the first dataset and fills its real ids into the Python snippet", async () => {
+    await openDrawer();
+    await waitFor(() => expect(panel().textContent).toContain('pull_dataset("ds_billing")'));
+    // Both the dataset id and the version id the run will measure are pre-filled.
+    expect(panel().textContent).toContain("dsv_12");
+    expect(panel().textContent).toContain('name="Billing routing"');
+    // Nothing runs from the panel — it is a snippet, not a form.
+    expect(screen.getByText("Nothing runs from this panel.")).toBeDefined();
+  });
+
+  it("switches the snippet to TypeScript and back", async () => {
+    await openDrawer();
+    await waitFor(() => expect(panel().textContent).toContain("pull_dataset"));
+
+    fireEvent.click(screen.getByRole("button", { name: "TypeScript" }));
+    await waitFor(() => expect(panel().textContent).toContain("await evaluate"));
+    expect(panel().textContent).toContain('new Dataset("Billing routing")');
+    expect(panel().textContent).not.toContain("pull_dataset");
+
+    fireEvent.click(screen.getByRole("button", { name: "Python" }));
+    await waitFor(() => expect(panel().textContent).toContain("pull_dataset"));
+  });
+
+  it("picking a different dataset rewrites the snippet's ids", async () => {
+    await openDrawer();
+    await waitFor(() => expect(panel().textContent).toContain("ds_billing"));
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(await screen.findByRole("option", { name: "Refund routing" }));
+
+    await waitFor(() => expect(panel().textContent).toContain('pull_dataset("ds_refunds")'));
+    expect(panel().textContent).toContain("dsv_3");
+  });
+
+  it("a datasetId prefills the dataset and hides the picker", async () => {
+    await openDrawer({ datasetId: "ds_refunds" });
+    // No selector at all when opened from a dataset.
+    expect(screen.queryByRole("combobox")).toBeNull();
+    await waitFor(() => expect(screen.getByText("Refund routing")).toBeDefined());
+    expect(panel().textContent).toContain('pull_dataset("ds_refunds")');
+  });
+
+  it("falls back to placeholder ids when the project has no datasets", async () => {
+    datasets = [];
+    await openDrawer();
+    await waitFor(() => expect(panel().textContent).toContain('pull_dataset("ds_...")'));
+    expect(screen.getByText("No datasets yet")).toBeDefined();
+  });
+
+  it("closes from the X, from Done, and from Escape", async () => {
+    const { onOpenChange } = await openDrawer();
+
+    fireEvent.click(screen.getByLabelText("Close"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    onOpenChange.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    onOpenChange.mockClear();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    // A key the drawer doesn't own is ignored.
+    onOpenChange.mockClear();
+    fireEvent.keyDown(window, { key: "a" });
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});
+
+const TARGET = {
+  contextLabel: "tc_9f2 · Billing routing",
+  input: "I was charged twice for my July invoice",
+  expected: "billing",
+  currentReview: "needs_review" as const,
+};
+
+describe("TestCaseReviewDrawer (server-wired)", () => {
+  it("renders nothing without a target", () => {
+    mount(<TestCaseReviewDrawer target={null} open onOpenChange={vi.fn()} onSubmit={vi.fn()} />);
+    expect(screen.queryByText("Review test case")).toBeNull();
+  });
+
+  it("shows the case being reviewed and every verification check", async () => {
+    mount(<TestCaseReviewDrawer target={TARGET} open onOpenChange={vi.fn()} onSubmit={vi.fn()} />);
+    expect(await screen.findByText("Review test case")).toBeDefined();
+    expect(screen.getByText("tc_9f2 · Billing routing")).toBeDefined();
+    expect(screen.getByText(/charged twice/)).toBeDefined();
+    expect(screen.getByText("billing")).toBeDefined();
+    expect(screen.getAllByRole("checkbox").length).toBe(5);
+    // Ready is advisory, and the copy says so.
+    expect(screen.getByText(/never blocks the case from an evaluation/)).toBeDefined();
+  });
+
+  it("Mark ready submits without a correction and closes", async () => {
+    const onSubmit = vi.fn();
+    const onOpenChange = vi.fn();
+    mount(
+      <TestCaseReviewDrawer target={TARGET} open onOpenChange={onOpenChange} onSubmit={onSubmit} />,
+    );
+    const boxes = await screen.findAllByRole("checkbox");
+    fireEvent.click(boxes[0]);
+    fireEvent.click(boxes[4]);
+    // Ticking then un-ticking still leaves the checks purely advisory.
+    fireEvent.click(boxes[4]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark ready" }));
+    expect(onSubmit).toHaveBeenCalledWith({ review: "ready", correctedExpected: undefined });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("a changed expected outcome rides along, trimmed", async () => {
+    const onSubmit = vi.fn();
+    mount(<TestCaseReviewDrawer target={TARGET} open onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+    fireEvent.change(await screen.findByLabelText(/Correct the expected outcome/), {
+      target: { value: "  refunds  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Needs work" }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      review: "needs_review",
+      correctedExpected: "refunds",
+    });
+  });
+
+  it("retyping the same expected outcome is not treated as a correction", async () => {
+    const onSubmit = vi.fn();
+    mount(<TestCaseReviewDrawer target={TARGET} open onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+    fireEvent.change(await screen.findByLabelText(/Correct the expected outcome/), {
+      target: { value: "billing" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Mark ready" }));
+    expect(onSubmit).toHaveBeenCalledWith({ review: "ready", correctedExpected: undefined });
+  });
+
+  it("an empty input and a missing expected read as placeholders", async () => {
+    mount(
+      <TestCaseReviewDrawer
+        target={{ ...TARGET, input: "", expected: null }}
+        open
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(await screen.findByText("—")).toBeDefined();
+    expect(screen.getByText(/Not required — a scorer judges the output directly/)).toBeDefined();
+    // With no expected, the correction field prompts with an example instead.
+    expect(screen.getByPlaceholderText("e.g. billing")).toBeDefined();
+  });
+
+  it("reopening on a new target resets the checks and the correction", async () => {
+    const onSubmit = vi.fn();
+    const { rerender } = render(
+      <TestCaseReviewDrawer target={TARGET} open onOpenChange={vi.fn()} onSubmit={onSubmit} />,
+    );
+    fireEvent.change(await screen.findByLabelText(/Correct the expected outcome/), {
+      target: { value: "refunds" },
+    });
+    fireEvent.click((await screen.findAllByRole("checkbox"))[0]);
+
+    rerender(
+      <TestCaseReviewDrawer
+        target={{ ...TARGET, contextLabel: "tc_aaa · Billing routing" }}
+        open
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText(/Correct the expected outcome/) as HTMLInputElement).value,
+      ).toBe(""),
+    );
+    expect(screen.getAllByRole("checkbox").every((b) => !(b as HTMLInputElement).checked)).toBe(
+      true,
+    );
+  });
+});

--- a/frontend/ui/src/features/evaluations/scorer-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/scorer-detail.smoke.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+/**
+ * The read-only, detector-style Scorer detail (task #5). Asserts the two scorer types —
+ * LLM judge (model + messages) and code snippet (source + language) — plus the shared
+ * config/metadata block, and honest "Not provided by SDK" fallbacks when the SDK reports
+ * no definition. Data contract: offline-eval/sdk-ask/scorer-definition-reporting.md.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup, screen, within } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+// ScorerDetailPanel calls useScorer (version history) only; stub it.
+vi.mock("./hooks", () => ({ useScorer: () => ({ data: { versions: [] } }) }));
+
+import { ScorerDetailPanel } from "./views/evaluations-view";
+import type { ScorerRegistryRow } from "./hooks";
+
+function row(p: Partial<ScorerRegistryRow>): ScorerRegistryRow {
+  return {
+    name: "s",
+    version: "1",
+    scoreCount: 10,
+    errorCount: 0,
+    errorRate: 0,
+    valueType: "numeric",
+    declaredValueType: "numeric",
+    direction: "higher_is_better",
+    threshold: 0.8,
+    numeric: { mean: 0.9, min: 0, max: 1, count: 10 },
+    passRate: null,
+    distribution: null,
+    runCount: 2,
+    evaluationCount: 1,
+    lastUsed: null,
+    recentErrors: [],
+    source: "SDK",
+    scorerType: null,
+    outputType: null,
+    description: null,
+    metadata: null,
+    model: null,
+    messages: null,
+    language: null,
+    sourceCode: null,
+    ...p,
+  };
+}
+
+const mount = (scorer: ScorerRegistryRow) =>
+  render(<ScorerDetailPanel projectId="p1" scorer={scorer} onClose={() => {}} />);
+
+afterEach(() => cleanup());
+
+describe("ScorerDetailPanel", () => {
+  it("LLM judge — shows model + messages + shared config", () => {
+    mount(
+      row({
+        name: "concise",
+        scorerType: "llm_judge",
+        outputType: "score",
+        threshold: 0.8,
+        description: "Judges answer conciseness",
+        metadata: { team: "quality" },
+        model: "claude-sonnet-5",
+        messages: [
+          { role: "system", content: "Rate the answer conciseness from 0 to 1." },
+          { role: "user", content: "ANSWER placeholder" },
+        ],
+      }),
+    );
+    const detail = screen.getByLabelText("Scorer detail");
+    expect(within(detail).getByText("LLM judge")).toBeDefined(); // header type badge
+    expect(within(detail).getByText("Model")).toBeDefined();
+    expect(within(detail).getByText("claude-sonnet-5")).toBeDefined();
+    expect(within(detail).getByText("Messages")).toBeDefined();
+    expect(within(detail).getByText("system")).toBeDefined();
+    expect(within(detail).getByText(/Rate the answer conciseness/)).toBeDefined();
+    // Shared config block.
+    expect(within(detail).getByText("Score")).toBeDefined(); // output type
+    expect(within(detail).getByText("Judges answer conciseness")).toBeDefined();
+    expect(detail.textContent).toContain("quality"); // metadata json
+    // Not a code scorer.
+    expect(within(detail).queryByText(/^Code/)).toBeNull();
+  });
+
+  it("Code snippet — shows source + language + shared config", () => {
+    mount(
+      row({
+        name: "exact_match",
+        version: "unversioned",
+        scorerType: "code",
+        outputType: "classification",
+        language: "python",
+        threshold: 1,
+        description: "Exact string match",
+        sourceCode: "def exact_match(ctx):\n    return 1.0 if ctx.output == ctx.expected else 0.0",
+      }),
+    );
+    const detail = screen.getByLabelText("Scorer detail");
+    expect(within(detail).getByText("Code")).toBeDefined(); // header type badge
+    expect(within(detail).getByText("Code · Python")).toBeDefined(); // card title
+    expect(detail.textContent).toContain("def exact_match"); // source (tokenized)
+    expect(within(detail).getByText("Classification")).toBeDefined(); // output type
+    expect(within(detail).queryByText("Model")).toBeNull();
+  });
+
+  it("No definition reported — honest 'Not provided by SDK' fallbacks", () => {
+    mount(row({ name: "routing_accuracy", declaredValueType: null, threshold: null }));
+    const detail = screen.getByLabelText("Scorer detail");
+    // No type badge for an undeclared scorer.
+    expect(within(detail).queryByText("LLM judge")).toBeNull();
+    expect(within(detail).queryByText("Code")).toBeNull();
+    expect(within(detail).getAllByText("Not provided by SDK").length).toBeGreaterThan(0);
+    // Observed usage is still shown honestly.
+    expect(within(detail).getByText("Observed usage")).toBeDefined();
+  });
+});

--- a/frontend/ui/src/features/evaluations/scorer-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/scorer-detail.smoke.test.tsx
@@ -1,9 +1,8 @@
 // @vitest-environment jsdom
 /**
- * The read-only, detector-style Scorer detail (task #5). Asserts the two scorer types —
- * LLM judge (model + messages) and code snippet (source + language) — plus the shared
- * config/metadata block, and honest "Not provided by SDK" fallbacks when the SDK reports
- * no definition. Data contract: offline-eval/sdk-ask/scorer-definition-reporting.md.
+ * The read-only, detector-style Scorer detail: Name, Model (LLM judge only),
+ * Prompt or code snippet, and Pass threshold. Everything renders read-only, and
+ * fields the SDK didn't report show a plain em dash.
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, cleanup, screen, within } from "@testing-library/react";
@@ -12,8 +11,6 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
   useSearchParams: () => new URLSearchParams(),
 }));
-// ScorerDetailPanel calls useScorer (version history) only; stub it.
-vi.mock("./hooks", () => ({ useScorer: () => ({ data: { versions: [] } }) }));
 
 import { ScorerDetailPanel } from "./views/evaluations-view";
 import type { ScorerRegistryRow } from "./hooks";
@@ -50,20 +47,17 @@ function row(p: Partial<ScorerRegistryRow>): ScorerRegistryRow {
 }
 
 const mount = (scorer: ScorerRegistryRow) =>
-  render(<ScorerDetailPanel projectId="p1" scorer={scorer} onClose={() => {}} />);
+  render(<ScorerDetailPanel scorer={scorer} onClose={() => {}} />);
 
 afterEach(() => cleanup());
 
 describe("ScorerDetailPanel", () => {
-  it("LLM judge — shows model + messages + shared config", () => {
+  it("LLM judge — Name, Model, Prompt, Pass threshold", () => {
     mount(
       row({
         name: "concise",
         scorerType: "llm_judge",
-        outputType: "score",
         threshold: 0.8,
-        description: "Judges answer conciseness",
-        metadata: { team: "quality" },
         model: "claude-sonnet-5",
         messages: [
           { role: "system", content: "Rate the answer conciseness from 0 to 1." },
@@ -72,49 +66,50 @@ describe("ScorerDetailPanel", () => {
       }),
     );
     const detail = screen.getByLabelText("Scorer detail");
-    expect(within(detail).getByText("LLM judge")).toBeDefined(); // header type badge
+    // The four detector-style cards.
+    expect(within(detail).getByText("Name")).toBeDefined();
     expect(within(detail).getByText("Model")).toBeDefined();
+    expect(within(detail).getByText("Prompt")).toBeDefined();
+    expect(within(detail).getByText("Pass threshold")).toBeDefined();
+    // Their values.
     expect(within(detail).getByText("claude-sonnet-5")).toBeDefined();
-    expect(within(detail).getByText("Messages")).toBeDefined();
     expect(within(detail).getByText("system")).toBeDefined();
     expect(within(detail).getByText(/Rate the answer conciseness/)).toBeDefined();
-    // Shared config block.
-    expect(within(detail).getByText("Score")).toBeDefined(); // output type
-    expect(within(detail).getByText("Judges answer conciseness")).toBeDefined();
-    expect(detail.textContent).toContain("quality"); // metadata json
-    // Not a code scorer.
-    expect(within(detail).queryByText(/^Code/)).toBeNull();
+    expect(detail.textContent).toContain("0.8");
+    // Removed sections are gone.
+    expect(within(detail).queryByText("Configuration")).toBeNull();
+    expect(within(detail).queryByText("Observed usage")).toBeNull();
+    expect(within(detail).queryByText("Code")).toBeNull();
   });
 
-  it("Code snippet — shows source + language + shared config", () => {
+  it("Code snippet — Name, Code, Pass threshold (no Model)", () => {
     mount(
       row({
         name: "exact_match",
         version: "unversioned",
         scorerType: "code",
-        outputType: "classification",
         language: "python",
         threshold: 1,
-        description: "Exact string match",
         sourceCode: "def exact_match(ctx):\n    return 1.0 if ctx.output == ctx.expected else 0.0",
       }),
     );
     const detail = screen.getByLabelText("Scorer detail");
-    expect(within(detail).getByText("Code")).toBeDefined(); // header type badge
-    expect(within(detail).getByText("Code · Python")).toBeDefined(); // card title
+    expect(within(detail).getByText("Code")).toBeDefined();
     expect(detail.textContent).toContain("def exact_match"); // source (tokenized)
-    expect(within(detail).getByText("Classification")).toBeDefined(); // output type
+    expect(within(detail).getByText("Pass threshold")).toBeDefined();
+    // A code scorer runs no model.
     expect(within(detail).queryByText("Model")).toBeNull();
+    expect(within(detail).queryByText("Prompt")).toBeNull();
   });
 
-  it("No definition reported — honest 'Not provided by SDK' fallbacks", () => {
+  it("No definition reported — em-dash fallbacks, no observed-usage block", () => {
     mount(row({ name: "routing_accuracy", declaredValueType: null, threshold: null }));
     const detail = screen.getByLabelText("Scorer detail");
-    // No type badge for an undeclared scorer.
-    expect(within(detail).queryByText("LLM judge")).toBeNull();
-    expect(within(detail).queryByText("Code")).toBeNull();
-    expect(within(detail).getAllByText("Not provided by SDK").length).toBeGreaterThan(0);
-    // Observed usage is still shown honestly.
-    expect(within(detail).getByText("Observed usage")).toBeDefined();
+    // Still shows the Name and Pass threshold cards, honestly empty.
+    expect(within(detail).getByText("Name")).toBeDefined();
+    expect(within(detail).getByText("Pass threshold")).toBeDefined();
+    expect(detail.textContent).toContain("—");
+    // No observed-usage/analytics block on the read-only detail.
+    expect(within(detail).queryByText("Observed usage")).toBeNull();
   });
 });

--- a/frontend/ui/src/features/evaluations/types.ts
+++ b/frontend/ui/src/features/evaluations/types.ts
@@ -2,22 +2,6 @@
  * Client-side shapes for the server-backed evaluation feature. Timestamps arrive
  * as ISO strings over JSON, so these mirror the Prisma rows with string dates.
  */
-import type { RunComparison, ResultComparison } from "@/lib/eval/comparison";
-
-export type { RunComparison, ResultComparison, Classification } from "@/lib/eval/comparison";
-
-/** The per-result comparison block the run-detail route embeds on each result. */
-export type ResultRowComparison = Pick<
-  ResultComparison,
-  | "caseChange"
-  | "pairing"
-  | "mainScore"
-  | "baselineDurationMs"
-  | "durationDeltaMs"
-  | "scorerCells"
-  | "regressedCellCount"
-  | "comparableCellCount"
->;
 
 export type ReviewStatus = "needs_review" | "ready";
 export type EvalResultStatus = "passed" | "failed" | "errored" | "not_scored";
@@ -82,10 +66,6 @@ export interface TestCaseRow {
 export interface DatasetDetailResponse {
   dataset: DatasetRow;
   currentVersion: DatasetVersionRow | null;
-  /** The version whose cases are returned (the requested one, or current). */
-  selectedVersion: DatasetVersionRow | null;
-  /** True when `selectedVersion` is the dataset's current version. */
-  isCurrentVersion: boolean;
   testCases: TestCaseRow[];
   versions: DatasetVersionRow[];
 }
@@ -130,8 +110,6 @@ export interface ResultRow {
   createTime: string;
   scores: ScoreRow[];
   humanScores: HumanScoreRow[];
-  /** Backend-derived candidate-vs-baseline comparison for this result. */
-  comparison: ResultRowComparison | null;
 }
 
 export interface RunRow {
@@ -152,8 +130,6 @@ export interface RunRow {
   scorerErrorCount: number;
   scorers: Array<{ name: string; version: string }> | null;
   model: string | null;
-  /** Structured run provenance (model, prompt, config, git). Free-form; may be null. */
-  metadata: Record<string, unknown> | null;
   startedAt: string;
   completedAt: string | null;
   evaluationName: string;
@@ -161,19 +137,10 @@ export interface RunRow {
   datasetVersionLabel: string;
   changeFromBaseline: number | null;
   errorCount: number;
-  /** Derived (list route): regressed test-case count when trustworthy, else null. */
-  regressedCaseCount?: number | null;
-  /** Derived: whether the candidate-vs-baseline comparison is trustworthy. */
-  baselineComparable?: boolean;
-  /** Run wall-clock (completedAt − startedAt), null while running. */
-  elapsedMs?: number | null;
 }
 
 export interface RunDetail extends RunRow {
   baselineComparable: boolean;
-  elapsedMs: number | null;
-  /** The backend-derived run-level comparison (single source of truth). */
-  comparison: RunComparison;
 }
 
 export interface RunDetailResponse {

--- a/frontend/ui/src/features/evaluations/types.ts
+++ b/frontend/ui/src/features/evaluations/types.ts
@@ -2,6 +2,25 @@
  * Client-side shapes for the server-backed evaluation feature. Timestamps arrive
  * as ISO strings over JSON, so these mirror the Prisma rows with string dates.
  */
+import type { RunComparison, ResultComparison } from "@/lib/eval/comparison";
+
+export type { RunComparison, ResultComparison, Classification } from "@/lib/eval/comparison";
+
+/** The per-result comparison block the run-detail route embeds on each result. */
+export type ResultRowComparison = Pick<
+  ResultComparison,
+  | "caseChange"
+  | "pairing"
+  | "mainScore"
+  | "baselineDurationMs"
+  | "durationDeltaMs"
+  | "scorerCells"
+  | "regressedCellCount"
+  | "comparableCellCount"
+> & {
+  /** The baseline case's trace id (for diffing tokens/cost/latency); null if none. */
+  baselineTraceId: string | null;
+};
 
 export type ReviewStatus = "needs_review" | "ready";
 export type EvalResultStatus = "passed" | "failed" | "errored" | "not_scored";
@@ -66,6 +85,10 @@ export interface TestCaseRow {
 export interface DatasetDetailResponse {
   dataset: DatasetRow;
   currentVersion: DatasetVersionRow | null;
+  /** The version whose cases are returned (the requested one, or current). */
+  selectedVersion: DatasetVersionRow | null;
+  /** True when `selectedVersion` is the dataset's current version. */
+  isCurrentVersion: boolean;
   testCases: TestCaseRow[];
   versions: DatasetVersionRow[];
 }
@@ -110,6 +133,8 @@ export interface ResultRow {
   createTime: string;
   scores: ScoreRow[];
   humanScores: HumanScoreRow[];
+  /** Backend-derived candidate-vs-baseline comparison for this result. */
+  comparison: ResultRowComparison | null;
 }
 
 export interface RunRow {
@@ -128,8 +153,20 @@ export interface RunRow {
   scoredCount: number;
   taskErrorCount: number;
   scorerErrorCount: number;
+  /**
+   * Per-status result counts, derived from the stored result rows (not from the
+   * SDK's counters). Pass rate = passedCount / (passedCount + failedCount);
+   * errored + not-scored are excluded from both sides. See
+   * docs/offline-eval-run-pass-rate-design.md.
+   */
+  passedCount: number;
+  failedCount: number;
+  erroredCount: number;
+  notScoredCount: number;
   scorers: Array<{ name: string; version: string }> | null;
   model: string | null;
+  /** Structured run provenance (model, prompt, config, git). Free-form; may be null. */
+  metadata: Record<string, unknown> | null;
   startedAt: string;
   completedAt: string | null;
   evaluationName: string;
@@ -137,15 +174,103 @@ export interface RunRow {
   datasetVersionLabel: string;
   changeFromBaseline: number | null;
   errorCount: number;
+  /** Derived (list route): regressed test-case count when trustworthy, else null. */
+  regressedCaseCount?: number | null;
+  /** Derived: whether the candidate-vs-baseline comparison is trustworthy. */
+  baselineComparable?: boolean;
+  /** Run wall-clock (completedAt − startedAt), null while running. */
+  elapsedMs?: number | null;
 }
 
 export interface RunDetail extends RunRow {
   baselineComparable: boolean;
+  elapsedMs: number | null;
+  /** The backend-derived run-level comparison (single source of truth). */
+  comparison: RunComparison;
 }
 
 export interface RunDetailResponse {
   run: RunDetail;
   results: ResultRow[];
+}
+
+/** One run's summary in the compare view (both sides of the A-vs-B comparison). */
+export interface CompareRunSummary {
+  id: string;
+  runNumber: number;
+  evaluationId: string;
+  evaluationName: string;
+  candidateVersion: string;
+  datasetVersionId: string;
+  datasetVersionLabel: string;
+  status: EvalRunStatus;
+  mainScore: number | null;
+  mainScoreName: string | null;
+  caseCount: number;
+  scoredCount: number;
+  taskErrorCount: number;
+  scorerErrorCount: number;
+  startedAt: string;
+  completedAt: string | null;
+  elapsedMs: number | null;
+}
+
+/** Raw per-scorer value on one side of a compared case (for the drawer's breakdown). */
+export interface CompareRawScore {
+  scorerName: string;
+  scorerVersion: string;
+  numericValue: number | null;
+  boolValue: boolean | null;
+  stringValue: string | null;
+  passed: boolean | null;
+  explanation: string | null;
+  error: string | null;
+}
+
+/** One case row in the compare view — the read contract the redesigned page consumes. */
+export interface CompareResultRow {
+  testCaseId: string;
+  /** Canonical (pinned dataset-version) content — what the engineer authored. */
+  input: string;
+  expectedOutput: string | null;
+  metadata: unknown;
+  provenance: {
+    sourceTraceId: string | null;
+    sourceSpanName: string | null;
+    sourceSpanKind: string | null;
+    captureReason: string;
+  } | null;
+  /** False when a run recorded an input different from the pinned dataset case. */
+  inputMatchesDataset: boolean;
+  candidateStatus: EvalResultStatus | null;
+  baselineStatus: EvalResultStatus | null;
+  candidateOutput: string | null;
+  baselineOutput: string | null;
+  candidateTraceId: string | null;
+  baselineTraceId: string | null;
+  candidateCost: number | null;
+  baselineCost: number | null;
+  candidateTaskError: string | null;
+  baselineTaskError: string | null;
+  candidateScores: CompareRawScore[];
+  baselineScores: CompareRawScore[];
+  /** Whether the candidate output differs from the baseline output; null if neither exists. */
+  outputChanged: boolean | null;
+  change: "improved" | "regressed" | "unchanged" | null;
+  comparison:
+    | (ResultRowComparison & {
+        baselineOutput: string | null;
+        /** Candidate case duration (task + scorers); null → Unknown, never 0. */
+        durationMs: number | null;
+      })
+    | null;
+}
+
+export interface CompareRunsResponse {
+  candidate: CompareRunSummary;
+  baseline: CompareRunSummary;
+  comparison: RunComparison;
+  results: CompareResultRow[];
 }
 
 export interface EvaluationRow {

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -2,15 +2,32 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { ChevronDown, ChevronRight, Copy, Download, FileCode, Play, X } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronRight,
+  Copy,
+  Database,
+  Download,
+  Expand,
+  FileCode,
+  FileText,
+  History,
+  Play,
+  Plus,
+  Shrink,
+  SquareArrowOutUpRight,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
-import { Input } from "@/components/ui/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/components/ui/toast";
+import { useLayout } from "@/components/layout/app-layout";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
 import { ProjectBreadcrumb } from "@/features/projects/components";
@@ -18,40 +35,60 @@ import { SpanKindIcon } from "@/features/traces";
 import { cn } from "@/lib/utils";
 import {
   EmptyState,
+  EvalBody,
   EvalPageHeader,
   ReviewBadge,
   EditableValueBlock,
+  SelectAllHeaderCell,
+  SelectRowCell,
   Timestamp,
-} from "@/features/offline-eval/components";
-import {
+  UploadControl,
+  useRowSelection,
   TestCaseReviewDrawer,
   type TestCaseReviewTarget,
-} from "../components/test-case-review-drawer";
-import { CAPTURE_REASON_LABEL } from "@/features/offline-eval/types";
-import {
-  changeSentiment,
-  pct,
-  SENTIMENT_CLASS,
-  signed,
-  truncate,
-} from "@/features/offline-eval/utils";
-import { useDataset, useUpdateTestCase, useEvaluationRuns } from "../hooks";
-import type { TestCaseRow, DatasetVersionRow, RunRow } from "../types";
+} from "@/features/offline-eval/components";
+import { CAPTURE_REASON_LABEL, type ReviewStatus } from "@/features/offline-eval/types";
+import { caseDisplayId, datasetInitCode, pct, truncate } from "@/features/offline-eval/utils";
+import { useDataset, useSaveTestCase, useUpdateTestCase, useEvaluationRuns } from "../hooks";
+import type { TestCaseRow } from "../types";
 import { RunEvaluationDrawer } from "../components/run-evaluation-drawer";
-import { RunStatusBadge } from "./evaluations-view";
 
+/** "Last 14 days" default, matching the traces/datasets lists. */
 const DEFAULT_DATE_FILTER =
   DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0];
 
-function metadataText(metadata: unknown): string {
-  return metadata && typeof metadata === "object" ? JSON.stringify(metadata, null, 2) : "";
+/** A dash for the list; empty reads as a placeholder, not a blank cell. */
+function orDash(value: string | null): React.ReactNode {
+  return value && value.trim() !== "" ? value : <span className="text-muted-foreground">-</span>;
+}
+
+/** Metadata is stored as unknown JSON; coerce to a flat record for display/edit. */
+function asRecord(metadata: unknown): Record<string, unknown> {
+  return metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? (metadata as Record<string, unknown>)
+    : {};
+}
+
+function metadataPreview(metadata: unknown): React.ReactNode {
+  const entries = Object.entries(asRecord(metadata));
+  if (entries.length === 0) return <span className="text-muted-foreground">-</span>;
+  return (
+    <span className="font-mono text-[11px] text-muted-foreground">
+      {truncate(entries.map(([k, v]) => `${k}: ${String(v)}`).join(", "), 48)}
+    </span>
+  );
 }
 
 /**
- * Dataset detail — faithful port of the prototype's dataset detail, wired to the
- * server: an EvalPageHeader with a Run-evaluation action, Test cases / Evaluation
- * history tabs, the immutable version picker, and a slide-in case panel with the
- * Review-test-case flow. Editing a case publishes a new dataset version.
+ * Dataset detail — a faithful port of the prototype's dataset detail, wired to
+ * the server.
+ *
+ * Columns are Created · Input · Expected · Metadata (empty reads as "-"). New
+ * row adds an empty test case; Import is a centered dialog. Selecting rows
+ * offers Duplicate, Add to dataset, and Delete, with an X to cancel. Focusing a
+ * row slides in a panel from the right (the way a trace opens) showing the
+ * input, expected, and metadata as editable value blocks. Editing publishes a
+ * new immutable dataset version — an earlier run's snapshot is never rewritten.
  */
 export function DatasetDetailView({
   projectId,
@@ -62,16 +99,26 @@ export function DatasetDetailView({
 }) {
   const { toast } = useToast();
   const { data, isLoading, error } = useDataset(projectId, datasetId);
+  const save = useSaveTestCase(projectId, datasetId);
+  const update = useUpdateTestCase(projectId, datasetId);
 
+  const [openCaseId, setOpenCaseId] = React.useState<string | null>(null);
+  const [reviewCaseId, setReviewCaseId] = React.useState<string | null>(null);
   const [keyword, setKeyword] = React.useState("");
   const [caseDate, setCaseDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
   const [caseStart, setCaseStart] = React.useState<Date | null>(null);
   const [caseEnd, setCaseEnd] = React.useState<Date | null>(null);
+  const [historyKeyword, setHistoryKeyword] = React.useState("");
+  const [historyDate, setHistoryDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
+  const [historyStart, setHistoryStart] = React.useState<Date | null>(null);
+  const [historyEnd, setHistoryEnd] = React.useState<Date | null>(null);
   const [runOpen, setRunOpen] = React.useState(false);
-  const [openCaseId, setOpenCaseId] = React.useState<string | null>(null);
-  const [reviewCaseId, setReviewCaseId] = React.useState<string | null>(null);
+  const [importOpen, setImportOpen] = React.useState(false);
+  const [codeOpen, setCodeOpen] = React.useState(false);
 
+  const dataset = data?.dataset ?? null;
   const allCases = React.useMemo(() => data?.testCases ?? [], [data]);
+
   const cases = React.useMemo(() => {
     const q = keyword.trim().toLowerCase();
     if (!q) return allCases;
@@ -80,27 +127,35 @@ export function DatasetDetailView({
     );
   }, [allCases, keyword]);
 
-  const openCase = openCaseId ? (cases.find((c) => c.id === openCaseId) ?? null) : null;
-  const reviewCase = reviewCaseId ? (cases.find((c) => c.id === reviewCaseId) ?? null) : null;
-  const update = useUpdateTestCase(projectId, datasetId);
+  const caseIds = React.useMemo(() => cases.map((c) => c.id), [cases]);
+  const sel = useRowSelection(caseIds);
 
   const evaluations = useEvaluationRuns(projectId, { dataset_id: datasetId });
-  const runs = evaluations.data?.data ?? [];
+  const runs = React.useMemo(() => evaluations.data?.data ?? [], [evaluations.data]);
+  const visibleRuns = React.useMemo(() => {
+    const q = historyKeyword.trim().toLowerCase();
+    if (!q) return runs;
+    return runs.filter(
+      (r) =>
+        r.evaluationName.toLowerCase().includes(q) ||
+        (r.mainScoreName ?? "").toLowerCase().includes(q),
+    );
+  }, [runs, historyKeyword]);
+
+  const openCase = openCaseId ? (cases.find((c) => c.id === openCaseId) ?? null) : null;
+  const reviewCase = reviewCaseId ? (cases.find((c) => c.id === reviewCaseId) ?? null) : null;
 
   const reviewTarget = React.useMemo<TestCaseReviewTarget | null>(() => {
-    if (!reviewCase || !data) return null;
+    if (!reviewCase || !dataset) return null;
     return {
-      contextLabel: `${reviewCase.testCaseId} · ${data.dataset.name}`,
+      contextLabel: `${caseDisplayId(reviewCase.testCaseId)} · ${dataset.name}`,
       input: reviewCase.input,
       expected: reviewCase.expected,
       currentReview: reviewCase.review,
     };
-  }, [reviewCase, data]);
+  }, [reviewCase, dataset]);
 
-  const submitReview = (result: {
-    review: "needs_review" | "ready";
-    correctedExpected?: string;
-  }) => {
+  const submitReview = (result: { review: ReviewStatus; correctedExpected?: string }) => {
     if (!reviewCase) return;
     update.mutate(
       {
@@ -118,6 +173,48 @@ export function DatasetDetailView({
     setReviewCaseId(null);
   };
 
+  const addEmptyRow = () => {
+    save.mutate(
+      { input: "", review: "needs_review", capture_reason: "manual" },
+      { onSuccess: () => toast({ title: "Empty row added", tone: "success" }) },
+    );
+  };
+
+  const duplicateSelected = () => {
+    const chosen = cases.filter((c) => sel.has(c.id));
+    if (chosen.length === 0) return;
+    Promise.all(
+      chosen.map((c) =>
+        save.mutateAsync({
+          input: c.input,
+          expected: c.expected,
+          metadata: asRecord(c.metadata),
+          capture_reason: "manual",
+        }),
+      ),
+    )
+      .then(() => toast({ title: `Duplicated ${chosen.length}`, tone: "success" }))
+      .catch((e) =>
+        toast({ title: "Could not duplicate", description: String(e), tone: "warning" }),
+      );
+    sel.clear();
+  };
+
+  const addSelectedToDataset = () => {
+    if (sel.count === 0) return;
+    // Cross-dataset copy needs a target picker that isn't wired yet.
+    toast({ title: "Add to another dataset — coming soon", tone: "success" });
+    sel.clear();
+  };
+
+  const deleteSelected = () => {
+    if (sel.count === 0) return;
+    // Removing a case republishes the version without it — not wired yet, so the
+    // action stays honest rather than pretending rows were removed.
+    toast({ title: "Deleting cases — coming soon", tone: "success" });
+    sel.clear();
+  };
+
   if (isLoading) {
     return (
       <>
@@ -128,18 +225,23 @@ export function DatasetDetailView({
       </>
     );
   }
-  if (error || !data) {
+  if (error || !dataset || !data) {
     return (
       <>
         <ProjectBreadcrumb projectId={projectId} current="Datasets" />
-        <div className="flex h-64 flex-col items-center justify-center gap-2 text-[13px]">
-          <p className="text-destructive">Dataset not found</p>
-          <Link
-            href={`/projects/${projectId}/datasets`}
-            className="text-[12px] text-muted-foreground underline"
-          >
-            Back to datasets
-          </Link>
+        <div className="flex h-full flex-col text-[13px]">
+          <EvalPageHeader title="Dataset not found" />
+          <EvalBody>
+            <EmptyState>
+              No dataset with the id {datasetId}.{" "}
+              <Link
+                href={`/projects/${projectId}/datasets`}
+                className="underline underline-offset-2"
+              >
+                Back to datasets
+              </Link>
+            </EmptyState>
+          </EvalBody>
         </div>
       </>
     );
@@ -150,16 +252,7 @@ export function DatasetDetailView({
       <ProjectBreadcrumb projectId={projectId} current="Datasets" />
       <div className="flex h-full flex-col text-[13px]">
         <EvalPageHeader
-          title={
-            <span className="flex items-center gap-2">
-              {data.dataset.name}
-              {data.currentVersion && (
-                <VersionPicker current={data.currentVersion} versions={data.versions} />
-              )}
-            </span>
-          }
-          backHref={`/projects/${projectId}/datasets`}
-          backLabel="Datasets"
+          title={dataset.name}
           action={
             <Button size="sm" className="h-7 gap-1.5 text-[12px]" onClick={() => setRunOpen(true)}>
               <Play className="h-3.5 w-3.5" aria-hidden />
@@ -179,6 +272,7 @@ export function DatasetDetailView({
           </TabsList>
 
           <TabsContent value="cases" className="flex min-h-0 flex-1 flex-col">
+            {/* Toolbar — the standard SearchFilterBar (search + actions + date). */}
             <SearchFilterBar
               searchValue={keyword}
               onSearchChange={setKeyword}
@@ -192,13 +286,79 @@ export function DatasetDetailView({
                 setCaseEnd(e);
               }}
             >
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 text-[12px]"
+                onClick={() => setImportOpen(true)}
+              >
+                <Upload className="h-3.5 w-3.5" aria-hidden />
+                Import
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 text-[12px]"
+                onClick={addEmptyRow}
+                disabled={save.isPending}
+              >
+                <Plus className="h-3.5 w-3.5" aria-hidden />
+                Row
+              </Button>
+
+              {/* Selection actions appear beside the editing actions when rows are selected. */}
+              {sel.count > 0 && (
+                <span className="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    onClick={sel.clear}
+                    aria-label="Cancel selection"
+                    className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  >
+                    <X className="h-3.5 w-3.5" aria-hidden />
+                  </button>
+                  <span className="text-[12px] font-medium tabular-nums">{sel.count} selected</span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+                    onClick={duplicateSelected}
+                  >
+                    <Copy className="h-3.5 w-3.5" aria-hidden />
+                    Duplicate
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+                    onClick={addSelectedToDataset}
+                  >
+                    <Plus className="h-3.5 w-3.5" aria-hidden />
+                    Add to dataset
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1 px-1.5 text-[12px] text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    onClick={deleteSelected}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" aria-hidden />
+                    Delete
+                  </Button>
+                  <span className="h-4 w-px bg-border" aria-hidden />
+                </span>
+              )}
+
+              {/* Spacer keeps the dataset-level actions flush against the date filter. */}
               <span className="flex-1" aria-hidden />
+
+              {/* Dataset-level actions (no dropdown). */}
               <span className="flex items-center gap-1">
                 <Button
                   variant="ghost"
                   size="sm"
                   className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-                  onClick={() => toast({ title: "Export coming soon", tone: "success" })}
+                  onClick={() => toast({ title: "Export — coming soon", tone: "success" })}
                 >
                   <Download className="h-3.5 w-3.5" aria-hidden />
                   Download
@@ -208,7 +368,7 @@ export function DatasetDetailView({
                   size="sm"
                   className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
                   onClick={() => {
-                    navigator.clipboard?.writeText(data.dataset.id);
+                    navigator.clipboard?.writeText(dataset.id);
                     toast({ title: "Dataset ID copied", tone: "success" });
                   }}
                 >
@@ -219,7 +379,7 @@ export function DatasetDetailView({
                   variant="ghost"
                   size="sm"
                   className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-                  onClick={() => setRunOpen(true)}
+                  onClick={() => setCodeOpen(true)}
                 >
                   <FileCode className="h-3.5 w-3.5" aria-hidden />
                   Init code
@@ -227,22 +387,27 @@ export function DatasetDetailView({
               </span>
             </SearchFilterBar>
 
+            {/* Table + focused-case slide-in panel */}
             <div className="min-h-0 flex-1 overflow-auto">
               {cases.length === 0 ? (
                 <EmptyState>
                   {keyword
                     ? "No cases match your search."
-                    : "No test cases yet — open a trace, select the root or a span, and save it as a test case."}
+                    : "No test cases yet — use Row to add one, or open a trace, select the root or a span, and save it as a test case."}
                 </EmptyState>
               ) : (
                 <Table>
                   <THead>
                     <TRHead>
+                      <SelectAllHeaderCell
+                        checked={sel.allSelected}
+                        indeterminate={sel.someSelected}
+                        onToggle={sel.toggleAll}
+                      />
                       <Th className="w-[150px]">Created</Th>
                       <Th>Input</Th>
                       <Th>Expected</Th>
-                      <Th className="w-[120px]">Review</Th>
-                      <Th>Source span</Th>
+                      <Th>Metadata</Th>
                     </TRHead>
                   </THead>
                   <TBody>
@@ -253,24 +418,17 @@ export function DatasetDetailView({
                         selected={tc.id === openCaseId}
                         onClick={() => setOpenCaseId(tc.id)}
                       >
+                        <SelectRowCell
+                          checked={sel.has(tc.id)}
+                          onToggle={() => sel.toggle(tc.id)}
+                          label={`Select ${tc.testCaseId}`}
+                        />
                         <Td className="whitespace-nowrap text-muted-foreground">
                           <Timestamp iso={tc.createTime} />
                         </Td>
-                        <Td>{truncate(tc.input, 60)}</Td>
-                        <Td className="text-muted-foreground">{tc.expected ?? "—"}</Td>
-                        <Td>
-                          <ReviewBadge status={tc.review} />
-                        </Td>
-                        <Td className="text-muted-foreground">
-                          {tc.sourceSpanName ? (
-                            <span className="inline-flex items-center gap-1.5">
-                              <SpanKindIcon kind={(tc.sourceSpanKind ?? "SPAN") as never} />
-                              {tc.sourceSpanName}
-                            </span>
-                          ) : (
-                            "—"
-                          )}
-                        </Td>
+                        <Td>{orDash(truncate(tc.input, 60) || null)}</Td>
+                        <Td>{orDash(tc.expected)}</Td>
+                        <Td>{metadataPreview(tc.metadata)}</Td>
                       </TR>
                     ))}
                   </TBody>
@@ -280,42 +438,136 @@ export function DatasetDetailView({
           </TabsContent>
 
           <TabsContent value="history" className="flex min-h-0 flex-1 flex-col">
-            <div className="min-h-0 flex-1 overflow-auto">
-              {runs.length === 0 ? (
-                <EmptyState>Nothing has been run against this dataset yet.</EmptyState>
+            <SearchFilterBar
+              searchValue={historyKeyword}
+              onSearchChange={setHistoryKeyword}
+              searchPlaceholder="Search evaluations..."
+              dateFilter={historyDate}
+              customStartDate={historyStart}
+              customEndDate={historyEnd}
+              onDateFilterChange={setHistoryDate}
+              onCustomRangeChange={(s, e) => {
+                setHistoryStart(s);
+                setHistoryEnd(e);
+              }}
+            />
+            <EvalBody>
+              {visibleRuns.length === 0 ? (
+                <EmptyState>
+                  {historyKeyword
+                    ? "No evaluations match your search."
+                    : `Nothing has been run against ${dataset.name} yet.`}
+                </EmptyState>
               ) : (
                 <Table>
                   <THead>
                     <TRHead>
                       <Th className="w-[170px]">Ran at</Th>
-                      <Th>Candidate version</Th>
-                      <Th className="w-[110px] text-right">Main score</Th>
-                      <Th className="w-[100px] text-right">Change</Th>
-                      <Th className="w-[160px]">Status</Th>
+                      <Th>Evaluation</Th>
+                      <Th>Main score</Th>
+                      <Th className="text-right">Score</Th>
                     </TRHead>
                   </THead>
                   <TBody>
-                    {runs.map((r) => (
-                      <RunHistoryRow key={r.id} projectId={projectId} run={r} />
+                    {visibleRuns.map((run) => (
+                      <TR key={run.id}>
+                        <Td className="whitespace-nowrap text-muted-foreground">
+                          <Timestamp iso={run.startedAt} />
+                        </Td>
+                        <Td>
+                          <Link
+                            href={`/projects/${projectId}/evaluations/${run.id}`}
+                            className="rounded hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                          >
+                            {run.evaluationName}
+                          </Link>
+                        </Td>
+                        <Td className="text-muted-foreground">{run.mainScoreName ?? "—"}</Td>
+                        <Td className="text-right tabular-nums">
+                          {run.mainScore === null ? (
+                            <span className="text-muted-foreground">—</span>
+                          ) : (
+                            pct(run.mainScore)
+                          )}
+                        </Td>
+                      </TR>
                     ))}
                   </TBody>
                 </Table>
               )}
-            </div>
+            </EvalBody>
           </TabsContent>
         </Tabs>
       </div>
 
+      {/* Focused case — slides in from the right like a trace. */}
       {openCase && (
         <CasePanel
+          testCase={openCase}
           projectId={projectId}
           datasetId={datasetId}
-          testCase={openCase}
           onClose={() => setOpenCaseId(null)}
           onReview={() => setReviewCaseId(openCase.id)}
+          onNavigate={(dir) => {
+            const idx = cases.findIndex((c) => c.id === openCase.id);
+            const next = dir === "up" ? idx - 1 : idx + 1;
+            if (next >= 0 && next < cases.length) setOpenCaseId(cases[next].id);
+          }}
+          canNavigateUp={cases.findIndex((c) => c.id === openCase.id) > 0}
+          canNavigateDown={cases.findIndex((c) => c.id === openCase.id) < cases.length - 1}
         />
       )}
 
+      {/* Import — centered island. */}
+      <Dialog open={importOpen} onOpenChange={setImportOpen}>
+        <DialogContent className="max-w-[520px]">
+          <DialogHeader>
+            <DialogTitle className="text-[13px] font-medium">Import test cases</DialogTitle>
+          </DialogHeader>
+          <UploadControl
+            onFile={(fileName) =>
+              toast({
+                title: "File selected — import coming soon",
+                description: `${fileName} would be imported.`,
+                tone: "success",
+              })
+            }
+          />
+          <p className="text-[11px] text-muted-foreground">
+            CSV or JSON. Bulk import isn&apos;t wired yet — add cases with Row, or save a span from
+            a trace.
+          </p>
+        </DialogContent>
+      </Dialog>
+
+      {/* Init code — the SDK snippet, in a dialog with a copy button. */}
+      <Dialog open={codeOpen} onOpenChange={setCodeOpen}>
+        <DialogContent className="max-w-[560px]">
+          <DialogHeader>
+            <DialogTitle className="text-[13px] font-medium">
+              Create this dataset in code
+            </DialogTitle>
+          </DialogHeader>
+          <pre className="overflow-x-auto rounded border border-border bg-muted/20 px-3 py-2.5 font-mono text-[11px] leading-relaxed">
+            {datasetInitCode(dataset.name)}
+          </pre>
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              className="h-7 text-[12px]"
+              onClick={() => {
+                navigator.clipboard?.writeText(datasetInitCode(dataset.name));
+                toast({ title: "Copied", tone: "success" });
+                setCodeOpen(false);
+              }}
+            >
+              Copy
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Launched from a dataset, so the snippet is prefilled with it. */}
       <RunEvaluationDrawer
         projectId={projectId}
         open={runOpen}
@@ -326,118 +578,98 @@ export function DatasetDetailView({
       <TestCaseReviewDrawer
         target={reviewTarget}
         open={reviewCaseId !== null}
-        onOpenChange={(o) => !o && setReviewCaseId(null)}
+        onOpenChange={(open) => !open && setReviewCaseId(null)}
         onSubmit={submitReview}
       />
     </>
   );
 }
 
-function RunHistoryRow({ projectId, run }: { projectId: string; run: RunRow }) {
-  const router = useRouter();
-  return (
-    <TR interactive onClick={() => router.push(`/projects/${projectId}/evaluations/${run.id}`)}>
-      <Td className="whitespace-nowrap text-muted-foreground">
-        <Timestamp iso={run.startedAt} />
-      </Td>
-      <Td className="font-mono text-[11px]">{run.candidateVersion}</Td>
-      <Td className="text-right tabular-nums">
-        {run.mainScore === null ? "—" : pct(run.mainScore)}
-      </Td>
-      <Td className="text-right tabular-nums">
-        {run.changeFromBaseline === null ? (
-          <span className="text-muted-foreground">—</span>
-        ) : (
-          <span className={SENTIMENT_CLASS[changeSentiment(run.changeFromBaseline)]}>
-            {signed(run.changeFromBaseline)} pp
-          </span>
-        )}
-      </Td>
-      <Td>
-        <RunStatusBadge status={run.status} />
-      </Td>
-    </TR>
-  );
-}
-
-function VersionPicker({
-  current,
-  versions,
-}: {
-  current: DatasetVersionRow;
-  versions: DatasetVersionRow[];
-}) {
-  const [open, setOpen] = React.useState(false);
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground">
-          {current.label}
-          <ChevronDown className="h-3 w-3" aria-hidden />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent align="start" className="max-h-[300px] w-64 overflow-y-auto p-1">
-        <p className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
-          Immutable snapshots
-        </p>
-        {versions.map((v) => (
-          <div
-            key={v.id}
-            className={cn(
-              "flex items-center justify-between rounded px-2 py-1 text-[12px]",
-              v.id === current.id ? "bg-muted/70" : "",
-            )}
-          >
-            <span>
-              {v.label}
-              {v.id === current.id && (
-                <span className="ml-1.5 text-[10px] text-muted-foreground">current</span>
-              )}
-            </span>
-            <span className="text-[11px] text-muted-foreground">
-              <Timestamp iso={v.createTime} />
-            </span>
-          </div>
-        ))}
-      </PopoverContent>
-    </Popover>
-  );
-}
-
-/** Slide-in case panel — matches the prototype's; editing publishes a version. */
+/**
+ * Slide-in case panel, matching the trace/span detail panel: a header with an
+ * icon, the row id, a copy button and the up/down/fullscreen/open-in-new-tab/
+ * close controls; then the created date; then Source / Captured chips (in place
+ * of a span kind). Input, expected, and metadata render as editable value
+ * blocks; saving any edit publishes a new immutable dataset version.
+ */
 function CasePanel({
+  testCase,
   projectId,
   datasetId,
-  testCase,
   onClose,
   onReview,
+  onNavigate,
+  canNavigateUp,
+  canNavigateDown,
 }: {
+  testCase: TestCaseRow;
   projectId: string;
   datasetId: string;
-  testCase: TestCaseRow;
   onClose: () => void;
   onReview: () => void;
+  onNavigate: (direction: "up" | "down") => void;
+  canNavigateUp: boolean;
+  canNavigateDown: boolean;
 }) {
   const { toast } = useToast();
-  const [expected, setExpected] = React.useState(testCase.expected ?? "");
+  const { sidebarCollapsed } = useLayout();
   const update = useUpdateTestCase(projectId, datasetId);
+  const [fullscreen, setFullscreen] = React.useState(false);
+  const [view, setView] = React.useState<"details" | "runs">("details");
+
+  // Editable buffers, seeded from the case and re-seeded when it changes.
+  // Input/expected are plain strings; metadata is edited as JSON and parsed back.
+  const initialMetadata = React.useMemo(() => {
+    const record = asRecord(testCase.metadata);
+    return Object.keys(record).length ? JSON.stringify(record, null, 2) : "";
+  }, [testCase.metadata]);
+  const [inputText, setInputText] = React.useState(testCase.input);
+  const [expectedText, setExpectedText] = React.useState(testCase.expected ?? "");
+  const [metadataText, setMetadataText] = React.useState(initialMetadata);
 
   React.useEffect(() => {
-    setExpected(testCase.expected ?? "");
-  }, [testCase.id, testCase.expected]);
+    setInputText(testCase.input);
+    setExpectedText(testCase.expected ?? "");
+    setMetadataText(initialMetadata);
+  }, [testCase.id, testCase.input, testCase.expected, initialMetadata]);
 
-  const dirty = expected.trim() !== (testCase.expected ?? "").trim();
-  const meta = metadataText(testCase.metadata);
-  const captureReason =
-    CAPTURE_REASON_LABEL[testCase.captureReason as keyof typeof CAPTURE_REASON_LABEL] ??
-    testCase.captureReason;
+  const dirty =
+    inputText !== testCase.input ||
+    expectedText !== (testCase.expected ?? "") ||
+    metadataText !== initialMetadata;
 
-  const saveExpected = () => {
+  // Metadata only persists when it parses to an object; a half-typed edit keeps
+  // the prior value rather than blowing it away.
+  const parseMetadata = (): Record<string, unknown> | null | undefined => {
+    if (metadataText.trim() === "") return null;
+    try {
+      const parsed = JSON.parse(metadataText);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      /* invalid JSON mid-edit */
+    }
+    return undefined; // leave stored metadata untouched
+  };
+
+  const saveEdits = () => {
+    const patch: {
+      input?: string;
+      expected?: string | null;
+      metadata?: Record<string, unknown> | null;
+    } = {};
+    if (inputText !== testCase.input) patch.input = inputText;
+    if (expectedText !== (testCase.expected ?? "")) {
+      patch.expected = expectedText.trim() === "" ? null : expectedText;
+    }
+    if (metadataText !== initialMetadata) {
+      const parsed = parseMetadata();
+      if (parsed !== undefined) patch.metadata = parsed;
+    }
+    if (Object.keys(patch).length === 0) return;
     update.mutate(
-      {
-        testCaseId: testCase.testCaseId,
-        patch: { expected: expected.trim() === "" ? null : expected.trim() },
-      },
+      { testCaseId: testCase.testCaseId, patch },
       {
         onSuccess: () => toast({ title: "Saved — new dataset version published", tone: "success" }),
       },
@@ -445,33 +677,86 @@ function CasePanel({
   };
 
   return (
-    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[45%] min-w-[520px] max-w-[94vw] flex-col border-l border-border bg-background shadow-xl">
+    <div
+      className={cn(
+        "animate-slide-in-right fixed bottom-0 right-0 z-50 flex flex-col border-l border-border bg-background shadow-xl transition-[width,top] duration-200",
+        fullscreen
+          ? sidebarCollapsed
+            ? "top-14 w-[calc(100%-3.5rem)]"
+            : "top-14 w-[calc(100%-12rem)]"
+          : "top-0 w-[45%] min-w-[520px] max-w-[94vw]",
+      )}
+    >
+      {/* Header — same shape as the trace/span detail panel. */}
       <div className="shrink-0 border-b border-border bg-muted/30 px-4 py-3">
         <div className="flex items-start justify-between gap-2">
           <div className="flex min-w-0 items-center gap-2">
-            <span className="text-sm font-medium">Test case</span>
+            <Database className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="text-sm font-medium">Row</span>
             <span className="truncate font-mono text-xs text-muted-foreground">
-              {testCase.testCaseId}
+              {caseDisplayId(testCase.testCaseId)}
             </span>
             <CopyButton
               value={testCase.testCaseId}
               className="h-6 w-6 text-muted-foreground hover:text-foreground"
               title="Copy ID"
             />
-            <ReviewBadge status={testCase.review} />
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 p-0"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            <X className="h-4 w-4" />
-          </Button>
+          <div className="flex shrink-0 items-center gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onNavigate("up")}
+              disabled={!canNavigateUp}
+              className="h-7 w-7 p-0"
+              title="Previous row"
+            >
+              <ArrowUp className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onNavigate("down")}
+              disabled={!canNavigateDown}
+              className="h-7 w-7 p-0"
+              title="Next row"
+            >
+              <ArrowDown className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setFullscreen((v) => !v)}
+              className="h-7 w-7 p-0"
+              title={fullscreen ? "Restore default size" : "Expand to full screen"}
+            >
+              {fullscreen ? <Shrink className="h-4 w-4" /> : <Expand className="h-4 w-4" />}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => window.open(`/projects/${projectId}/datasets/${datasetId}`, "_blank")}
+              className="h-7 w-7 p-0"
+              title="Open in new tab"
+            >
+              <SquareArrowOutUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0"
+              onClick={onClose}
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
 
+        <Timestamp iso={testCase.createTime} className="mt-1 block text-xs text-muted-foreground" />
+
         <div className="mt-2 flex flex-wrap items-center gap-2">
+          <ReviewBadge status={testCase.review} />
           {testCase.sourceTraceId ? (
             <Link
               href={`/projects/${projectId}/traces?traceId=${testCase.sourceTraceId}&fullscreen=1`}
@@ -488,74 +773,117 @@ function CasePanel({
               <span className="font-medium">Added manually</span>
             </span>
           )}
+          {/* Why this case was captured — read-only context. */}
           <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
             <span className="text-muted-foreground">Captured:</span>
-            <span className="font-medium">{captureReason}</span>
+            <span className="font-medium">
+              {CAPTURE_REASON_LABEL[testCase.captureReason as keyof typeof CAPTURE_REASON_LABEL] ??
+                testCase.captureReason}
+            </span>
           </span>
         </div>
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 text-[12px]">
-        <EditableValueBlock
-          label="Input"
-          text={testCase.input}
-          onChange={() => {}}
-          boxed
-          minRows={2}
-          readOnly
-        />
+      {/* View toggle — Details / Runs, where a trace shows Tree / Timeline. */}
+      <div className="flex h-10 shrink-0 items-center border-b border-border px-2">
+        <button
+          type="button"
+          onClick={() => setView("details")}
+          className={cn(
+            "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
+            view === "details"
+              ? "bg-muted text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <FileText className="h-3.5 w-3.5" /> Details
+        </button>
+        <button
+          type="button"
+          onClick={() => setView("runs")}
+          className={cn(
+            "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
+            view === "runs"
+              ? "bg-muted text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <History className="h-3.5 w-3.5" /> Runs
+        </button>
+      </div>
 
-        <div>
-          <p className="mb-1 text-[11px] text-muted-foreground">Expected outcome</p>
-          <div className="flex items-center gap-2">
-            <Input
-              value={expected}
-              onChange={(e) => setExpected(e.target.value)}
-              placeholder="No expected outcome — a scorer judges the output directly."
-              className="h-7 text-[12px]"
+      {view === "details" ? (
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 text-[12px]">
+          <EditableValueBlock
+            label="Input"
+            text={inputText}
+            onChange={setInputText}
+            copyable
+            autoDetectKind
+            boxed
+            minRows={2}
+          />
+          <EditableValueBlock
+            label="Expected"
+            text={expectedText}
+            onChange={setExpectedText}
+            copyable
+            autoDetectKind
+            boxed
+            minRows={2}
+          />
+          {/* Recorded production output — read-only, kept separate from Expected. */}
+          {testCase.recordedOutput !== null && (
+            <EditableValueBlock
+              label="What happened in production"
+              text={testCase.recordedOutput}
+              onChange={() => {}}
+              copyable
+              autoDetectKind
+              boxed
+              minRows={2}
+              readOnly
             />
-            <Button
-              size="sm"
-              className="h-7 shrink-0 text-[12px]"
-              disabled={!dirty || update.isPending}
-              onClick={saveExpected}
-            >
-              Save
-            </Button>
-          </div>
-          <p className="mt-1 text-[11px] text-muted-foreground">
+          )}
+          <EditableValueBlock
+            label="Metadata"
+            text={metadataText}
+            defaultKind="json"
+            onChange={setMetadataText}
+            copyable
+            autoDetectKind
+            boxed
+            minRows={2}
+          />
+          <p className="text-[11px] leading-snug text-muted-foreground">
             Saving publishes a new dataset version — it changes what future runs are compared
             against and never rewrites a snapshot an earlier run used.
           </p>
         </div>
+      ) : (
+        <div className="min-h-0 flex-1 overflow-auto p-4">
+          <EmptyState>
+            Per-case run history appears here once your application or CI reports evaluation results
+            for this test case.
+          </EmptyState>
+        </div>
+      )}
 
-        {testCase.recordedOutput !== null && (
-          <EditableValueBlock
-            label="What happened in production"
-            text={testCase.recordedOutput}
-            onChange={() => {}}
-            boxed
-            minRows={2}
-            readOnly
-          />
+      {/* Save (when edited) + Review — primary actions, at the bottom. */}
+      <div className="flex shrink-0 items-center gap-2 border-t border-border p-3">
+        {dirty && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 flex-1 text-[12px]"
+            disabled={update.isPending}
+            onClick={saveEdits}
+          >
+            Save changes
+          </Button>
         )}
-
-        {meta && (
-          <EditableValueBlock
-            label="Metadata"
-            text={meta}
-            onChange={() => {}}
-            defaultKind="json"
-            boxed
-            minRows={2}
-            readOnly
-          />
-        )}
-      </div>
-
-      <div className="shrink-0 border-t border-border p-3">
-        <Button size="sm" className="h-8 w-full text-[12px]" onClick={onReview}>
-          Review test case
+        <Button size="sm" className="h-8 flex-1 text-[12px]" onClick={onReview}>
+          Review
         </Button>
       </div>
     </div>

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -2,22 +2,57 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { ArrowLeft, ChevronDown, Database, X } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { ChevronDown, ChevronRight, Copy, Download, FileCode, Play, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useToast } from "@/components/ui/toast";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import { ReviewBadge, Timestamp, EditableValueBlock } from "@/features/offline-eval/components";
+import { SpanKindIcon } from "@/features/traces";
 import { cn } from "@/lib/utils";
-import { useDataset, useUpdateTestCase } from "../hooks";
-import type { TestCaseRow } from "../types";
+import {
+  EmptyState,
+  EvalPageHeader,
+  ReviewBadge,
+  EditableValueBlock,
+  Timestamp,
+} from "@/features/offline-eval/components";
+import {
+  TestCaseReviewDrawer,
+  type TestCaseReviewTarget,
+} from "../components/test-case-review-drawer";
+import { CAPTURE_REASON_LABEL } from "@/features/offline-eval/types";
+import {
+  changeSentiment,
+  pct,
+  SENTIMENT_CLASS,
+  signed,
+  truncate,
+} from "@/features/offline-eval/utils";
+import { useDataset, useUpdateTestCase, useEvaluationRuns } from "../hooks";
+import type { TestCaseRow, DatasetVersionRow, RunRow } from "../types";
+import { RunEvaluationDrawer } from "../components/run-evaluation-drawer";
+import { RunStatusBadge } from "./evaluations-view";
 
-function truncate(s: string, n = 70) {
-  return s.length <= n ? s : `${s.slice(0, n - 1)}…`;
+const DEFAULT_DATE_FILTER =
+  DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0];
+
+function metadataText(metadata: unknown): string {
+  return metadata && typeof metadata === "object" ? JSON.stringify(metadata, null, 2) : "";
 }
 
-/** Real, server-backed dataset detail: current version's test cases + versions. */
+/**
+ * Dataset detail — faithful port of the prototype's dataset detail, wired to the
+ * server: an EvalPageHeader with a Run-evaluation action, Test cases / Evaluation
+ * history tabs, the immutable version picker, and a slide-in case panel with the
+ * Review-test-case flow. Editing a case publishes a new dataset version.
+ */
 export function DatasetDetailView({
   projectId,
   datasetId,
@@ -25,77 +60,193 @@ export function DatasetDetailView({
   projectId: string;
   datasetId: string;
 }) {
+  const { toast } = useToast();
   const { data, isLoading, error } = useDataset(projectId, datasetId);
-  const [openCaseId, setOpenCaseId] = React.useState<string | null>(null);
 
-  const testCases = data?.testCases ?? [];
-  const openCase = openCaseId ? (testCases.find((t) => t.id === openCaseId) ?? null) : null;
+  const [keyword, setKeyword] = React.useState("");
+  const [caseDate, setCaseDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
+  const [caseStart, setCaseStart] = React.useState<Date | null>(null);
+  const [caseEnd, setCaseEnd] = React.useState<Date | null>(null);
+  const [runOpen, setRunOpen] = React.useState(false);
+  const [openCaseId, setOpenCaseId] = React.useState<string | null>(null);
+  const [reviewCaseId, setReviewCaseId] = React.useState<string | null>(null);
+
+  const allCases = React.useMemo(() => data?.testCases ?? [], [data]);
+  const cases = React.useMemo(() => {
+    const q = keyword.trim().toLowerCase();
+    if (!q) return allCases;
+    return allCases.filter(
+      (c) => c.input.toLowerCase().includes(q) || (c.expected ?? "").toLowerCase().includes(q),
+    );
+  }, [allCases, keyword]);
+
+  const openCase = openCaseId ? (cases.find((c) => c.id === openCaseId) ?? null) : null;
+  const reviewCase = reviewCaseId ? (cases.find((c) => c.id === reviewCaseId) ?? null) : null;
+  const update = useUpdateTestCase(projectId, datasetId);
+
+  const evaluations = useEvaluationRuns(projectId, { dataset_id: datasetId });
+  const runs = evaluations.data?.data ?? [];
+
+  const reviewTarget = React.useMemo<TestCaseReviewTarget | null>(() => {
+    if (!reviewCase || !data) return null;
+    return {
+      contextLabel: `${reviewCase.testCaseId} · ${data.dataset.name}`,
+      input: reviewCase.input,
+      expected: reviewCase.expected,
+      currentReview: reviewCase.review,
+    };
+  }, [reviewCase, data]);
+
+  const submitReview = (result: {
+    review: "needs_review" | "ready";
+    correctedExpected?: string;
+  }) => {
+    if (!reviewCase) return;
+    update.mutate(
+      {
+        testCaseId: reviewCase.testCaseId,
+        patch: {
+          review: result.review,
+          ...(result.correctedExpected ? { expected: result.correctedExpected } : {}),
+        },
+      },
+      {
+        onSuccess: () =>
+          toast({ title: "Review saved — new dataset version published", tone: "success" }),
+      },
+    );
+    setReviewCaseId(null);
+  };
+
+  if (isLoading) {
+    return (
+      <>
+        <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+        <div className="flex h-64 items-center justify-center text-[13px] text-muted-foreground">
+          Loading dataset...
+        </div>
+      </>
+    );
+  }
+  if (error || !data) {
+    return (
+      <>
+        <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+        <div className="flex h-64 flex-col items-center justify-center gap-2 text-[13px]">
+          <p className="text-destructive">Dataset not found</p>
+          <Link
+            href={`/projects/${projectId}/datasets`}
+            className="text-[12px] text-muted-foreground underline"
+          >
+            Back to datasets
+          </Link>
+        </div>
+      </>
+    );
+  }
 
   return (
     <>
       <ProjectBreadcrumb projectId={projectId} current="Datasets" />
-      <div className="flex flex-1 flex-col overflow-hidden text-[13px]">
-        {isLoading ? (
-          <div className="flex h-64 items-center justify-center">
-            <p className="text-[13px] text-muted-foreground">Loading dataset...</p>
-          </div>
-        ) : error || !data ? (
-          <div className="flex h-64 flex-col items-center justify-center gap-2">
-            <p className="text-[13px] text-destructive">Dataset not found</p>
-            <Link
-              href={`/projects/${projectId}/datasets`}
-              className="text-[12px] text-muted-foreground underline"
+      <div className="flex h-full flex-col text-[13px]">
+        <EvalPageHeader
+          title={
+            <span className="flex items-center gap-2">
+              {data.dataset.name}
+              {data.currentVersion && (
+                <VersionPicker current={data.currentVersion} versions={data.versions} />
+              )}
+            </span>
+          }
+          backHref={`/projects/${projectId}/datasets`}
+          backLabel="Datasets"
+          action={
+            <Button size="sm" className="h-7 gap-1.5 text-[12px]" onClick={() => setRunOpen(true)}>
+              <Play className="h-3.5 w-3.5" aria-hidden />
+              Run evaluation
+            </Button>
+          }
+        />
+
+        <Tabs defaultValue="cases" className="flex min-h-0 flex-1 flex-col">
+          <TabsList className="shrink-0 px-4 pt-2" aria-label="Dataset views">
+            <TabsTrigger value="cases" count={cases.length}>
+              Test cases
+            </TabsTrigger>
+            <TabsTrigger value="history" count={runs.length}>
+              Evaluation history
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="cases" className="flex min-h-0 flex-1 flex-col">
+            <SearchFilterBar
+              searchValue={keyword}
+              onSearchChange={setKeyword}
+              searchPlaceholder="Search cases..."
+              dateFilter={caseDate}
+              customStartDate={caseStart}
+              customEndDate={caseEnd}
+              onDateFilterChange={setCaseDate}
+              onCustomRangeChange={(s, e) => {
+                setCaseStart(s);
+                setCaseEnd(e);
+              }}
             >
-              Back to datasets
-            </Link>
-          </div>
-        ) : (
-          <>
-            <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2">
-              <div className="flex min-w-0 items-center gap-2">
-                <Link
-                  href={`/projects/${projectId}/datasets`}
-                  className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                  title="Back to datasets"
+              <span className="flex-1" aria-hidden />
+              <span className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+                  onClick={() => toast({ title: "Export coming soon", tone: "success" })}
                 >
-                  <ArrowLeft className="h-4 w-4" />
-                </Link>
-                <Database className="h-4 w-4 shrink-0 text-muted-foreground" />
-                <h1 className="truncate text-[13px] font-medium">{data.dataset.name}</h1>
-                {data.currentVersion && (
-                  <VersionPicker
-                    label={data.currentVersion.label}
-                    versions={data.versions}
-                    isCurrent={(id) => id === data.dataset.currentVersionId}
-                  />
-                )}
-                <span className="text-[12px] text-muted-foreground">
-                  {data.versions.length} {data.versions.length === 1 ? "version" : "versions"}
-                </span>
-              </div>
-            </div>
+                  <Download className="h-3.5 w-3.5" aria-hidden />
+                  Download
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+                  onClick={() => {
+                    navigator.clipboard?.writeText(data.dataset.id);
+                    toast({ title: "Dataset ID copied", tone: "success" });
+                  }}
+                >
+                  <Copy className="h-3.5 w-3.5" aria-hidden />
+                  Copy ID
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+                  onClick={() => setRunOpen(true)}
+                >
+                  <FileCode className="h-3.5 w-3.5" aria-hidden />
+                  Init code
+                </Button>
+              </span>
+            </SearchFilterBar>
 
             <div className="min-h-0 flex-1 overflow-auto">
-              {testCases.length === 0 ? (
-                <div className="flex h-64 flex-col items-center justify-center gap-2">
-                  <p className="text-[13px] text-muted-foreground">No test cases yet</p>
-                  <p className="text-[12px] text-muted-foreground">
-                    Open a trace, select the root or a span, and save it as a test case.
-                  </p>
-                </div>
+              {cases.length === 0 ? (
+                <EmptyState>
+                  {keyword
+                    ? "No cases match your search."
+                    : "No test cases yet — open a trace, select the root or a span, and save it as a test case."}
+                </EmptyState>
               ) : (
                 <Table>
                   <THead>
                     <TRHead>
-                      <Th className="w-[160px]">Created</Th>
+                      <Th className="w-[150px]">Created</Th>
                       <Th>Input</Th>
                       <Th>Expected</Th>
-                      <Th className="w-[130px]">Review</Th>
+                      <Th className="w-[120px]">Review</Th>
                       <Th>Source span</Th>
                     </TRHead>
                   </THead>
                   <TBody>
-                    {testCases.map((tc) => (
+                    {cases.map((tc) => (
                       <TR
                         key={tc.id}
                         interactive
@@ -112,11 +263,9 @@ export function DatasetDetailView({
                         </Td>
                         <Td className="text-muted-foreground">
                           {tc.sourceSpanName ? (
-                            <span>
+                            <span className="inline-flex items-center gap-1.5">
+                              <SpanKindIcon kind={(tc.sourceSpanKind ?? "SPAN") as never} />
                               {tc.sourceSpanName}
-                              {tc.sourceSpanKind ? (
-                                <span className="ml-1 text-[11px]">({tc.sourceSpanKind})</span>
-                              ) : null}
                             </span>
                           ) : (
                             "—"
@@ -128,8 +277,33 @@ export function DatasetDetailView({
                 </Table>
               )}
             </div>
-          </>
-        )}
+          </TabsContent>
+
+          <TabsContent value="history" className="flex min-h-0 flex-1 flex-col">
+            <div className="min-h-0 flex-1 overflow-auto">
+              {runs.length === 0 ? (
+                <EmptyState>Nothing has been run against this dataset yet.</EmptyState>
+              ) : (
+                <Table>
+                  <THead>
+                    <TRHead>
+                      <Th className="w-[170px]">Ran at</Th>
+                      <Th>Candidate version</Th>
+                      <Th className="w-[110px] text-right">Main score</Th>
+                      <Th className="w-[100px] text-right">Change</Th>
+                      <Th className="w-[160px]">Status</Th>
+                    </TRHead>
+                  </THead>
+                  <TBody>
+                    {runs.map((r) => (
+                      <RunHistoryRow key={r.id} projectId={projectId} run={r} />
+                    ))}
+                  </TBody>
+                </Table>
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
       </div>
 
       {openCase && (
@@ -138,31 +312,71 @@ export function DatasetDetailView({
           datasetId={datasetId}
           testCase={openCase}
           onClose={() => setOpenCaseId(null)}
+          onReview={() => setReviewCaseId(openCase.id)}
         />
       )}
+
+      <RunEvaluationDrawer
+        projectId={projectId}
+        open={runOpen}
+        onOpenChange={setRunOpen}
+        datasetId={datasetId}
+      />
+
+      <TestCaseReviewDrawer
+        target={reviewTarget}
+        open={reviewCaseId !== null}
+        onOpenChange={(o) => !o && setReviewCaseId(null)}
+        onSubmit={submitReview}
+      />
     </>
   );
 }
 
+function RunHistoryRow({ projectId, run }: { projectId: string; run: RunRow }) {
+  const router = useRouter();
+  return (
+    <TR interactive onClick={() => router.push(`/projects/${projectId}/evaluations/${run.id}`)}>
+      <Td className="whitespace-nowrap text-muted-foreground">
+        <Timestamp iso={run.startedAt} />
+      </Td>
+      <Td className="font-mono text-[11px]">{run.candidateVersion}</Td>
+      <Td className="text-right tabular-nums">
+        {run.mainScore === null ? "—" : pct(run.mainScore)}
+      </Td>
+      <Td className="text-right tabular-nums">
+        {run.changeFromBaseline === null ? (
+          <span className="text-muted-foreground">—</span>
+        ) : (
+          <span className={SENTIMENT_CLASS[changeSentiment(run.changeFromBaseline)]}>
+            {signed(run.changeFromBaseline)} pp
+          </span>
+        )}
+      </Td>
+      <Td>
+        <RunStatusBadge status={run.status} />
+      </Td>
+    </TR>
+  );
+}
+
 function VersionPicker({
-  label,
+  current,
   versions,
-  isCurrent,
 }: {
-  label: string;
-  versions: { id: string; label: string; versionNumber: number; createTime: string }[];
-  isCurrent: (id: string) => boolean;
+  current: DatasetVersionRow;
+  versions: DatasetVersionRow[];
 }) {
   const [open, setOpen] = React.useState(false);
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground">
-          {label}
+          {current.label}
           <ChevronDown className="h-3 w-3" aria-hidden />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="max-h-[300px] w-56 overflow-y-auto p-1">
+      <PopoverContent align="start" className="max-h-[300px] w-64 overflow-y-auto p-1">
         <p className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
           Immutable snapshots
         </p>
@@ -171,12 +385,12 @@ function VersionPicker({
             key={v.id}
             className={cn(
               "flex items-center justify-between rounded px-2 py-1 text-[12px]",
-              isCurrent(v.id) ? "bg-muted/70" : "",
+              v.id === current.id ? "bg-muted/70" : "",
             )}
           >
             <span>
               {v.label}
-              {isCurrent(v.id) && (
+              {v.id === current.id && (
                 <span className="ml-1.5 text-[10px] text-muted-foreground">current</span>
               )}
             </span>
@@ -190,18 +404,21 @@ function VersionPicker({
   );
 }
 
-/** Slide-in panel for one test case. Editing Expected publishes a new version. */
+/** Slide-in case panel — matches the prototype's; editing publishes a version. */
 function CasePanel({
   projectId,
   datasetId,
   testCase,
   onClose,
+  onReview,
 }: {
   projectId: string;
   datasetId: string;
   testCase: TestCaseRow;
   onClose: () => void;
+  onReview: () => void;
 }) {
+  const { toast } = useToast();
   const [expected, setExpected] = React.useState(testCase.expected ?? "");
   const update = useUpdateTestCase(projectId, datasetId);
 
@@ -210,53 +427,75 @@ function CasePanel({
   }, [testCase.id, testCase.expected]);
 
   const dirty = expected.trim() !== (testCase.expected ?? "").trim();
-  const metadataText =
-    testCase.metadata && typeof testCase.metadata === "object"
-      ? JSON.stringify(testCase.metadata, null, 2)
-      : "";
+  const meta = metadataText(testCase.metadata);
+  const captureReason =
+    CAPTURE_REASON_LABEL[testCase.captureReason as keyof typeof CAPTURE_REASON_LABEL] ??
+    testCase.captureReason;
 
   const saveExpected = () => {
-    update.mutate({
-      testCaseId: testCase.testCaseId,
-      patch: { expected: expected.trim() === "" ? null : expected.trim() },
-    });
+    update.mutate(
+      {
+        testCaseId: testCase.testCaseId,
+        patch: { expected: expected.trim() === "" ? null : expected.trim() },
+      },
+      {
+        onSuccess: () => toast({ title: "Saved — new dataset version published", tone: "success" }),
+      },
+    );
   };
 
   return (
     <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[45%] min-w-[520px] max-w-[94vw] flex-col border-l border-border bg-background shadow-xl">
-      <div className="flex shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4 py-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <span className="text-sm font-medium">Test case</span>
-          <span className="truncate font-mono text-xs text-muted-foreground">
-            {testCase.testCaseId}
-          </span>
-          <ReviewBadge status={testCase.review} />
+      <div className="shrink-0 border-b border-border bg-muted/30 px-4 py-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="text-sm font-medium">Test case</span>
+            <span className="truncate font-mono text-xs text-muted-foreground">
+              {testCase.testCaseId}
+            </span>
+            <CopyButton
+              value={testCase.testCaseId}
+              className="h-6 w-6 text-muted-foreground hover:text-foreground"
+              title="Copy ID"
+            />
+            <ReviewBadge status={testCase.review} />
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </Button>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 w-7 p-0"
-          onClick={onClose}
-          aria-label="Close"
-        >
-          <X className="h-4 w-4" />
-        </Button>
+
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          {testCase.sourceTraceId ? (
+            <Link
+              href={`/projects/${projectId}/traces?traceId=${testCase.sourceTraceId}&fullscreen=1`}
+              className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 py-1 pl-2.5 pr-1.5 text-xs transition-colors hover:bg-muted"
+            >
+              <span className="text-muted-foreground">Source:</span>
+              <SpanKindIcon kind={(testCase.sourceSpanKind ?? "SPAN") as never} />
+              <span className="font-medium">{testCase.sourceSpanName ?? "trace"}</span>
+              <ChevronRight className="h-3 w-3 text-muted-foreground" />
+            </Link>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
+              <span className="text-muted-foreground">Source:</span>
+              <span className="font-medium">Added manually</span>
+            </span>
+          )}
+          <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
+            <span className="text-muted-foreground">Captured:</span>
+            <span className="font-medium">{captureReason}</span>
+          </span>
+        </div>
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-4 text-[12px]">
-        {testCase.sourceTraceId && (
-          <Link
-            href={`/projects/${projectId}/traces?traceId=${testCase.sourceTraceId}&fullscreen=1`}
-            className="inline-flex w-fit items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs transition-colors hover:bg-muted"
-          >
-            <span className="text-muted-foreground">Source:</span>
-            <span className="font-medium">{testCase.sourceSpanName ?? "trace"}</span>
-            {testCase.sourceSpanKind && (
-              <span className="text-muted-foreground">({testCase.sourceSpanKind})</span>
-            )}
-          </Link>
-        )}
-
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 text-[12px]">
         <EditableValueBlock
           label="Input"
           text={testCase.input}
@@ -301,10 +540,10 @@ function CasePanel({
           />
         )}
 
-        {metadataText && (
+        {meta && (
           <EditableValueBlock
             label="Metadata"
-            text={metadataText}
+            text={meta}
             onChange={() => {}}
             defaultKind="json"
             boxed
@@ -312,6 +551,12 @@ function CasePanel({
             readOnly
           />
         )}
+      </div>
+
+      <div className="shrink-0 border-t border-border p-3">
+        <Button size="sm" className="h-8 w-full text-[12px]" onClick={onReview}>
+          Review test case
+        </Button>
       </div>
     </div>
   );

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -289,10 +289,26 @@ export function DatasetDetailView({
 
   return (
     <>
-      <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+      <ProjectBreadcrumb
+        projectId={projectId}
+        trail={[{ label: "Datasets", href: `/projects/${projectId}/datasets` }]}
+        current={dataset.name}
+      />
       <div className="flex h-full flex-col text-[13px]">
         <EvalPageHeader
-          title={dataset.name}
+          title={
+            <span className="flex flex-wrap items-center gap-2">
+              <span>{dataset.name}</span>
+              <span className="font-mono text-xs font-normal text-muted-foreground">
+                {dataset.id}
+              </span>
+              <CopyButton
+                value={dataset.id}
+                className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                title="Copy dataset ID"
+              />
+            </span>
+          }
           action={
             <Button size="sm" className="h-7 gap-1.5 text-[12px]" onClick={() => setRunOpen(true)}>
               <Play className="h-3.5 w-3.5" aria-hidden />

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -24,6 +24,13 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -125,7 +132,10 @@ export function DatasetDetailView({
   const { toast } = useToast();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { data, isLoading, error } = useDataset(projectId, datasetId);
+  // null = the current version. Selecting an older version loads its snapshot
+  // (read-only — editing always branches from the current version).
+  const [selectedVersionId, setSelectedVersionId] = React.useState<string | null>(null);
+  const { data, isLoading, error } = useDataset(projectId, datasetId, selectedVersionId);
   const save = useSaveTestCase(projectId, datasetId);
   const update = useUpdateTestCase(projectId, datasetId);
 
@@ -158,6 +168,9 @@ export function DatasetDetailView({
   const [codeOpen, setCodeOpen] = React.useState(false);
 
   const dataset = data?.dataset ?? null;
+  const versions = React.useMemo(() => data?.versions ?? [], [data]);
+  const selectedVersion = data?.selectedVersion ?? null;
+  const isCurrentVersion = data?.isCurrentVersion ?? true;
   const allCases = React.useMemo(() => data?.testCases ?? [], [data]);
 
   const cases = React.useMemo(() => {
@@ -297,10 +310,10 @@ export function DatasetDetailView({
       <ProjectBreadcrumb
         projectId={projectId}
         trail={[
-          { label: "Datasets", href: `/projects/${projectId}/datasets` },
           {
-            // The dataset name is a dropdown of all datasets, like the project
-            // segment — pick another to jump straight to its detail page.
+            // Just the dataset segment (no separate "Datasets" crumb) — a dropdown
+            // of all datasets, like the project segment. Its menu header still links
+            // to the Datasets list, so that page stays one click away.
             label: dataset.name,
             menuHeader: { label: "Datasets", href: `/projects/${projectId}/datasets` },
             options: allDatasets.map((d) => ({
@@ -320,6 +333,11 @@ export function DatasetDetailView({
               <span className="font-mono text-xs font-normal text-muted-foreground">
                 {dataset.id}
               </span>
+              <CopyButton
+                value={dataset.id}
+                className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                title="Copy dataset ID"
+              />
             </span>
           }
           action={
@@ -329,6 +347,43 @@ export function DatasetDetailView({
             </Button>
           }
         />
+
+        {/* Version bar — pick a snapshot to view (previous versions are read-only),
+            with its immutable version id + copy. */}
+        <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 py-1.5 text-[12px]">
+          <span className="text-muted-foreground">Version</span>
+          <Select value={selectedVersion?.id ?? ""} onValueChange={(v) => setSelectedVersionId(v)}>
+            <SelectTrigger className="h-7 w-[240px] text-[12px]">
+              <SelectValue placeholder="Current version" />
+            </SelectTrigger>
+            <SelectContent>
+              {versions.map((v) => (
+                <SelectItem key={v.id} value={v.id} className="text-[12px]">
+                  v{v.versionNumber}
+                  {v.id === dataset.currentVersionId ? " (current)" : ""}
+                  {v.label ? ` · ${v.label}` : ""}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {selectedVersion && (
+            <>
+              <span className="font-mono text-[11px] text-muted-foreground">
+                {selectedVersion.id}
+              </span>
+              <CopyButton
+                value={selectedVersion.id}
+                className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                title="Copy version ID"
+              />
+            </>
+          )}
+          {!isCurrentVersion && (
+            <span className="ml-auto rounded border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-700 dark:text-amber-300">
+              Viewing an older version — read only
+            </span>
+          )}
+        </div>
 
         <Tabs defaultValue="cases" className="flex min-h-0 flex-1 flex-col">
           <TabsList className="shrink-0 px-4 pt-2" aria-label="Dataset views">
@@ -360,6 +415,9 @@ export function DatasetDetailView({
                 size="sm"
                 className="h-7 gap-1.5 text-[12px]"
                 onClick={() => setImportOpen(true)}
+                // Editing branches from the current version, so it's disabled while
+                // viewing an older snapshot.
+                disabled={!isCurrentVersion}
               >
                 <Upload className="h-3.5 w-3.5" aria-hidden />
                 Import
@@ -369,7 +427,7 @@ export function DatasetDetailView({
                 size="sm"
                 className="h-7 gap-1.5 text-[12px]"
                 onClick={addEmptyRow}
-                disabled={save.isPending}
+                disabled={save.isPending || !isCurrentVersion}
               >
                 <Plus className="h-3.5 w-3.5" aria-hidden />
                 Row
@@ -572,6 +630,7 @@ export function DatasetDetailView({
           testCase={openCase}
           projectId={projectId}
           datasetId={datasetId}
+          readOnly={!isCurrentVersion}
           onClose={() => setOpenCaseId(null)}
           onReview={() => setReviewCaseId(openCase.id)}
           onNavigate={(dir) => {
@@ -668,6 +727,7 @@ function CasePanel({
   testCase,
   projectId,
   datasetId,
+  readOnly = false,
   onClose,
   onReview,
   onNavigate,
@@ -677,6 +737,9 @@ function CasePanel({
   testCase: TestCaseRow;
   projectId: string;
   datasetId: string;
+  /** Viewing an older snapshot: fields and Save are disabled (editing branches
+   * from the current version, not this one). */
+  readOnly?: boolean;
   onClose: () => void;
   onReview: () => void;
   onNavigate: (direction: "up" | "down") => void;
@@ -708,9 +771,10 @@ function CasePanel({
   }, [testCase.id, testCase.input, testCase.expected, initialMetadata]);
 
   const dirty =
-    inputText !== testCase.input ||
-    expectedText !== (testCase.expected ?? "") ||
-    metadataText !== initialMetadata;
+    !readOnly &&
+    (inputText !== testCase.input ||
+      expectedText !== (testCase.expected ?? "") ||
+      metadataText !== initialMetadata);
 
   // Metadata only persists when it parses to an object; a half-typed edit keeps
   // the prior value rather than blowing it away.
@@ -902,6 +966,7 @@ function CasePanel({
             autoDetectKind
             boxed
             minRows={2}
+            readOnly={readOnly}
           />
           <EditableValueBlock
             key={`expected-${testCase.id}`}
@@ -912,6 +977,7 @@ function CasePanel({
             autoDetectKind
             boxed
             minRows={2}
+            readOnly={readOnly}
           />
           {/* Recorded production output — read-only, kept separate from Expected. */}
           {testCase.recordedOutput !== null && (
@@ -937,6 +1003,7 @@ function CasePanel({
             autoDetectKind
             boxed
             minRows={2}
+            readOnly={readOnly}
           />
           <p className="text-[11px] leading-snug text-muted-foreground">
             Saving publishes a new dataset version — it changes what future runs are compared

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -275,6 +275,11 @@ export function DatasetDetailView({
               <span className="font-mono text-xs font-normal text-muted-foreground">
                 {dataset.id}
               </span>
+              <CopyButton
+                value={dataset.id}
+                className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                title="Copy dataset ID"
+              />
             </span>
           }
         />

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -56,12 +56,10 @@ import {
   TestCaseReviewDrawer,
   type TestCaseReviewTarget,
 } from "@/features/offline-eval/components";
-import { tokenizeCode } from "@/features/offline-eval/components/syntax";
 import { CAPTURE_REASON_LABEL, type ReviewStatus } from "@/features/offline-eval/types";
 import {
   caseDisplayId,
   changeSentiment,
-  datasetPullCode,
   pct,
   scoreDisplay,
   SENTIMENT_CLASS,
@@ -77,6 +75,7 @@ import {
 } from "../hooks";
 import type { TestCaseRow } from "../types";
 import { RunEvaluationDrawer } from "../components/run-evaluation-drawer";
+import { DatasetPullCodeDrawer } from "../components/dataset-pull-code-drawer";
 
 /** "Last 14 days" default, matching the traces/datasets lists. */
 const DEFAULT_DATE_FILTER =
@@ -665,38 +664,13 @@ export function DatasetDetailView({
         </DialogContent>
       </Dialog>
 
-      {/* Init code — the SDK snippet, in a dialog with a copy button. */}
-      <Dialog open={codeOpen} onOpenChange={setCodeOpen}>
-        <DialogContent className="max-w-[560px]">
-          <DialogHeader>
-            <DialogTitle className="text-[13px] font-medium">Pull this dataset in code</DialogTitle>
-          </DialogHeader>
-          {/* Padding on the wrapper, scroll on the inner <pre>: a horizontal
-              scrollbar can't eat the bottom padding (see run-evaluation-drawer). */}
-          <div className="rounded border border-border bg-muted/20 px-3 pb-5 pt-2.5">
-            <pre className="overflow-x-auto whitespace-pre font-mono text-[11px] leading-relaxed">
-              {tokenizeCode(datasetPullCode(dataset.id)).map((t, i) => (
-                <span key={i} className={t.cls || undefined}>
-                  {t.text}
-                </span>
-              ))}
-            </pre>
-          </div>
-          <div className="flex justify-end">
-            <Button
-              size="sm"
-              className="h-7 text-[12px]"
-              onClick={() => {
-                navigator.clipboard?.writeText(datasetPullCode(dataset.id));
-                toast({ title: "Copied", tone: "success" });
-                setCodeOpen(false);
-              }}
-            >
-              Copy
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* Pull code — a right-side slide-out, like the Run-evaluation starter code. */}
+      <DatasetPullCodeDrawer
+        datasetId={dataset.id}
+        datasetName={dataset.name}
+        open={codeOpen}
+        onOpenChange={setCodeOpen}
+      />
 
       {/* Launched from a dataset, so the snippet is prefilled with it. */}
       <RunEvaluationDrawer

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -60,7 +60,12 @@ import { CAPTURE_REASON_LABEL, type ReviewStatus } from "@/features/offline-eval
 import {
   caseDisplayId,
   changeSentiment,
-  pct,
+  datasetPullCode,
+  datasetPullCodeTs,
+  datasetPullVersionCode,
+  datasetPullVersionCodeTs,
+  pctFraction,
+  signedPoints,
   scoreDisplay,
   SENTIMENT_CLASS,
   truncate,
@@ -75,7 +80,7 @@ import {
 } from "../hooks";
 import type { TestCaseRow } from "../types";
 import { RunEvaluationDrawer } from "../components/run-evaluation-drawer";
-import { DatasetPullCodeDrawer } from "../components/dataset-pull-code-drawer";
+import { PullCodeDrawer, type PullOption } from "../components/pull-code-drawer";
 
 /** "Last 14 days" default, matching the traces/datasets lists. */
 const DEFAULT_DATE_FILTER =
@@ -590,8 +595,9 @@ export function DatasetDetailView({
                     <TRHead>
                       <Th className="w-[170px]">Ran at</Th>
                       <Th>Evaluation</Th>
-                      <Th>Main score</Th>
-                      <Th className="text-right">Score</Th>
+                      <Th className="w-[140px]">Candidate version</Th>
+                      <Th className="w-[100px] text-right">Score</Th>
+                      <Th className="w-[100px] text-right">Change</Th>
                     </TRHead>
                   </THead>
                   <TBody>
@@ -605,12 +611,25 @@ export function DatasetDetailView({
                           <Timestamp iso={run.startedAt} />
                         </Td>
                         <Td className="font-medium">{run.evaluationName}</Td>
-                        <Td className="text-muted-foreground">{run.mainScoreName ?? "—"}</Td>
+                        <Td className="font-mono text-[11px]">{run.candidateVersion}</Td>
+                        {/* Same Score/Change presentation as the Evaluations Runs tab. */}
                         <Td className="text-right tabular-nums">
                           {run.mainScore === null ? (
                             <span className="text-muted-foreground">—</span>
                           ) : (
-                            pct(run.mainScore)
+                            pctFraction(run.mainScore)
+                          )}
+                        </Td>
+                        <Td className="text-right tabular-nums">
+                          {run.changeFromBaseline === null ||
+                          run.changeFromBaseline === undefined ? (
+                            <span className="text-muted-foreground">—</span>
+                          ) : (
+                            <span
+                              className={SENTIMENT_CLASS[changeSentiment(run.changeFromBaseline)]}
+                            >
+                              {signedPoints(run.changeFromBaseline)} pp
+                            </span>
                           )}
                         </Td>
                       </TR>
@@ -664,10 +683,42 @@ export function DatasetDetailView({
         </DialogContent>
       </Dialog>
 
-      {/* Pull code — a right-side slide-out, like the Run-evaluation starter code. */}
-      <DatasetPullCodeDrawer
-        datasetId={dataset.id}
-        datasetName={dataset.name}
+      {/* Pull code — the shared drawer: pull the latest version, or this exact one. */}
+      <PullCodeDrawer
+        title="Pull this dataset in code"
+        subtitle={
+          <>
+            Fetch <span className="font-medium text-foreground">{dataset.name}</span> to run an
+            evaluation against. Only the dataset is pullable — an evaluation or run id isn&apos;t.
+          </>
+        }
+        options={
+          [
+            {
+              id: "latest",
+              label: "Pull dataset (latest)",
+              note: "The dataset's CURRENT published version — moves as the dataset is edited.",
+              py: datasetPullCode(dataset.id),
+              ts: datasetPullCodeTs(dataset.id),
+            },
+            ...(selectedVersion
+              ? [
+                  {
+                    id: "version",
+                    label: "Pull this exact version",
+                    note: (
+                      <>
+                        The immutable snapshot{" "}
+                        <span className="font-mono">{selectedVersion.id}</span> — never changes.
+                      </>
+                    ),
+                    py: datasetPullVersionCode(selectedVersion.id),
+                    ts: datasetPullVersionCodeTs(selectedVersion.id),
+                  },
+                ]
+              : []),
+          ] satisfies PullOption[]
+        }
         open={codeOpen}
         onOpenChange={setCodeOpen}
       />

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -13,7 +13,6 @@ import {
   FileCode,
   FileText,
   History,
-  Play,
   Plus,
   Shrink,
   SquareArrowOutUpRight,
@@ -46,7 +45,6 @@ import {
   EvalPageHeader,
   ReviewBadge,
   EditableValueBlock,
-  EvalResultBadge,
   SelectAllHeaderCell,
   SelectRowCell,
   Timestamp,
@@ -56,14 +54,12 @@ import {
   type TestCaseReviewTarget,
 } from "@/features/offline-eval/components";
 import { CAPTURE_REASON_LABEL, type ReviewStatus } from "@/features/offline-eval/types";
+import { RunStatusBadge, ScoreValue, formatCost, formatElapsed } from "./evaluations-view";
+import { PassRate } from "../components/pass-rate";
 import {
   caseDisplayId,
   datasetPullCode,
   datasetPullCodeTs,
-  datasetPullVersionCode,
-  datasetPullVersionCodeTs,
-  pctFraction,
-  scoreDisplay,
   truncate,
 } from "@/features/offline-eval/utils";
 import {
@@ -75,7 +71,6 @@ import {
   useTestCaseRuns,
 } from "../hooks";
 import type { TestCaseRow } from "../types";
-import { RunEvaluationDrawer } from "../components/run-evaluation-drawer";
 import { PullCodeDrawer, type PullOption } from "../components/pull-code-drawer";
 
 /** "Last 14 days" default, matching the traces/datasets lists. */
@@ -156,7 +151,6 @@ export function DatasetDetailView({
   const [historyDate, setHistoryDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
   const [historyStart, setHistoryStart] = React.useState<Date | null>(null);
   const [historyEnd, setHistoryEnd] = React.useState<Date | null>(null);
-  const [runOpen, setRunOpen] = React.useState(false);
   const [importOpen, setImportOpen] = React.useState(false);
   const [codeOpen, setCodeOpen] = React.useState(false);
 
@@ -326,18 +320,7 @@ export function DatasetDetailView({
               <span className="font-mono text-xs font-normal text-muted-foreground">
                 {dataset.id}
               </span>
-              <CopyButton
-                value={dataset.id}
-                className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                title="Copy dataset ID"
-              />
             </span>
-          }
-          action={
-            <Button size="sm" className="h-7 gap-1.5 text-[12px]" onClick={() => setRunOpen(true)}>
-              <Play className="h-3.5 w-3.5" aria-hidden />
-              Run evaluation
-            </Button>
           }
         />
 
@@ -478,18 +461,6 @@ export function DatasetDetailView({
                   variant="ghost"
                   size="sm"
                   className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-                  onClick={() => {
-                    navigator.clipboard?.writeText(dataset.id);
-                    toast({ title: "Dataset ID copied", tone: "success" });
-                  }}
-                >
-                  <Copy className="h-3.5 w-3.5" aria-hidden />
-                  Copy ID
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
                   onClick={() => setCodeOpen(true)}
                 >
                   <FileCode className="h-3.5 w-3.5" aria-hidden />
@@ -537,9 +508,13 @@ export function DatasetDetailView({
                         <Td className="whitespace-nowrap text-muted-foreground">
                           <Timestamp iso={tc.createTime} />
                         </Td>
-                        <Td>{orDash(truncate(tc.input, 60) || null)}</Td>
-                        <Td>{orDash(tc.expected)}</Td>
-                        <Td>{metadataPreview(tc.metadata)}</Td>
+                        <Td className="max-w-[320px] truncate" title={tc.input || undefined}>
+                          {orDash(tc.input || null)}
+                        </Td>
+                        <Td className="max-w-[320px] truncate" title={tc.expected ?? undefined}>
+                          {orDash(tc.expected)}
+                        </Td>
+                        <Td className="max-w-[240px] truncate">{metadataPreview(tc.metadata)}</Td>
                       </TR>
                     ))}
                   </TBody>
@@ -573,11 +548,14 @@ export function DatasetDetailView({
                 <Table>
                   <THead>
                     <TRHead>
-                      <Th className="w-[170px]">Ran at</Th>
-                      <Th>Evaluation</Th>
-                      <Th className="w-[140px]">Candidate version</Th>
-                      <Th className="w-[100px] text-right">Score</Th>
+                      <Th>Evaluation / Run</Th>
+                      <Th>Dataset</Th>
+                      <Th className="w-[110px] text-right">Main score</Th>
+                      <Th className="w-[100px] text-right">Passed</Th>
                       <Th className="w-[100px] text-right">Cost</Th>
+                      <Th className="w-[90px] text-right">Duration</Th>
+                      <Th className="w-[150px]">Status</Th>
+                      <Th className="w-[130px] text-right">Timestamp</Th>
                     </TRHead>
                   </THead>
                   <TBody>
@@ -587,22 +565,34 @@ export function DatasetDetailView({
                         interactive
                         onClick={() => router.push(`/projects/${projectId}/evaluations/${run.id}`)}
                       >
-                        <Td className="whitespace-nowrap text-muted-foreground">
-                          <Timestamp iso={run.startedAt} />
+                        <Td>
+                          <div className="font-medium">{run.evaluationName}</div>
+                          <div className="text-[11px] text-muted-foreground">
+                            Run #{run.runNumber} ·{" "}
+                            <span className="font-mono">{run.candidateVersion}</span>
+                          </div>
                         </Td>
-                        <Td className="font-medium">{run.evaluationName}</Td>
-                        <Td className="font-mono text-[11px]">{run.candidateVersion}</Td>
+                        <Td className="text-muted-foreground">
+                          <div>{run.datasetName}</div>
+                          <div className="text-[11px]">{run.datasetVersionLabel}</div>
+                        </Td>
                         <Td className="text-right tabular-nums">
-                          {run.mainScore === null ? (
-                            <span className="text-muted-foreground">—</span>
-                          ) : (
-                            pctFraction(run.mainScore)
-                          )}
+                          <ScoreValue value={run.mainScore} />
+                        </Td>
+                        <Td className="text-right tabular-nums">
+                          <PassRate counts={run} />
                         </Td>
                         <Td className="text-right tabular-nums text-muted-foreground">
-                          {run.cost === null || run.cost === undefined
-                            ? "—"
-                            : `$${run.cost < 1 ? run.cost.toFixed(4) : run.cost.toFixed(2)}`}
+                          {formatCost(run.cost)}
+                        </Td>
+                        <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
+                          {formatElapsed(run.elapsedMs)}
+                        </Td>
+                        <Td>
+                          <RunStatusBadge status={run.status} />
+                        </Td>
+                        <Td className="whitespace-nowrap text-right text-muted-foreground">
+                          <Timestamp iso={run.startedAt} />
                         </Td>
                       </TR>
                     ))}
@@ -620,6 +610,7 @@ export function DatasetDetailView({
           testCase={openCase}
           projectId={projectId}
           datasetId={datasetId}
+          datasetName={dataset.name}
           readOnly={!isCurrentVersion}
           onClose={() => setOpenCaseId(null)}
           onReview={() => setReviewCaseId(openCase.id)}
@@ -655,7 +646,7 @@ export function DatasetDetailView({
         </DialogContent>
       </Dialog>
 
-      {/* Pull code — the shared drawer: pull the latest version, or this exact one. */}
+      {/* Pull code — the shared drawer: one snippet that fetches the dataset. */}
       <PullCodeDrawer
         title="Pull this dataset in code"
         subtitle={
@@ -668,39 +659,15 @@ export function DatasetDetailView({
           [
             {
               id: "latest",
-              label: "Pull dataset (latest)",
-              note: "The dataset's CURRENT published version — moves as the dataset is edited.",
+              label: "Pull dataset",
+              note: "Fetches the dataset's current published version when the run starts.",
               py: datasetPullCode(dataset.id),
               ts: datasetPullCodeTs(dataset.id),
             },
-            ...(selectedVersion
-              ? [
-                  {
-                    id: "version",
-                    label: "Pull this exact version",
-                    note: (
-                      <>
-                        The immutable snapshot{" "}
-                        <span className="font-mono">{selectedVersion.id}</span> — never changes.
-                      </>
-                    ),
-                    py: datasetPullVersionCode(selectedVersion.id),
-                    ts: datasetPullVersionCodeTs(selectedVersion.id),
-                  },
-                ]
-              : []),
           ] satisfies PullOption[]
         }
         open={codeOpen}
         onOpenChange={setCodeOpen}
-      />
-
-      {/* Launched from a dataset, so the snippet is prefilled with it. */}
-      <RunEvaluationDrawer
-        projectId={projectId}
-        open={runOpen}
-        onOpenChange={setRunOpen}
-        datasetId={datasetId}
       />
 
       <TestCaseReviewDrawer
@@ -724,6 +691,7 @@ function CasePanel({
   testCase,
   projectId,
   datasetId,
+  datasetName,
   readOnly = false,
   onClose,
   onReview,
@@ -734,6 +702,7 @@ function CasePanel({
   testCase: TestCaseRow;
   projectId: string;
   datasetId: string;
+  datasetName: string;
   /** Viewing an older snapshot: fields and Save are disabled (editing branches
    * from the current version, not this one). */
   readOnly?: boolean;
@@ -744,6 +713,7 @@ function CasePanel({
   canNavigateDown: boolean;
 }) {
   const { toast } = useToast();
+  const router = useRouter();
   const { sidebarCollapsed } = useLayout();
   const update = useUpdateTestCase(projectId, datasetId);
   const caseRuns = useTestCaseRuns(projectId, datasetId, testCase.testCaseId);
@@ -963,6 +933,7 @@ function CasePanel({
             autoDetectKind
             boxed
             minRows={2}
+            collapsible
             readOnly={readOnly}
           />
           <EditableValueBlock
@@ -974,6 +945,7 @@ function CasePanel({
             autoDetectKind
             boxed
             minRows={2}
+            collapsible
             readOnly={readOnly}
           />
           {/* Recorded production output — read-only, kept separate from Expected. */}
@@ -987,6 +959,7 @@ function CasePanel({
               autoDetectKind
               boxed
               minRows={2}
+              collapsible
               readOnly
             />
           )}
@@ -1000,6 +973,7 @@ function CasePanel({
             autoDetectKind
             boxed
             minRows={2}
+            collapsible
             readOnly={readOnly}
           />
           <p className="text-[11px] leading-snug text-muted-foreground">
@@ -1018,38 +992,27 @@ function CasePanel({
             <Table>
               <THead>
                 <TRHead>
-                  <Th className="w-[150px]">Ran at</Th>
-                  <Th>Candidate version</Th>
-                  <Th className="w-[90px] text-right">Score</Th>
-                  <Th className="w-[110px]">Status</Th>
+                  <Th>Evaluation / Run</Th>
+                  <Th>Dataset</Th>
+                  <Th className="w-[110px] text-right">Main score</Th>
                 </TRHead>
               </THead>
               <TBody>
                 {runs.map((r) => (
-                  <TR key={r.resultId}>
-                    <Td className="whitespace-nowrap text-muted-foreground">
-                      <Timestamp iso={r.ranAt} />
-                    </Td>
+                  <TR
+                    key={r.resultId}
+                    interactive
+                    onClick={() => router.push(`/projects/${projectId}/evaluations/${r.runId}`)}
+                  >
                     <Td>
-                      <Link
-                        href={`/projects/${projectId}/evaluations/${r.runId}`}
-                        className="rounded font-mono text-[11px] hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                      >
-                        {r.candidateVersion}
-                      </Link>
-                      <span className="ml-1.5 text-[11px] text-muted-foreground">
-                        {r.evaluationName}
-                      </span>
+                      <div className="font-medium">{r.evaluationName}</div>
+                      <div className="text-[11px] text-muted-foreground">
+                        Run #{r.runNumber} · <span className="font-mono">{r.candidateVersion}</span>
+                      </div>
                     </Td>
+                    <Td className="text-muted-foreground">{datasetName}</Td>
                     <Td className="text-right tabular-nums">
-                      {r.score === null ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : (
-                        scoreDisplay(r.score)
-                      )}
-                    </Td>
-                    <Td>
-                      <EvalResultBadge status={r.status as never} />
+                      <ScoreValue value={r.score} />
                     </Td>
                   </TR>
                 ))}

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   ArrowDown,
   ArrowUp,
@@ -39,6 +40,7 @@ import {
   EvalPageHeader,
   ReviewBadge,
   EditableValueBlock,
+  EvalResultBadge,
   SelectAllHeaderCell,
   SelectRowCell,
   Timestamp,
@@ -47,15 +49,37 @@ import {
   TestCaseReviewDrawer,
   type TestCaseReviewTarget,
 } from "@/features/offline-eval/components";
+import { tokenizeCode } from "@/features/offline-eval/components/syntax";
 import { CAPTURE_REASON_LABEL, type ReviewStatus } from "@/features/offline-eval/types";
-import { caseDisplayId, datasetInitCode, pct, truncate } from "@/features/offline-eval/utils";
-import { useDataset, useSaveTestCase, useUpdateTestCase, useEvaluationRuns } from "../hooks";
+import {
+  caseDisplayId,
+  changeSentiment,
+  datasetInitCode,
+  pct,
+  scoreDisplay,
+  SENTIMENT_CLASS,
+  truncate,
+} from "@/features/offline-eval/utils";
+import {
+  useDataset,
+  useSaveTestCase,
+  useUpdateTestCase,
+  useEvaluationRuns,
+  useTestCaseRuns,
+} from "../hooks";
 import type { TestCaseRow } from "../types";
 import { RunEvaluationDrawer } from "../components/run-evaluation-drawer";
 
 /** "Last 14 days" default, matching the traces/datasets lists. */
 const DEFAULT_DATE_FILTER =
   DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0];
+
+/** Map a per-case change direction to a signed delta for the sentiment colour. */
+const CHANGE_DELTA: Record<"improved" | "regressed" | "unchanged", number> = {
+  improved: 1,
+  regressed: -1,
+  unchanged: 0,
+};
 
 /** A dash for the list; empty reads as a placeholder, not a blank cell. */
 function orDash(value: string | null): React.ReactNode {
@@ -98,11 +122,27 @@ export function DatasetDetailView({
   datasetId: string;
 }) {
   const { toast } = useToast();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const { data, isLoading, error } = useDataset(projectId, datasetId);
   const save = useSaveTestCase(projectId, datasetId);
   const update = useUpdateTestCase(projectId, datasetId);
 
   const [openCaseId, setOpenCaseId] = React.useState<string | null>(null);
+
+  // Deep link: /datasets/[id]?case=<testCaseId> opens that case's panel once (e.g.
+  // "View source test case" from an evaluation result). Matched on the stable
+  // testCaseId, not the per-version row id.
+  const handledCaseParam = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    const caseParam = searchParams.get("case");
+    if (!caseParam || !data || handledCaseParam.current === caseParam) return;
+    const match = data.testCases.find((c) => c.testCaseId === caseParam);
+    if (match) {
+      setOpenCaseId(match.id);
+      handledCaseParam.current = caseParam;
+    }
+  }, [searchParams, data]);
   const [reviewCaseId, setReviewCaseId] = React.useState<string | null>(null);
   const [keyword, setKeyword] = React.useState("");
   const [caseDate, setCaseDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
@@ -470,18 +510,15 @@ export function DatasetDetailView({
                   </THead>
                   <TBody>
                     {visibleRuns.map((run) => (
-                      <TR key={run.id}>
+                      <TR
+                        key={run.id}
+                        interactive
+                        onClick={() => router.push(`/projects/${projectId}/evaluations/${run.id}`)}
+                      >
                         <Td className="whitespace-nowrap text-muted-foreground">
                           <Timestamp iso={run.startedAt} />
                         </Td>
-                        <Td>
-                          <Link
-                            href={`/projects/${projectId}/evaluations/${run.id}`}
-                            className="rounded hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                          >
-                            {run.evaluationName}
-                          </Link>
-                        </Td>
+                        <Td className="font-medium">{run.evaluationName}</Td>
                         <Td className="text-muted-foreground">{run.mainScoreName ?? "—"}</Td>
                         <Td className="text-right tabular-nums">
                           {run.mainScore === null ? (
@@ -548,8 +585,12 @@ export function DatasetDetailView({
               Create this dataset in code
             </DialogTitle>
           </DialogHeader>
-          <pre className="overflow-x-auto rounded border border-border bg-muted/20 px-3 py-2.5 font-mono text-[11px] leading-relaxed">
-            {datasetInitCode(dataset.name)}
+          <pre className="overflow-x-auto whitespace-pre rounded border border-border bg-muted/20 px-3 py-2.5 font-mono text-[11px] leading-relaxed">
+            {tokenizeCode(datasetInitCode(dataset.name)).map((t, i) => (
+              <span key={i} className={t.cls || undefined}>
+                {t.text}
+              </span>
+            ))}
           </pre>
           <div className="flex justify-end">
             <Button
@@ -614,6 +655,8 @@ function CasePanel({
   const { toast } = useToast();
   const { sidebarCollapsed } = useLayout();
   const update = useUpdateTestCase(projectId, datasetId);
+  const caseRuns = useTestCaseRuns(projectId, datasetId, testCase.testCaseId);
+  const runs = caseRuns.data?.data ?? [];
   const [fullscreen, setFullscreen] = React.useState(false);
   const [view, setView] = React.useState<"details" | "runs">("details");
 
@@ -809,12 +852,18 @@ function CasePanel({
           )}
         >
           <History className="h-3.5 w-3.5" /> Runs
+          {runs.length > 0 && (
+            <span className="rounded bg-muted px-1 text-[10px] tabular-nums text-muted-foreground">
+              {runs.length}
+            </span>
+          )}
         </button>
       </div>
 
       {view === "details" ? (
         <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 text-[12px]">
           <EditableValueBlock
+            key={`input-${testCase.id}`}
             label="Input"
             text={inputText}
             onChange={setInputText}
@@ -824,6 +873,7 @@ function CasePanel({
             minRows={2}
           />
           <EditableValueBlock
+            key={`expected-${testCase.id}`}
             label="Expected"
             text={expectedText}
             onChange={setExpectedText}
@@ -835,6 +885,7 @@ function CasePanel({
           {/* Recorded production output — read-only, kept separate from Expected. */}
           {testCase.recordedOutput !== null && (
             <EditableValueBlock
+              key={`recorded-${testCase.id}`}
               label="What happened in production"
               text={testCase.recordedOutput}
               onChange={() => {}}
@@ -846,9 +897,10 @@ function CasePanel({
             />
           )}
           <EditableValueBlock
+            key={`metadata-${testCase.id}`}
             label="Metadata"
             text={metadataText}
-            defaultKind="json"
+            defaultKind="pretty"
             onChange={setMetadataText}
             copyable
             autoDetectKind
@@ -862,10 +914,63 @@ function CasePanel({
         </div>
       ) : (
         <div className="min-h-0 flex-1 overflow-auto p-4">
-          <EmptyState>
-            Per-case run history appears here once your application or CI reports evaluation results
-            for this test case.
-          </EmptyState>
+          {runs.length === 0 ? (
+            <EmptyState>
+              No evaluation run has measured this test case yet. Runs appear here once your
+              application or CI reports them.
+            </EmptyState>
+          ) : (
+            <Table>
+              <THead>
+                <TRHead>
+                  <Th className="w-[150px]">Ran at</Th>
+                  <Th>Candidate version</Th>
+                  <Th className="w-[90px] text-right">Score</Th>
+                  <Th className="w-[100px]">Change</Th>
+                  <Th className="w-[110px]">Status</Th>
+                </TRHead>
+              </THead>
+              <TBody>
+                {runs.map((r) => (
+                  <TR key={r.resultId}>
+                    <Td className="whitespace-nowrap text-muted-foreground">
+                      <Timestamp iso={r.ranAt} />
+                    </Td>
+                    <Td>
+                      <Link
+                        href={`/projects/${projectId}/evaluations/${r.runId}`}
+                        className="rounded font-mono text-[11px] hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      >
+                        {r.candidateVersion}
+                      </Link>
+                      <span className="ml-1.5 text-[11px] text-muted-foreground">
+                        {r.evaluationName}
+                      </span>
+                    </Td>
+                    <Td className="text-right tabular-nums">
+                      {r.score === null ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : (
+                        scoreDisplay(r.score)
+                      )}
+                    </Td>
+                    <Td>
+                      {r.change === null ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : (
+                        <span className={SENTIMENT_CLASS[changeSentiment(CHANGE_DELTA[r.change])]}>
+                          {r.change}
+                        </span>
+                      )}
+                    </Td>
+                    <Td>
+                      <EvalResultBadge status={r.status as never} />
+                    </Td>
+                  </TR>
+                ))}
+              </TBody>
+            </Table>
+          )}
         </div>
       )}
 

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -54,7 +54,7 @@ import { CAPTURE_REASON_LABEL, type ReviewStatus } from "@/features/offline-eval
 import {
   caseDisplayId,
   changeSentiment,
-  datasetInitCode,
+  datasetPullCode,
   pct,
   scoreDisplay,
   SENTIMENT_CLASS,
@@ -62,6 +62,7 @@ import {
 } from "@/features/offline-eval/utils";
 import {
   useDataset,
+  useDatasets,
   useSaveTestCase,
   useUpdateTestCase,
   useEvaluationRuns,
@@ -169,6 +170,10 @@ export function DatasetDetailView({
 
   const caseIds = React.useMemo(() => cases.map((c) => c.id), [cases]);
   const sel = useRowSelection(caseIds);
+
+  // All datasets in the project, for the breadcrumb's dataset switcher.
+  const { data: allDatasetsData } = useDatasets(projectId, { limit: 200 });
+  const allDatasets = React.useMemo(() => allDatasetsData?.data ?? [], [allDatasetsData]);
 
   const evaluations = useEvaluationRuns(projectId, { dataset_id: datasetId });
   const runs = React.useMemo(() => evaluations.data?.data ?? [], [evaluations.data]);
@@ -291,8 +296,21 @@ export function DatasetDetailView({
     <>
       <ProjectBreadcrumb
         projectId={projectId}
-        trail={[{ label: "Datasets", href: `/projects/${projectId}/datasets` }]}
-        current={dataset.name}
+        trail={[
+          { label: "Datasets", href: `/projects/${projectId}/datasets` },
+          {
+            // The dataset name is a dropdown of all datasets, like the project
+            // segment — pick another to jump straight to its detail page.
+            label: dataset.name,
+            menuHeader: { label: "Datasets", href: `/projects/${projectId}/datasets` },
+            options: allDatasets.map((d) => ({
+              id: d.id,
+              label: d.name,
+              href: `/projects/${projectId}/datasets/${d.id}`,
+              isCurrent: d.id === dataset.id,
+            })),
+          },
+        ]}
       />
       <div className="flex h-full flex-col text-[13px]">
         <EvalPageHeader
@@ -302,11 +320,6 @@ export function DatasetDetailView({
               <span className="font-mono text-xs font-normal text-muted-foreground">
                 {dataset.id}
               </span>
-              <CopyButton
-                value={dataset.id}
-                className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                title="Copy dataset ID"
-              />
             </span>
           }
           action={
@@ -438,7 +451,7 @@ export function DatasetDetailView({
                   onClick={() => setCodeOpen(true)}
                 >
                   <FileCode className="h-3.5 w-3.5" aria-hidden />
-                  Init code
+                  Pull code
                 </Button>
               </span>
             </SearchFilterBar>
@@ -597,23 +610,25 @@ export function DatasetDetailView({
       <Dialog open={codeOpen} onOpenChange={setCodeOpen}>
         <DialogContent className="max-w-[560px]">
           <DialogHeader>
-            <DialogTitle className="text-[13px] font-medium">
-              Create this dataset in code
-            </DialogTitle>
+            <DialogTitle className="text-[13px] font-medium">Pull this dataset in code</DialogTitle>
           </DialogHeader>
-          <pre className="overflow-x-auto whitespace-pre rounded border border-border bg-muted/20 px-3 py-2.5 font-mono text-[11px] leading-relaxed">
-            {tokenizeCode(datasetInitCode(dataset.name)).map((t, i) => (
-              <span key={i} className={t.cls || undefined}>
-                {t.text}
-              </span>
-            ))}
-          </pre>
+          {/* Padding on the wrapper, scroll on the inner <pre>: a horizontal
+              scrollbar can't eat the bottom padding (see run-evaluation-drawer). */}
+          <div className="rounded border border-border bg-muted/20 px-3 pb-5 pt-2.5">
+            <pre className="overflow-x-auto whitespace-pre font-mono text-[11px] leading-relaxed">
+              {tokenizeCode(datasetPullCode(dataset.id)).map((t, i) => (
+                <span key={i} className={t.cls || undefined}>
+                  {t.text}
+                </span>
+              ))}
+            </pre>
+          </div>
           <div className="flex justify-end">
             <Button
               size="sm"
               className="h-7 text-[12px]"
               onClick={() => {
-                navigator.clipboard?.writeText(datasetInitCode(dataset.name));
+                navigator.clipboard?.writeText(datasetPullCode(dataset.id));
                 toast({ title: "Copied", tone: "success" });
                 setCodeOpen(false);
               }}

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -64,7 +64,6 @@ import {
 } from "@/features/offline-eval/utils";
 import {
   useDataset,
-  useDatasets,
   useSaveTestCase,
   useUpdateTestCase,
   useEvaluationRuns,
@@ -171,10 +170,6 @@ export function DatasetDetailView({
   const caseIds = React.useMemo(() => cases.map((c) => c.id), [cases]);
   const sel = useRowSelection(caseIds);
 
-  // All datasets in the project, for the breadcrumb's dataset switcher.
-  const { data: allDatasetsData } = useDatasets(projectId, { limit: 200 });
-  const allDatasets = React.useMemo(() => allDatasetsData?.data ?? [], [allDatasetsData]);
-
   const evaluations = useEvaluationRuns(projectId, { dataset_id: datasetId });
   const runs = React.useMemo(() => evaluations.data?.data ?? [], [evaluations.data]);
   const visibleRuns = React.useMemo(() => {
@@ -263,7 +258,7 @@ export function DatasetDetailView({
   if (isLoading) {
     return (
       <>
-        <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+        <ProjectBreadcrumb projectId={projectId} />
         <div className="flex h-64 items-center justify-center text-[13px] text-muted-foreground">
           Loading dataset...
         </div>
@@ -273,9 +268,12 @@ export function DatasetDetailView({
   if (error || !dataset || !data) {
     return (
       <>
-        <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+        <ProjectBreadcrumb projectId={projectId} />
         <div className="flex h-full flex-col text-[13px]">
-          <EvalPageHeader title="Dataset not found" />
+          <EvalPageHeader
+            parent={{ label: "Datasets", href: `/projects/${projectId}/datasets` }}
+            title="Dataset not found"
+          />
           <EvalBody>
             <EmptyState>
               No dataset with the id {datasetId}.{" "}
@@ -294,26 +292,10 @@ export function DatasetDetailView({
 
   return (
     <>
-      <ProjectBreadcrumb
-        projectId={projectId}
-        trail={[
-          {
-            // Just the dataset segment (no separate "Datasets" crumb) — a dropdown
-            // of all datasets, like the project segment. Its menu header still links
-            // to the Datasets list, so that page stays one click away.
-            label: dataset.name,
-            menuHeader: { label: "Datasets", href: `/projects/${projectId}/datasets` },
-            options: allDatasets.map((d) => ({
-              id: d.id,
-              label: d.name,
-              href: `/projects/${projectId}/datasets/${d.id}`,
-              isCurrent: d.id === dataset.id,
-            })),
-          },
-        ]}
-      />
+      <ProjectBreadcrumb projectId={projectId} />
       <div className="flex h-full flex-col text-[13px]">
         <EvalPageHeader
+          parent={{ label: "Datasets", href: `/projects/${projectId}/datasets` }}
           title={
             <span className="flex flex-wrap items-center gap-2">
               <span>{dataset.name}</span>
@@ -995,6 +977,7 @@ function CasePanel({
                   <Th>Evaluation / Run</Th>
                   <Th>Dataset</Th>
                   <Th className="w-[110px] text-right">Main score</Th>
+                  <Th className="w-[130px] text-right">Timestamp</Th>
                 </TRHead>
               </THead>
               <TBody>
@@ -1013,6 +996,9 @@ function CasePanel({
                     <Td className="text-muted-foreground">{datasetName}</Td>
                     <Td className="text-right tabular-nums">
                       <ScoreValue value={r.score} />
+                    </Td>
+                    <Td className="whitespace-nowrap text-right text-muted-foreground">
+                      <Timestamp iso={r.ranAt} />
                     </Td>
                   </TR>
                 ))}

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -7,7 +7,6 @@ import {
   ArrowDown,
   ArrowUp,
   ChevronRight,
-  Copy,
   Database,
   Expand,
   FileCode,
@@ -16,8 +15,6 @@ import {
   Plus,
   Shrink,
   SquareArrowOutUpRight,
-  Trash2,
-  Upload,
   X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -29,7 +26,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/components/ui/toast";
@@ -45,11 +41,7 @@ import {
   EvalPageHeader,
   ReviewBadge,
   EditableValueBlock,
-  SelectAllHeaderCell,
-  SelectRowCell,
   Timestamp,
-  UploadControl,
-  useRowSelection,
   TestCaseReviewDrawer,
   type TestCaseReviewTarget,
 } from "@/features/offline-eval/components";
@@ -99,11 +91,11 @@ function metadataPreview(metadata: unknown): React.ReactNode {
 }
 
 /**
- * Dataset detail — a faithful port of the prototype's dataset detail, wired to
+ * Dataset detail — the dataset detail surface, wired to
  * the server.
  *
  * Columns are Created · Input · Expected · Metadata (empty reads as "-"). New
- * row adds an empty test case; Import is a centered dialog. Selecting rows
+ * row adds an empty test case.
  * offers Duplicate, Add to dataset, and Delete, with an X to cancel. Focusing a
  * row slides in a panel from the right (the way a trace opens) showing the
  * input, expected, and metadata as editable value blocks. Editing publishes a
@@ -150,7 +142,6 @@ export function DatasetDetailView({
   const [historyDate, setHistoryDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
   const [historyStart, setHistoryStart] = React.useState<Date | null>(null);
   const [historyEnd, setHistoryEnd] = React.useState<Date | null>(null);
-  const [importOpen, setImportOpen] = React.useState(false);
   const [codeOpen, setCodeOpen] = React.useState(false);
 
   const dataset = data?.dataset ?? null;
@@ -166,9 +157,6 @@ export function DatasetDetailView({
       (c) => c.input.toLowerCase().includes(q) || (c.expected ?? "").toLowerCase().includes(q),
     );
   }, [allCases, keyword]);
-
-  const caseIds = React.useMemo(() => cases.map((c) => c.id), [cases]);
-  const sel = useRowSelection(caseIds);
 
   const evaluations = useEvaluationRuns(projectId, { dataset_id: datasetId });
   const runs = React.useMemo(() => evaluations.data?.data ?? [], [evaluations.data]);
@@ -218,41 +206,6 @@ export function DatasetDetailView({
       { input: "", review: "needs_review", capture_reason: "manual" },
       { onSuccess: () => toast({ title: "Empty row added", tone: "success" }) },
     );
-  };
-
-  const duplicateSelected = () => {
-    const chosen = cases.filter((c) => sel.has(c.id));
-    if (chosen.length === 0) return;
-    Promise.all(
-      chosen.map((c) =>
-        save.mutateAsync({
-          input: c.input,
-          expected: c.expected,
-          metadata: asRecord(c.metadata),
-          capture_reason: "manual",
-        }),
-      ),
-    )
-      .then(() => toast({ title: `Duplicated ${chosen.length}`, tone: "success" }))
-      .catch((e) =>
-        toast({ title: "Could not duplicate", description: String(e), tone: "warning" }),
-      );
-    sel.clear();
-  };
-
-  const addSelectedToDataset = () => {
-    if (sel.count === 0) return;
-    // Cross-dataset copy needs a target picker that isn't wired yet.
-    toast({ title: "Add to another dataset — coming soon", tone: "success" });
-    sel.clear();
-  };
-
-  const deleteSelected = () => {
-    if (sel.count === 0) return;
-    // Removing a case republishes the version without it — not wired yet, so the
-    // action stays honest rather than pretending rows were removed.
-    toast({ title: "Deleting cases — coming soon", tone: "success" });
-    sel.clear();
   };
 
   if (isLoading) {
@@ -372,67 +325,12 @@ export function DatasetDetailView({
                 variant="outline"
                 size="sm"
                 className="h-7 gap-1.5 text-[12px]"
-                onClick={() => setImportOpen(true)}
-                // Editing branches from the current version, so it's disabled while
-                // viewing an older snapshot.
-                disabled={!isCurrentVersion}
-              >
-                <Upload className="h-3.5 w-3.5" aria-hidden />
-                Import
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 gap-1.5 text-[12px]"
                 onClick={addEmptyRow}
                 disabled={save.isPending || !isCurrentVersion}
               >
                 <Plus className="h-3.5 w-3.5" aria-hidden />
                 Row
               </Button>
-
-              {/* Selection actions appear beside the editing actions when rows are selected. */}
-              {sel.count > 0 && (
-                <span className="flex items-center gap-1.5">
-                  <button
-                    type="button"
-                    onClick={sel.clear}
-                    aria-label="Cancel selection"
-                    className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                  >
-                    <X className="h-3.5 w-3.5" aria-hidden />
-                  </button>
-                  <span className="text-[12px] font-medium tabular-nums">{sel.count} selected</span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 gap-1 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-                    onClick={duplicateSelected}
-                  >
-                    <Copy className="h-3.5 w-3.5" aria-hidden />
-                    Duplicate
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 gap-1 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-                    onClick={addSelectedToDataset}
-                  >
-                    <Plus className="h-3.5 w-3.5" aria-hidden />
-                    Add to dataset
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 gap-1 px-1.5 text-[12px] text-destructive hover:bg-destructive/10 hover:text-destructive"
-                    onClick={deleteSelected}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" aria-hidden />
-                    Delete
-                  </Button>
-                  <span className="h-4 w-px bg-border" aria-hidden />
-                </span>
-              )}
 
               {/* Spacer keeps the dataset-level actions flush against the date filter. */}
               <span className="flex-1" aria-hidden />
@@ -463,11 +361,6 @@ export function DatasetDetailView({
                 <Table>
                   <THead>
                     <TRHead>
-                      <SelectAllHeaderCell
-                        checked={sel.allSelected}
-                        indeterminate={sel.someSelected}
-                        onToggle={sel.toggleAll}
-                      />
                       <Th className="w-[150px]">Created</Th>
                       <Th>Input</Th>
                       <Th>Expected</Th>
@@ -482,11 +375,6 @@ export function DatasetDetailView({
                         selected={tc.id === openCaseId}
                         onClick={() => setOpenCaseId(tc.id)}
                       >
-                        <SelectRowCell
-                          checked={sel.has(tc.id)}
-                          onToggle={() => sel.toggle(tc.id)}
-                          label={`Select ${tc.testCaseId}`}
-                        />
                         <Td className="whitespace-nowrap text-muted-foreground">
                           <Timestamp iso={tc.createTime} />
                         </Td>
@@ -605,28 +493,6 @@ export function DatasetDetailView({
           canNavigateDown={cases.findIndex((c) => c.id === openCase.id) < cases.length - 1}
         />
       )}
-
-      {/* Import — centered island. */}
-      <Dialog open={importOpen} onOpenChange={setImportOpen}>
-        <DialogContent className="max-w-[520px]">
-          <DialogHeader>
-            <DialogTitle className="text-[13px] font-medium">Import test cases</DialogTitle>
-          </DialogHeader>
-          <UploadControl
-            onFile={(fileName) =>
-              toast({
-                title: "File selected — import coming soon",
-                description: `${fileName} would be imported.`,
-                tone: "success",
-              })
-            }
-          />
-          <p className="text-[11px] text-muted-foreground">
-            CSV or JSON. Bulk import isn&apos;t wired yet — add cases with Row, or save a span from
-            a trace.
-          </p>
-        </DialogContent>
-      </Dialog>
 
       {/* Pull code — the shared drawer: one snippet that fetches the dataset. */}
       <PullCodeDrawer

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -111,7 +111,11 @@ export function DatasetDetailView({
   // null = the current version. Selecting an older version loads its snapshot
   // (read-only — editing always branches from the current version).
   const [selectedVersionId, setSelectedVersionId] = React.useState<string | null>(null);
-  const { data, isLoading, error, refetch } = useDataset(projectId, datasetId, selectedVersionId);
+  const { data, isLoading, error, refetch, isFetching } = useDataset(
+    projectId,
+    datasetId,
+    selectedVersionId,
+  );
   const save = useSaveTestCase(projectId, datasetId);
   const update = useUpdateTestCase(projectId, datasetId);
 
@@ -142,7 +146,10 @@ export function DatasetDetailView({
   // to `undefined === null` -> false on the server, which would otherwise lock
   // the page read-only before the first row can ever be added.
   const hasVersions = versions.length > 0;
-  const isCurrentVersion = !hasVersions || (data?.isCurrentVersion ?? true);
+  // While a newly-selected version is still loading, `data` reflects the PREVIOUS
+  // snapshot, so treat the page as non-current (read-only) until the fetch settles —
+  // otherwise a click mid-fetch would edit/publish against the wrong version.
+  const isCurrentVersion = (!hasVersions || (data?.isCurrentVersion ?? true)) && !isFetching;
   const allCases = React.useMemo(() => data?.testCases ?? [], [data]);
 
   const cases = React.useMemo(() => {
@@ -328,7 +335,9 @@ export function DatasetDetailView({
                 {selectedVersion?.label ? ` · ${selectedVersion.label}` : ""} — read only.{" "}
                 <button
                   type="button"
-                  onClick={() => setSelectedVersionId(data.currentVersion?.id ?? null)}
+                  // null = follow the LIVE current pointer. Pinning the current version's
+                  // id would strand the page on a now-historical version after the next edit.
+                  onClick={() => setSelectedVersionId(null)}
                   className="underline underline-offset-2"
                 >
                   Back to current

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -2,113 +2,22 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
-import {
-  ArrowDown,
-  ArrowUp,
-  ChevronRight,
-  Copy,
-  Database,
-  Expand,
-  FileCode,
-  FileText,
-  History,
-  Plus,
-  Shrink,
-  SquareArrowOutUpRight,
-  Trash2,
-  Upload,
-  X,
-} from "lucide-react";
+import { ArrowLeft, ChevronDown, Database, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { CopyButton } from "@/components/ui/copy-button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useToast } from "@/components/ui/toast";
-import { useLayout } from "@/components/layout/app-layout";
-import { SearchFilterBar } from "@/components/search-filter-bar";
-import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import { SpanKindIcon } from "@/features/traces";
+import { ReviewBadge, Timestamp, EditableValueBlock } from "@/features/offline-eval/components";
 import { cn } from "@/lib/utils";
-import {
-  EmptyState,
-  EvalBody,
-  EvalPageHeader,
-  ReviewBadge,
-  EditableValueBlock,
-  SelectAllHeaderCell,
-  SelectRowCell,
-  Timestamp,
-  UploadControl,
-  useRowSelection,
-  TestCaseReviewDrawer,
-  type TestCaseReviewTarget,
-} from "@/features/offline-eval/components";
-import { CAPTURE_REASON_LABEL, type ReviewStatus } from "@/features/offline-eval/types";
-import { RunStatusBadge, ScoreValue, formatCost, formatElapsed } from "./evaluations-view";
-import { PassRate } from "../components/pass-rate";
-import {
-  caseDisplayId,
-  datasetPullCode,
-  datasetPullCodeTs,
-  truncate,
-} from "@/features/offline-eval/utils";
-import {
-  useDataset,
-  useSaveTestCase,
-  useUpdateTestCase,
-  useEvaluationRuns,
-  useTestCaseRuns,
-} from "../hooks";
+import { useDataset, useUpdateTestCase } from "../hooks";
 import type { TestCaseRow } from "../types";
-import { PullCodeDrawer, type PullOption } from "../components/pull-code-drawer";
 
-/** "Last 14 days" default, matching the traces/datasets lists. */
-const DEFAULT_DATE_FILTER =
-  DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0];
-
-/** A dash for the list; empty reads as a placeholder, not a blank cell. */
-function orDash(value: string | null): React.ReactNode {
-  return value && value.trim() !== "" ? value : <span className="text-muted-foreground">-</span>;
+function truncate(s: string, n = 70) {
+  return s.length <= n ? s : `${s.slice(0, n - 1)}…`;
 }
 
-/** Metadata is stored as unknown JSON; coerce to a flat record for display/edit. */
-function asRecord(metadata: unknown): Record<string, unknown> {
-  return metadata && typeof metadata === "object" && !Array.isArray(metadata)
-    ? (metadata as Record<string, unknown>)
-    : {};
-}
-
-function metadataPreview(metadata: unknown): React.ReactNode {
-  const entries = Object.entries(asRecord(metadata));
-  if (entries.length === 0) return <span className="text-muted-foreground">-</span>;
-  return (
-    <span className="font-mono text-[11px] text-muted-foreground">
-      {truncate(entries.map(([k, v]) => `${k}: ${String(v)}`).join(", "), 48)}
-    </span>
-  );
-}
-
-/**
- * Dataset detail — the dataset detail surface, wired to
- * the server.
- *
- * Columns are Created · Input · Expected · Metadata (empty reads as "-"). New
- * row adds an empty test case; Import is a centered dialog. Selecting rows
- * offers Duplicate, Add to dataset, and Delete, with an X to cancel. Focusing a
- * row slides in a panel from the right (the way a trace opens) showing the
- * input, expected, and metadata as editable value blocks. Editing publishes a
- * new immutable dataset version — an earlier run's snapshot is never rewritten.
- */
+/** Real, server-backed dataset detail: current version's test cases + versions. */
 export function DatasetDetailView({
   projectId,
   datasetId,
@@ -116,914 +25,293 @@ export function DatasetDetailView({
   projectId: string;
   datasetId: string;
 }) {
-  const { toast } = useToast();
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  // null = the current version. Selecting an older version loads its snapshot
-  // (read-only — editing always branches from the current version).
-  const [selectedVersionId, setSelectedVersionId] = React.useState<string | null>(null);
-  const { data, isLoading, error } = useDataset(projectId, datasetId, selectedVersionId);
-  const save = useSaveTestCase(projectId, datasetId);
-  const update = useUpdateTestCase(projectId, datasetId);
-
+  const { data, isLoading, error } = useDataset(projectId, datasetId);
   const [openCaseId, setOpenCaseId] = React.useState<string | null>(null);
 
-  // Deep link: /datasets/[id]?case=<testCaseId> opens that case's panel once (e.g.
-  // "View source test case" from an evaluation result). Matched on the stable
-  // testCaseId, not the per-version row id.
-  const handledCaseParam = React.useRef<string | null>(null);
-  React.useEffect(() => {
-    const caseParam = searchParams.get("case");
-    if (!caseParam || !data || handledCaseParam.current === caseParam) return;
-    const match = data.testCases.find((c) => c.testCaseId === caseParam);
-    if (match) {
-      setOpenCaseId(match.id);
-      handledCaseParam.current = caseParam;
-    }
-  }, [searchParams, data]);
-  const [reviewCaseId, setReviewCaseId] = React.useState<string | null>(null);
-  const [keyword, setKeyword] = React.useState("");
-  const [caseDate, setCaseDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
-  const [caseStart, setCaseStart] = React.useState<Date | null>(null);
-  const [caseEnd, setCaseEnd] = React.useState<Date | null>(null);
-  const [historyKeyword, setHistoryKeyword] = React.useState("");
-  const [historyDate, setHistoryDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
-  const [historyStart, setHistoryStart] = React.useState<Date | null>(null);
-  const [historyEnd, setHistoryEnd] = React.useState<Date | null>(null);
-  const [importOpen, setImportOpen] = React.useState(false);
-  const [codeOpen, setCodeOpen] = React.useState(false);
-
-  const dataset = data?.dataset ?? null;
-  const versions = React.useMemo(() => data?.versions ?? [], [data]);
-  const selectedVersion = data?.selectedVersion ?? null;
-  const isCurrentVersion = data?.isCurrentVersion ?? true;
-  const allCases = React.useMemo(() => data?.testCases ?? [], [data]);
-
-  const cases = React.useMemo(() => {
-    const q = keyword.trim().toLowerCase();
-    if (!q) return allCases;
-    return allCases.filter(
-      (c) => c.input.toLowerCase().includes(q) || (c.expected ?? "").toLowerCase().includes(q),
-    );
-  }, [allCases, keyword]);
-
-  const caseIds = React.useMemo(() => cases.map((c) => c.id), [cases]);
-  const sel = useRowSelection(caseIds);
-
-  const evaluations = useEvaluationRuns(projectId, { dataset_id: datasetId });
-  const runs = React.useMemo(() => evaluations.data?.data ?? [], [evaluations.data]);
-  const visibleRuns = React.useMemo(() => {
-    const q = historyKeyword.trim().toLowerCase();
-    if (!q) return runs;
-    return runs.filter(
-      (r) =>
-        r.evaluationName.toLowerCase().includes(q) ||
-        (r.mainScoreName ?? "").toLowerCase().includes(q),
-    );
-  }, [runs, historyKeyword]);
-
-  const openCase = openCaseId ? (cases.find((c) => c.id === openCaseId) ?? null) : null;
-  const reviewCase = reviewCaseId ? (cases.find((c) => c.id === reviewCaseId) ?? null) : null;
-
-  const reviewTarget = React.useMemo<TestCaseReviewTarget | null>(() => {
-    if (!reviewCase || !dataset) return null;
-    return {
-      contextLabel: `${caseDisplayId(reviewCase.testCaseId)} · ${dataset.name}`,
-      input: reviewCase.input,
-      expected: reviewCase.expected,
-      currentReview: reviewCase.review,
-    };
-  }, [reviewCase, dataset]);
-
-  const submitReview = (result: { review: ReviewStatus; correctedExpected?: string }) => {
-    if (!reviewCase) return;
-    update.mutate(
-      {
-        testCaseId: reviewCase.testCaseId,
-        patch: {
-          review: result.review,
-          ...(result.correctedExpected ? { expected: result.correctedExpected } : {}),
-        },
-      },
-      {
-        onSuccess: () =>
-          toast({ title: "Review saved — new dataset version published", tone: "success" }),
-      },
-    );
-    setReviewCaseId(null);
-  };
-
-  const addEmptyRow = () => {
-    save.mutate(
-      { input: "", review: "needs_review", capture_reason: "manual" },
-      { onSuccess: () => toast({ title: "Empty row added", tone: "success" }) },
-    );
-  };
-
-  const duplicateSelected = () => {
-    const chosen = cases.filter((c) => sel.has(c.id));
-    if (chosen.length === 0) return;
-    Promise.all(
-      chosen.map((c) =>
-        save.mutateAsync({
-          input: c.input,
-          expected: c.expected,
-          metadata: asRecord(c.metadata),
-          capture_reason: "manual",
-        }),
-      ),
-    )
-      .then(() => toast({ title: `Duplicated ${chosen.length}`, tone: "success" }))
-      .catch((e) =>
-        toast({ title: "Could not duplicate", description: String(e), tone: "warning" }),
-      );
-    sel.clear();
-  };
-
-  const addSelectedToDataset = () => {
-    if (sel.count === 0) return;
-    // Cross-dataset copy needs a target picker that isn't wired yet.
-    toast({ title: "Add to another dataset — coming soon", tone: "success" });
-    sel.clear();
-  };
-
-  const deleteSelected = () => {
-    if (sel.count === 0) return;
-    // Removing a case republishes the version without it — not wired yet, so the
-    // action stays honest rather than pretending rows were removed.
-    toast({ title: "Deleting cases — coming soon", tone: "success" });
-    sel.clear();
-  };
-
-  if (isLoading) {
-    return (
-      <>
-        <ProjectBreadcrumb projectId={projectId} />
-        <div className="flex h-64 items-center justify-center text-[13px] text-muted-foreground">
-          Loading dataset...
-        </div>
-      </>
-    );
-  }
-  if (error || !dataset || !data) {
-    return (
-      <>
-        <ProjectBreadcrumb projectId={projectId} />
-        <div className="flex h-full flex-col text-[13px]">
-          <EvalPageHeader
-            parent={{ label: "Datasets", href: `/projects/${projectId}/datasets` }}
-            title="Dataset not found"
-          />
-          <EvalBody>
-            <EmptyState>
-              No dataset with the id {datasetId}.{" "}
-              <Link
-                href={`/projects/${projectId}/datasets`}
-                className="underline underline-offset-2"
-              >
-                Back to datasets
-              </Link>
-            </EmptyState>
-          </EvalBody>
-        </div>
-      </>
-    );
-  }
+  const testCases = data?.testCases ?? [];
+  const openCase = openCaseId ? (testCases.find((t) => t.id === openCaseId) ?? null) : null;
 
   return (
     <>
-      <ProjectBreadcrumb projectId={projectId} />
-      <div className="flex h-full flex-col text-[13px]">
-        <EvalPageHeader
-          parent={{ label: "Datasets", href: `/projects/${projectId}/datasets` }}
-          title={
-            <span className="flex flex-wrap items-center gap-2">
-              <span>{dataset.name}</span>
-              <span className="font-mono text-xs font-normal text-muted-foreground">
-                {dataset.id}
-              </span>
-            </span>
-          }
-        />
-
-        {/* Version bar — pick a snapshot to view (previous versions are read-only),
-            with its immutable version id + copy. */}
-        <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 py-1.5 text-[12px]">
-          <span className="text-muted-foreground">Version</span>
-          <Select value={selectedVersion?.id ?? ""} onValueChange={(v) => setSelectedVersionId(v)}>
-            <SelectTrigger className="h-7 w-[240px] text-[12px]">
-              <SelectValue placeholder="Current version" />
-            </SelectTrigger>
-            <SelectContent>
-              {versions.map((v) => (
-                <SelectItem key={v.id} value={v.id} className="text-[12px]">
-                  v{v.versionNumber}
-                  {v.id === dataset.currentVersionId ? " (current)" : ""}
-                  {v.label ? ` · ${v.label}` : ""}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {selectedVersion && (
-            <>
-              <span className="font-mono text-[11px] text-muted-foreground">
-                {selectedVersion.id}
-              </span>
-              <CopyButton
-                value={selectedVersion.id}
-                className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                title="Copy version ID"
-              />
-            </>
-          )}
-          {!isCurrentVersion && (
-            <span className="ml-auto rounded border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-700 dark:text-amber-300">
-              Viewing an older version — read only
-            </span>
-          )}
-        </div>
-
-        <Tabs defaultValue="cases" className="flex min-h-0 flex-1 flex-col">
-          <TabsList className="shrink-0 px-4 pt-2" aria-label="Dataset views">
-            <TabsTrigger value="cases" count={cases.length}>
-              Test cases
-            </TabsTrigger>
-            <TabsTrigger value="history" count={runs.length}>
-              Evaluation history
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="cases" className="flex min-h-0 flex-1 flex-col">
-            {/* Toolbar — the standard SearchFilterBar (search + actions + date). */}
-            <SearchFilterBar
-              searchValue={keyword}
-              onSearchChange={setKeyword}
-              searchPlaceholder="Search cases..."
-              dateFilter={caseDate}
-              customStartDate={caseStart}
-              customEndDate={caseEnd}
-              onDateFilterChange={setCaseDate}
-              onCustomRangeChange={(s, e) => {
-                setCaseStart(s);
-                setCaseEnd(e);
-              }}
+      <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+      <div className="flex flex-1 flex-col overflow-hidden text-[13px]">
+        {isLoading ? (
+          <div className="flex h-64 items-center justify-center">
+            <p className="text-[13px] text-muted-foreground">Loading dataset...</p>
+          </div>
+        ) : error || !data ? (
+          <div className="flex h-64 flex-col items-center justify-center gap-2">
+            <p className="text-[13px] text-destructive">Dataset not found</p>
+            <Link
+              href={`/projects/${projectId}/datasets`}
+              className="text-[12px] text-muted-foreground underline"
             >
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 gap-1.5 text-[12px]"
-                onClick={() => setImportOpen(true)}
-                // Editing branches from the current version, so it's disabled while
-                // viewing an older snapshot.
-                disabled={!isCurrentVersion}
-              >
-                <Upload className="h-3.5 w-3.5" aria-hidden />
-                Import
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 gap-1.5 text-[12px]"
-                onClick={addEmptyRow}
-                disabled={save.isPending || !isCurrentVersion}
-              >
-                <Plus className="h-3.5 w-3.5" aria-hidden />
-                Row
-              </Button>
-
-              {/* Selection actions appear beside the editing actions when rows are selected. */}
-              {sel.count > 0 && (
-                <span className="flex items-center gap-1.5">
-                  <button
-                    type="button"
-                    onClick={sel.clear}
-                    aria-label="Cancel selection"
-                    className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                  >
-                    <X className="h-3.5 w-3.5" aria-hidden />
-                  </button>
-                  <span className="text-[12px] font-medium tabular-nums">{sel.count} selected</span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 gap-1 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-                    onClick={duplicateSelected}
-                  >
-                    <Copy className="h-3.5 w-3.5" aria-hidden />
-                    Duplicate
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 gap-1 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-                    onClick={addSelectedToDataset}
-                  >
-                    <Plus className="h-3.5 w-3.5" aria-hidden />
-                    Add to dataset
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 gap-1 px-1.5 text-[12px] text-destructive hover:bg-destructive/10 hover:text-destructive"
-                    onClick={deleteSelected}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" aria-hidden />
-                    Delete
-                  </Button>
-                  <span className="h-4 w-px bg-border" aria-hidden />
-                </span>
-              )}
-
-              {/* Spacer keeps the dataset-level actions flush against the date filter. */}
-              <span className="flex-1" aria-hidden />
-
-              {/* Dataset-level actions (no dropdown). */}
-              <span className="flex items-center gap-1">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-                  onClick={() => setCodeOpen(true)}
+              Back to datasets
+            </Link>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2">
+              <div className="flex min-w-0 items-center gap-2">
+                <Link
+                  href={`/projects/${projectId}/datasets`}
+                  className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                  title="Back to datasets"
                 >
-                  <FileCode className="h-3.5 w-3.5" aria-hidden />
-                  Pull code
-                </Button>
-              </span>
-            </SearchFilterBar>
+                  <ArrowLeft className="h-4 w-4" />
+                </Link>
+                <Database className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <h1 className="truncate text-[13px] font-medium">{data.dataset.name}</h1>
+                {data.currentVersion && (
+                  <VersionPicker
+                    label={data.currentVersion.label}
+                    versions={data.versions}
+                    isCurrent={(id) => id === data.dataset.currentVersionId}
+                  />
+                )}
+                <span className="text-[12px] text-muted-foreground">
+                  {data.versions.length} {data.versions.length === 1 ? "version" : "versions"}
+                </span>
+              </div>
+            </div>
 
-            {/* Table + focused-case slide-in panel */}
             <div className="min-h-0 flex-1 overflow-auto">
-              {cases.length === 0 ? (
-                <EmptyState>
-                  {keyword
-                    ? "No cases match your search."
-                    : "No test cases yet — use Row to add one, or open a trace, select the root or a span, and save it as a test case."}
-                </EmptyState>
+              {testCases.length === 0 ? (
+                <div className="flex h-64 flex-col items-center justify-center gap-2">
+                  <p className="text-[13px] text-muted-foreground">No test cases yet</p>
+                  <p className="text-[12px] text-muted-foreground">
+                    Open a trace, select the root or a span, and save it as a test case.
+                  </p>
+                </div>
               ) : (
                 <Table>
                   <THead>
                     <TRHead>
-                      <SelectAllHeaderCell
-                        checked={sel.allSelected}
-                        indeterminate={sel.someSelected}
-                        onToggle={sel.toggleAll}
-                      />
-                      <Th className="w-[150px]">Created</Th>
+                      <Th className="w-[160px]">Created</Th>
                       <Th>Input</Th>
                       <Th>Expected</Th>
-                      <Th>Metadata</Th>
+                      <Th className="w-[130px]">Review</Th>
+                      <Th>Source span</Th>
                     </TRHead>
                   </THead>
                   <TBody>
-                    {cases.map((tc) => (
+                    {testCases.map((tc) => (
                       <TR
                         key={tc.id}
                         interactive
                         selected={tc.id === openCaseId}
                         onClick={() => setOpenCaseId(tc.id)}
                       >
-                        <SelectRowCell
-                          checked={sel.has(tc.id)}
-                          onToggle={() => sel.toggle(tc.id)}
-                          label={`Select ${tc.testCaseId}`}
-                        />
                         <Td className="whitespace-nowrap text-muted-foreground">
                           <Timestamp iso={tc.createTime} />
                         </Td>
-                        <Td className="max-w-[320px] truncate" title={tc.input || undefined}>
-                          {orDash(tc.input || null)}
+                        <Td>{truncate(tc.input, 60)}</Td>
+                        <Td className="text-muted-foreground">{tc.expected ?? "—"}</Td>
+                        <Td>
+                          <ReviewBadge status={tc.review} />
                         </Td>
-                        <Td className="max-w-[320px] truncate" title={tc.expected ?? undefined}>
-                          {orDash(tc.expected)}
+                        <Td className="text-muted-foreground">
+                          {tc.sourceSpanName ? (
+                            <span>
+                              {tc.sourceSpanName}
+                              {tc.sourceSpanKind ? (
+                                <span className="ml-1 text-[11px]">({tc.sourceSpanKind})</span>
+                              ) : null}
+                            </span>
+                          ) : (
+                            "—"
+                          )}
                         </Td>
-                        <Td className="max-w-[240px] truncate">{metadataPreview(tc.metadata)}</Td>
                       </TR>
                     ))}
                   </TBody>
                 </Table>
               )}
             </div>
-          </TabsContent>
-
-          <TabsContent value="history" className="flex min-h-0 flex-1 flex-col">
-            <SearchFilterBar
-              searchValue={historyKeyword}
-              onSearchChange={setHistoryKeyword}
-              searchPlaceholder="Search evaluations..."
-              dateFilter={historyDate}
-              customStartDate={historyStart}
-              customEndDate={historyEnd}
-              onDateFilterChange={setHistoryDate}
-              onCustomRangeChange={(s, e) => {
-                setHistoryStart(s);
-                setHistoryEnd(e);
-              }}
-            />
-            <EvalBody>
-              {visibleRuns.length === 0 ? (
-                <EmptyState>
-                  {historyKeyword
-                    ? "No evaluations match your search."
-                    : `Nothing has been run against ${dataset.name} yet.`}
-                </EmptyState>
-              ) : (
-                <Table>
-                  <THead>
-                    <TRHead>
-                      <Th>Evaluation / Run</Th>
-                      <Th>Dataset</Th>
-                      <Th className="w-[110px] text-right">Main score</Th>
-                      <Th className="w-[100px] text-right">Passed</Th>
-                      <Th className="w-[100px] text-right">Cost</Th>
-                      <Th className="w-[90px] text-right">Duration</Th>
-                      <Th className="w-[150px]">Status</Th>
-                      <Th className="w-[130px] text-right">Timestamp</Th>
-                    </TRHead>
-                  </THead>
-                  <TBody>
-                    {visibleRuns.map((run) => (
-                      <TR
-                        key={run.id}
-                        interactive
-                        onClick={() => router.push(`/projects/${projectId}/evaluations/${run.id}`)}
-                      >
-                        <Td>
-                          <div className="font-medium">{run.evaluationName}</div>
-                          <div className="text-[11px] text-muted-foreground">
-                            Run #{run.runNumber} ·{" "}
-                            <span className="font-mono">{run.candidateVersion}</span>
-                          </div>
-                        </Td>
-                        <Td className="text-muted-foreground">
-                          <div>{run.datasetName}</div>
-                          <div className="text-[11px]">{run.datasetVersionLabel}</div>
-                        </Td>
-                        <Td className="text-right tabular-nums">
-                          <ScoreValue value={run.mainScore} />
-                        </Td>
-                        <Td className="text-right tabular-nums">
-                          <PassRate counts={run} />
-                        </Td>
-                        <Td className="text-right tabular-nums text-muted-foreground">
-                          {formatCost(run.cost)}
-                        </Td>
-                        <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
-                          {formatElapsed(run.elapsedMs)}
-                        </Td>
-                        <Td>
-                          <RunStatusBadge status={run.status} />
-                        </Td>
-                        <Td className="whitespace-nowrap text-right text-muted-foreground">
-                          <Timestamp iso={run.startedAt} />
-                        </Td>
-                      </TR>
-                    ))}
-                  </TBody>
-                </Table>
-              )}
-            </EvalBody>
-          </TabsContent>
-        </Tabs>
+          </>
+        )}
       </div>
 
-      {/* Focused case — slides in from the right like a trace. */}
       {openCase && (
         <CasePanel
-          testCase={openCase}
           projectId={projectId}
           datasetId={datasetId}
-          datasetName={dataset.name}
-          readOnly={!isCurrentVersion}
+          testCase={openCase}
           onClose={() => setOpenCaseId(null)}
-          onReview={() => setReviewCaseId(openCase.id)}
-          onNavigate={(dir) => {
-            const idx = cases.findIndex((c) => c.id === openCase.id);
-            const next = dir === "up" ? idx - 1 : idx + 1;
-            if (next >= 0 && next < cases.length) setOpenCaseId(cases[next].id);
-          }}
-          canNavigateUp={cases.findIndex((c) => c.id === openCase.id) > 0}
-          canNavigateDown={cases.findIndex((c) => c.id === openCase.id) < cases.length - 1}
         />
       )}
-
-      {/* Import — centered island. */}
-      <Dialog open={importOpen} onOpenChange={setImportOpen}>
-        <DialogContent className="max-w-[520px]">
-          <DialogHeader>
-            <DialogTitle className="text-[13px] font-medium">Import test cases</DialogTitle>
-          </DialogHeader>
-          <UploadControl
-            onFile={(fileName) =>
-              toast({
-                title: "File selected — import coming soon",
-                description: `${fileName} would be imported.`,
-                tone: "success",
-              })
-            }
-          />
-          <p className="text-[11px] text-muted-foreground">
-            CSV or JSON. Bulk import isn&apos;t wired yet — add cases with Row, or save a span from
-            a trace.
-          </p>
-        </DialogContent>
-      </Dialog>
-
-      {/* Pull code — the shared drawer: one snippet that fetches the dataset. */}
-      <PullCodeDrawer
-        title="Pull this dataset in code"
-        subtitle={
-          <>
-            Fetch <span className="font-medium text-foreground">{dataset.name}</span> to run an
-            evaluation against. Only the dataset is pullable — an evaluation or run id isn&apos;t.
-          </>
-        }
-        options={
-          [
-            {
-              id: "latest",
-              label: "Pull dataset",
-              note: "Fetches the dataset's current published version when the run starts.",
-              py: datasetPullCode(dataset.id),
-              ts: datasetPullCodeTs(dataset.id),
-            },
-          ] satisfies PullOption[]
-        }
-        open={codeOpen}
-        onOpenChange={setCodeOpen}
-      />
-
-      <TestCaseReviewDrawer
-        target={reviewTarget}
-        open={reviewCaseId !== null}
-        onOpenChange={(open) => !open && setReviewCaseId(null)}
-        onSubmit={submitReview}
-      />
     </>
   );
 }
 
-/**
- * Slide-in case panel, matching the trace/span detail panel: a header with an
- * icon, the row id, a copy button and the up/down/fullscreen/open-in-new-tab/
- * close controls; then the created date; then Source / Captured chips (in place
- * of a span kind). Input, expected, and metadata render as editable value
- * blocks; saving any edit publishes a new immutable dataset version.
- */
+function VersionPicker({
+  label,
+  versions,
+  isCurrent,
+}: {
+  label: string;
+  versions: { id: string; label: string; versionNumber: number; createTime: string }[];
+  isCurrent: (id: string) => boolean;
+}) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground">
+          {label}
+          <ChevronDown className="h-3 w-3" aria-hidden />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="max-h-[300px] w-56 overflow-y-auto p-1">
+        <p className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+          Immutable snapshots
+        </p>
+        {versions.map((v) => (
+          <div
+            key={v.id}
+            className={cn(
+              "flex items-center justify-between rounded px-2 py-1 text-[12px]",
+              isCurrent(v.id) ? "bg-muted/70" : "",
+            )}
+          >
+            <span>
+              {v.label}
+              {isCurrent(v.id) && (
+                <span className="ml-1.5 text-[10px] text-muted-foreground">current</span>
+              )}
+            </span>
+            <span className="text-[11px] text-muted-foreground">
+              <Timestamp iso={v.createTime} />
+            </span>
+          </div>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/** Slide-in panel for one test case. Editing Expected publishes a new version. */
 function CasePanel({
-  testCase,
   projectId,
   datasetId,
-  datasetName,
-  readOnly = false,
+  testCase,
   onClose,
-  onReview,
-  onNavigate,
-  canNavigateUp,
-  canNavigateDown,
 }: {
-  testCase: TestCaseRow;
   projectId: string;
   datasetId: string;
-  datasetName: string;
-  /** Viewing an older snapshot: fields and Save are disabled (editing branches
-   * from the current version, not this one). */
-  readOnly?: boolean;
+  testCase: TestCaseRow;
   onClose: () => void;
-  onReview: () => void;
-  onNavigate: (direction: "up" | "down") => void;
-  canNavigateUp: boolean;
-  canNavigateDown: boolean;
 }) {
-  const { toast } = useToast();
-  const router = useRouter();
-  const { sidebarCollapsed } = useLayout();
+  const [expected, setExpected] = React.useState(testCase.expected ?? "");
   const update = useUpdateTestCase(projectId, datasetId);
-  const caseRuns = useTestCaseRuns(projectId, datasetId, testCase.testCaseId);
-  const runs = caseRuns.data?.data ?? [];
-  const [fullscreen, setFullscreen] = React.useState(false);
-  const [view, setView] = React.useState<"details" | "runs">("details");
-
-  // Editable buffers, seeded from the case and re-seeded when it changes.
-  // Input/expected are plain strings; metadata is edited as JSON and parsed back.
-  const initialMetadata = React.useMemo(() => {
-    const record = asRecord(testCase.metadata);
-    return Object.keys(record).length ? JSON.stringify(record, null, 2) : "";
-  }, [testCase.metadata]);
-  const [inputText, setInputText] = React.useState(testCase.input);
-  const [expectedText, setExpectedText] = React.useState(testCase.expected ?? "");
-  const [metadataText, setMetadataText] = React.useState(initialMetadata);
 
   React.useEffect(() => {
-    setInputText(testCase.input);
-    setExpectedText(testCase.expected ?? "");
-    setMetadataText(initialMetadata);
-  }, [testCase.id, testCase.input, testCase.expected, initialMetadata]);
+    setExpected(testCase.expected ?? "");
+  }, [testCase.id, testCase.expected]);
 
-  const dirty =
-    !readOnly &&
-    (inputText !== testCase.input ||
-      expectedText !== (testCase.expected ?? "") ||
-      metadataText !== initialMetadata);
+  const dirty = expected.trim() !== (testCase.expected ?? "").trim();
+  const metadataText =
+    testCase.metadata && typeof testCase.metadata === "object"
+      ? JSON.stringify(testCase.metadata, null, 2)
+      : "";
 
-  // Metadata only persists when it parses to an object; a half-typed edit keeps
-  // the prior value rather than blowing it away.
-  const parseMetadata = (): Record<string, unknown> | null | undefined => {
-    if (metadataText.trim() === "") return null;
-    try {
-      const parsed = JSON.parse(metadataText);
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        return parsed as Record<string, unknown>;
-      }
-    } catch {
-      /* invalid JSON mid-edit */
-    }
-    return undefined; // leave stored metadata untouched
-  };
-
-  const saveEdits = () => {
-    const patch: {
-      input?: string;
-      expected?: string | null;
-      metadata?: Record<string, unknown> | null;
-    } = {};
-    if (inputText !== testCase.input) patch.input = inputText;
-    if (expectedText !== (testCase.expected ?? "")) {
-      patch.expected = expectedText.trim() === "" ? null : expectedText;
-    }
-    if (metadataText !== initialMetadata) {
-      const parsed = parseMetadata();
-      if (parsed !== undefined) patch.metadata = parsed;
-    }
-    if (Object.keys(patch).length === 0) return;
-    update.mutate(
-      { testCaseId: testCase.testCaseId, patch },
-      {
-        onSuccess: () => toast({ title: "Saved — new dataset version published", tone: "success" }),
-      },
-    );
+  const saveExpected = () => {
+    update.mutate({
+      testCaseId: testCase.testCaseId,
+      patch: { expected: expected.trim() === "" ? null : expected.trim() },
+    });
   };
 
   return (
-    <div
-      className={cn(
-        "animate-slide-in-right fixed bottom-0 right-0 z-50 flex flex-col border-l border-border bg-background shadow-xl transition-[width,top] duration-200",
-        fullscreen
-          ? sidebarCollapsed
-            ? "top-14 w-[calc(100%-3.5rem)]"
-            : "top-14 w-[calc(100%-12rem)]"
-          : "top-0 w-[45%] min-w-[520px] max-w-[94vw]",
-      )}
-    >
-      {/* Header — same shape as the trace/span detail panel. */}
-      <div className="shrink-0 border-b border-border bg-muted/30 px-4 py-3">
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex min-w-0 items-center gap-2">
-            <Database className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <span className="text-sm font-medium">Row</span>
-            <span className="truncate font-mono text-xs text-muted-foreground">
-              {caseDisplayId(testCase.testCaseId)}
-            </span>
-            <CopyButton
-              value={testCase.testCaseId}
-              className="h-6 w-6 text-muted-foreground hover:text-foreground"
-              title="Copy ID"
-            />
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onNavigate("up")}
-              disabled={!canNavigateUp}
-              className="h-7 w-7 p-0"
-              title="Previous row"
-            >
-              <ArrowUp className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onNavigate("down")}
-              disabled={!canNavigateDown}
-              className="h-7 w-7 p-0"
-              title="Next row"
-            >
-              <ArrowDown className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setFullscreen((v) => !v)}
-              className="h-7 w-7 p-0"
-              title={fullscreen ? "Restore default size" : "Expand to full screen"}
-            >
-              {fullscreen ? <Shrink className="h-4 w-4" /> : <Expand className="h-4 w-4" />}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => window.open(`/projects/${projectId}/datasets/${datasetId}`, "_blank")}
-              className="h-7 w-7 p-0"
-              title="Open in new tab"
-            >
-              <SquareArrowOutUpRight className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 w-7 p-0"
-              onClick={onClose}
-              aria-label="Close"
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-
-        <Timestamp iso={testCase.createTime} className="mt-1 block text-xs text-muted-foreground" />
-
-        <div className="mt-2 flex flex-wrap items-center gap-2">
-          <ReviewBadge status={testCase.review} />
-          {testCase.sourceTraceId ? (
-            <Link
-              href={`/projects/${projectId}/traces?traceId=${testCase.sourceTraceId}&fullscreen=1`}
-              className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 py-1 pl-2.5 pr-1.5 text-xs transition-colors hover:bg-muted"
-            >
-              <span className="text-muted-foreground">Source:</span>
-              <SpanKindIcon kind={(testCase.sourceSpanKind ?? "SPAN") as never} />
-              <span className="font-medium">{testCase.sourceSpanName ?? "trace"}</span>
-              <ChevronRight className="h-3 w-3 text-muted-foreground" />
-            </Link>
-          ) : (
-            <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
-              <span className="text-muted-foreground">Source:</span>
-              <span className="font-medium">Added manually</span>
-            </span>
-          )}
-          {/* Why this case was captured — read-only context. */}
-          <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
-            <span className="text-muted-foreground">Captured:</span>
-            <span className="font-medium">
-              {CAPTURE_REASON_LABEL[testCase.captureReason as keyof typeof CAPTURE_REASON_LABEL] ??
-                testCase.captureReason}
-            </span>
+    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[45%] min-w-[520px] max-w-[94vw] flex-col border-l border-border bg-background shadow-xl">
+      <div className="flex shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4 py-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="text-sm font-medium">Test case</span>
+          <span className="truncate font-mono text-xs text-muted-foreground">
+            {testCase.testCaseId}
           </span>
+          <ReviewBadge status={testCase.review} />
         </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </Button>
       </div>
 
-      {/* View toggle — Details / Runs, where a trace shows Tree / Timeline. */}
-      <div className="flex h-10 shrink-0 items-center border-b border-border px-2">
-        <button
-          type="button"
-          onClick={() => setView("details")}
-          className={cn(
-            "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
-            view === "details"
-              ? "bg-muted text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-        >
-          <FileText className="h-3.5 w-3.5" /> Details
-        </button>
-        <button
-          type="button"
-          onClick={() => setView("runs")}
-          className={cn(
-            "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
-            view === "runs"
-              ? "bg-muted text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-        >
-          <History className="h-3.5 w-3.5" /> Runs
-          {runs.length > 0 && (
-            <span className="rounded bg-muted px-1 text-[10px] tabular-nums text-muted-foreground">
-              {runs.length}
-            </span>
-          )}
-        </button>
-      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-4 text-[12px]">
+        {testCase.sourceTraceId && (
+          <Link
+            href={`/projects/${projectId}/traces?traceId=${testCase.sourceTraceId}&fullscreen=1`}
+            className="inline-flex w-fit items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs transition-colors hover:bg-muted"
+          >
+            <span className="text-muted-foreground">Source:</span>
+            <span className="font-medium">{testCase.sourceSpanName ?? "trace"}</span>
+            {testCase.sourceSpanKind && (
+              <span className="text-muted-foreground">({testCase.sourceSpanKind})</span>
+            )}
+          </Link>
+        )}
 
-      {view === "details" ? (
-        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 text-[12px]">
-          <EditableValueBlock
-            key={`input-${testCase.id}`}
-            label="Input"
-            text={inputText}
-            onChange={setInputText}
-            copyable
-            autoDetectKind
-            boxed
-            minRows={2}
-            collapsible
-            readOnly={readOnly}
-          />
-          <EditableValueBlock
-            key={`expected-${testCase.id}`}
-            label="Expected"
-            text={expectedText}
-            onChange={setExpectedText}
-            copyable
-            autoDetectKind
-            boxed
-            minRows={2}
-            collapsible
-            readOnly={readOnly}
-          />
-          {/* Recorded production output — read-only, kept separate from Expected. */}
-          {testCase.recordedOutput !== null && (
-            <EditableValueBlock
-              key={`recorded-${testCase.id}`}
-              label="What happened in production"
-              text={testCase.recordedOutput}
-              onChange={() => {}}
-              copyable
-              autoDetectKind
-              boxed
-              minRows={2}
-              collapsible
-              readOnly
+        <EditableValueBlock
+          label="Input"
+          text={testCase.input}
+          onChange={() => {}}
+          boxed
+          minRows={2}
+          readOnly
+        />
+
+        <div>
+          <p className="mb-1 text-[11px] text-muted-foreground">Expected outcome</p>
+          <div className="flex items-center gap-2">
+            <Input
+              value={expected}
+              onChange={(e) => setExpected(e.target.value)}
+              placeholder="No expected outcome — a scorer judges the output directly."
+              className="h-7 text-[12px]"
             />
-          )}
-          <EditableValueBlock
-            key={`metadata-${testCase.id}`}
-            label="Metadata"
-            text={metadataText}
-            defaultKind="pretty"
-            onChange={setMetadataText}
-            copyable
-            autoDetectKind
-            boxed
-            minRows={2}
-            collapsible
-            readOnly={readOnly}
-          />
-          <p className="text-[11px] leading-snug text-muted-foreground">
+            <Button
+              size="sm"
+              className="h-7 shrink-0 text-[12px]"
+              disabled={!dirty || update.isPending}
+              onClick={saveExpected}
+            >
+              Save
+            </Button>
+          </div>
+          <p className="mt-1 text-[11px] text-muted-foreground">
             Saving publishes a new dataset version — it changes what future runs are compared
             against and never rewrites a snapshot an earlier run used.
           </p>
         </div>
-      ) : (
-        <div className="min-h-0 flex-1 overflow-auto p-4">
-          {runs.length === 0 ? (
-            <EmptyState>
-              No evaluation run has measured this test case yet. Runs appear here once your
-              application or CI reports them.
-            </EmptyState>
-          ) : (
-            <Table>
-              <THead>
-                <TRHead>
-                  <Th>Evaluation / Run</Th>
-                  <Th>Dataset</Th>
-                  <Th className="w-[110px] text-right">Main score</Th>
-                  <Th className="w-[130px] text-right">Timestamp</Th>
-                </TRHead>
-              </THead>
-              <TBody>
-                {runs.map((r) => (
-                  <TR
-                    key={r.resultId}
-                    interactive
-                    onClick={() => router.push(`/projects/${projectId}/evaluations/${r.runId}`)}
-                  >
-                    <Td>
-                      <div className="font-medium">{r.evaluationName}</div>
-                      <div className="text-[11px] text-muted-foreground">
-                        Run #{r.runNumber} · <span className="font-mono">{r.candidateVersion}</span>
-                      </div>
-                    </Td>
-                    <Td className="text-muted-foreground">{datasetName}</Td>
-                    <Td className="text-right tabular-nums">
-                      <ScoreValue value={r.score} />
-                    </Td>
-                    <Td className="whitespace-nowrap text-right text-muted-foreground">
-                      <Timestamp iso={r.ranAt} />
-                    </Td>
-                  </TR>
-                ))}
-              </TBody>
-            </Table>
-          )}
-        </div>
-      )}
 
-      {/* Save (when edited) + Review — primary actions, at the bottom. */}
-      <div className="flex shrink-0 items-center gap-2 border-t border-border p-3">
-        {dirty && (
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-8 flex-1 text-[12px]"
-            disabled={update.isPending}
-            onClick={saveEdits}
-          >
-            Save changes
-          </Button>
+        {testCase.recordedOutput !== null && (
+          <EditableValueBlock
+            label="What happened in production"
+            text={testCase.recordedOutput}
+            onChange={() => {}}
+            boxed
+            minRows={2}
+            readOnly
+          />
         )}
-        <Button size="sm" className="h-8 flex-1 text-[12px]" onClick={onReview}>
-          Review
-        </Button>
+
+        {metadataText && (
+          <EditableValueBlock
+            label="Metadata"
+            text={metadataText}
+            onChange={() => {}}
+            defaultKind="json"
+            boxed
+            minRows={2}
+            readOnly
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -31,7 +31,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/components/ui/toast";
 import { useLayout } from "@/components/layout/app-layout";
 import { SearchFilterBar } from "@/components/search-filter-bar";
-import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { SpanKindIcon } from "@/features/traces";
 import { cn } from "@/lib/utils";
@@ -52,6 +51,8 @@ import {
   caseDisplayId,
   datasetPullCode,
   datasetPullCodeTs,
+  datasetPullVersionCode,
+  datasetPullVersionCodeTs,
   truncate,
 } from "@/features/offline-eval/utils";
 import {
@@ -63,10 +64,6 @@ import {
 } from "../hooks";
 import type { TestCaseRow } from "../types";
 import { PullCodeDrawer, type PullOption } from "../components/pull-code-drawer";
-
-/** "Last 14 days" default, matching the traces/datasets lists. */
-const DEFAULT_DATE_FILTER =
-  DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0];
 
 /** A dash for the list; empty reads as a placeholder, not a blank cell. */
 function orDash(value: string | null): React.ReactNode {
@@ -114,7 +111,7 @@ export function DatasetDetailView({
   // null = the current version. Selecting an older version loads its snapshot
   // (read-only — editing always branches from the current version).
   const [selectedVersionId, setSelectedVersionId] = React.useState<string | null>(null);
-  const { data, isLoading, error } = useDataset(projectId, datasetId, selectedVersionId);
+  const { data, isLoading, error, refetch } = useDataset(projectId, datasetId, selectedVersionId);
   const save = useSaveTestCase(projectId, datasetId);
   const update = useUpdateTestCase(projectId, datasetId);
 
@@ -135,19 +132,17 @@ export function DatasetDetailView({
   }, [searchParams, data]);
   const [reviewCaseId, setReviewCaseId] = React.useState<string | null>(null);
   const [keyword, setKeyword] = React.useState("");
-  const [caseDate, setCaseDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
-  const [caseStart, setCaseStart] = React.useState<Date | null>(null);
-  const [caseEnd, setCaseEnd] = React.useState<Date | null>(null);
   const [historyKeyword, setHistoryKeyword] = React.useState("");
-  const [historyDate, setHistoryDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
-  const [historyStart, setHistoryStart] = React.useState<Date | null>(null);
-  const [historyEnd, setHistoryEnd] = React.useState<Date | null>(null);
   const [codeOpen, setCodeOpen] = React.useState(false);
 
   const dataset = data?.dataset ?? null;
   const versions = React.useMemo(() => data?.versions ?? [], [data]);
   const selectedVersion = data?.selectedVersion ?? null;
-  const isCurrentVersion = data?.isCurrentVersion ?? true;
+  // A freshly created dataset has no versions yet: `isCurrentVersion` computes
+  // to `undefined === null` -> false on the server, which would otherwise lock
+  // the page read-only before the first row can ever be added.
+  const hasVersions = versions.length > 0;
+  const isCurrentVersion = !hasVersions || (data?.isCurrentVersion ?? true);
   const allCases = React.useMemo(() => data?.testCases ?? [], [data]);
 
   const cases = React.useMemo(() => {
@@ -204,11 +199,15 @@ export function DatasetDetailView({
   const addEmptyRow = () => {
     save.mutate(
       { input: "", review: "needs_review", capture_reason: "manual" },
-      { onSuccess: () => toast({ title: "Empty row added", tone: "success" }) },
+      {
+        onSuccess: () => toast({ title: "Empty row added", tone: "success" }),
+        onError: (e) =>
+          toast({ title: "Could not add row", description: String(e), tone: "warning" }),
+      },
     );
   };
 
-  if (isLoading) {
+  if (isLoading && !data) {
     return (
       <>
         <ProjectBreadcrumb projectId={projectId} />
@@ -218,24 +217,45 @@ export function DatasetDetailView({
       </>
     );
   }
-  if (error || !dataset || !data) {
+  // Only fall back to a whole-page state when there is genuinely no data to
+  // show — not merely on `error`, which `useDataset`'s placeholderData can
+  // leave set alongside the *previous* (still-valid) response, e.g. a
+  // transient failure while switching versions. That case falls through and
+  // renders the page with the last-good snapshot instead of losing it.
+  if (!dataset || !data) {
+    const notFound = error instanceof Error && /\b404\b/.test(error.message);
     return (
       <>
         <ProjectBreadcrumb projectId={projectId} />
         <div className="flex h-full flex-col text-[13px]">
           <EvalPageHeader
             parent={{ label: "Datasets", href: `/projects/${projectId}/datasets` }}
-            title="Dataset not found"
+            title={notFound ? "Dataset not found" : "Couldn't load dataset"}
           />
           <EvalBody>
             <EmptyState>
-              No dataset with the id {datasetId}.{" "}
-              <Link
-                href={`/projects/${projectId}/datasets`}
-                className="underline underline-offset-2"
-              >
-                Back to datasets
-              </Link>
+              {notFound ? (
+                <>
+                  No dataset with the id {datasetId}.{" "}
+                  <Link
+                    href={`/projects/${projectId}/datasets`}
+                    className="underline underline-offset-2"
+                  >
+                    Back to datasets
+                  </Link>
+                </>
+              ) : (
+                <>
+                  Something went wrong loading this dataset.{" "}
+                  <button
+                    type="button"
+                    onClick={() => refetch()}
+                    className="underline underline-offset-2"
+                  >
+                    Try again
+                  </button>
+                </>
+              )}
             </EmptyState>
           </EvalBody>
         </div>
@@ -260,41 +280,58 @@ export function DatasetDetailView({
         />
 
         {/* Version bar — pick a snapshot to view (previous versions are read-only),
-            with its immutable version id + copy. */}
-        <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 py-1.5 text-[12px]">
-          <span className="text-muted-foreground">Version</span>
-          <Select value={selectedVersion?.id ?? ""} onValueChange={(v) => setSelectedVersionId(v)}>
-            <SelectTrigger className="h-7 w-[240px] text-[12px]">
-              <SelectValue placeholder="Current version" />
-            </SelectTrigger>
-            <SelectContent>
-              {versions.map((v) => (
-                <SelectItem key={v.id} value={v.id} className="text-[12px]">
-                  v{v.versionNumber}
-                  {v.id === dataset.currentVersionId ? " (current)" : ""}
-                  {v.label ? ` · ${v.label}` : ""}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {selectedVersion && (
-            <>
-              <span className="font-mono text-[11px] text-muted-foreground">
-                {selectedVersion.id}
+            with its immutable version id + copy. Hidden entirely on a freshly
+            created dataset: there is nothing to select yet. */}
+        {hasVersions && (
+          <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 py-1.5 text-[12px]">
+            <span className="text-muted-foreground">Version</span>
+            <Select
+              value={selectedVersion?.id ?? ""}
+              onValueChange={(v) => setSelectedVersionId(v)}
+            >
+              <SelectTrigger className="h-7 w-[240px] text-[12px]">
+                <SelectValue placeholder="Current version" />
+              </SelectTrigger>
+              <SelectContent>
+                {versions.map((v) => (
+                  <SelectItem key={v.id} value={v.id} className="text-[12px]">
+                    v{v.versionNumber}
+                    {v.id === dataset.currentVersionId ? " (current)" : ""}
+                    {v.label ? ` · ${v.label}` : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {selectedVersion && (
+              <>
+                <span className="font-mono text-[11px] text-muted-foreground">
+                  {selectedVersion.id}
+                </span>
+                <CopyButton
+                  value={selectedVersion.id}
+                  className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                  title="Copy version ID"
+                />
+              </>
+            )}
+            {!isCurrentVersion && (
+              <span
+                role="status"
+                className="ml-auto rounded border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-700 dark:text-amber-300"
+              >
+                Viewing v{selectedVersion?.versionNumber}
+                {selectedVersion?.label ? ` · ${selectedVersion.label}` : ""} — read only.{" "}
+                <button
+                  type="button"
+                  onClick={() => setSelectedVersionId(data.currentVersion?.id ?? null)}
+                  className="underline underline-offset-2"
+                >
+                  Back to current
+                </button>
               </span>
-              <CopyButton
-                value={selectedVersion.id}
-                className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                title="Copy version ID"
-              />
-            </>
-          )}
-          {!isCurrentVersion && (
-            <span className="ml-auto rounded border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-700 dark:text-amber-300">
-              Viewing an older version — read only
-            </span>
-          )}
-        </div>
+            )}
+          </div>
+        )}
 
         <Tabs defaultValue="cases" className="flex min-h-0 flex-1 flex-col">
           <TabsList className="shrink-0 px-4 pt-2" aria-label="Dataset views">
@@ -307,19 +344,13 @@ export function DatasetDetailView({
           </TabsList>
 
           <TabsContent value="cases" className="flex min-h-0 flex-1 flex-col">
-            {/* Toolbar — the standard SearchFilterBar (search + actions + date). */}
+            {/* Toolbar — the standard SearchFilterBar (search + actions). No date
+                filter: nothing here reads it — a rendered-but-inert filter chip
+                falsely implies the table is scoped to it. */}
             <SearchFilterBar
               searchValue={keyword}
               onSearchChange={setKeyword}
               searchPlaceholder="Search cases..."
-              dateFilter={caseDate}
-              customStartDate={caseStart}
-              customEndDate={caseEnd}
-              onDateFilterChange={setCaseDate}
-              onCustomRangeChange={(s, e) => {
-                setCaseStart(s);
-                setCaseEnd(e);
-              }}
             >
               <Button
                 variant="outline"
@@ -332,7 +363,7 @@ export function DatasetDetailView({
                 Row
               </Button>
 
-              {/* Spacer keeps the dataset-level actions flush against the date filter. */}
+              {/* Spacer keeps the dataset-level actions flush right. */}
               <span className="flex-1" aria-hidden />
 
               {/* Dataset-level actions (no dropdown). */}
@@ -398,14 +429,6 @@ export function DatasetDetailView({
               searchValue={historyKeyword}
               onSearchChange={setHistoryKeyword}
               searchPlaceholder="Search evaluations..."
-              dateFilter={historyDate}
-              customStartDate={historyStart}
-              customEndDate={historyEnd}
-              onDateFilterChange={setHistoryDate}
-              onCustomRangeChange={(s, e) => {
-                setHistoryStart(s);
-                setHistoryEnd(e);
-              }}
             />
             <EvalBody>
               {visibleRuns.length === 0 ? (
@@ -504,15 +527,30 @@ export function DatasetDetailView({
           </>
         }
         options={
-          [
-            {
-              id: "latest",
-              label: "Pull dataset",
-              note: "Fetches the dataset's current published version when the run starts.",
-              py: datasetPullCode(dataset.id),
-              ts: datasetPullCodeTs(dataset.id),
-            },
-          ] satisfies PullOption[]
+          // While pinned to an older, read-only snapshot, swap in the exact
+          // version so "pull code" reproduces what's actually on screen instead
+          // of the dataset's (different) current version. Swap, not add — the
+          // drawer's contract is a single option, resolved to whichever version
+          // is in view.
+          (selectedVersion && !isCurrentVersion
+            ? [
+                {
+                  id: "version",
+                  label: `Pull v${selectedVersion.versionNumber}`,
+                  note: "This exact immutable snapshot — never changes.",
+                  py: datasetPullVersionCode(selectedVersion.id),
+                  ts: datasetPullVersionCodeTs(selectedVersion.id),
+                },
+              ]
+            : [
+                {
+                  id: "latest",
+                  label: "Pull dataset",
+                  note: "Fetches the dataset's current published version when the run starts.",
+                  py: datasetPullCode(dataset.id),
+                  ts: datasetPullCodeTs(dataset.id),
+                },
+              ]) satisfies PullOption[]
         }
         open={codeOpen}
         onOpenChange={setCodeOpen}

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -9,7 +9,6 @@ import {
   ChevronRight,
   Copy,
   Database,
-  Download,
   Expand,
   FileCode,
   FileText,
@@ -59,15 +58,12 @@ import {
 import { CAPTURE_REASON_LABEL, type ReviewStatus } from "@/features/offline-eval/types";
 import {
   caseDisplayId,
-  changeSentiment,
   datasetPullCode,
   datasetPullCodeTs,
   datasetPullVersionCode,
   datasetPullVersionCodeTs,
   pctFraction,
-  signedPoints,
   scoreDisplay,
-  SENTIMENT_CLASS,
   truncate,
 } from "@/features/offline-eval/utils";
 import {
@@ -85,13 +81,6 @@ import { PullCodeDrawer, type PullOption } from "../components/pull-code-drawer"
 /** "Last 14 days" default, matching the traces/datasets lists. */
 const DEFAULT_DATE_FILTER =
   DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0];
-
-/** Map a per-case change direction to a signed delta for the sentiment colour. */
-const CHANGE_DELTA: Record<"improved" | "regressed" | "unchanged", number> = {
-  improved: 1,
-  regressed: -1,
-  unchanged: 0,
-};
 
 /** A dash for the list; empty reads as a placeholder, not a blank cell. */
 function orDash(value: string | null): React.ReactNode {
@@ -489,15 +478,6 @@ export function DatasetDetailView({
                   variant="ghost"
                   size="sm"
                   className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-                  onClick={() => toast({ title: "Export — coming soon", tone: "success" })}
-                >
-                  <Download className="h-3.5 w-3.5" aria-hidden />
-                  Download
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
                   onClick={() => {
                     navigator.clipboard?.writeText(dataset.id);
                     toast({ title: "Dataset ID copied", tone: "success" });
@@ -597,7 +577,7 @@ export function DatasetDetailView({
                       <Th>Evaluation</Th>
                       <Th className="w-[140px]">Candidate version</Th>
                       <Th className="w-[100px] text-right">Score</Th>
-                      <Th className="w-[100px] text-right">Change</Th>
+                      <Th className="w-[100px] text-right">Cost</Th>
                     </TRHead>
                   </THead>
                   <TBody>
@@ -612,7 +592,6 @@ export function DatasetDetailView({
                         </Td>
                         <Td className="font-medium">{run.evaluationName}</Td>
                         <Td className="font-mono text-[11px]">{run.candidateVersion}</Td>
-                        {/* Same Score/Change presentation as the Evaluations Runs tab. */}
                         <Td className="text-right tabular-nums">
                           {run.mainScore === null ? (
                             <span className="text-muted-foreground">—</span>
@@ -620,17 +599,10 @@ export function DatasetDetailView({
                             pctFraction(run.mainScore)
                           )}
                         </Td>
-                        <Td className="text-right tabular-nums">
-                          {run.changeFromBaseline === null ||
-                          run.changeFromBaseline === undefined ? (
-                            <span className="text-muted-foreground">—</span>
-                          ) : (
-                            <span
-                              className={SENTIMENT_CLASS[changeSentiment(run.changeFromBaseline)]}
-                            >
-                              {signedPoints(run.changeFromBaseline)} pp
-                            </span>
-                          )}
+                        <Td className="text-right tabular-nums text-muted-foreground">
+                          {run.cost === null || run.cost === undefined
+                            ? "—"
+                            : `$${run.cost < 1 ? run.cost.toFixed(4) : run.cost.toFixed(2)}`}
                         </Td>
                       </TR>
                     ))}
@@ -1049,7 +1021,6 @@ function CasePanel({
                   <Th className="w-[150px]">Ran at</Th>
                   <Th>Candidate version</Th>
                   <Th className="w-[90px] text-right">Score</Th>
-                  <Th className="w-[100px]">Change</Th>
                   <Th className="w-[110px]">Status</Th>
                 </TRHead>
               </THead>
@@ -1075,15 +1046,6 @@ function CasePanel({
                         <span className="text-muted-foreground">—</span>
                       ) : (
                         scoreDisplay(r.score)
-                      )}
-                    </Td>
-                    <Td>
-                      {r.change === null ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : (
-                        <span className={SENTIMENT_CLASS[changeSentiment(CHANGE_DELTA[r.change])]}>
-                          {r.change}
-                        </span>
                       )}
                     </Td>
                     <Td>

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -2,225 +2,224 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
-import { Trash2, X } from "lucide-react";
+import { Database } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { SearchFilterBar } from "@/components/search-filter-bar";
-import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
-import { useToast } from "@/components/ui/toast";
-import { ProjectBreadcrumb } from "@/features/projects/components";
+import { Input } from "@/components/ui/input";
 import {
-  DatasetActionsMenu,
-  SelectAllHeaderCell,
-  SelectRowCell,
-  Timestamp,
-  useRowSelection,
-} from "@/features/offline-eval/components";
-import { useDatasets, useDeleteDataset, useEvaluations } from "../hooks";
-import type { DatasetRow } from "../types";
-import { NewDatasetPanel, DatasetEditPanel } from "../components/dataset-panels";
-
-const DEFAULT_DATE_FILTER =
-  DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0];
-
-const TH =
-  "h-7 whitespace-nowrap border-r border-border/50 px-3 text-left text-[12px] font-medium text-muted-foreground";
-const TD = "border-r border-border/50 px-3 py-1.5 text-[12px]";
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
+import { ProjectBreadcrumb } from "@/features/projects/components";
+import { Timestamp } from "@/features/offline-eval/components";
+import { useDatasets, useCreateDataset } from "../hooks";
 
 /**
- * Dataset list — the dataset library, wired to the server: tracing-style
- * search + date filter, row
- * selection with "N selected · Delete" beside the search, a three-dot
- * Edit/Delete menu, and right-side New/Edit panels.
+ * Real, server-backed Datasets list. Data comes from
+ * /api/projects/[id]/datasets — never the prototype fixtures.
  */
 export function DatasetsView({ projectId }: { projectId: string }) {
   const router = useRouter();
-  const { toast } = useToast();
-
   const [keyword, setKeyword] = React.useState("");
-  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
-  const [customStart, setCustomStart] = React.useState<Date | null>(null);
-  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
-  const [newOpen, setNewOpen] = React.useState(false);
-  const [editing, setEditing] = React.useState<DatasetRow | null>(null);
+  const [createOpen, setCreateOpen] = React.useState(false);
 
   const { data, isLoading, error } = useDatasets(projectId, {
     search_query: keyword.trim() || undefined,
   });
-  const datasets = React.useMemo(() => data?.data ?? [], [data]);
-  const del = useDeleteDataset(projectId);
-
-  // Evaluations-per-dataset comes from the lineage list (one row per evaluation
-  // purpose, each carrying its datasetId); the dataset row itself has no count.
-  const { data: evaluationsData } = useEvaluations(projectId);
-  const evalCountByDataset = React.useMemo(() => {
-    const map = new Map<string, number>();
-    for (const e of evaluationsData?.data ?? []) {
-      map.set(e.datasetId, (map.get(e.datasetId) ?? 0) + 1);
-    }
-    return map;
-  }, [evaluationsData]);
-
-  const ids = React.useMemo(() => datasets.map((d) => d.id), [datasets]);
-  const sel = useRowSelection(ids);
-
-  const deleteOne = (dataset: DatasetRow) => {
-    del.mutate(dataset.id, {
-      onSuccess: () => toast({ title: `Deleted ${dataset.name}`, tone: "success" }),
-      onError: (e) => toast({ title: "Could not delete", description: String(e), tone: "warning" }),
-    });
-  };
-
-  const deleteSelected = () => {
-    const chosen = [...sel.selected];
-    if (chosen.length === 0) return;
-    Promise.all(chosen.map((id) => del.mutateAsync(id)))
-      .then(() => toast({ title: `${chosen.length} deleted`, tone: "success" }))
-      .catch((e) => toast({ title: "Could not delete", description: String(e), tone: "warning" }));
-    sel.clear();
-  };
+  const datasets = data?.data ?? [];
+  const total = data?.meta?.total ?? 0;
+  const isEmptyProject = !isLoading && !error && total === 0 && !keyword;
+  const isEmptySearch = !isLoading && !error && datasets.length === 0 && !!keyword;
 
   return (
-    <div className="flex h-full flex-col text-[13px]">
-      {/* Populates the app's top breadcrumb bar (workspace / project). Without a
-          mounted ProjectBreadcrumb the header goes blank on this route. */}
+    <>
       <ProjectBreadcrumb projectId={projectId} current="Datasets" />
-      <div className="flex items-center justify-between border-b border-border px-4 py-2">
-        <h1 className="text-[13px] font-medium">Datasets</h1>
-        <Button size="sm" className="h-7 text-[12px]" onClick={() => setNewOpen(true)}>
-          New Dataset
-        </Button>
-      </div>
 
-      <SearchFilterBar
-        searchValue={keyword}
-        onSearchChange={setKeyword}
-        searchPlaceholder="Search datasets..."
-        dateFilter={dateFilter}
-        customStartDate={customStart}
-        customEndDate={customEnd}
-        onDateFilterChange={setDateFilter}
-        onCustomRangeChange={(s, e) => {
-          setCustomStart(s);
-          setCustomEnd(e);
-        }}
-      >
-        {sel.count > 0 && (
-          <span className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={sel.clear}
-              aria-label="Cancel selection"
-              className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            >
-              <X className="h-3.5 w-3.5" aria-hidden />
-            </button>
-            <span className="text-[12px] font-medium tabular-nums">{sel.count} selected</span>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 gap-1 px-1.5 text-[12px] text-destructive hover:bg-destructive/10 hover:text-destructive"
-              onClick={deleteSelected}
-            >
-              <Trash2 className="h-3.5 w-3.5" aria-hidden />
-              Delete
-            </Button>
-          </span>
-        )}
-        <span className="flex-1" aria-hidden />
-      </SearchFilterBar>
+      <div className="flex flex-1 flex-col overflow-hidden text-[13px]">
+        <div className="flex items-center justify-between border-b border-border px-4 py-2">
+          <h1 className="text-[13px] font-medium">Datasets</h1>
+          <Button size="sm" className="h-7 text-[12px]" onClick={() => setCreateOpen(true)}>
+            New Dataset
+          </Button>
+        </div>
 
-      <div className="min-h-0 flex-1 overflow-auto">
-        <table className="w-full">
-          <thead className="sticky top-0 bg-background">
-            <tr className="border-b border-border bg-muted/50">
-              <SelectAllHeaderCell
-                checked={sel.allSelected}
-                indeterminate={sel.someSelected}
-                onToggle={sel.toggleAll}
-              />
-              <th className={`${TH} w-[170px]`}>Last updated</th>
-              <th className={`${TH} w-[240px]`}>Dataset ID</th>
-              <th className={TH}>Name</th>
-              <th className={`${TH} w-[110px] text-right`}>Test cases</th>
-              <th className={`${TH} w-[110px] text-right`}>Evaluations</th>
-              <th className="w-[56px] px-2 py-1.5 text-right text-[12px] font-medium text-muted-foreground">
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {isLoading ? (
-              <RowMessage>Loading datasets...</RowMessage>
-            ) : error ? (
-              <RowMessage tone="destructive">Error loading datasets</RowMessage>
-            ) : datasets.length === 0 ? (
-              <RowMessage>
-                {keyword
-                  ? "No datasets match your search."
-                  : "No datasets yet — save a trace or span as a test case to start one."}
-              </RowMessage>
-            ) : (
-              datasets.map((dataset) => (
-                <tr
-                  key={dataset.id}
-                  onClick={() => router.push(`/projects/${projectId}/datasets/${dataset.id}`)}
-                  className="cursor-pointer border-b border-border/50 transition-colors last:border-0 hover:bg-muted/50"
-                >
-                  <SelectRowCell
-                    checked={sel.has(dataset.id)}
-                    onToggle={() => sel.toggle(dataset.id)}
-                    label={`Select ${dataset.name}`}
-                  />
-                  <td className={`${TD} whitespace-nowrap text-muted-foreground`}>
-                    <Timestamp iso={dataset.updateTime} />
-                  </td>
-                  <td
-                    className={`${TD} max-w-[240px] truncate font-mono text-[11px] text-muted-foreground`}
-                    title={dataset.id}
+        <div className="flex items-center gap-2 border-b border-border px-4 py-2">
+          <Input
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            placeholder="Search datasets..."
+            className="h-7 max-w-xs text-[12px]"
+          />
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto">
+          {isLoading ? (
+            <div className="flex h-64 items-center justify-center">
+              <p className="text-[13px] text-muted-foreground">Loading datasets...</p>
+            </div>
+          ) : error ? (
+            <div className="flex h-64 items-center justify-center">
+              <p className="text-[13px] text-destructive">Error loading datasets</p>
+            </div>
+          ) : isEmptyProject ? (
+            <div className="flex h-64 flex-col items-center justify-center gap-3">
+              <Database className="h-8 w-8 text-muted-foreground/40" />
+              <p className="text-[13px] text-muted-foreground">No datasets yet</p>
+              <p className="text-[12px] text-muted-foreground">
+                Save a trace or span as a test case to start a dataset.
+              </p>
+              <Button size="sm" className="h-7 text-[12px]" onClick={() => setCreateOpen(true)}>
+                New Dataset
+              </Button>
+            </div>
+          ) : isEmptySearch ? (
+            <div className="flex h-64 flex-col items-center justify-center gap-2">
+              <p className="text-[13px] text-muted-foreground">
+                No datasets match &ldquo;{keyword}&rdquo;
+              </p>
+              <button
+                className="text-[12px] text-muted-foreground underline"
+                onClick={() => setKeyword("")}
+              >
+                Clear search
+              </button>
+            </div>
+          ) : (
+            <Table>
+              <THead>
+                <TRHead>
+                  <Th>Name</Th>
+                  <Th className="w-[110px] text-right">Test cases</Th>
+                  <Th className="w-[90px] text-right">Versions</Th>
+                  <Th className="w-[170px]">Updated</Th>
+                </TRHead>
+              </THead>
+              <TBody>
+                {datasets.map((d) => (
+                  <TR
+                    key={d.id}
+                    interactive
+                    onClick={() => router.push(`/projects/${projectId}/datasets/${d.id}`)}
                   >
-                    {dataset.id}
-                  </td>
-                  <td className={`${TD} font-medium`}>{dataset.name}</td>
-                  <td className={`${TD} text-right tabular-nums`}>{dataset.caseCount}</td>
-                  <td className={`${TD} text-right tabular-nums text-muted-foreground`}>
-                    {evalCountByDataset.get(dataset.id) || "—"}
-                  </td>
-                  <td className="px-2 text-right">
-                    <DatasetActionsMenu
-                      onEdit={() => setEditing(dataset)}
-                      onDelete={() => deleteOne(dataset)}
-                    />
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+                    <Td>
+                      <span className="font-medium">{d.name}</span>
+                      {d.description && (
+                        <span className="ml-2 text-muted-foreground">{d.description}</span>
+                      )}
+                    </Td>
+                    <Td className="text-right tabular-nums">{d.caseCount}</Td>
+                    <Td className="text-right tabular-nums text-muted-foreground">
+                      {d.versionCount}
+                    </Td>
+                    <Td className="whitespace-nowrap text-muted-foreground">
+                      <Timestamp iso={d.updateTime} />
+                    </Td>
+                  </TR>
+                ))}
+              </TBody>
+            </Table>
+          )}
+        </div>
       </div>
 
-      <NewDatasetPanel projectId={projectId} open={newOpen} onOpenChange={setNewOpen} />
-      {editing && (
-        <DatasetEditPanel
-          projectId={projectId}
-          dataset={editing}
-          onClose={() => setEditing(null)}
-        />
-      )}
-    </div>
+      <NewDatasetDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        projectId={projectId}
+        onCreated={(id) => router.push(`/projects/${projectId}/datasets/${id}`)}
+      />
+    </>
   );
 }
 
-function RowMessage({ children, tone }: { children: React.ReactNode; tone?: "destructive" }) {
+function NewDatasetDialog({
+  open,
+  onOpenChange,
+  projectId,
+  onCreated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  onCreated: (id: string) => void;
+}) {
+  const [name, setName] = React.useState("");
+  const [description, setDescription] = React.useState("");
+  const create = useCreateDataset(projectId);
+
+  React.useEffect(() => {
+    if (open) {
+      setName("");
+      setDescription("");
+    }
+  }, [open]);
+
+  const submit = async () => {
+    if (!name.trim()) return;
+    const res = await create.mutateAsync({
+      name: name.trim(),
+      description: description.trim() || null,
+    });
+    onOpenChange(false);
+    onCreated(res.dataset.id);
+  };
+
   return (
-    <tr>
-      <td
-        colSpan={7}
-        className={`px-3 py-10 text-center text-[12px] ${
-          tone ? "text-destructive" : "text-muted-foreground"
-        }`}
-      >
-        {children}
-      </td>
-    </tr>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle className="text-[13px] font-medium">New dataset</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 text-[12px]">
+          <div>
+            <label className="mb-1 block text-[11px] text-muted-foreground">Name</label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Billing routing"
+              autoFocus
+              className="h-7 text-[12px]"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-[11px] text-muted-foreground">
+              Description <span className="font-normal">(optional)</span>
+            </label>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Billing questions that should reach the billing team."
+              className="h-7 text-[12px]"
+            />
+          </div>
+          {create.isError && (
+            <p className="text-[11px] text-destructive">
+              {(create.error as Error)?.message ?? "Failed to create dataset"}
+            </p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-[12px]"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            className="h-7 text-[12px]"
+            disabled={!name.trim() || create.isPending}
+            onClick={submit}
+          >
+            Create dataset
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
 import { useToast } from "@/components/ui/toast";
+import { ProjectBreadcrumb } from "@/features/projects/components";
 import {
   DatasetActionsMenu,
   SelectAllHeaderCell,
@@ -80,6 +81,9 @@ export function DatasetsView({ projectId }: { projectId: string }) {
 
   return (
     <div className="flex h-full flex-col text-[13px]">
+      {/* Populates the app's top breadcrumb bar (workspace / project). Without a
+          mounted ProjectBreadcrumb the header goes blank on this route. */}
+      <ProjectBreadcrumb projectId={projectId} current="Datasets" />
       <div className="flex items-center justify-between border-b border-border px-4 py-2">
         <h1 className="text-[13px] font-medium">Datasets</h1>
         <Button size="sm" className="h-7 text-[12px]" onClick={() => setNewOpen(true)}>

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -2,19 +2,12 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
-import { Trash2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
 import { useToast } from "@/components/ui/toast";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import {
-  DatasetActionsMenu,
-  SelectAllHeaderCell,
-  SelectRowCell,
-  Timestamp,
-  useRowSelection,
-} from "@/features/offline-eval/components";
+import { DatasetActionsMenu, Timestamp } from "@/features/offline-eval/components";
 import { useDatasets, useDeleteDataset, useEvaluations } from "../hooks";
 import type { DatasetRow } from "../types";
 import { NewDatasetPanel, DatasetEditPanel } from "../components/dataset-panels";
@@ -27,10 +20,9 @@ const TH =
 const TD = "border-r border-border/50 px-3 py-1.5 text-[12px]";
 
 /**
- * Dataset list — a faithful port of the offline-eval prototype's dataset
- * library, wired to the server: tracing-style search + date filter, row
- * selection with "N selected · Delete" beside the search, a three-dot
- * Edit/Delete menu, and right-side New/Edit panels.
+ * Dataset list — the dataset library, wired to the server: tracing-style
+ * search + date filter, a three-dot Edit/Delete menu, and right-side New/Edit
+ * panels.
  */
 export function DatasetsView({ projectId }: { projectId: string }) {
   const router = useRouter();
@@ -60,23 +52,11 @@ export function DatasetsView({ projectId }: { projectId: string }) {
     return map;
   }, [evaluationsData]);
 
-  const ids = React.useMemo(() => datasets.map((d) => d.id), [datasets]);
-  const sel = useRowSelection(ids);
-
   const deleteOne = (dataset: DatasetRow) => {
     del.mutate(dataset.id, {
       onSuccess: () => toast({ title: `Deleted ${dataset.name}`, tone: "success" }),
       onError: (e) => toast({ title: "Could not delete", description: String(e), tone: "warning" }),
     });
-  };
-
-  const deleteSelected = () => {
-    const chosen = [...sel.selected];
-    if (chosen.length === 0) return;
-    Promise.all(chosen.map((id) => del.mutateAsync(id)))
-      .then(() => toast({ title: `${chosen.length} deleted`, tone: "success" }))
-      .catch((e) => toast({ title: "Could not delete", description: String(e), tone: "warning" }));
-    sel.clear();
   };
 
   return (
@@ -104,28 +84,6 @@ export function DatasetsView({ projectId }: { projectId: string }) {
           setCustomEnd(e);
         }}
       >
-        {sel.count > 0 && (
-          <span className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={sel.clear}
-              aria-label="Cancel selection"
-              className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            >
-              <X className="h-3.5 w-3.5" aria-hidden />
-            </button>
-            <span className="text-[12px] font-medium tabular-nums">{sel.count} selected</span>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 gap-1 px-1.5 text-[12px] text-destructive hover:bg-destructive/10 hover:text-destructive"
-              onClick={deleteSelected}
-            >
-              <Trash2 className="h-3.5 w-3.5" aria-hidden />
-              Delete
-            </Button>
-          </span>
-        )}
         <span className="flex-1" aria-hidden />
       </SearchFilterBar>
 
@@ -133,11 +91,6 @@ export function DatasetsView({ projectId }: { projectId: string }) {
         <table className="w-full">
           <thead className="sticky top-0 bg-background">
             <tr className="border-b border-border bg-muted/50">
-              <SelectAllHeaderCell
-                checked={sel.allSelected}
-                indeterminate={sel.someSelected}
-                onToggle={sel.toggleAll}
-              />
               <th className={`${TH} w-[170px]`}>Last updated</th>
               <th className={`${TH} w-[240px]`}>Dataset ID</th>
               <th className={TH}>Name</th>
@@ -166,11 +119,6 @@ export function DatasetsView({ projectId }: { projectId: string }) {
                   onClick={() => router.push(`/projects/${projectId}/datasets/${dataset.id}`)}
                   className="cursor-pointer border-b border-border/50 transition-colors last:border-0 hover:bg-muted/50"
                 >
-                  <SelectRowCell
-                    checked={sel.has(dataset.id)}
-                    onToggle={() => sel.toggle(dataset.id)}
-                    label={`Select ${dataset.name}`}
-                  />
                   <td className={`${TD} whitespace-nowrap text-muted-foreground`}>
                     <Timestamp iso={dataset.updateTime} />
                   </td>

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -2,224 +2,227 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
-import { Database } from "lucide-react";
+import { Download, Trash2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
+import { useToast } from "@/components/ui/toast";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
-import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
-import { ProjectBreadcrumb } from "@/features/projects/components";
-import { Timestamp } from "@/features/offline-eval/components";
-import { useDatasets, useCreateDataset } from "../hooks";
+  DatasetActionsMenu,
+  SelectAllHeaderCell,
+  SelectRowCell,
+  Timestamp,
+  useRowSelection,
+} from "@/features/offline-eval/components";
+import { useDatasets, useDeleteDataset, useEvaluations } from "../hooks";
+import type { DatasetRow } from "../types";
+import { NewDatasetPanel, DatasetEditPanel } from "../components/dataset-panels";
+
+const DEFAULT_DATE_FILTER =
+  DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0];
+
+const TH =
+  "h-7 whitespace-nowrap border-r border-border/50 px-3 text-left text-[12px] font-medium text-muted-foreground";
+const TD = "border-r border-border/50 px-3 py-1.5 text-[12px]";
 
 /**
- * Real, server-backed Datasets list. Data comes from
- * /api/projects/[id]/datasets — never the prototype fixtures.
+ * Dataset list — a faithful port of the offline-eval prototype's dataset
+ * library, wired to the server: tracing-style search + date filter, row
+ * selection with "N selected · Delete" beside the search, a three-dot
+ * Edit/Delete menu, and right-side New/Edit panels.
  */
 export function DatasetsView({ projectId }: { projectId: string }) {
   const router = useRouter();
+  const { toast } = useToast();
+
   const [keyword, setKeyword] = React.useState("");
-  const [createOpen, setCreateOpen] = React.useState(false);
+  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
+  const [customStart, setCustomStart] = React.useState<Date | null>(null);
+  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
+  const [newOpen, setNewOpen] = React.useState(false);
+  const [editing, setEditing] = React.useState<DatasetRow | null>(null);
 
   const { data, isLoading, error } = useDatasets(projectId, {
     search_query: keyword.trim() || undefined,
   });
-  const datasets = data?.data ?? [];
-  const total = data?.meta?.total ?? 0;
-  const isEmptyProject = !isLoading && !error && total === 0 && !keyword;
-  const isEmptySearch = !isLoading && !error && datasets.length === 0 && !!keyword;
+  const datasets = React.useMemo(() => data?.data ?? [], [data]);
+  const del = useDeleteDataset(projectId);
 
-  return (
-    <>
-      <ProjectBreadcrumb projectId={projectId} current="Datasets" />
-
-      <div className="flex flex-1 flex-col overflow-hidden text-[13px]">
-        <div className="flex items-center justify-between border-b border-border px-4 py-2">
-          <h1 className="text-[13px] font-medium">Datasets</h1>
-          <Button size="sm" className="h-7 text-[12px]" onClick={() => setCreateOpen(true)}>
-            New Dataset
-          </Button>
-        </div>
-
-        <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-          <Input
-            value={keyword}
-            onChange={(e) => setKeyword(e.target.value)}
-            placeholder="Search datasets..."
-            className="h-7 max-w-xs text-[12px]"
-          />
-        </div>
-
-        <div className="min-h-0 flex-1 overflow-auto">
-          {isLoading ? (
-            <div className="flex h-64 items-center justify-center">
-              <p className="text-[13px] text-muted-foreground">Loading datasets...</p>
-            </div>
-          ) : error ? (
-            <div className="flex h-64 items-center justify-center">
-              <p className="text-[13px] text-destructive">Error loading datasets</p>
-            </div>
-          ) : isEmptyProject ? (
-            <div className="flex h-64 flex-col items-center justify-center gap-3">
-              <Database className="h-8 w-8 text-muted-foreground/40" />
-              <p className="text-[13px] text-muted-foreground">No datasets yet</p>
-              <p className="text-[12px] text-muted-foreground">
-                Save a trace or span as a test case to start a dataset.
-              </p>
-              <Button size="sm" className="h-7 text-[12px]" onClick={() => setCreateOpen(true)}>
-                New Dataset
-              </Button>
-            </div>
-          ) : isEmptySearch ? (
-            <div className="flex h-64 flex-col items-center justify-center gap-2">
-              <p className="text-[13px] text-muted-foreground">
-                No datasets match &ldquo;{keyword}&rdquo;
-              </p>
-              <button
-                className="text-[12px] text-muted-foreground underline"
-                onClick={() => setKeyword("")}
-              >
-                Clear search
-              </button>
-            </div>
-          ) : (
-            <Table>
-              <THead>
-                <TRHead>
-                  <Th>Name</Th>
-                  <Th className="w-[110px] text-right">Test cases</Th>
-                  <Th className="w-[90px] text-right">Versions</Th>
-                  <Th className="w-[170px]">Updated</Th>
-                </TRHead>
-              </THead>
-              <TBody>
-                {datasets.map((d) => (
-                  <TR
-                    key={d.id}
-                    interactive
-                    onClick={() => router.push(`/projects/${projectId}/datasets/${d.id}`)}
-                  >
-                    <Td>
-                      <span className="font-medium">{d.name}</span>
-                      {d.description && (
-                        <span className="ml-2 text-muted-foreground">{d.description}</span>
-                      )}
-                    </Td>
-                    <Td className="text-right tabular-nums">{d.caseCount}</Td>
-                    <Td className="text-right tabular-nums text-muted-foreground">
-                      {d.versionCount}
-                    </Td>
-                    <Td className="whitespace-nowrap text-muted-foreground">
-                      <Timestamp iso={d.updateTime} />
-                    </Td>
-                  </TR>
-                ))}
-              </TBody>
-            </Table>
-          )}
-        </div>
-      </div>
-
-      <NewDatasetDialog
-        open={createOpen}
-        onOpenChange={setCreateOpen}
-        projectId={projectId}
-        onCreated={(id) => router.push(`/projects/${projectId}/datasets/${id}`)}
-      />
-    </>
-  );
-}
-
-function NewDatasetDialog({
-  open,
-  onOpenChange,
-  projectId,
-  onCreated,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  projectId: string;
-  onCreated: (id: string) => void;
-}) {
-  const [name, setName] = React.useState("");
-  const [description, setDescription] = React.useState("");
-  const create = useCreateDataset(projectId);
-
-  React.useEffect(() => {
-    if (open) {
-      setName("");
-      setDescription("");
+  // Evaluations-per-dataset comes from the lineage list (one row per evaluation
+  // purpose, each carrying its datasetId); the dataset row itself has no count.
+  const { data: evaluationsData } = useEvaluations(projectId);
+  const evalCountByDataset = React.useMemo(() => {
+    const map = new Map<string, number>();
+    for (const e of evaluationsData?.data ?? []) {
+      map.set(e.datasetId, (map.get(e.datasetId) ?? 0) + 1);
     }
-  }, [open]);
+    return map;
+  }, [evaluationsData]);
 
-  const submit = async () => {
-    if (!name.trim()) return;
-    const res = await create.mutateAsync({
-      name: name.trim(),
-      description: description.trim() || null,
+  const ids = React.useMemo(() => datasets.map((d) => d.id), [datasets]);
+  const sel = useRowSelection(ids);
+
+  const deleteOne = (dataset: DatasetRow) => {
+    del.mutate(dataset.id, {
+      onSuccess: () => toast({ title: `Deleted ${dataset.name}`, tone: "success" }),
+      onError: (e) => toast({ title: "Could not delete", description: String(e), tone: "warning" }),
     });
-    onOpenChange(false);
-    onCreated(res.dataset.id);
+  };
+
+  const deleteSelected = () => {
+    const chosen = [...sel.selected];
+    if (chosen.length === 0) return;
+    Promise.all(chosen.map((id) => del.mutateAsync(id)))
+      .then(() => toast({ title: `${chosen.length} deleted`, tone: "success" }))
+      .catch((e) => toast({ title: "Could not delete", description: String(e), tone: "warning" }));
+    sel.clear();
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[440px]">
-        <DialogHeader>
-          <DialogTitle className="text-[13px] font-medium">New dataset</DialogTitle>
-        </DialogHeader>
-        <div className="flex flex-col gap-3 text-[12px]">
-          <div>
-            <label className="mb-1 block text-[11px] text-muted-foreground">Name</label>
-            <Input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="Billing routing"
-              autoFocus
-              className="h-7 text-[12px]"
-            />
-          </div>
-          <div>
-            <label className="mb-1 block text-[11px] text-muted-foreground">
-              Description <span className="font-normal">(optional)</span>
-            </label>
-            <Input
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Billing questions that should reach the billing team."
-              className="h-7 text-[12px]"
-            />
-          </div>
-          {create.isError && (
-            <p className="text-[11px] text-destructive">
-              {(create.error as Error)?.message ?? "Failed to create dataset"}
-            </p>
-          )}
-        </div>
-        <DialogFooter>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 text-[12px]"
-            onClick={() => onOpenChange(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            size="sm"
-            className="h-7 text-[12px]"
-            disabled={!name.trim() || create.isPending}
-            onClick={submit}
-          >
-            Create dataset
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <div className="flex h-full flex-col text-[13px]">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2">
+        <h1 className="text-[13px] font-medium">Datasets</h1>
+        <Button size="sm" className="h-7 text-[12px]" onClick={() => setNewOpen(true)}>
+          New Dataset
+        </Button>
+      </div>
+
+      <SearchFilterBar
+        searchValue={keyword}
+        onSearchChange={setKeyword}
+        searchPlaceholder="Search datasets..."
+        dateFilter={dateFilter}
+        customStartDate={customStart}
+        customEndDate={customEnd}
+        onDateFilterChange={setDateFilter}
+        onCustomRangeChange={(s, e) => {
+          setCustomStart(s);
+          setCustomEnd(e);
+        }}
+      >
+        {sel.count > 0 && (
+          <span className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={sel.clear}
+              aria-label="Cancel selection"
+              className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
+            </button>
+            <span className="text-[12px] font-medium tabular-nums">{sel.count} selected</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 px-1.5 text-[12px] text-destructive hover:bg-destructive/10 hover:text-destructive"
+              onClick={deleteSelected}
+            >
+              <Trash2 className="h-3.5 w-3.5" aria-hidden />
+              Delete
+            </Button>
+          </span>
+        )}
+        <span className="flex-1" aria-hidden />
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+          onClick={() => toast({ title: "Export coming soon", tone: "success" })}
+        >
+          <Download className="h-3.5 w-3.5" aria-hidden />
+          Download
+        </Button>
+      </SearchFilterBar>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <table className="w-full">
+          <thead className="sticky top-0 bg-background">
+            <tr className="border-b border-border bg-muted/50">
+              <SelectAllHeaderCell
+                checked={sel.allSelected}
+                indeterminate={sel.someSelected}
+                onToggle={sel.toggleAll}
+              />
+              <th className={`${TH} w-[170px]`}>Last updated</th>
+              <th className={TH}>Dataset ID</th>
+              <th className={TH}>Name</th>
+              <th className={`${TH} w-[110px] text-right`}>Test cases</th>
+              <th className={`${TH} w-[110px] text-right`}>Evaluations</th>
+              <th className="w-[56px] px-2 py-1.5 text-right text-[12px] font-medium text-muted-foreground">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <RowMessage>Loading datasets...</RowMessage>
+            ) : error ? (
+              <RowMessage tone="destructive">Error loading datasets</RowMessage>
+            ) : datasets.length === 0 ? (
+              <RowMessage>
+                {keyword
+                  ? "No datasets match your search."
+                  : "No datasets yet — save a trace or span as a test case to start one."}
+              </RowMessage>
+            ) : (
+              datasets.map((dataset) => (
+                <tr
+                  key={dataset.id}
+                  onClick={() => router.push(`/projects/${projectId}/datasets/${dataset.id}`)}
+                  className="cursor-pointer border-b border-border/50 transition-colors last:border-0 hover:bg-muted/50"
+                >
+                  <SelectRowCell
+                    checked={sel.has(dataset.id)}
+                    onToggle={() => sel.toggle(dataset.id)}
+                    label={`Select ${dataset.name}`}
+                  />
+                  <td className={`${TD} whitespace-nowrap text-muted-foreground`}>
+                    <Timestamp iso={dataset.updateTime} />
+                  </td>
+                  <td className={`${TD} font-mono text-[11px] text-muted-foreground`}>
+                    {dataset.id}
+                  </td>
+                  <td className={`${TD} font-medium`}>{dataset.name}</td>
+                  <td className={`${TD} text-right tabular-nums`}>{dataset.caseCount}</td>
+                  <td className={`${TD} text-right tabular-nums text-muted-foreground`}>
+                    {evalCountByDataset.get(dataset.id) || "—"}
+                  </td>
+                  <td className="px-2 text-right">
+                    <DatasetActionsMenu
+                      onEdit={() => setEditing(dataset)}
+                      onDelete={() => deleteOne(dataset)}
+                    />
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <NewDatasetPanel projectId={projectId} open={newOpen} onOpenChange={setNewOpen} />
+      {editing && (
+        <DatasetEditPanel
+          projectId={projectId}
+          dataset={editing}
+          onClose={() => setEditing(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function RowMessage({ children, tone }: { children: React.ReactNode; tone?: "destructive" }) {
+  return (
+    <tr>
+      <td
+        colSpan={7}
+        className={`px-3 py-10 text-center text-[12px] ${
+          tone ? "text-destructive" : "text-muted-foreground"
+        }`}
+      >
+        {children}
+      </td>
+    </tr>
   );
 }

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -1,19 +1,19 @@
 "use client";
 
 import * as React from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { SearchFilterBar } from "@/components/search-filter-bar";
-import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
+import { ListPagination } from "@/components/list-pagination";
+import { useUrlPagination } from "@/lib/hooks/use-url-pagination";
 import { useToast } from "@/components/ui/toast";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { DatasetActionsMenu, Timestamp } from "@/features/offline-eval/components";
 import { useDatasets, useDeleteDataset, useEvaluations } from "../hooks";
 import type { DatasetRow } from "../types";
 import { NewDatasetPanel, DatasetEditPanel } from "../components/dataset-panels";
-
-const DEFAULT_DATE_FILTER =
-  DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0];
+import { DeleteDatasetDialog } from "../components/delete-dataset-dialog";
 
 const TH =
   "h-7 whitespace-nowrap border-r border-border/50 px-3 text-left text-[12px] font-medium text-muted-foreground";
@@ -29,16 +29,18 @@ export function DatasetsView({ projectId }: { projectId: string }) {
   const { toast } = useToast();
 
   const [keyword, setKeyword] = React.useState("");
-  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
-  const [customStart, setCustomStart] = React.useState<Date | null>(null);
-  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
   const [newOpen, setNewOpen] = React.useState(false);
   const [editing, setEditing] = React.useState<DatasetRow | null>(null);
+  const [deleteTarget, setDeleteTarget] = React.useState<DatasetRow | null>(null);
 
-  const { data, isLoading, error } = useDatasets(projectId, {
+  const { page, limit, goToPage, setLimit } = useUrlPagination(50);
+  const { data, isLoading, error, refetch } = useDatasets(projectId, {
     search_query: keyword.trim() || undefined,
+    page,
+    limit,
   });
   const datasets = React.useMemo(() => data?.data ?? [], [data]);
+  const meta = data?.meta;
   const del = useDeleteDataset(projectId);
 
   // Evaluations-per-dataset comes from the lineage list (one row per evaluation
@@ -52,9 +54,14 @@ export function DatasetsView({ projectId }: { projectId: string }) {
     return map;
   }, [evaluationsData]);
 
-  const deleteOne = (dataset: DatasetRow) => {
+  const confirmDelete = () => {
+    if (!deleteTarget) return;
+    const dataset = deleteTarget;
     del.mutate(dataset.id, {
-      onSuccess: () => toast({ title: `Deleted ${dataset.name}`, tone: "success" }),
+      onSuccess: () => {
+        toast({ title: `Deleted ${dataset.name}`, tone: "success" });
+        setDeleteTarget(null);
+      },
       onError: (e) => toast({ title: "Could not delete", description: String(e), tone: "warning" }),
     });
   };
@@ -71,18 +78,13 @@ export function DatasetsView({ projectId }: { projectId: string }) {
         </Button>
       </div>
 
+      {/* No date filter here: the list has no date predicate to apply one to
+          (server-side search only), and a rendered-but-inert filter chip would
+          falsely read as an applied constraint. */}
       <SearchFilterBar
         searchValue={keyword}
         onSearchChange={setKeyword}
         searchPlaceholder="Search datasets..."
-        dateFilter={dateFilter}
-        customStartDate={customStart}
-        customEndDate={customEnd}
-        onDateFilterChange={setDateFilter}
-        onCustomRangeChange={(s, e) => {
-          setCustomStart(s);
-          setCustomEnd(e);
-        }}
       >
         <span className="flex-1" aria-hidden />
       </SearchFilterBar>
@@ -95,6 +97,7 @@ export function DatasetsView({ projectId }: { projectId: string }) {
               <th className={`${TH} w-[240px]`}>Dataset ID</th>
               <th className={TH}>Name</th>
               <th className={`${TH} w-[110px] text-right`}>Test cases</th>
+              <th className={`${TH} w-[90px] text-right`}>Versions</th>
               <th className={`${TH} w-[110px] text-right`}>Evaluations</th>
               <th className="w-[56px] px-2 py-1.5 text-right text-[12px] font-medium text-muted-foreground">
                 Actions
@@ -105,7 +108,16 @@ export function DatasetsView({ projectId }: { projectId: string }) {
             {isLoading ? (
               <RowMessage>Loading datasets...</RowMessage>
             ) : error ? (
-              <RowMessage tone="destructive">Error loading datasets</RowMessage>
+              <RowMessage tone="destructive">
+                Error loading datasets.{" "}
+                <button
+                  type="button"
+                  onClick={() => refetch()}
+                  className="underline underline-offset-2"
+                >
+                  Try again
+                </button>
+              </RowMessage>
             ) : datasets.length === 0 ? (
               <RowMessage>
                 {keyword
@@ -113,38 +125,65 @@ export function DatasetsView({ projectId }: { projectId: string }) {
                   : "No datasets yet — save a trace or span as a test case to start one."}
               </RowMessage>
             ) : (
-              datasets.map((dataset) => (
-                <tr
-                  key={dataset.id}
-                  onClick={() => router.push(`/projects/${projectId}/datasets/${dataset.id}`)}
-                  className="cursor-pointer border-b border-border/50 transition-colors last:border-0 hover:bg-muted/50"
-                >
-                  <td className={`${TD} whitespace-nowrap text-muted-foreground`}>
-                    <Timestamp iso={dataset.updateTime} />
-                  </td>
-                  <td
-                    className={`${TD} max-w-[240px] truncate font-mono text-[11px] text-muted-foreground`}
-                    title={dataset.id}
+              datasets.map((dataset) => {
+                const href = `/projects/${projectId}/datasets/${dataset.id}`;
+                return (
+                  <tr
+                    key={dataset.id}
+                    onClick={() => router.push(href)}
+                    className="cursor-pointer border-b border-border/50 transition-colors last:border-0 hover:bg-muted/50"
                   >
-                    {dataset.id}
-                  </td>
-                  <td className={`${TD} font-medium`}>{dataset.name}</td>
-                  <td className={`${TD} text-right tabular-nums`}>{dataset.caseCount}</td>
-                  <td className={`${TD} text-right tabular-nums text-muted-foreground`}>
-                    {evalCountByDataset.get(dataset.id) || "—"}
-                  </td>
-                  <td className="px-2 text-right">
-                    <DatasetActionsMenu
-                      onEdit={() => setEditing(dataset)}
-                      onDelete={() => deleteOne(dataset)}
-                    />
-                  </td>
-                </tr>
-              ))
+                    <td className={`${TD} whitespace-nowrap text-muted-foreground`}>
+                      <Timestamp iso={dataset.updateTime} />
+                    </td>
+                    <td
+                      className={`${TD} max-w-[240px] truncate font-mono text-[11px] text-muted-foreground`}
+                      title={dataset.id}
+                    >
+                      {dataset.id}
+                    </td>
+                    <td className={`${TD} font-medium`}>
+                      {/* A real link, not just a clickable <tr>: keyboard-reachable,
+                          and middle-click / open-in-new-tab / copy-link all work.
+                          The row's onClick above stays as a mouse convenience. */}
+                      <Link
+                        href={href}
+                        className="rounded outline-none hover:underline focus-visible:ring-1 focus-visible:ring-ring"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {dataset.name}
+                      </Link>
+                    </td>
+                    <td className={`${TD} text-right tabular-nums`}>{dataset.caseCount}</td>
+                    <td className={`${TD} text-right tabular-nums text-muted-foreground`}>
+                      {dataset.versionCount}
+                    </td>
+                    <td className={`${TD} text-right tabular-nums text-muted-foreground`}>
+                      {evalCountByDataset.get(dataset.id) ?? 0}
+                    </td>
+                    <td className="px-2 text-right">
+                      <DatasetActionsMenu
+                        onEdit={() => setEditing(dataset)}
+                        onDelete={() => setDeleteTarget(dataset)}
+                      />
+                    </td>
+                  </tr>
+                );
+              })
             )}
           </tbody>
         </table>
       </div>
+
+      {meta && meta.total > 0 && (
+        <ListPagination
+          page={meta.page}
+          limit={meta.limit}
+          total={meta.total}
+          onPageChange={goToPage}
+          onLimitChange={setLimit}
+        />
+      )}
 
       <NewDatasetPanel projectId={projectId} open={newOpen} onOpenChange={setNewOpen} />
       {editing && (
@@ -152,6 +191,16 @@ export function DatasetsView({ projectId }: { projectId: string }) {
           projectId={projectId}
           dataset={editing}
           onClose={() => setEditing(null)}
+        />
+      )}
+      {deleteTarget && (
+        <DeleteDatasetDialog
+          datasetName={deleteTarget.name}
+          caseCount={deleteTarget.caseCount}
+          isOpen
+          onClose={() => setDeleteTarget(null)}
+          onConfirm={confirmDelete}
+          isDeleting={del.isPending}
         />
       )}
     </div>

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
-import { Download, Trash2, X } from "lucide-react";
+import { Trash2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
@@ -127,15 +127,6 @@ export function DatasetsView({ projectId }: { projectId: string }) {
           </span>
         )}
         <span className="flex-1" aria-hidden />
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-          onClick={() => toast({ title: "Export coming soon", tone: "success" })}
-        >
-          <Download className="h-3.5 w-3.5" aria-hidden />
-          Download
-        </Button>
       </SearchFilterBar>
 
       <div className="min-h-0 flex-1 overflow-auto">

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -139,7 +139,7 @@ export function DatasetsView({ projectId }: { projectId: string }) {
                 onToggle={sel.toggleAll}
               />
               <th className={`${TH} w-[170px]`}>Last updated</th>
-              <th className={TH}>Dataset ID</th>
+              <th className={`${TH} w-[240px]`}>Dataset ID</th>
               <th className={TH}>Name</th>
               <th className={`${TH} w-[110px] text-right`}>Test cases</th>
               <th className={`${TH} w-[110px] text-right`}>Evaluations</th>
@@ -174,7 +174,10 @@ export function DatasetsView({ projectId }: { projectId: string }) {
                   <td className={`${TD} whitespace-nowrap text-muted-foreground`}>
                     <Timestamp iso={dataset.updateTime} />
                   </td>
-                  <td className={`${TD} font-mono text-[11px] text-muted-foreground`}>
+                  <td
+                    className={`${TD} max-w-[240px] truncate font-mono text-[11px] text-muted-foreground`}
+                    title={dataset.id}
+                  >
                     {dataset.id}
                   </td>
                   <td className={`${TD} font-medium`}>{dataset.name}</td>

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -19,7 +19,12 @@ import { useToast } from "@/components/ui/toast";
 import { cn } from "@/lib/utils";
 import { EmptyState, Timestamp } from "@/features/offline-eval/components";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import { changeSentiment, pct, SENTIMENT_CLASS, signed } from "@/features/offline-eval/utils";
+import {
+  changeSentiment,
+  pctFraction,
+  SENTIMENT_CLASS,
+  signedPoints,
+} from "@/features/offline-eval/utils";
 import {
   useDatasets,
   useEvaluationRuns,
@@ -111,7 +116,18 @@ export function EvaluationsView({ projectId }: { projectId: string }) {
 // Runs — the flat execution list.
 // ---------------------------------------------------------------------------
 
-const RUNS_COLUMN_COUNT = 8;
+const RUNS_COLUMN_COUNT = 10;
+
+/** Human elapsed duration; "—" when unknown (never 0). */
+function formatElapsed(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s % 60);
+  return `${m}m ${rem}s`;
+}
 
 function RunsTab({ projectId }: { projectId: string }) {
   const router = useRouter();
@@ -202,8 +218,10 @@ function RunsTab({ projectId }: { projectId: string }) {
               <Th>Dataset</Th>
               <Th className="w-[110px] text-right">Main score</Th>
               <Th className="w-[100px] text-right">Change</Th>
-              <Th className="w-[160px]">Status</Th>
+              <Th className="w-[100px] text-right">Regressions</Th>
+              <Th className="w-[150px]">Status</Th>
               <Th className="w-[80px] text-right">Errors</Th>
+              <Th className="w-[90px] text-right">Duration</Th>
               <Th className="w-[130px] text-right">Started</Th>
             </TRHead>
           </THead>
@@ -245,7 +263,7 @@ function RunsTab({ projectId }: { projectId: string }) {
                       {r.mainScore === null ? (
                         <span className="text-muted-foreground">—</span>
                       ) : (
-                        pct(r.mainScore)
+                        pctFraction(r.mainScore)
                       )}
                     </Td>
                     <Td className="text-right tabular-nums">
@@ -253,8 +271,19 @@ function RunsTab({ projectId }: { projectId: string }) {
                         <span className="text-muted-foreground">—</span>
                       ) : (
                         <span className={SENTIMENT_CLASS[changeSentiment(r.changeFromBaseline)]}>
-                          {signed(r.changeFromBaseline)} pp
+                          {signedPoints(r.changeFromBaseline)} pp
                         </span>
+                      )}
+                    </Td>
+                    <Td className="text-right tabular-nums">
+                      {/* Regressed TEST CASES (not score cells). "—" when there's no
+                          trustworthy baseline to count against. */}
+                      {r.regressedCaseCount === null || r.regressedCaseCount === undefined ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : r.regressedCaseCount === 0 ? (
+                        <span className="text-muted-foreground">0</span>
+                      ) : (
+                        <span className={SENTIMENT_CLASS.bad}>{r.regressedCaseCount}</span>
                       )}
                     </Td>
                     <Td>
@@ -262,6 +291,9 @@ function RunsTab({ projectId }: { projectId: string }) {
                     </Td>
                     <Td className="text-right tabular-nums">
                       {errors === 0 ? <span className="text-muted-foreground">—</span> : errors}
+                    </Td>
+                    <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
+                      {formatElapsed(r.elapsedMs)}
                     </Td>
                     <Td className="whitespace-nowrap text-right text-muted-foreground">
                       <Timestamp iso={r.startedAt} />
@@ -386,7 +418,7 @@ function EvaluationsTab({
                     {suite.latestRun?.mainScore == null ? (
                       <span className="text-muted-foreground">—</span>
                     ) : (
-                      pct(suite.latestRun.mainScore)
+                      pctFraction(suite.latestRun.mainScore)
                     )}
                   </Td>
                   <Td className="whitespace-nowrap text-right text-muted-foreground">

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -2,19 +2,8 @@
 
 import * as React from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import {
-  ChevronDown,
-  ChevronRight,
-  GitCompare,
-  Layers,
-  ListChecks,
-  Ruler,
-  Search,
-  X,
-} from "lucide-react";
+import { ChevronDown, ChevronRight, Layers, ListChecks, Ruler, Search, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -28,27 +17,12 @@ import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
 import { Input } from "@/components/ui/input";
 import { CopyButton } from "@/components/ui/copy-button";
 import { HighlightedCode } from "@/features/offline-eval/components/syntax";
-import { useToast } from "@/components/ui/toast";
 import { cn } from "@/lib/utils";
-import {
-  EmptyState,
-  Timestamp,
-  useRowSelection,
-  SelectAllHeaderCell,
-  SelectRowCell,
-  BulkActionBar,
-} from "@/features/offline-eval/components";
+import { EmptyState, Timestamp } from "@/features/offline-eval/components";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { PassRate } from "../components/pass-rate";
 import { pctFraction, SENTIMENT_CLASS } from "@/features/offline-eval/utils";
-import {
-  useDatasets,
-  useEvaluationRuns,
-  useScorers,
-  useScorer,
-  useDeleteRuns,
-  type ScorerRegistryRow,
-} from "../hooks";
+import { useDatasets, useEvaluationRuns, useScorers, type ScorerRegistryRow } from "../hooks";
 import { EVAL_RUN_STATUS_LABEL, type EvalRunStatus, type RunRow } from "../types";
 
 // Run-centric: the Evaluations page is one table of immutable runs. Scorers is the
@@ -120,7 +94,7 @@ export function EvaluationsView({ projectId }: { projectId: string }) {
 // Runs — the flat execution list.
 // ---------------------------------------------------------------------------
 
-const RUNS_COLUMN_COUNT = 9;
+const RUNS_COLUMN_COUNT = 8;
 
 /** Human elapsed duration; "—" when unknown (never 0). */
 export function formatElapsed(ms: number | null | undefined): string {
@@ -156,30 +130,17 @@ export function formatCost(cost: number | null | undefined): React.ReactNode {
 function RunTableRow({
   run: r,
   projectId,
-  selected,
-  onToggle,
   showEvaluation = true,
   indent = false,
 }: {
   run: RunRow;
   projectId: string;
-  selected: boolean;
-  onToggle: () => void;
   showEvaluation?: boolean;
   indent?: boolean;
 }) {
   const router = useRouter();
   return (
-    <TR
-      interactive
-      selected={selected}
-      onClick={() => router.push(`/projects/${projectId}/evaluations/${r.id}`)}
-    >
-      <SelectRowCell
-        checked={selected}
-        onToggle={onToggle}
-        label={`Select ${r.evaluationName} #${r.runNumber}`}
-      />
+    <TR interactive onClick={() => router.push(`/projects/${projectId}/evaluations/${r.id}`)}>
       <Td className={cn(indent && "pl-6")}>
         {showEvaluation && (
           <button
@@ -312,17 +273,11 @@ function GroupHeaderRow({
   isOpen,
   onToggle,
   projectId,
-  selected,
-  indeterminate,
-  onToggleSelect,
 }: {
   group: RunGroup;
   isOpen: boolean;
   onToggle: () => void;
   projectId: string;
-  selected: boolean;
-  indeterminate: boolean;
-  onToggleSelect: () => void;
 }) {
   const router = useRouter();
   const latest = group.runs[0];
@@ -330,22 +285,6 @@ function GroupHeaderRow({
   const agg = React.useMemo(() => aggregateGroup(group.runs), [group.runs]);
   return (
     <TR className="bg-muted/40 font-medium">
-      {/* Group selection: selects/deselects every run in the lineage at once. */}
-      <td
-        className="w-8 border-r border-border/50 px-3 py-1.5"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <Checkbox
-          checked={selected}
-          indeterminate={indeterminate}
-          onCheckedChange={onToggleSelect}
-          aria-label={
-            selected
-              ? `Deselect all runs in ${group.evaluationName}`
-              : `Select all runs in ${group.evaluationName}`
-          }
-        />
-      </td>
       <Td>
         <div className="flex items-center gap-1.5">
           <button
@@ -463,13 +402,11 @@ function Toggle({
 }
 
 function RunsTab({ projectId }: { projectId: string }) {
-  const router = useRouter();
   const searchParams = useSearchParams();
   // Scoping the list to one evaluation lineage lives in the URL (?evaluation=<id>) so
   // browser back/forward and sharing work.
   const scopedEvalId = searchParams.get("evaluation");
 
-  const { toast } = useToast();
   const [keyword, setKeyword] = React.useState("");
   const [datasetFilter, setDatasetFilter] = React.useState(ALL);
   const [statusFilter, setStatusFilter] = React.useState(ALL);
@@ -501,47 +438,6 @@ function RunsTab({ projectId }: { projectId: string }) {
   );
   const grouped = groupBy && !scopedEvalId;
   const groups = React.useMemo(() => (grouped ? groupRunsByEvaluation(runs) : []), [grouped, runs]);
-
-  const runIds = React.useMemo(() => runs.map((r) => r.id), [runs]);
-  const sel = useRowSelection(runIds);
-  const deleteRuns = useDeleteRuns(projectId);
-  const deleteSelected = () => {
-    const ids = [...sel.selected];
-    if (ids.length === 0) return;
-    if (
-      !window.confirm(
-        `Delete ${ids.length} run${ids.length === 1 ? "" : "s"}? This can't be undone.`,
-      )
-    )
-      return;
-    deleteRuns.mutate(ids, {
-      onSuccess: () => {
-        sel.clear();
-        toast({
-          title: `Deleted ${ids.length} run${ids.length === 1 ? "" : "s"}`,
-          tone: "success",
-        });
-      },
-      onError: () => toast({ title: "Could not delete runs", tone: "warning" }),
-    });
-  };
-
-  // Comparison is an action: select exactly two runs to compare. Newer → candidate,
-  // older → baseline (by start time); the compare page makes roles explicit + swappable.
-  const comparePair = React.useMemo(() => {
-    const chosen = runs.filter((r) => sel.has(r.id));
-    if (chosen.length !== 2) return null;
-    const [newer, older] = [...chosen].sort(
-      (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
-    );
-    return { candidate: newer.id, baseline: older.id };
-  }, [runs, sel]);
-  const openCompare = () => {
-    if (!comparePair) return;
-    router.push(
-      `/projects/${projectId}/evaluations/compare?baseline=${comparePair.baseline}&candidate=${comparePair.candidate}`,
-    );
-  };
 
   const toggleGroup = (id: string) =>
     setExpanded((cur) => {
@@ -615,34 +511,10 @@ function RunsTab({ projectId }: { projectId: string }) {
         <LineageHeader run={allRuns[0]} runCount={allRuns.length} projectId={projectId} />
       )}
 
-      <BulkActionBar
-        count={sel.count}
-        onDelete={deleteSelected}
-        onClear={sel.clear}
-        extra={
-          comparePair && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6 gap-1 px-1.5 text-[12px]"
-              onClick={openCompare}
-            >
-              <GitCompare className="h-3.5 w-3.5" aria-hidden />
-              Compare
-            </Button>
-          )
-        }
-      />
-
       <div className="min-h-0 flex-1 overflow-auto">
         <Table>
           <THead>
             <TRHead>
-              <SelectAllHeaderCell
-                checked={sel.allSelected}
-                indeterminate={sel.someSelected}
-                onToggle={sel.toggleAll}
-              />
               <Th>Evaluation / Run</Th>
               <Th>Dataset</Th>
               <Th className="w-[110px] text-right">Main score</Th>
@@ -671,46 +543,28 @@ function RunsTab({ projectId }: { projectId: string }) {
                 </EmptyState>
               </Cell>
             ) : grouped ? (
-              groups.map((g) => {
-                const groupIds = g.runs.map((r) => r.id);
-                const groupAll = groupIds.every((id) => sel.has(id));
-                const groupSome = !groupAll && groupIds.some((id) => sel.has(id));
-                return (
-                  <React.Fragment key={g.evaluationId}>
-                    <GroupHeaderRow
-                      group={g}
-                      isOpen={expanded.has(g.evaluationId)}
-                      onToggle={() => toggleGroup(g.evaluationId)}
-                      projectId={projectId}
-                      selected={groupAll}
-                      indeterminate={groupSome}
-                      onToggleSelect={() => sel.setMany(groupIds, !groupAll)}
-                    />
-                    {expanded.has(g.evaluationId) &&
-                      g.runs.map((r) => (
-                        <RunTableRow
-                          key={r.id}
-                          run={r}
-                          projectId={projectId}
-                          selected={sel.has(r.id)}
-                          onToggle={() => sel.toggle(r.id)}
-                          showEvaluation={false}
-                          indent
-                        />
-                      ))}
-                  </React.Fragment>
-                );
-              })
-            ) : (
-              runs.map((r) => (
-                <RunTableRow
-                  key={r.id}
-                  run={r}
-                  projectId={projectId}
-                  selected={sel.has(r.id)}
-                  onToggle={() => sel.toggle(r.id)}
-                />
+              groups.map((g) => (
+                <React.Fragment key={g.evaluationId}>
+                  <GroupHeaderRow
+                    group={g}
+                    isOpen={expanded.has(g.evaluationId)}
+                    onToggle={() => toggleGroup(g.evaluationId)}
+                    projectId={projectId}
+                  />
+                  {expanded.has(g.evaluationId) &&
+                    g.runs.map((r) => (
+                      <RunTableRow
+                        key={r.id}
+                        run={r}
+                        projectId={projectId}
+                        showEvaluation={false}
+                        indent
+                      />
+                    ))}
+                </React.Fragment>
               ))
+            ) : (
+              runs.map((r) => <RunTableRow key={r.id} run={r} projectId={projectId} />)
             )}
           </TBody>
         </Table>
@@ -721,7 +575,7 @@ function RunsTab({ projectId }: { projectId: string }) {
 
 // ---------------------------------------------------------------------------
 // Scorers — read-only registry, aggregated from reported runs. Master-detail,
-// echoing the prototype: a table on the left, a detail aside on the right.
+// a table on the left, a detail aside on the right.
 //
 // A scorer's definition — what it measures, its type, scope, and score format —
 // lives in the customer's SDK code and is never reported to the server, so the
@@ -730,8 +584,7 @@ function RunsTab({ projectId }: { projectId: string }) {
 // the source of truth for the rest, rather than fabricating descriptive text.
 // ---------------------------------------------------------------------------
 
-// +1 for the leading selection checkbox column.
-const SCORERS_COLUMN_COUNT = 5;
+const SCORERS_COLUMN_COUNT = 8;
 
 const VALUE_TYPE_LABEL: Record<ScorerRegistryRow["valueType"], string> = {
   numeric: "Numeric",
@@ -741,16 +594,8 @@ const VALUE_TYPE_LABEL: Record<ScorerRegistryRow["valueType"], string> = {
   unknown: "Unknown",
 };
 
-const DIRECTION_LABEL: Record<NonNullable<ScorerRegistryRow["direction"]>, string> = {
-  higher_is_better: "Higher is better",
-  lower_is_better: "Lower is better",
-  none: "No direction",
-};
-
 function ScorersTab({ projectId }: { projectId: string }) {
   const { data, isLoading, error } = useScorers(projectId);
-  // Memoized so the derived id list (and therefore row selection) is stable
-  // across renders rather than churning on a fresh array identity.
   const allScorers = React.useMemo(() => data?.data ?? [], [data]);
   const [keyword, setKeyword] = React.useState("");
   const scorers = React.useMemo(() => {
@@ -766,12 +611,6 @@ function ScorersTab({ projectId }: { projectId: string }) {
   const [openKey, setOpenKey] = React.useState<string | null>(null);
   const active = allScorers.find((s) => `${s.name}@${s.version}` === openKey) ?? null;
 
-  // Checkbox selection, independent of which scorer the panel is showing. The registry
-  // is derived from reported runs, so there is nothing to delete — the bar offers
-  // selection + Clear only.
-  const scorerKeys = React.useMemo(() => scorers.map((s) => `${s.name}@${s.version}`), [scorers]);
-  const sel = useRowSelection(scorerKeys);
-
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="border-b border-border bg-background px-3 py-1.5">
@@ -785,20 +624,18 @@ function ScorersTab({ projectId }: { projectId: string }) {
           />
         </div>
       </div>
-      <BulkActionBar count={sel.count} onClear={sel.clear} />
       <div className="min-h-0 flex-1 overflow-auto">
         <Table>
           <THead>
             <TRHead>
-              <SelectAllHeaderCell
-                checked={sel.allSelected}
-                indeterminate={sel.someSelected}
-                onToggle={sel.toggleAll}
-              />
               <Th>Scorer</Th>
               <Th className="w-[110px]">Output</Th>
-              <Th className="w-[120px] text-right">Scores</Th>
-              <Th className="w-[120px] text-right">Error rate</Th>
+              <Th className="w-[100px] text-right">Evaluations</Th>
+              <Th className="w-[80px] text-right">Runs</Th>
+              <Th className="w-[90px] text-right">Scores</Th>
+              <Th className="w-[90px] text-right">Pass rate</Th>
+              <Th className="w-[100px] text-right">Error rate</Th>
+              <Th className="w-[140px] text-right">Last used</Th>
             </TRHead>
           </THead>
           <TBody>
@@ -831,11 +668,6 @@ function ScorersTab({ projectId }: { projectId: string }) {
                     selected={key === openKey}
                     onClick={() => setOpenKey(key)}
                   >
-                    <SelectRowCell
-                      checked={sel.has(key)}
-                      onToggle={() => sel.toggle(key)}
-                      label={`Select ${s.name} ${s.version}`}
-                    />
                     <Td>
                       <span className="flex items-baseline gap-1.5">
                         <span className="font-medium">{s.name}</span>
@@ -848,7 +680,18 @@ function ScorersTab({ projectId }: { projectId: string }) {
                       <Badge variant="outline">{VALUE_TYPE_LABEL[s.valueType]}</Badge>
                     </Td>
                     <Td className="text-right tabular-nums text-muted-foreground">
-                      {s.scoreCount}
+                      {s.evaluationCount}
+                    </Td>
+                    <Td className="text-right tabular-nums text-muted-foreground">{s.runCount}</Td>
+                    <Td className="text-right tabular-nums text-muted-foreground">
+                      {s.scoreCount.toLocaleString("en-US")}
+                    </Td>
+                    <Td className="text-right tabular-nums">
+                      {s.passRate === null ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : (
+                        `${(s.passRate * 100).toFixed(1)}%`
+                      )}
                     </Td>
                     <Td className="text-right tabular-nums">
                       {s.errorRate === 0 ? (
@@ -857,6 +700,13 @@ function ScorersTab({ projectId }: { projectId: string }) {
                         <span className={SENTIMENT_CLASS.bad}>
                           {(s.errorRate * 100).toFixed(1)}%
                         </span>
+                      )}
+                    </Td>
+                    <Td className="whitespace-nowrap text-right text-muted-foreground">
+                      {s.lastUsed ? (
+                        <Timestamp iso={s.lastUsed} />
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
                       )}
                     </Td>
                   </TR>
@@ -870,7 +720,6 @@ function ScorersTab({ projectId }: { projectId: string }) {
       {active && (
         <ScorerDetailPanel
           key={`${active.name}@${active.version}`}
-          projectId={projectId}
           scorer={active}
           onClose={() => setOpenKey(null)}
         />
@@ -885,10 +734,6 @@ function fmtScorerVersion(v: string): string {
   return /^\d/.test(v) ? `v${v}` : v;
 }
 
-const OUTPUT_TYPE_LABEL: Record<"score" | "classification", string> = {
-  score: "Score",
-  classification: "Classification",
-};
 const LANGUAGE_LABEL: Record<"python" | "typescript", string> = {
   python: "Python",
   typescript: "TypeScript",
@@ -911,18 +756,6 @@ function definitionTypeLabel(
 ): string | null {
   if (kind === "llm_judge") return "LLM judge";
   if (kind === "code") return s.language ? LANGUAGE_LABEL[s.language] : "Code";
-  return null;
-}
-
-/** Output type (Score / Classification): the SDK's declared value wins; otherwise it's
- *  inferred from the declared/observed value type, and flagged as inferred. */
-function outputTypeOf(s: ScorerRegistryRow): { text: string; inferred: boolean } | null {
-  if (s.outputType) return { text: OUTPUT_TYPE_LABEL[s.outputType], inferred: false };
-  const vt =
-    s.declaredValueType ??
-    (s.valueType !== "unknown" && s.valueType !== "mixed" ? s.valueType : null);
-  if (vt === "categorical") return { text: "Classification", inferred: true };
-  if (vt === "numeric" || vt === "boolean") return { text: "Score", inferred: true };
   return null;
 }
 
@@ -952,16 +785,6 @@ function ScorerCard({
   );
 }
 
-/** A labelled fact row inside a card. */
-function ScorerFact({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="flex items-start justify-between gap-6 py-0.5">
-      <dt className="shrink-0 text-[11px] text-muted-foreground">{label}</dt>
-      <dd className="min-w-0 text-right text-[12px]">{children}</dd>
-    </div>
-  );
-}
-
 /**
  * Read-only scorer detail — a bigger, detector-style subpage (mirrors DetectorPanel's
  * 70%-width right slide-in with bordered cards). It does NOT dim/blur the page behind it
@@ -970,11 +793,9 @@ function ScorerFact({ label, children }: { label: string; children: React.ReactN
  * anything unreported reads "Not provided by SDK", never invented from the name.
  */
 export function ScorerDetailPanel({
-  projectId,
   scorer,
   onClose,
 }: {
-  projectId: string;
   scorer: ScorerRegistryRow;
   onClose: () => void;
 }) {
@@ -1027,43 +848,46 @@ export function ScorerDetailPanel({
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto text-[12px]">
-        <ScorerDetail projectId={projectId} scorer={scorer} kind={kind} />
+        <ScorerDetail scorer={scorer} kind={kind} />
       </div>
     </div>
   );
 }
 
 function ScorerDetail({
-  projectId,
   scorer,
   kind,
 }: {
-  projectId: string;
   scorer: ScorerRegistryRow;
   kind: "llm_judge" | "code" | null;
 }) {
-  const maxCount = scorer.distribution?.reduce((m, d) => Math.max(m, d.count), 0) ?? 0;
-  const family = useScorer(projectId, scorer.name);
-  const versions = family.data?.versions ?? [];
-  const ot = outputTypeOf(scorer);
-  const metadataText =
-    scorer.metadata != null &&
-    (typeof scorer.metadata !== "object" || Object.keys(scorer.metadata).length > 0)
-      ? JSON.stringify(scorer.metadata, null, 2)
-      : null;
-
-  const typeLabel = definitionTypeLabel(scorer, kind);
   return (
     <div className="flex flex-col gap-3 p-4">
-      {/* Definition — leads with the exact type: LLM judge, Python, or TypeScript. */}
-      <div className="flex items-baseline gap-2">
-        <h3 className="text-[13px] font-semibold">Definition</h3>
-        <span className="text-[13px] font-medium text-muted-foreground">{typeLabel ?? "—"}</span>
-      </div>
-      {/* Type-specific body */}
+      {/* Name */}
+      <ScorerCard title="Name">
+        <div className="flex items-baseline gap-2">
+          <span className="text-[13px] font-medium text-foreground">{scorer.name}</span>
+          <span className="text-[11px] text-muted-foreground">
+            {fmtScorerVersion(scorer.version)}
+          </span>
+        </div>
+      </ScorerCard>
+
+      {/* Model — LLM judge only (a code scorer runs no model). */}
+      {kind === "llm_judge" && (
+        <ScorerCard title="Model">
+          {scorer.model ? (
+            <span className="font-mono text-[12px]">{scorer.model}</span>
+          ) : (
+            <NotProvided />
+          )}
+        </ScorerCard>
+      )}
+
+      {/* Prompt (LLM judge) or code snippet (code scorer). */}
       {kind === "code" ? (
         <ScorerCard
-          title="Source"
+          title="Code"
           action={
             scorer.sourceCode ? (
               <CopyButton
@@ -1084,19 +908,8 @@ function ScorerDetail({
             <NotProvided />
           )}
         </ScorerCard>
-      ) : kind === "llm_judge" ? (
-        // One "Prompt" card: the model sits in the header; messages are role-labelled
-        // rows separated by dividers (no card-in-card nesting).
-        <ScorerCard
-          title="Prompt"
-          action={
-            scorer.model ? (
-              <span className="font-mono text-[11px] text-muted-foreground">{scorer.model}</span>
-            ) : (
-              <span className="text-[11px] text-muted-foreground">— no model</span>
-            )
-          }
-        >
+      ) : (
+        <ScorerCard title="Prompt">
           {scorer.messages && scorer.messages.length > 0 ? (
             <div className="divide-y divide-border">
               {scorer.messages.map((m, i) => (
@@ -1114,171 +927,14 @@ function ScorerDetail({
             <NotProvided />
           )}
         </ScorerCard>
-      ) : (
-        <ScorerCard title="Definition">
-          <p className="text-[11px] leading-relaxed text-muted-foreground">
-            The SDK hasn&apos;t reported this scorer&apos;s definition — an LLM judge&apos;s model
-            &amp; messages, or a code scorer&apos;s snippet.
-          </p>
-        </ScorerCard>
       )}
 
-      {/* Shared configuration */}
-      <ScorerCard title="Configuration">
-        <dl>
-          <ScorerFact label="Output type">
-            {ot ? (
-              <>
-                {ot.text}
-                {ot.inferred && (
-                  <span className="ml-1 text-[11px] text-muted-foreground">(inferred)</span>
-                )}
-              </>
-            ) : (
-              <NotProvided />
-            )}
-          </ScorerFact>
-          <ScorerFact label="Pass threshold">
-            {scorer.threshold !== null ? (
-              <span className="tabular-nums">{scorer.threshold}</span>
-            ) : (
-              <NotProvided />
-            )}
-          </ScorerFact>
-          <ScorerFact label="Direction">
-            {scorer.direction ? DIRECTION_LABEL[scorer.direction] : <NotProvided />}
-          </ScorerFact>
-          <ScorerFact label="Description">
-            {scorer.description ? scorer.description : <NotProvided />}
-          </ScorerFact>
-        </dl>
-      </ScorerCard>
-
-      {/* Metadata */}
-      <ScorerCard title="Metadata">
-        {metadataText ? (
-          <HighlightedCode
-            code={metadataText}
-            className="max-h-[30vh] overflow-auto whitespace-pre font-mono text-[11px] leading-relaxed"
-          />
+      {/* Pass threshold — the read-only analogue of the detector's Sampling. */}
+      <ScorerCard title="Pass threshold">
+        {scorer.threshold !== null ? (
+          <span className="text-[12px] tabular-nums">{scorer.threshold}</span>
         ) : (
           <NotProvided />
-        )}
-      </ScorerCard>
-
-      {/* Observed usage — honest stats derived from reported scores. */}
-      <ScorerCard title="Observed usage">
-        <dl>
-          <ScorerFact label="Evaluations">
-            <span className="tabular-nums">{scorer.evaluationCount}</span>
-          </ScorerFact>
-          <ScorerFact label="Runs">
-            <span className="tabular-nums">{scorer.runCount}</span>
-          </ScorerFact>
-          <ScorerFact label="Scored results">
-            <span className="tabular-nums">{scorer.scoreCount.toLocaleString("en-US")}</span>
-          </ScorerFact>
-          {scorer.numeric && (
-            <>
-              <ScorerFact label="Mean">
-                <span className="tabular-nums">{scorer.numeric.mean.toFixed(3)}</span>
-              </ScorerFact>
-              <ScorerFact label="Range">
-                <span className="tabular-nums">
-                  {scorer.numeric.min.toFixed(2)} – {scorer.numeric.max.toFixed(2)}
-                </span>
-              </ScorerFact>
-            </>
-          )}
-          {scorer.passRate !== null && (
-            <ScorerFact label="Pass rate">
-              <span className="tabular-nums">{(scorer.passRate * 100).toFixed(1)}%</span>
-            </ScorerFact>
-          )}
-          <ScorerFact label="Error rate">
-            {scorer.errorCount === 0 ? (
-              <span className="tabular-nums text-muted-foreground">0%</span>
-            ) : (
-              <span className={cn("tabular-nums", SENTIMENT_CLASS.bad)}>
-                {(scorer.errorRate * 100).toFixed(1)}% ({scorer.errorCount} of {scorer.scoreCount})
-              </span>
-            )}
-          </ScorerFact>
-          <ScorerFact label="Last used">
-            {scorer.lastUsed ? (
-              <Timestamp iso={scorer.lastUsed} className="inline" />
-            ) : (
-              <span className="text-muted-foreground">—</span>
-            )}
-          </ScorerFact>
-        </dl>
-
-        {scorer.distribution && scorer.distribution.length > 0 && (
-          <div className="mt-3">
-            <div className="mb-1 text-[11px] text-muted-foreground">Score distribution</div>
-            <ul className="flex flex-col gap-1.5">
-              {scorer.distribution.map((d) => (
-                <li key={d.label} className="flex items-center gap-2 text-[11px]">
-                  <span className="w-24 shrink-0 truncate" title={d.label}>
-                    {d.label}
-                  </span>
-                  <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
-                    <span
-                      className="block h-full rounded-full bg-foreground/70"
-                      style={{ width: `${maxCount > 0 ? (d.count / maxCount) * 100 : 0}%` }}
-                    />
-                  </span>
-                  <span className="w-10 shrink-0 text-right tabular-nums text-muted-foreground">
-                    {d.count}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        {scorer.recentErrors.length > 0 && (
-          <div className="mt-3">
-            <div className="mb-1 text-[11px] text-muted-foreground">Recent scorer errors</div>
-            <ul className="flex flex-col gap-1.5">
-              {scorer.recentErrors.map((e, i) => (
-                <li
-                  key={i}
-                  className="rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 font-mono text-[11px] leading-relaxed text-amber-700 dark:text-amber-300"
-                >
-                  {e.message}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        {versions.length > 1 && (
-          <div className="mt-3">
-            <div className="mb-1 text-[11px] text-muted-foreground">Version history</div>
-            <ul className="flex flex-col gap-0.5">
-              {versions.map((v) => (
-                <li
-                  key={v.version}
-                  className={cn(
-                    "flex items-center justify-between gap-2 rounded px-1.5 py-0.5 text-[11px]",
-                    v.version === scorer.version && "bg-muted/60",
-                  )}
-                >
-                  <span className="flex items-center gap-1.5">
-                    <span className="font-medium">{fmtScorerVersion(v.version)}</span>
-                    {v.version === scorer.version && (
-                      <span className="text-[10px] text-muted-foreground">viewing</span>
-                    )}
-                  </span>
-                  <span className="tabular-nums text-muted-foreground">
-                    {v.scoreCount} scored{v.lastUsed ? " · " : ""}
-                    {v.lastUsed && <Timestamp iso={v.lastUsed} className="inline" />}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
         )}
       </ScorerCard>
     </div>

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -2,10 +2,9 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
-import { FlaskConical, ListChecks } from "lucide-react";
+import { Download, FlaskConical, ListChecks, Ruler } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -13,19 +12,30 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
-import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
-import { ProjectBreadcrumb } from "@/features/projects/components";
-import { Timestamp } from "@/features/offline-eval/components";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
+import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
+import { useToast } from "@/components/ui/toast";
 import { cn } from "@/lib/utils";
-import { useDatasets, useEvaluationRuns, useEvaluations } from "../hooks";
+import { EmptyState, Timestamp } from "@/features/offline-eval/components";
+import { changeSentiment, pct, SENTIMENT_CLASS, signed } from "@/features/offline-eval/utils";
+import {
+  useDatasets,
+  useEvaluationRuns,
+  useEvaluations,
+  useScorers,
+  type ScorerRegistryRow,
+} from "../hooks";
 import { EVAL_RUN_STATUS_LABEL, type EvalRunStatus } from "../types";
+import { RunEvaluationDrawer } from "../components/run-evaluation-drawer";
+
+type Tab = "runs" | "evaluations" | "scorers";
+
+const TABS: Array<{ id: Tab; label: string; icon: typeof ListChecks }> = [
+  { id: "runs", label: "Runs", icon: ListChecks },
+  { id: "evaluations", label: "Evaluations", icon: FlaskConical },
+  { id: "scorers", label: "Scorers", icon: Ruler },
+];
 
 const STATUS_VARIANT: Record<EvalRunStatus, "success" | "danger" | "warning" | "default"> = {
   running: "default",
@@ -40,63 +50,76 @@ export function RunStatusBadge({ status }: { status: EvalRunStatus }) {
 }
 
 const ALL = "__all__";
-type Tab = "runs" | "evaluations";
 
-/** Real, server-backed Evaluations page: runs (executions) + grouped lineages. */
 export function EvaluationsView({ projectId }: { projectId: string }) {
+  const router = useRouter();
   const [tab, setTab] = React.useState<Tab>("runs");
   const [runOpen, setRunOpen] = React.useState(false);
 
   return (
-    <>
-      <ProjectBreadcrumb projectId={projectId} current="Evaluations" />
-      <div className="flex flex-1 flex-col overflow-hidden text-[13px]">
-        <div className="flex items-center justify-between border-b border-border bg-background pr-3">
-          <div className="flex">
-            {(
-              [
-                { id: "runs", label: "Runs", icon: ListChecks },
-                { id: "evaluations", label: "Evaluations", icon: FlaskConical },
-              ] as const
-            ).map((t) => {
-              const Icon = t.icon;
-              const active = t.id === tab;
-              return (
-                <button
-                  key={t.id}
-                  type="button"
-                  onClick={() => setTab(t.id)}
-                  className={cn(
-                    "flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors",
-                    active
-                      ? "border-foreground bg-muted text-foreground"
-                      : "border-transparent text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  <Icon className="h-3.5 w-3.5" />
-                  {t.label}
-                </button>
-              );
-            })}
-          </div>
+    <div className="flex h-full flex-col text-[12px]">
+      {/* Tab bar — same shape as the Traces page's Traces/Users/Sessions bar. */}
+      <div className="flex items-center justify-between border-b border-border bg-background pr-3">
+        <div className="flex">
+          {TABS.map((t) => {
+            const Icon = t.icon;
+            const active = t.id === tab;
+            return (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setTab(t.id)}
+                className={cn(
+                  "flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors",
+                  active
+                    ? "border-foreground bg-muted text-foreground"
+                    : "border-transparent text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {t.label}
+              </button>
+            );
+          })}
+        </div>
+        {tab !== "scorers" && (
           <Button size="sm" className="h-7 text-[12px]" onClick={() => setRunOpen(true)}>
             Run evaluation
           </Button>
-        </div>
-
-        {tab === "runs" ? <RunsTab projectId={projectId} /> : <LineagesTab projectId={projectId} />}
+        )}
       </div>
 
-      <RunEvaluationDialog open={runOpen} onOpenChange={setRunOpen} />
-    </>
+      {tab === "runs" && <RunsTab projectId={projectId} />}
+      {tab === "evaluations" && (
+        <EvaluationsTab
+          projectId={projectId}
+          onOpenRun={(runId) => router.push(`/projects/${projectId}/evaluations/${runId}`)}
+        />
+      )}
+      {tab === "scorers" && <ScorersTab projectId={projectId} />}
+
+      <RunEvaluationDrawer projectId={projectId} open={runOpen} onOpenChange={setRunOpen} />
+    </div>
   );
 }
 
+// ---------------------------------------------------------------------------
+// Runs — the flat execution list.
+// ---------------------------------------------------------------------------
+
+const RUNS_COLUMN_COUNT = 8;
+
 function RunsTab({ projectId }: { projectId: string }) {
   const router = useRouter();
+  const { toast } = useToast();
   const [keyword, setKeyword] = React.useState("");
   const [datasetFilter, setDatasetFilter] = React.useState(ALL);
   const [statusFilter, setStatusFilter] = React.useState(ALL);
+  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
+    DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0],
+  );
+  const [customStart, setCustomStart] = React.useState<Date | null>(null);
+  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
 
   const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
   const { data, isLoading, error } = useEvaluationRuns(projectId, {
@@ -105,18 +128,25 @@ function RunsTab({ projectId }: { projectId: string }) {
     status: statusFilter === ALL ? undefined : statusFilter,
   });
   const runs = data?.data ?? [];
+  const filtered = keyword || datasetFilter !== ALL || statusFilter !== ALL;
 
   return (
     <>
-      <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2">
-        <Input
-          value={keyword}
-          onChange={(e) => setKeyword(e.target.value)}
-          placeholder="Search runs..."
-          className="h-7 max-w-xs text-[12px]"
-        />
+      <SearchFilterBar
+        searchValue={keyword}
+        onSearchChange={setKeyword}
+        searchPlaceholder="Search runs..."
+        dateFilter={dateFilter}
+        customStartDate={customStart}
+        customEndDate={customEnd}
+        onDateFilterChange={setDateFilter}
+        onCustomRangeChange={(s, e) => {
+          setCustomStart(s);
+          setCustomEnd(e);
+        }}
+      >
         <Select value={datasetFilter} onValueChange={setDatasetFilter}>
-          <SelectTrigger className="h-7 w-[170px] text-[12px]">
+          <SelectTrigger className="h-7 w-[160px] text-[12px]">
             <SelectValue placeholder="Dataset" />
           </SelectTrigger>
           <SelectContent>
@@ -130,8 +160,9 @@ function RunsTab({ projectId }: { projectId: string }) {
             ))}
           </SelectContent>
         </Select>
+
         <Select value={statusFilter} onValueChange={setStatusFilter}>
-          <SelectTrigger className="h-7 w-[180px] text-[12px]">
+          <SelectTrigger className="h-7 w-[170px] text-[12px]">
             <SelectValue placeholder="Status" />
           </SelectTrigger>
           <SelectContent>
@@ -145,178 +176,369 @@ function RunsTab({ projectId }: { projectId: string }) {
             ))}
           </SelectContent>
         </Select>
-      </div>
+
+        <span className="flex-1" aria-hidden />
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+          onClick={() => toast({ title: "Export coming soon", tone: "success" })}
+        >
+          <Download className="h-3.5 w-3.5" aria-hidden />
+          Download
+        </Button>
+      </SearchFilterBar>
 
       <div className="min-h-0 flex-1 overflow-auto">
-        {isLoading ? (
-          <Centered>Loading runs...</Centered>
-        ) : error ? (
-          <Centered tone="destructive">Error loading runs</Centered>
-        ) : runs.length === 0 ? (
-          <Centered>
-            No evaluation runs yet. Runs appear here once your application or CI reports them via
-            the SDK.
-          </Centered>
-        ) : (
-          <Table>
-            <THead>
-              <TRHead>
-                <Th>Name</Th>
-                <Th className="w-[150px]">Candidate version</Th>
-                <Th>Dataset</Th>
-                <Th className="w-[110px] text-right">Main score</Th>
-                <Th className="w-[100px] text-right">Change</Th>
-                <Th className="w-[170px]">Status</Th>
-                <Th className="w-[80px] text-right">Errors</Th>
-                <Th className="w-[150px] text-right">Started</Th>
-              </TRHead>
-            </THead>
-            <TBody>
-              {runs.map((r) => (
-                <TR
-                  key={r.id}
-                  interactive
-                  onClick={() => router.push(`/projects/${projectId}/evaluations/${r.id}`)}
-                >
-                  <Td className="font-medium">
-                    {r.evaluationName}
-                    <span className="ml-1.5 font-normal text-muted-foreground">#{r.runNumber}</span>
-                  </Td>
-                  <Td className="font-mono text-[11px]">{r.candidateVersion}</Td>
-                  <Td className="text-muted-foreground">{r.datasetName ?? "—"}</Td>
-                  <Td className="text-right tabular-nums">
-                    {r.mainScore === null ? (
-                      <span className="text-muted-foreground">—</span>
-                    ) : (
-                      `${r.mainScore.toFixed(1)}%`
-                    )}
-                  </Td>
-                  <Td className="text-right tabular-nums">
-                    {r.changeFromBaseline === null ? (
-                      <span className="text-muted-foreground">—</span>
-                    ) : (
-                      <span
-                        className={r.changeFromBaseline >= 0 ? "text-emerald-600" : "text-red-600"}
-                      >
-                        {r.changeFromBaseline >= 0 ? "+" : ""}
-                        {r.changeFromBaseline.toFixed(1)} pp
+        <Table>
+          <THead>
+            <TRHead>
+              <Th>Name</Th>
+              <Th className="w-[140px]">Candidate version</Th>
+              <Th>Dataset</Th>
+              <Th className="w-[110px] text-right">Main score</Th>
+              <Th className="w-[100px] text-right">Change</Th>
+              <Th className="w-[160px]">Status</Th>
+              <Th className="w-[80px] text-right">Errors</Th>
+              <Th className="w-[130px] text-right">Started</Th>
+            </TRHead>
+          </THead>
+          <TBody>
+            {isLoading ? (
+              <Cell colSpan={RUNS_COLUMN_COUNT}>
+                <EmptyState>Loading runs...</EmptyState>
+              </Cell>
+            ) : error ? (
+              <Cell colSpan={RUNS_COLUMN_COUNT}>
+                <EmptyState>Error loading runs</EmptyState>
+              </Cell>
+            ) : runs.length === 0 ? (
+              <Cell colSpan={RUNS_COLUMN_COUNT}>
+                <EmptyState>
+                  {filtered
+                    ? "No runs match these filters."
+                    : "No evaluation runs yet. Use Run evaluation for the SDK snippet."}
+                </EmptyState>
+              </Cell>
+            ) : (
+              runs.map((r) => {
+                const errors = r.errorCount;
+                return (
+                  <TR
+                    key={r.id}
+                    interactive
+                    onClick={() => router.push(`/projects/${projectId}/evaluations/${r.id}`)}
+                  >
+                    <Td className="font-medium">
+                      {r.evaluationName}
+                      <span className="ml-1.5 font-normal text-muted-foreground">
+                        #{r.runNumber}
                       </span>
-                    )}
-                  </Td>
-                  <Td>
-                    <RunStatusBadge status={r.status} />
-                  </Td>
-                  <Td className="text-right tabular-nums">
-                    {r.errorCount === 0 ? (
-                      <span className="text-muted-foreground">—</span>
-                    ) : (
-                      r.errorCount
-                    )}
-                  </Td>
-                  <Td className="whitespace-nowrap text-right text-muted-foreground">
-                    <Timestamp iso={r.startedAt} />
-                  </Td>
-                </TR>
-              ))}
-            </TBody>
-          </Table>
-        )}
+                    </Td>
+                    <Td className="font-mono text-[11px]">{r.candidateVersion}</Td>
+                    <Td className="text-muted-foreground">{r.datasetName}</Td>
+                    <Td className="text-right tabular-nums">
+                      {r.mainScore === null ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : (
+                        pct(r.mainScore)
+                      )}
+                    </Td>
+                    <Td className="text-right tabular-nums">
+                      {r.changeFromBaseline === null ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : (
+                        <span className={SENTIMENT_CLASS[changeSentiment(r.changeFromBaseline)]}>
+                          {signed(r.changeFromBaseline)} pp
+                        </span>
+                      )}
+                    </Td>
+                    <Td>
+                      <RunStatusBadge status={r.status} />
+                    </Td>
+                    <Td className="text-right tabular-nums">
+                      {errors === 0 ? <span className="text-muted-foreground">—</span> : errors}
+                    </Td>
+                    <Td className="whitespace-nowrap text-right text-muted-foreground">
+                      <Timestamp iso={r.startedAt} />
+                    </Td>
+                  </TR>
+                );
+              })
+            )}
+          </TBody>
+        </Table>
       </div>
     </>
   );
 }
 
-function LineagesTab({ projectId }: { projectId: string }) {
-  const router = useRouter();
+// ---------------------------------------------------------------------------
+// Evaluations — one row per purpose (lineage), from the server.
+// ---------------------------------------------------------------------------
+
+const SUITES_COLUMN_COUNT = 6;
+
+function EvaluationsTab({
+  projectId,
+  onOpenRun,
+}: {
+  projectId: string;
+  onOpenRun: (runId: string) => void;
+}) {
+  const { toast } = useToast();
+  const [keyword, setKeyword] = React.useState("");
+  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
+    DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0],
+  );
+  const [customStart, setCustomStart] = React.useState<Date | null>(null);
+  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
+
   const { data, isLoading, error } = useEvaluations(projectId);
-  const evals = data?.data ?? [];
+  const suites = React.useMemo(() => {
+    const all = data?.data ?? [];
+    const q = keyword.trim().toLowerCase();
+    if (!q) return all;
+    return all.filter(
+      (s) => s.name.toLowerCase().includes(q) || (s.datasetName ?? "").toLowerCase().includes(q),
+    );
+  }, [data, keyword]);
 
   return (
-    <div className="min-h-0 flex-1 overflow-auto">
-      {isLoading ? (
-        <Centered>Loading evaluations...</Centered>
-      ) : error ? (
-        <Centered tone="destructive">Error loading evaluations</Centered>
-      ) : evals.length === 0 ? (
-        <Centered>No evaluations yet.</Centered>
-      ) : (
+    <>
+      <SearchFilterBar
+        searchValue={keyword}
+        onSearchChange={setKeyword}
+        searchPlaceholder="Search evaluations..."
+        dateFilter={dateFilter}
+        customStartDate={customStart}
+        customEndDate={customEnd}
+        onDateFilterChange={setDateFilter}
+        onCustomRangeChange={(s, e) => {
+          setCustomStart(s);
+          setCustomEnd(e);
+        }}
+      >
+        <span className="flex-1" aria-hidden />
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+          onClick={() => toast({ title: "Export coming soon", tone: "success" })}
+        >
+          <Download className="h-3.5 w-3.5" aria-hidden />
+          Download
+        </Button>
+      </SearchFilterBar>
+
+      <div className="min-h-0 flex-1 overflow-auto">
         <Table>
           <THead>
             <TRHead>
               <Th>Evaluation</Th>
               <Th>Dataset</Th>
-              <Th className="w-[80px] text-right">Runs</Th>
+              <Th className="w-[90px] text-right">Runs</Th>
               <Th className="w-[150px]">Latest candidate</Th>
-              <Th className="w-[120px] text-right">Latest score</Th>
-              <Th className="w-[150px] text-right">Last run</Th>
+              <Th className="w-[130px] text-right">Latest score</Th>
+              <Th className="w-[130px] text-right">Last run</Th>
             </TRHead>
           </THead>
           <TBody>
-            {evals.map((e) => (
-              <TR
-                key={e.id}
-                interactive={!!e.latestRun}
-                onClick={() =>
-                  e.latestRun && router.push(`/projects/${projectId}/evaluations/${e.latestRun.id}`)
-                }
-              >
-                <Td className="font-medium">{e.name}</Td>
-                <Td className="text-muted-foreground">{e.datasetName ?? "—"}</Td>
-                <Td className="text-right tabular-nums text-muted-foreground">{e.runCount}</Td>
-                <Td className="font-mono text-[11px]">{e.latestRun?.candidateVersion ?? "—"}</Td>
-                <Td className="text-right tabular-nums">
-                  {e.latestRun?.mainScore == null ? (
-                    <span className="text-muted-foreground">—</span>
-                  ) : (
-                    `${e.latestRun.mainScore.toFixed(1)}%`
-                  )}
-                </Td>
-                <Td className="whitespace-nowrap text-right text-muted-foreground">
-                  {e.latestRun ? <Timestamp iso={e.latestRun.startedAt} /> : "—"}
-                </Td>
-              </TR>
-            ))}
+            {isLoading ? (
+              <Cell colSpan={SUITES_COLUMN_COUNT}>
+                <EmptyState>Loading evaluations...</EmptyState>
+              </Cell>
+            ) : error ? (
+              <Cell colSpan={SUITES_COLUMN_COUNT}>
+                <EmptyState>Error loading evaluations</EmptyState>
+              </Cell>
+            ) : suites.length === 0 ? (
+              <Cell colSpan={SUITES_COLUMN_COUNT}>
+                <EmptyState>
+                  {keyword ? "No evaluations match your search." : "No evaluations yet."}
+                </EmptyState>
+              </Cell>
+            ) : (
+              suites.map((suite) => (
+                <TR
+                  key={suite.id}
+                  interactive
+                  onClick={() => suite.latestRun && onOpenRun(suite.latestRun.id)}
+                >
+                  <Td className="font-medium">
+                    {suite.name}
+                    <span className="ml-1.5 font-mono text-[11px] font-normal text-muted-foreground">
+                      {suite.id}
+                    </span>
+                  </Td>
+                  <Td className="text-muted-foreground">{suite.datasetName ?? "—"}</Td>
+                  <Td className="text-right tabular-nums text-muted-foreground">
+                    {suite.runCount}
+                  </Td>
+                  <Td className="font-mono text-[11px]">
+                    {suite.latestRun?.candidateVersion ?? "—"}
+                  </Td>
+                  <Td className="text-right tabular-nums">
+                    {suite.latestRun?.mainScore == null ? (
+                      <span className="text-muted-foreground">—</span>
+                    ) : (
+                      pct(suite.latestRun.mainScore)
+                    )}
+                  </Td>
+                  <Td className="whitespace-nowrap text-right text-muted-foreground">
+                    {suite.latestRun ? <Timestamp iso={suite.latestRun.startedAt} /> : "—"}
+                  </Td>
+                </TR>
+              ))
+            )}
           </TBody>
         </Table>
-      )}
+      </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scorers — read-only registry, aggregated from reported runs. Master-detail,
+// echoing the prototype: a table on the left, a detail aside on the right.
+//
+// A scorer's definition — what it measures, its type, scope, and score format —
+// lives in the customer's SDK code and is never reported to the server, so the
+// server-backed registry carries only the aggregates it can see (name, version,
+// score count, error rate). The detail aside surfaces those and names the SDK as
+// the source of truth for the rest, rather than fabricating descriptive text.
+// ---------------------------------------------------------------------------
+
+const SCORERS_COLUMN_COUNT = 3;
+
+function ScorersTab({ projectId }: { projectId: string }) {
+  const { data, isLoading, error } = useScorers(projectId);
+  const scorers = data?.data ?? [];
+  const [selectedKey, setSelectedKey] = React.useState<string | null>(null);
+  const selected =
+    scorers.find((s) => `${s.name}@${s.version}` === selectedKey) ?? scorers[0] ?? null;
+
+  return (
+    <div className="flex min-h-0 flex-1">
+      <div className="min-w-0 flex-1 overflow-auto">
+        <Table>
+          <THead>
+            <TRHead>
+              <Th>Scorer</Th>
+              <Th className="w-[120px] text-right">Scores</Th>
+              <Th className="w-[120px] text-right">Error rate</Th>
+            </TRHead>
+          </THead>
+          <TBody>
+            {isLoading ? (
+              <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                <EmptyState>Loading scorers...</EmptyState>
+              </Cell>
+            ) : error ? (
+              <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                <EmptyState>Error loading scorers</EmptyState>
+              </Cell>
+            ) : scorers.length === 0 ? (
+              <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                <EmptyState>
+                  No scorers yet. Scorers are defined in your SDK code and appear here once a run
+                  reports them.
+                </EmptyState>
+              </Cell>
+            ) : (
+              scorers.map((s) => {
+                const key = `${s.name}@${s.version}`;
+                return (
+                  <TR
+                    key={key}
+                    interactive
+                    selected={key === `${selected?.name}@${selected?.version}`}
+                    onClick={() => setSelectedKey(key)}
+                  >
+                    <Td>
+                      <span className="flex items-baseline gap-1.5">
+                        <span className="font-medium">{s.name}</span>
+                        <span className="text-[11px] text-muted-foreground">{s.version}</span>
+                      </span>
+                    </Td>
+                    <Td className="text-right tabular-nums text-muted-foreground">
+                      {s.scoreCount}
+                    </Td>
+                    <Td className="text-right tabular-nums text-muted-foreground">
+                      {s.errorRate === 0 ? "—" : `${(s.errorRate * 100).toFixed(1)}%`}
+                    </Td>
+                  </TR>
+                );
+              })
+            )}
+          </TBody>
+        </Table>
+      </div>
+
+      <aside
+        aria-label="Scorer detail"
+        className="w-[360px] shrink-0 overflow-auto border-l border-border"
+      >
+        {selected ? (
+          <ScorerDetail key={`${selected.name}@${selected.version}`} scorer={selected} />
+        ) : (
+          <EmptyState>Select a scorer to see what it reports.</EmptyState>
+        )}
+      </aside>
     </div>
   );
 }
 
-function Centered({ children, tone }: { children: React.ReactNode; tone?: "destructive" }) {
+function ScorerSection({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="flex h-64 items-center justify-center px-6 text-center">
-      <p className={cn("text-[13px]", tone ? "text-destructive" : "text-muted-foreground")}>
-        {children}
-      </p>
-    </div>
+    <section className="border-t border-border px-3 py-2.5">
+      <h3 className="text-[11px] font-medium text-muted-foreground">{title}</h3>
+      <div className="mt-1.5">{children}</div>
+    </section>
   );
 }
 
-function RunEvaluationDialog({
-  open,
-  onOpenChange,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) {
+function ScorerDetail({ scorer }: { scorer: ScorerRegistryRow }) {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[480px]">
-        <DialogHeader>
-          <DialogTitle className="text-[13px] font-medium">Run evaluation</DialogTitle>
-        </DialogHeader>
+    <div className="flex flex-col">
+      <div className="px-3 py-2.5">
+        <div className="flex items-baseline gap-1.5">
+          <h2 className="text-[13px] font-medium">{scorer.name}</h2>
+          <span className="text-[11px] text-muted-foreground">{scorer.version}</span>
+        </div>
+      </div>
+
+      <ScorerSection title="Definition">
         <p className="text-[12px] leading-relaxed text-muted-foreground">
-          Evaluations run in your application or CI environment using the TraceRoot SDK, and report
-          their results back here. Nothing runs from the browser. Starter code will be shown here
-          once the evaluation SDK is available.
+          This scorer is defined in your SDK code. What it measures, its type, scope, and score
+          format live with the code and are not reported to TraceRoot — only the scores it produces
+          are.
         </p>
-        <DialogFooter>
-          <Button size="sm" className="h-7 text-[12px]" onClick={() => onOpenChange(false)}>
-            Done
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      </ScorerSection>
+
+      <ScorerSection title="Scores reported">
+        <p className="text-[12px] tabular-nums text-muted-foreground">
+          {scorer.scoreCount.toLocaleString("en-US")}
+        </p>
+      </ScorerSection>
+
+      <ScorerSection title="Error rate">
+        <p className="text-[12px] text-muted-foreground">
+          {scorer.errorCount === 0
+            ? "No failures in the runs reported so far."
+            : `${(scorer.errorRate * 100).toFixed(1)}% of results could not be judged (${scorer.errorCount.toLocaleString(
+                "en-US",
+              )} of ${scorer.scoreCount.toLocaleString("en-US")}).`}
+        </p>
+      </ScorerSection>
+    </div>
+  );
+}
+
+function Cell({ colSpan, children }: { colSpan: number; children: React.ReactNode }) {
+  return (
+    <tr>
+      <td colSpan={colSpan}>{children}</td>
+    </tr>
   );
 }

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -2,8 +2,20 @@
 
 import * as React from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ChevronDown, ChevronRight, Layers, ListChecks, Ruler, Search, X } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronDown,
+  ChevronRight,
+  Layers,
+  ListChecks,
+  Ruler,
+  Search,
+  X,
+} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ModelSelector } from "@/features/ai-assistant/components/model-selector";
 import {
   Select,
   SelectContent,
@@ -18,7 +30,7 @@ import { Input } from "@/components/ui/input";
 import { CopyButton } from "@/components/ui/copy-button";
 import { HighlightedCode } from "@/features/offline-eval/components/syntax";
 import { cn } from "@/lib/utils";
-import { EmptyState, Timestamp } from "@/features/offline-eval/components";
+import { EmptyState, Timestamp, LineNumberedTextarea } from "@/features/offline-eval/components";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { PassRate } from "../components/pass-rate";
 import { pctFraction, SENTIMENT_CLASS } from "@/features/offline-eval/utils";
@@ -610,6 +622,15 @@ function ScorersTab({ projectId }: { projectId: string }) {
   // than a persistent split-pane.
   const [openKey, setOpenKey] = React.useState<string | null>(null);
   const active = allScorers.find((s) => `${s.name}@${s.version}` === openKey) ?? null;
+  const activeIndex = scorers.findIndex((s) => `${s.name}@${s.version}` === openKey);
+  const navigateScorer = (dir: "up" | "down") => {
+    if (activeIndex === -1) return;
+    const next = dir === "up" ? activeIndex - 1 : activeIndex + 1;
+    if (next >= 0 && next < scorers.length) {
+      const s = scorers[next];
+      setOpenKey(`${s.name}@${s.version}`);
+    }
+  };
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -694,12 +715,12 @@ function ScorersTab({ projectId }: { projectId: string }) {
                       )}
                     </Td>
                     <Td className="text-right tabular-nums">
-                      {s.errorRate === 0 ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : (
+                      {s.errorRate > 0 ? (
                         <span className={SENTIMENT_CLASS.bad}>
                           {(s.errorRate * 100).toFixed(1)}%
                         </span>
+                      ) : (
+                        <span className="text-muted-foreground">0%</span>
                       )}
                     </Td>
                     <Td className="whitespace-nowrap text-right text-muted-foreground">
@@ -722,6 +743,9 @@ function ScorersTab({ projectId }: { projectId: string }) {
           key={`${active.name}@${active.version}`}
           scorer={active}
           onClose={() => setOpenKey(null)}
+          onNavigate={navigateScorer}
+          canNavigateUp={activeIndex > 0}
+          canNavigateDown={activeIndex !== -1 && activeIndex < scorers.length - 1}
         />
       )}
     </div>
@@ -795,9 +819,15 @@ function ScorerCard({
 export function ScorerDetailPanel({
   scorer,
   onClose,
+  onNavigate,
+  canNavigateUp,
+  canNavigateDown,
 }: {
   scorer: ScorerRegistryRow;
   onClose: () => void;
+  onNavigate?: (dir: "up" | "down") => void;
+  canNavigateUp?: boolean;
+  canNavigateDown?: boolean;
 }) {
   React.useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -837,14 +867,41 @@ export function ScorerDetailPanel({
             title="Copy scorer id"
           />
         </div>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close"
-          className="rounded-sm text-muted-foreground hover:text-foreground"
-        >
-          <X className="h-4 w-4" />
-        </button>
+        <div className="flex items-center gap-1">
+          {onNavigate && (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onNavigate("up")}
+                disabled={!canNavigateUp}
+                className="h-7 w-7 p-0"
+                title="Previous scorer"
+              >
+                <ArrowUp className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onNavigate("down")}
+                disabled={!canNavigateDown}
+                className="h-7 w-7 p-0"
+                title="Next scorer"
+              >
+                <ArrowDown className="h-4 w-4" />
+              </Button>
+            </>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            aria-label="Close"
+            className="h-7 w-7 p-0"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto text-[12px]">
@@ -861,26 +918,24 @@ function ScorerDetail({
   scorer: ScorerRegistryRow;
   kind: "llm_judge" | "code" | null;
 }) {
+  const systemPrompt = scorer.messages?.find((m) => m.role === "system")?.content ?? null;
   return (
     <div className="flex flex-col gap-3 p-4">
-      {/* Name */}
+      {/* Name — read-only, in the detector's editable-field chrome. */}
       <ScorerCard title="Name">
-        <div className="flex items-baseline gap-2">
-          <span className="text-[13px] font-medium text-foreground">{scorer.name}</span>
-          <span className="text-[11px] text-muted-foreground">
-            {fmtScorerVersion(scorer.version)}
-          </span>
-        </div>
+        <Input value={scorer.name} readOnly className="h-7 text-[13px]" />
       </ScorerCard>
 
-      {/* Model — LLM judge only (a code scorer runs no model). */}
+      {/* Model — the detector's model dropdown, rendered read-only (the wrapper
+          blocks pointer + focus, so it shows the model but never opens). */}
       {kind === "llm_judge" && (
         <ScorerCard title="Model">
-          {scorer.model ? (
-            <span className="font-mono text-[12px]">{scorer.model}</span>
-          ) : (
-            <NotProvided />
-          )}
+          <div className="pointer-events-none [&_*]:pointer-events-none">
+            <ModelSelector
+              value={{ model: scorer.model ?? "", provider: "", source: "system", adapter: "" }}
+              onChange={() => {}}
+            />
+          </div>
         </ScorerCard>
       )}
 
@@ -910,29 +965,38 @@ function ScorerDetail({
         </ScorerCard>
       ) : (
         <ScorerCard title="Prompt">
-          {scorer.messages && scorer.messages.length > 0 ? (
-            <div className="divide-y divide-border">
-              {scorer.messages.map((m, i) => (
-                <div key={i} className="py-2 first:pt-0 last:pb-0">
-                  <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                    {m.role}
-                  </div>
-                  <pre className="max-h-[30vh] overflow-auto whitespace-pre-wrap font-mono text-[11px] leading-relaxed">
-                    {m.content}
-                  </pre>
-                </div>
-              ))}
-            </div>
+          {systemPrompt ? (
+            <LineNumberedTextarea
+              value={systemPrompt}
+              onChange={() => {}}
+              readOnly
+              aria-label="System prompt"
+            />
           ) : (
             <NotProvided />
           )}
         </ScorerCard>
       )}
 
-      {/* Pass threshold — the read-only analogue of the detector's Sampling. */}
+      {/* Pass threshold — read-only draggable bar, mirroring the detector's Sampling. */}
       <ScorerCard title="Pass threshold">
         {scorer.threshold !== null ? (
-          <span className="text-[12px] tabular-nums">{scorer.threshold}</span>
+          <div className="flex items-center gap-3">
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={Math.min(1, Math.max(0, scorer.threshold))}
+              readOnly
+              tabIndex={-1}
+              aria-label="Pass threshold"
+              className="pointer-events-none flex-1 accent-foreground"
+            />
+            <span className="w-12 shrink-0 text-right text-[13px] tabular-nums text-muted-foreground">
+              {scorer.threshold}
+            </span>
+          </div>
         ) : (
           <NotProvided />
         )}

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -17,7 +17,14 @@ import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
 import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
 import { useToast } from "@/components/ui/toast";
 import { cn } from "@/lib/utils";
-import { EmptyState, Timestamp } from "@/features/offline-eval/components";
+import {
+  EmptyState,
+  Timestamp,
+  useRowSelection,
+  SelectAllHeaderCell,
+  SelectRowCell,
+  BulkActionBar,
+} from "@/features/offline-eval/components";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import {
   changeSentiment,
@@ -30,6 +37,7 @@ import {
   useEvaluationRuns,
   useEvaluations,
   useScorers,
+  useDeleteRuns,
   type ScorerRegistryRow,
 } from "../hooks";
 import { EVAL_RUN_STATUS_LABEL, type EvalRunStatus } from "../types";
@@ -116,7 +124,7 @@ export function EvaluationsView({ projectId }: { projectId: string }) {
 // Runs — the flat execution list.
 // ---------------------------------------------------------------------------
 
-const RUNS_COLUMN_COUNT = 10;
+const RUNS_COLUMN_COUNT = 11;
 
 /** Human elapsed duration; "—" when unknown (never 0). */
 function formatElapsed(ms: number | null | undefined): string {
@@ -147,8 +155,33 @@ function RunsTab({ projectId }: { projectId: string }) {
     dataset_id: datasetFilter === ALL ? undefined : datasetFilter,
     status: statusFilter === ALL ? undefined : statusFilter,
   });
-  const runs = data?.data ?? [];
+  const runs = React.useMemo(() => data?.data ?? [], [data]);
   const filtered = keyword || datasetFilter !== ALL || statusFilter !== ALL;
+
+  // Row selection + bulk delete, matching the dataset cases table.
+  const runIds = React.useMemo(() => runs.map((r) => r.id), [runs]);
+  const sel = useRowSelection(runIds);
+  const deleteRuns = useDeleteRuns(projectId);
+  const deleteSelected = () => {
+    const ids = [...sel.selected];
+    if (ids.length === 0) return;
+    if (
+      !window.confirm(
+        `Delete ${ids.length} run${ids.length === 1 ? "" : "s"}? This can't be undone.`,
+      )
+    )
+      return;
+    deleteRuns.mutate(ids, {
+      onSuccess: () => {
+        sel.clear();
+        toast({
+          title: `Deleted ${ids.length} run${ids.length === 1 ? "" : "s"}`,
+          tone: "success",
+        });
+      },
+      onError: () => toast({ title: "Could not delete runs", tone: "warning" }),
+    });
+  };
 
   return (
     <>
@@ -209,10 +242,17 @@ function RunsTab({ projectId }: { projectId: string }) {
         </Button>
       </SearchFilterBar>
 
+      <BulkActionBar count={sel.count} onDelete={deleteSelected} onClear={sel.clear} />
+
       <div className="min-h-0 flex-1 overflow-auto">
         <Table>
           <THead>
             <TRHead>
+              <SelectAllHeaderCell
+                checked={sel.allSelected}
+                indeterminate={sel.someSelected}
+                onToggle={sel.toggleAll}
+              />
               <Th>Name</Th>
               <Th className="w-[140px]">Candidate version</Th>
               <Th>Dataset</Th>
@@ -249,8 +289,14 @@ function RunsTab({ projectId }: { projectId: string }) {
                   <TR
                     key={r.id}
                     interactive
+                    selected={sel.has(r.id)}
                     onClick={() => router.push(`/projects/${projectId}/evaluations/${r.id}`)}
                   >
+                    <SelectRowCell
+                      checked={sel.has(r.id)}
+                      onToggle={() => sel.toggle(r.id)}
+                      label={`Select ${r.evaluationName} #${r.runNumber}`}
+                    />
                     <Td className="font-medium">
                       {r.evaluationName}
                       <span className="ml-1.5 font-normal text-muted-foreground">
@@ -313,7 +359,8 @@ function RunsTab({ projectId }: { projectId: string }) {
 // Evaluations — one row per purpose (lineage), from the server.
 // ---------------------------------------------------------------------------
 
-const SUITES_COLUMN_COUNT = 6;
+// +1 for the leading selection checkbox column.
+const SUITES_COLUMN_COUNT = 7;
 
 function EvaluationsTab({
   projectId,
@@ -339,6 +386,11 @@ function EvaluationsTab({
       (s) => s.name.toLowerCase().includes(q) || (s.datasetName ?? "").toLowerCase().includes(q),
     );
   }, [data, keyword]);
+
+  // Row selection, matching the Runs tab. There is no delete API for an evaluation
+  // lineage, so the bar offers selection + Clear without a Delete action.
+  const suiteIds = React.useMemo(() => suites.map((s) => s.id), [suites]);
+  const sel = useRowSelection(suiteIds);
 
   return (
     <>
@@ -367,10 +419,17 @@ function EvaluationsTab({
         </Button>
       </SearchFilterBar>
 
+      <BulkActionBar count={sel.count} onClear={sel.clear} />
+
       <div className="min-h-0 flex-1 overflow-auto">
         <Table>
           <THead>
             <TRHead>
+              <SelectAllHeaderCell
+                checked={sel.allSelected}
+                indeterminate={sel.someSelected}
+                onToggle={sel.toggleAll}
+              />
               <Th>Evaluation</Th>
               <Th>Dataset</Th>
               <Th className="w-[90px] text-right">Runs</Th>
@@ -399,8 +458,14 @@ function EvaluationsTab({
                 <TR
                   key={suite.id}
                   interactive
+                  selected={sel.has(suite.id)}
                   onClick={() => suite.latestRun && onOpenRun(suite.latestRun.id)}
                 >
+                  <SelectRowCell
+                    checked={sel.has(suite.id)}
+                    onToggle={() => sel.toggle(suite.id)}
+                    label={`Select ${suite.name}`}
+                  />
                   <Td className="font-medium">
                     {suite.name}
                     <span className="ml-1.5 font-mono text-[11px] font-normal text-muted-foreground">
@@ -445,70 +510,117 @@ function EvaluationsTab({
 // the source of truth for the rest, rather than fabricating descriptive text.
 // ---------------------------------------------------------------------------
 
-const SCORERS_COLUMN_COUNT = 3;
+// +1 for the leading selection checkbox column.
+const SCORERS_COLUMN_COUNT = 5;
+
+const VALUE_TYPE_LABEL: Record<ScorerRegistryRow["valueType"], string> = {
+  numeric: "Numeric",
+  boolean: "Boolean",
+  categorical: "Categorical",
+  mixed: "Mixed",
+  unknown: "Unknown",
+};
+
+const DIRECTION_LABEL: Record<NonNullable<ScorerRegistryRow["direction"]>, string> = {
+  higher_is_better: "Higher is better",
+  lower_is_better: "Lower is better",
+  none: "No direction",
+};
 
 function ScorersTab({ projectId }: { projectId: string }) {
   const { data, isLoading, error } = useScorers(projectId);
-  const scorers = data?.data ?? [];
+  // Memoized so the derived id list (and therefore row selection) is stable
+  // across renders rather than churning on a fresh array identity.
+  const scorers = React.useMemo(() => data?.data ?? [], [data]);
   const [selectedKey, setSelectedKey] = React.useState<string | null>(null);
   const selected =
     scorers.find((s) => `${s.name}@${s.version}` === selectedKey) ?? scorers[0] ?? null;
 
+  // Checkbox selection, independent of which scorer the detail aside is showing.
+  // The registry is derived from reported runs, so there is nothing to delete —
+  // the bar offers selection + Clear only.
+  const scorerKeys = React.useMemo(() => scorers.map((s) => `${s.name}@${s.version}`), [scorers]);
+  const sel = useRowSelection(scorerKeys);
+
   return (
     <div className="flex min-h-0 flex-1">
-      <div className="min-w-0 flex-1 overflow-auto">
-        <Table>
-          <THead>
-            <TRHead>
-              <Th>Scorer</Th>
-              <Th className="w-[120px] text-right">Scores</Th>
-              <Th className="w-[120px] text-right">Error rate</Th>
-            </TRHead>
-          </THead>
-          <TBody>
-            {isLoading ? (
-              <Cell colSpan={SCORERS_COLUMN_COUNT}>
-                <EmptyState>Loading scorers...</EmptyState>
-              </Cell>
-            ) : error ? (
-              <Cell colSpan={SCORERS_COLUMN_COUNT}>
-                <EmptyState>Error loading scorers</EmptyState>
-              </Cell>
-            ) : scorers.length === 0 ? (
-              <Cell colSpan={SCORERS_COLUMN_COUNT}>
-                <EmptyState>
-                  No scorers yet. Scorers are defined in your SDK code and appear here once a run
-                  reports them.
-                </EmptyState>
-              </Cell>
-            ) : (
-              scorers.map((s) => {
-                const key = `${s.name}@${s.version}`;
-                return (
-                  <TR
-                    key={key}
-                    interactive
-                    selected={key === `${selected?.name}@${selected?.version}`}
-                    onClick={() => setSelectedKey(key)}
-                  >
-                    <Td>
-                      <span className="flex items-baseline gap-1.5">
-                        <span className="font-medium">{s.name}</span>
-                        <span className="text-[11px] text-muted-foreground">{s.version}</span>
-                      </span>
-                    </Td>
-                    <Td className="text-right tabular-nums text-muted-foreground">
-                      {s.scoreCount}
-                    </Td>
-                    <Td className="text-right tabular-nums text-muted-foreground">
-                      {s.errorRate === 0 ? "—" : `${(s.errorRate * 100).toFixed(1)}%`}
-                    </Td>
-                  </TR>
-                );
-              })
-            )}
-          </TBody>
-        </Table>
+      {/* Left column: the selection bar stays pinned above the scrolling table. */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <BulkActionBar count={sel.count} onClear={sel.clear} />
+        <div className="min-h-0 flex-1 overflow-auto">
+          <Table>
+            <THead>
+              <TRHead>
+                <SelectAllHeaderCell
+                  checked={sel.allSelected}
+                  indeterminate={sel.someSelected}
+                  onToggle={sel.toggleAll}
+                />
+                <Th>Scorer</Th>
+                <Th className="w-[110px]">Type</Th>
+                <Th className="w-[120px] text-right">Scores</Th>
+                <Th className="w-[120px] text-right">Error rate</Th>
+              </TRHead>
+            </THead>
+            <TBody>
+              {isLoading ? (
+                <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                  <EmptyState>Loading scorers...</EmptyState>
+                </Cell>
+              ) : error ? (
+                <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                  <EmptyState>Error loading scorers</EmptyState>
+                </Cell>
+              ) : scorers.length === 0 ? (
+                <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                  <EmptyState>
+                    No scorers yet. Scorers are defined in your SDK code and appear here once a run
+                    reports them.
+                  </EmptyState>
+                </Cell>
+              ) : (
+                scorers.map((s) => {
+                  const key = `${s.name}@${s.version}`;
+                  return (
+                    <TR
+                      key={key}
+                      interactive
+                      selected={key === `${selected?.name}@${selected?.version}`}
+                      onClick={() => setSelectedKey(key)}
+                    >
+                      <SelectRowCell
+                        checked={sel.has(key)}
+                        onToggle={() => sel.toggle(key)}
+                        label={`Select ${s.name} ${s.version}`}
+                      />
+                      <Td>
+                        <span className="flex items-baseline gap-1.5">
+                          <span className="font-medium">{s.name}</span>
+                          <span className="text-[11px] text-muted-foreground">{s.version}</span>
+                        </span>
+                      </Td>
+                      <Td>
+                        <Badge variant="outline">{VALUE_TYPE_LABEL[s.valueType]}</Badge>
+                      </Td>
+                      <Td className="text-right tabular-nums text-muted-foreground">
+                        {s.scoreCount}
+                      </Td>
+                      <Td className="text-right tabular-nums">
+                        {s.errorRate === 0 ? (
+                          <span className="text-muted-foreground">—</span>
+                        ) : (
+                          <span className={SENTIMENT_CLASS.bad}>
+                            {(s.errorRate * 100).toFixed(1)}%
+                          </span>
+                        )}
+                      </Td>
+                    </TR>
+                  );
+                })
+              )}
+            </TBody>
+          </Table>
+        </div>
       </div>
 
       <aside
@@ -534,38 +646,140 @@ function ScorerSection({ title, children }: { title: string; children: React.Rea
   );
 }
 
+/** A labelled scalar for the config/stats rows. */
+function ScorerFact({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-0.5">
+      <dt className="text-[11px] text-muted-foreground">{label}</dt>
+      <dd className="text-[12px] tabular-nums">{children}</dd>
+    </div>
+  );
+}
+
+/**
+ * Scorer detail — everything TraceRoot has OBSERVED about a scorer (the SDK owns
+ * its definition): value type + declared config, the score distribution, pass and
+ * error rates with recent failures, and where it's used. All derived from the
+ * scores it has reported.
+ */
 function ScorerDetail({ scorer }: { scorer: ScorerRegistryRow }) {
+  const maxCount = scorer.distribution?.reduce((m, d) => Math.max(m, d.count), 0) ?? 0;
+
   return (
     <div className="flex flex-col">
       <div className="px-3 py-2.5">
-        <div className="flex items-baseline gap-1.5">
+        <div className="flex flex-wrap items-baseline gap-1.5">
           <h2 className="text-[13px] font-medium">{scorer.name}</h2>
           <span className="text-[11px] text-muted-foreground">{scorer.version}</span>
+          <Badge variant="outline" className="ml-auto">
+            {VALUE_TYPE_LABEL[scorer.valueType]}
+          </Badge>
         </div>
       </div>
 
-      <ScorerSection title="Definition">
-        <p className="text-[12px] leading-relaxed text-muted-foreground">
-          This scorer is defined in your SDK code. What it measures, its type, scope, and score
-          format live with the code and are not reported to TraceRoot — only the scores it produces
-          are.
-        </p>
+      <ScorerSection title="Config">
+        <dl>
+          <ScorerFact label="Value type">
+            {VALUE_TYPE_LABEL[scorer.declaredValueType ?? scorer.valueType]}
+            {scorer.declaredValueType === null && (
+              <span className="ml-1 text-[11px] text-muted-foreground">(inferred)</span>
+            )}
+          </ScorerFact>
+          <ScorerFact label="Direction">
+            {scorer.direction ? (
+              DIRECTION_LABEL[scorer.direction]
+            ) : (
+              <span className="text-muted-foreground">Not declared</span>
+            )}
+          </ScorerFact>
+          <ScorerFact label="Threshold">
+            {scorer.threshold !== null ? (
+              scorer.threshold
+            ) : (
+              <span className="text-muted-foreground">—</span>
+            )}
+          </ScorerFact>
+        </dl>
       </ScorerSection>
 
-      <ScorerSection title="Scores reported">
-        <p className="text-[12px] tabular-nums text-muted-foreground">
-          {scorer.scoreCount.toLocaleString("en-US")}
-        </p>
+      <ScorerSection title="Scores">
+        <dl>
+          <ScorerFact label="Reported">{scorer.scoreCount.toLocaleString("en-US")}</ScorerFact>
+          {scorer.numeric && (
+            <>
+              <ScorerFact label="Mean">{scorer.numeric.mean.toFixed(3)}</ScorerFact>
+              <ScorerFact label="Range">
+                {scorer.numeric.min.toFixed(2)} – {scorer.numeric.max.toFixed(2)}
+              </ScorerFact>
+            </>
+          )}
+          {scorer.passRate !== null && (
+            <ScorerFact label="Pass rate">{(scorer.passRate * 100).toFixed(1)}%</ScorerFact>
+          )}
+        </dl>
       </ScorerSection>
 
-      <ScorerSection title="Error rate">
-        <p className="text-[12px] text-muted-foreground">
-          {scorer.errorCount === 0
-            ? "No failures in the runs reported so far."
-            : `${(scorer.errorRate * 100).toFixed(1)}% of results could not be judged (${scorer.errorCount.toLocaleString(
-                "en-US",
-              )} of ${scorer.scoreCount.toLocaleString("en-US")}).`}
-        </p>
+      {scorer.distribution && scorer.distribution.length > 0 && (
+        <ScorerSection title="Distribution">
+          <ul className="flex flex-col gap-1.5">
+            {scorer.distribution.map((d) => (
+              <li key={d.label} className="flex items-center gap-2 text-[11px]">
+                <span className="w-20 shrink-0 truncate" title={d.label}>
+                  {d.label}
+                </span>
+                <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+                  <span
+                    className="block h-full rounded-full bg-foreground/70"
+                    style={{ width: `${maxCount > 0 ? (d.count / maxCount) * 100 : 0}%` }}
+                  />
+                </span>
+                <span className="w-10 shrink-0 text-right tabular-nums text-muted-foreground">
+                  {d.count}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </ScorerSection>
+      )}
+
+      <ScorerSection title="Reliability">
+        <dl>
+          <ScorerFact label="Error rate">
+            {scorer.errorCount === 0 ? (
+              <span className="text-muted-foreground">0%</span>
+            ) : (
+              <span className={SENTIMENT_CLASS.bad}>
+                {(scorer.errorRate * 100).toFixed(1)}% ({scorer.errorCount} of {scorer.scoreCount})
+              </span>
+            )}
+          </ScorerFact>
+        </dl>
+        {scorer.recentErrors.length > 0 && (
+          <ul className="mt-2 flex flex-col gap-1.5">
+            {scorer.recentErrors.map((e, i) => (
+              <li
+                key={i}
+                className="rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 font-mono text-[11px] leading-relaxed text-amber-700 dark:text-amber-300"
+              >
+                {e.message}
+              </li>
+            ))}
+          </ul>
+        )}
+      </ScorerSection>
+
+      <ScorerSection title="Usage">
+        <dl>
+          <ScorerFact label="Evaluations">{scorer.evaluationCount}</ScorerFact>
+          <ScorerFact label="Runs">{scorer.runCount}</ScorerFact>
+          <ScorerFact label="Last used">
+            {scorer.lastUsed ? (
+              <Timestamp iso={scorer.lastUsed} className="inline" />
+            ) : (
+              <span className="text-muted-foreground">—</span>
+            )}
+          </ScorerFact>
+        </dl>
       </ScorerSection>
     </div>
   );

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -1075,7 +1075,7 @@ function ScorerDetail({
       {/* Definition — leads with the exact type: LLM judge, Python, or TypeScript. */}
       <div className="flex items-baseline gap-2">
         <h3 className="text-[13px] font-semibold">Definition</h3>
-        <span className="text-[13px] font-medium text-foreground">{typeLabel ?? "—"}</span>
+        <span className="text-[13px] font-medium text-muted-foreground">{typeLabel ?? "—"}</span>
       </div>
       {/* Type-specific body */}
       {kind === "code" ? (

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -120,10 +120,10 @@ export function EvaluationsView({ projectId }: { projectId: string }) {
 // Runs — the flat execution list.
 // ---------------------------------------------------------------------------
 
-const RUNS_COLUMN_COUNT = 10;
+const RUNS_COLUMN_COUNT = 9;
 
 /** Human elapsed duration; "—" when unknown (never 0). */
-function formatElapsed(ms: number | null | undefined): string {
+export function formatElapsed(ms: number | null | undefined): string {
   if (ms === null || ms === undefined) return "—";
   if (ms < 1000) return `${ms}ms`;
   const s = ms / 1000;
@@ -133,7 +133,7 @@ function formatElapsed(ms: number | null | undefined): string {
   return `${m}m ${rem}s`;
 }
 
-function ScoreValue({ value }: { value: number | null }) {
+export function ScoreValue({ value }: { value: number | null }) {
   return value === null ? (
     <span className="text-muted-foreground">—</span>
   ) : (
@@ -142,7 +142,7 @@ function ScoreValue({ value }: { value: number | null }) {
 }
 
 /** Total run cost; "—" when no case reported a cost (never a misleading $0). */
-function formatCost(cost: number | null | undefined): React.ReactNode {
+export function formatCost(cost: number | null | undefined): React.ReactNode {
   if (cost === null || cost === undefined) return <span className="text-muted-foreground">—</span>;
   return `$${cost < 1 ? cost.toFixed(4) : cost.toFixed(2)}`;
 }
@@ -209,14 +209,11 @@ function RunTableRow({
         <PassRate counts={r} />
       </Td>
       <Td className="text-right tabular-nums text-muted-foreground">{formatCost(r.cost)}</Td>
-      <Td>
-        <RunStatusBadge status={r.status} />
-      </Td>
-      <Td className="text-right tabular-nums">
-        {r.errorCount === 0 ? <span className="text-muted-foreground">—</span> : r.errorCount}
-      </Td>
       <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
         {formatElapsed(r.elapsedMs)}
+      </Td>
+      <Td>
+        <RunStatusBadge status={r.status} />
       </Td>
       <Td className="whitespace-nowrap text-right text-muted-foreground">
         <Timestamp iso={r.startedAt} />
@@ -264,13 +261,12 @@ function groupRunsByEvaluation(runs: RunRow[]): RunGroup[] {
 }
 
 /** Per-lineage aggregate across a group's runs — pooled where a total is meaningful
- *  (passed, cost, errors, duration) and averaged for the score. */
+ *  (passed, cost, duration) and averaged for the score. */
 function aggregateGroup(runs: RunRow[]) {
   let passedCount = 0,
     failedCount = 0,
     erroredCount = 0,
     notScoredCount = 0,
-    errors = 0,
     durationMs = 0,
     hasDuration = false,
     scoreSum = 0,
@@ -282,7 +278,6 @@ function aggregateGroup(runs: RunRow[]) {
     failedCount += r.failedCount ?? 0;
     erroredCount += r.erroredCount ?? 0;
     notScoredCount += r.notScoredCount ?? 0;
-    errors += r.errorCount ?? 0;
     if (r.elapsedMs != null) {
       durationMs += r.elapsedMs;
       hasDuration = true;
@@ -298,7 +293,6 @@ function aggregateGroup(runs: RunRow[]) {
   }
   return {
     counts: { passedCount, failedCount, erroredCount, notScoredCount },
-    errors,
     durationMs: hasDuration ? durationMs : null,
     avgScore: scoreN > 0 ? scoreSum / scoreN : null,
     cost: hasCost ? cost : null,
@@ -395,23 +389,13 @@ function GroupHeaderRow({
         {formatCost(agg.cost)}
         {agg.cost !== null && <AggCaption>total</AggCaption>}
       </Td>
-      <Td>
-        <RunStatusBadge status={latest.status} />
-        <AggCaption>latest</AggCaption>
-      </Td>
-      <Td className="text-right tabular-nums">
-        {agg.errors === 0 ? (
-          <span className="text-muted-foreground">—</span>
-        ) : (
-          <>
-            {agg.errors}
-            <AggCaption>total</AggCaption>
-          </>
-        )}
-      </Td>
       <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
         {formatElapsed(agg.durationMs)}
         {agg.durationMs !== null && <AggCaption>total</AggCaption>}
+      </Td>
+      <Td>
+        <RunStatusBadge status={latest.status} />
+        <AggCaption>latest</AggCaption>
       </Td>
       <Td className="whitespace-nowrap text-right font-normal text-muted-foreground">
         <Timestamp iso={latest.startedAt} />
@@ -664,10 +648,9 @@ function RunsTab({ projectId }: { projectId: string }) {
               <Th className="w-[110px] text-right">Main score</Th>
               <Th className="w-[100px] text-right">Passed</Th>
               <Th className="w-[100px] text-right">Cost</Th>
-              <Th className="w-[150px]">Status</Th>
-              <Th className="w-[80px] text-right">Errors</Th>
               <Th className="w-[90px] text-right">Duration</Th>
-              <Th className="w-[130px] text-right">Started</Th>
+              <Th className="w-[150px]">Status</Th>
+              <Th className="w-[130px] text-right">Timestamp</Th>
             </TRHead>
           </THead>
           <TBody>
@@ -1102,38 +1085,40 @@ function ScorerDetail({
           )}
         </ScorerCard>
       ) : kind === "llm_judge" ? (
-        <>
-          <ScorerCard title="Model">
-            {scorer.model ? (
-              <span className="font-mono text-[12px]">{scorer.model}</span>
+        // One "Prompt" card: the model sits in the header; messages are role-labelled
+        // rows separated by dividers (no card-in-card nesting).
+        <ScorerCard
+          title="Prompt"
+          action={
+            scorer.model ? (
+              <span className="font-mono text-[11px] text-muted-foreground">{scorer.model}</span>
             ) : (
-              <NotProvided />
-            )}
-          </ScorerCard>
-          <ScorerCard title="Messages">
-            {scorer.messages && scorer.messages.length > 0 ? (
-              <div className="flex flex-col gap-2">
-                {scorer.messages.map((m, i) => (
-                  <div key={i} className="border border-border">
-                    <div className="border-b border-border bg-muted/30 px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                      {m.role}
-                    </div>
-                    <pre className="max-h-[30vh] overflow-auto whitespace-pre-wrap px-2 py-1.5 font-mono text-[11px] leading-relaxed">
-                      {m.content}
-                    </pre>
+              <span className="text-[11px] text-muted-foreground">— no model</span>
+            )
+          }
+        >
+          {scorer.messages && scorer.messages.length > 0 ? (
+            <div className="divide-y divide-border">
+              {scorer.messages.map((m, i) => (
+                <div key={i} className="py-2 first:pt-0 last:pb-0">
+                  <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    {m.role}
                   </div>
-                ))}
-              </div>
-            ) : (
-              <NotProvided />
-            )}
-          </ScorerCard>
-        </>
+                  <pre className="max-h-[30vh] overflow-auto whitespace-pre-wrap font-mono text-[11px] leading-relaxed">
+                    {m.content}
+                  </pre>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <NotProvided />
+          )}
+        </ScorerCard>
       ) : (
         <ScorerCard title="Definition">
           <p className="text-[11px] leading-relaxed text-muted-foreground">
-            The SDK hasn&apos;t reported this scorer&apos;s type or definition — an LLM judge&apos;s
-            model &amp; messages, or a code scorer&apos;s snippet. <NotProvided />.
+            The SDK hasn&apos;t reported this scorer&apos;s definition — an LLM judge&apos;s model
+            &amp; messages, or a code scorer&apos;s snippet.
           </p>
         </ScorerCard>
       )}

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -1,20 +1,11 @@
 "use client";
 
 import * as React from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import {
-  ChevronDown,
-  ChevronRight,
-  GitCompare,
-  Layers,
-  ListChecks,
-  Ruler,
-  Search,
-  X,
-} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { FlaskConical, ListChecks } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -22,45 +13,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { SearchFilterBar } from "@/components/search-filter-bar";
-import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
-import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
-import { Input } from "@/components/ui/input";
-import { CopyButton } from "@/components/ui/copy-button";
-import { HighlightedCode } from "@/features/offline-eval/components/syntax";
-import { useToast } from "@/components/ui/toast";
-import { cn } from "@/lib/utils";
 import {
-  EmptyState,
-  Timestamp,
-  useRowSelection,
-  SelectAllHeaderCell,
-  SelectRowCell,
-  BulkActionBar,
-} from "@/features/offline-eval/components";
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import { PassRate } from "../components/pass-rate";
-import { pctFraction, SENTIMENT_CLASS } from "@/features/offline-eval/utils";
-import {
-  useDatasets,
-  useEvaluationRuns,
-  useScorers,
-  useScorer,
-  useDeleteRuns,
-  type ScorerRegistryRow,
-} from "../hooks";
-import { EVAL_RUN_STATUS_LABEL, type EvalRunStatus, type RunRow } from "../types";
-
-// Run-centric: the Evaluations page is one table of immutable runs. Scorers is the
-// SDK-authored catalog. There is no separate "unique evaluations", "all runs", or
-// "compare" tab — lineage is reached by grouping/filtering, and comparison is an
-// action that opens a shareable /evaluations/compare route.
-type Tab = "evaluations" | "scorers";
-
-const TABS: Array<{ id: Tab; label: string; icon: typeof ListChecks }> = [
-  { id: "evaluations", label: "Evaluations", icon: ListChecks },
-  { id: "scorers", label: "Scorers", icon: Ruler },
-];
+import { Timestamp } from "@/features/offline-eval/components";
+import { cn } from "@/lib/utils";
+import { useDatasets, useEvaluationRuns, useEvaluations } from "../hooks";
+import { EVAL_RUN_STATUS_LABEL, type EvalRunStatus } from "../types";
 
 const STATUS_VARIANT: Record<EvalRunStatus, "success" | "danger" | "warning" | "default"> = {
   running: "default",
@@ -75,499 +40,83 @@ export function RunStatusBadge({ status }: { status: EvalRunStatus }) {
 }
 
 const ALL = "__all__";
+type Tab = "runs" | "evaluations";
 
+/** Real, server-backed Evaluations page: runs (executions) + grouped lineages. */
 export function EvaluationsView({ projectId }: { projectId: string }) {
-  const [tab, setTab] = React.useState<Tab>("evaluations");
+  const [tab, setTab] = React.useState<Tab>("runs");
+  const [runOpen, setRunOpen] = React.useState(false);
 
   return (
-    <div className="flex h-full flex-col text-[12px]">
-      {/* Populates the app's top breadcrumb bar (workspace / project). Without a
-          mounted ProjectBreadcrumb the header goes blank on this route. */}
+    <>
       <ProjectBreadcrumb projectId={projectId} current="Evaluations" />
-      {/* Tab bar — same shape as the Traces page's Traces/Users/Sessions bar. */}
-      <div className="flex items-center justify-between border-b border-border bg-background pr-3">
-        <div className="flex">
-          {TABS.map((t) => {
-            const Icon = t.icon;
-            const active = t.id === tab;
-            return (
-              <button
-                key={t.id}
-                type="button"
-                onClick={() => setTab(t.id)}
-                className={cn(
-                  "flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors",
-                  active
-                    ? "border-foreground bg-muted text-foreground"
-                    : "border-transparent text-muted-foreground hover:text-foreground",
-                )}
-              >
-                <Icon className="h-3.5 w-3.5" />
-                {t.label}
-              </button>
-            );
-          })}
+      <div className="flex flex-1 flex-col overflow-hidden text-[13px]">
+        <div className="flex items-center justify-between border-b border-border bg-background pr-3">
+          <div className="flex">
+            {(
+              [
+                { id: "runs", label: "Runs", icon: ListChecks },
+                { id: "evaluations", label: "Evaluations", icon: FlaskConical },
+              ] as const
+            ).map((t) => {
+              const Icon = t.icon;
+              const active = t.id === tab;
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => setTab(t.id)}
+                  className={cn(
+                    "flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors",
+                    active
+                      ? "border-foreground bg-muted text-foreground"
+                      : "border-transparent text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                  {t.label}
+                </button>
+              );
+            })}
+          </div>
+          <Button size="sm" className="h-7 text-[12px]" onClick={() => setRunOpen(true)}>
+            Run evaluation
+          </Button>
         </div>
+
+        {tab === "runs" ? <RunsTab projectId={projectId} /> : <LineagesTab projectId={projectId} />}
       </div>
 
-      {tab === "evaluations" && <RunsTab projectId={projectId} />}
-      {tab === "scorers" && <ScorersTab projectId={projectId} />}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Runs — the flat execution list.
-// ---------------------------------------------------------------------------
-
-const RUNS_COLUMN_COUNT = 9;
-
-/** Human elapsed duration; "—" when unknown (never 0). */
-export function formatElapsed(ms: number | null | undefined): string {
-  if (ms === null || ms === undefined) return "—";
-  if (ms < 1000) return `${ms}ms`;
-  const s = ms / 1000;
-  if (s < 60) return `${s.toFixed(1)}s`;
-  const m = Math.floor(s / 60);
-  const rem = Math.round(s % 60);
-  return `${m}m ${rem}s`;
-}
-
-export function ScoreValue({ value }: { value: number | null }) {
-  return value === null ? (
-    <span className="text-muted-foreground">—</span>
-  ) : (
-    <>{pctFraction(value)}</>
-  );
-}
-
-/** Total run cost; "—" when no case reported a cost (never a misleading $0). */
-export function formatCost(cost: number | null | undefined): React.ReactNode {
-  if (cost === null || cost === undefined) return <span className="text-muted-foreground">—</span>;
-  return `$${cost < 1 ? cost.toFixed(4) : cost.toFixed(2)}`;
-}
-
-/**
- * One immutable run row. Shared by the flat table and grouped mode (there is no
- * second run-table implementation). `showEvaluation=false` hides the lineage line
- * inside an expanded group, where the group header already names it. Clicking the
- * evaluation name scopes the list to that lineage (?evaluation=<id>).
- */
-function RunTableRow({
-  run: r,
-  projectId,
-  selected,
-  onToggle,
-  showEvaluation = true,
-  indent = false,
-}: {
-  run: RunRow;
-  projectId: string;
-  selected: boolean;
-  onToggle: () => void;
-  showEvaluation?: boolean;
-  indent?: boolean;
-}) {
-  const router = useRouter();
-  return (
-    <TR
-      interactive
-      selected={selected}
-      onClick={() => router.push(`/projects/${projectId}/evaluations/${r.id}`)}
-    >
-      <SelectRowCell
-        checked={selected}
-        onToggle={onToggle}
-        label={`Select ${r.evaluationName} #${r.runNumber}`}
-      />
-      <Td className={cn(indent && "pl-6")}>
-        {showEvaluation && (
-          <button
-            type="button"
-            className="rounded font-medium hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            title="Scope to this evaluation"
-            onClick={(e) => {
-              e.stopPropagation();
-              router.push(`/projects/${projectId}/evaluations?evaluation=${r.evaluationId}`);
-            }}
-          >
-            {r.evaluationName}
-          </button>
-        )}
-        <div className="text-[11px] text-muted-foreground">
-          Run #{r.runNumber} · <span className="font-mono">{r.candidateVersion}</span>
-        </div>
-      </Td>
-      <Td className="text-muted-foreground">
-        <div>{r.datasetName}</div>
-        <div className="text-[11px]">{r.datasetVersionLabel}</div>
-      </Td>
-      <Td className="text-right tabular-nums">
-        <ScoreValue value={r.mainScore} />
-      </Td>
-      <Td className="text-right tabular-nums">
-        <PassRate counts={r} />
-      </Td>
-      <Td className="text-right tabular-nums text-muted-foreground">{formatCost(r.cost)}</Td>
-      <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
-        {formatElapsed(r.elapsedMs)}
-      </Td>
-      <Td>
-        <RunStatusBadge status={r.status} />
-      </Td>
-      <Td className="whitespace-nowrap text-right text-muted-foreground">
-        <Timestamp iso={r.startedAt} />
-      </Td>
-    </TR>
-  );
-}
-
-/** Newest run per evaluation lineage (runs arrive newest-first), keeping the latest
- *  even when it's running/failed — never silently substituting an older one. */
-function latestPerEvaluation(runs: RunRow[]): RunRow[] {
-  const seen = new Set<string>();
-  const out: RunRow[] = [];
-  for (const r of runs) {
-    if (!seen.has(r.evaluationId)) {
-      seen.add(r.evaluationId);
-      out.push(r);
-    }
-  }
-  return out;
-}
-
-interface RunGroup {
-  evaluationId: string;
-  evaluationName: string;
-  datasetName: string | null;
-  runs: RunRow[]; // newest first
-}
-
-/** Group by the STABLE evaluation id (not display-name text). First seen is the latest. */
-function groupRunsByEvaluation(runs: RunRow[]): RunGroup[] {
-  const map = new Map<string, RunGroup>();
-  for (const r of runs) {
-    const g = map.get(r.evaluationId);
-    if (g) g.runs.push(r);
-    else
-      map.set(r.evaluationId, {
-        evaluationId: r.evaluationId,
-        evaluationName: r.evaluationName,
-        datasetName: r.datasetName,
-        runs: [r],
-      });
-  }
-  return [...map.values()];
-}
-
-/** Per-lineage aggregate across a group's runs — pooled where a total is meaningful
- *  (passed, cost, duration) and averaged for the score. */
-function aggregateGroup(runs: RunRow[]) {
-  let passedCount = 0,
-    failedCount = 0,
-    erroredCount = 0,
-    notScoredCount = 0,
-    durationMs = 0,
-    hasDuration = false,
-    scoreSum = 0,
-    scoreN = 0,
-    cost = 0,
-    hasCost = false;
-  for (const r of runs) {
-    passedCount += r.passedCount ?? 0;
-    failedCount += r.failedCount ?? 0;
-    erroredCount += r.erroredCount ?? 0;
-    notScoredCount += r.notScoredCount ?? 0;
-    if (r.elapsedMs != null) {
-      durationMs += r.elapsedMs;
-      hasDuration = true;
-    }
-    if (r.mainScore != null) {
-      scoreSum += r.mainScore;
-      scoreN += 1;
-    }
-    if (r.cost != null) {
-      cost += r.cost;
-      hasCost = true;
-    }
-  }
-  return {
-    counts: { passedCount, failedCount, erroredCount, notScoredCount },
-    durationMs: hasDuration ? durationMs : null,
-    avgScore: scoreN > 0 ? scoreSum / scoreN : null,
-    cost: hasCost ? cost : null,
-  };
-}
-
-/** Tiny muted caption under an aggregate value, naming how it was rolled up. */
-function AggCaption({ children }: { children: React.ReactNode }) {
-  return <div className="text-[10px] font-normal text-muted-foreground">{children}</div>;
-}
-
-/** Collapsed group summary: the evaluation name + run count, and per-column aggregate
- *  totals across the lineage aligned under the same columns as the run rows. Expands to
- *  the (reused) run rows. */
-function GroupHeaderRow({
-  group,
-  isOpen,
-  onToggle,
-  projectId,
-  selected,
-  indeterminate,
-  onToggleSelect,
-}: {
-  group: RunGroup;
-  isOpen: boolean;
-  onToggle: () => void;
-  projectId: string;
-  selected: boolean;
-  indeterminate: boolean;
-  onToggleSelect: () => void;
-}) {
-  const router = useRouter();
-  const latest = group.runs[0];
-  const earlier = group.runs.length - 1;
-  const agg = React.useMemo(() => aggregateGroup(group.runs), [group.runs]);
-  return (
-    <TR className="bg-muted/40 font-medium">
-      {/* Group selection: selects/deselects every run in the lineage at once. */}
-      <td
-        className="w-8 border-r border-border/50 px-3 py-1.5"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <Checkbox
-          checked={selected}
-          indeterminate={indeterminate}
-          onCheckedChange={onToggleSelect}
-          aria-label={
-            selected
-              ? `Deselect all runs in ${group.evaluationName}`
-              : `Select all runs in ${group.evaluationName}`
-          }
-        />
-      </td>
-      <Td>
-        <div className="flex items-center gap-1.5">
-          <button
-            type="button"
-            onClick={onToggle}
-            className="rounded p-0.5 text-muted-foreground hover:text-foreground"
-            aria-label={isOpen ? "Collapse" : "Expand"}
-            aria-expanded={isOpen}
-          >
-            {isOpen ? (
-              <ChevronDown className="h-3.5 w-3.5" />
-            ) : (
-              <ChevronRight className="h-3.5 w-3.5" />
-            )}
-          </button>
-          <button
-            type="button"
-            className="rounded hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            title="Scope to this evaluation"
-            onClick={() =>
-              router.push(`/projects/${projectId}/evaluations?evaluation=${group.evaluationId}`)
-            }
-          >
-            {group.evaluationName}
-          </button>
-        </div>
-        <div className="pl-6 text-[11px] font-normal text-muted-foreground">
-          {group.runs.length} run{group.runs.length === 1 ? "" : "s"}
-          {earlier > 0 && ` · ${earlier} earlier`}
-        </div>
-      </Td>
-      <Td className="text-muted-foreground">{group.datasetName}</Td>
-      <Td className="text-right tabular-nums">
-        <ScoreValue value={agg.avgScore} />
-        {agg.avgScore !== null && <AggCaption>avg</AggCaption>}
-      </Td>
-      <Td className="text-right font-normal tabular-nums">
-        <PassRate counts={agg.counts} />
-      </Td>
-      <Td className="text-right tabular-nums text-muted-foreground">
-        {formatCost(agg.cost)}
-        {agg.cost !== null && <AggCaption>total</AggCaption>}
-      </Td>
-      <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
-        {formatElapsed(agg.durationMs)}
-        {agg.durationMs !== null && <AggCaption>total</AggCaption>}
-      </Td>
-      <Td>
-        <RunStatusBadge status={latest.status} />
-        <AggCaption>latest</AggCaption>
-      </Td>
-      <Td className="whitespace-nowrap text-right font-normal text-muted-foreground">
-        <Timestamp iso={latest.startedAt} />
-        <AggCaption>latest</AggCaption>
-      </Td>
-    </TR>
-  );
-}
-
-/** Compact lineage header shown when the list is scoped to one evaluation. */
-function LineageHeader({
-  run,
-  runCount,
-  projectId,
-}: {
-  run: RunRow;
-  runCount: number;
-  projectId: string;
-}) {
-  const router = useRouter();
-  return (
-    <div className="flex flex-wrap items-center gap-2 border-b border-border bg-muted/20 px-3 py-2 text-[12px]">
-      <ListChecks className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
-      <span className="font-medium">{run.evaluationName}</span>
-      <span className="text-muted-foreground">
-        {run.datasetName ?? "—"} · {runCount} run{runCount === 1 ? "" : "s"} · latest
-      </span>
-      <RunStatusBadge status={run.status} />
-      <button
-        type="button"
-        onClick={() => router.push(`/projects/${projectId}/evaluations`)}
-        className="ml-auto rounded px-1.5 py-0.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground"
-      >
-        Clear filter
-      </button>
-    </div>
-  );
-}
-
-/** Small pill toggle for the restrained run-table controls. */
-function Toggle({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={active}
-      className={cn(
-        "flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-[12px] transition-colors",
-        active
-          ? "border-foreground/30 bg-muted text-foreground"
-          : "border-input text-muted-foreground hover:text-foreground",
-      )}
-    >
-      {children}
-    </button>
+      <RunEvaluationDialog open={runOpen} onOpenChange={setRunOpen} />
+    </>
   );
 }
 
 function RunsTab({ projectId }: { projectId: string }) {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  // Scoping the list to one evaluation lineage lives in the URL (?evaluation=<id>) so
-  // browser back/forward and sharing work.
-  const scopedEvalId = searchParams.get("evaluation");
-
-  const { toast } = useToast();
   const [keyword, setKeyword] = React.useState("");
   const [datasetFilter, setDatasetFilter] = React.useState(ALL);
   const [statusFilter, setStatusFilter] = React.useState(ALL);
-  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
-    DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0],
-  );
-  const [customStart, setCustomStart] = React.useState<Date | null>(null);
-  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
-  const [latestOnly, setLatestOnly] = React.useState(false);
-  const [groupBy, setGroupBy] = React.useState(false);
-  const [expanded, setExpanded] = React.useState<Set<string>>(new Set());
 
   const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
   const { data, isLoading, error } = useEvaluationRuns(projectId, {
-    evaluation_id: scopedEvalId ?? undefined,
     search_query: keyword.trim() || undefined,
     dataset_id: datasetFilter === ALL ? undefined : datasetFilter,
     status: statusFilter === ALL ? undefined : statusFilter,
   });
-  const allRuns = React.useMemo(() => data?.data ?? [], [data]);
-  const filtered = !!keyword || datasetFilter !== ALL || statusFilter !== ALL;
-
-  // Latest-only is a client-side convenience over the loaded page (newest-first);
-  // grouping is client-side on the stable evaluation id. When scoped to one lineage,
-  // grouping is meaningless (a single group) so it's suppressed.
-  const runs = React.useMemo(
-    () => (latestOnly ? latestPerEvaluation(allRuns) : allRuns),
-    [allRuns, latestOnly],
-  );
-  const grouped = groupBy && !scopedEvalId;
-  const groups = React.useMemo(() => (grouped ? groupRunsByEvaluation(runs) : []), [grouped, runs]);
-
-  const runIds = React.useMemo(() => runs.map((r) => r.id), [runs]);
-  const sel = useRowSelection(runIds);
-  const deleteRuns = useDeleteRuns(projectId);
-  const deleteSelected = () => {
-    const ids = [...sel.selected];
-    if (ids.length === 0) return;
-    if (
-      !window.confirm(
-        `Delete ${ids.length} run${ids.length === 1 ? "" : "s"}? This can't be undone.`,
-      )
-    )
-      return;
-    deleteRuns.mutate(ids, {
-      onSuccess: () => {
-        sel.clear();
-        toast({
-          title: `Deleted ${ids.length} run${ids.length === 1 ? "" : "s"}`,
-          tone: "success",
-        });
-      },
-      onError: () => toast({ title: "Could not delete runs", tone: "warning" }),
-    });
-  };
-
-  // Comparison is an action: select exactly two runs to compare. Newer → candidate,
-  // older → baseline (by start time); the compare page makes roles explicit + swappable.
-  const comparePair = React.useMemo(() => {
-    const chosen = runs.filter((r) => sel.has(r.id));
-    if (chosen.length !== 2) return null;
-    const [newer, older] = [...chosen].sort(
-      (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
-    );
-    return { candidate: newer.id, baseline: older.id };
-  }, [runs, sel]);
-  const openCompare = () => {
-    if (!comparePair) return;
-    router.push(
-      `/projects/${projectId}/evaluations/compare?baseline=${comparePair.baseline}&candidate=${comparePair.candidate}`,
-    );
-  };
-
-  const toggleGroup = (id: string) =>
-    setExpanded((cur) => {
-      const next = new Set(cur);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
+  const runs = data?.data ?? [];
 
   return (
     <>
-      <SearchFilterBar
-        searchValue={keyword}
-        onSearchChange={setKeyword}
-        searchPlaceholder="Search runs..."
-        dateFilter={dateFilter}
-        customStartDate={customStart}
-        customEndDate={customEnd}
-        onDateFilterChange={setDateFilter}
-        onCustomRangeChange={(s, e) => {
-          setCustomStart(s);
-          setCustomEnd(e);
-        }}
-      >
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2">
+        <Input
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="Search runs..."
+          className="h-7 max-w-xs text-[12px]"
+        />
         <Select value={datasetFilter} onValueChange={setDatasetFilter}>
-          <SelectTrigger className="h-7 w-[160px] text-[12px]">
+          <SelectTrigger className="h-7 w-[170px] text-[12px]">
             <SelectValue placeholder="Dataset" />
           </SelectTrigger>
           <SelectContent>
@@ -581,9 +130,8 @@ function RunsTab({ projectId }: { projectId: string }) {
             ))}
           </SelectContent>
         </Select>
-
         <Select value={statusFilter} onValueChange={setStatusFilter}>
-          <SelectTrigger className="h-7 w-[170px] text-[12px]">
+          <SelectTrigger className="h-7 w-[180px] text-[12px]">
             <SelectValue placeholder="Status" />
           </SelectTrigger>
           <SelectContent>
@@ -597,698 +145,178 @@ function RunsTab({ projectId }: { projectId: string }) {
             ))}
           </SelectContent>
         </Select>
-
-        <Toggle active={latestOnly} onClick={() => setLatestOnly((v) => !v)}>
-          Latest only
-        </Toggle>
-        {!scopedEvalId && (
-          <Toggle active={groupBy} onClick={() => setGroupBy((v) => !v)}>
-            <Layers className="h-3.5 w-3.5" aria-hidden />
-            Group by evaluation
-          </Toggle>
-        )}
-
-        <span className="flex-1" aria-hidden />
-      </SearchFilterBar>
-
-      {scopedEvalId && allRuns[0] && (
-        <LineageHeader run={allRuns[0]} runCount={allRuns.length} projectId={projectId} />
-      )}
-
-      <BulkActionBar
-        count={sel.count}
-        onDelete={deleteSelected}
-        onClear={sel.clear}
-        extra={
-          comparePair && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6 gap-1 px-1.5 text-[12px]"
-              onClick={openCompare}
-            >
-              <GitCompare className="h-3.5 w-3.5" aria-hidden />
-              Compare
-            </Button>
-          )
-        }
-      />
+      </div>
 
       <div className="min-h-0 flex-1 overflow-auto">
-        <Table>
-          <THead>
-            <TRHead>
-              <SelectAllHeaderCell
-                checked={sel.allSelected}
-                indeterminate={sel.someSelected}
-                onToggle={sel.toggleAll}
-              />
-              <Th>Evaluation / Run</Th>
-              <Th>Dataset</Th>
-              <Th className="w-[110px] text-right">Main score</Th>
-              <Th className="w-[100px] text-right">Passed</Th>
-              <Th className="w-[100px] text-right">Cost</Th>
-              <Th className="w-[90px] text-right">Duration</Th>
-              <Th className="w-[150px]">Status</Th>
-              <Th className="w-[130px] text-right">Timestamp</Th>
-            </TRHead>
-          </THead>
-          <TBody>
-            {isLoading ? (
-              <Cell colSpan={RUNS_COLUMN_COUNT}>
-                <EmptyState>Loading runs...</EmptyState>
-              </Cell>
-            ) : error ? (
-              <Cell colSpan={RUNS_COLUMN_COUNT}>
-                <EmptyState>Error loading runs</EmptyState>
-              </Cell>
-            ) : runs.length === 0 ? (
-              <Cell colSpan={RUNS_COLUMN_COUNT}>
-                <EmptyState>
-                  {filtered || scopedEvalId
-                    ? "No runs match these filters."
-                    : "No evaluation runs yet. Report a run from your SDK and it appears here."}
-                </EmptyState>
-              </Cell>
-            ) : grouped ? (
-              groups.map((g) => {
-                const groupIds = g.runs.map((r) => r.id);
-                const groupAll = groupIds.every((id) => sel.has(id));
-                const groupSome = !groupAll && groupIds.some((id) => sel.has(id));
-                return (
-                  <React.Fragment key={g.evaluationId}>
-                    <GroupHeaderRow
-                      group={g}
-                      isOpen={expanded.has(g.evaluationId)}
-                      onToggle={() => toggleGroup(g.evaluationId)}
-                      projectId={projectId}
-                      selected={groupAll}
-                      indeterminate={groupSome}
-                      onToggleSelect={() => sel.setMany(groupIds, !groupAll)}
-                    />
-                    {expanded.has(g.evaluationId) &&
-                      g.runs.map((r) => (
-                        <RunTableRow
-                          key={r.id}
-                          run={r}
-                          projectId={projectId}
-                          selected={sel.has(r.id)}
-                          onToggle={() => sel.toggle(r.id)}
-                          showEvaluation={false}
-                          indent
-                        />
-                      ))}
-                  </React.Fragment>
-                );
-              })
-            ) : (
-              runs.map((r) => (
-                <RunTableRow
+        {isLoading ? (
+          <Centered>Loading runs...</Centered>
+        ) : error ? (
+          <Centered tone="destructive">Error loading runs</Centered>
+        ) : runs.length === 0 ? (
+          <Centered>
+            No evaluation runs yet. Runs appear here once your application or CI reports them via
+            the SDK.
+          </Centered>
+        ) : (
+          <Table>
+            <THead>
+              <TRHead>
+                <Th>Name</Th>
+                <Th className="w-[150px]">Candidate version</Th>
+                <Th>Dataset</Th>
+                <Th className="w-[110px] text-right">Main score</Th>
+                <Th className="w-[100px] text-right">Change</Th>
+                <Th className="w-[170px]">Status</Th>
+                <Th className="w-[80px] text-right">Errors</Th>
+                <Th className="w-[150px] text-right">Started</Th>
+              </TRHead>
+            </THead>
+            <TBody>
+              {runs.map((r) => (
+                <TR
                   key={r.id}
-                  run={r}
-                  projectId={projectId}
-                  selected={sel.has(r.id)}
-                  onToggle={() => sel.toggle(r.id)}
-                />
-              ))
-            )}
-          </TBody>
-        </Table>
+                  interactive
+                  onClick={() => router.push(`/projects/${projectId}/evaluations/${r.id}`)}
+                >
+                  <Td className="font-medium">
+                    {r.evaluationName}
+                    <span className="ml-1.5 font-normal text-muted-foreground">#{r.runNumber}</span>
+                  </Td>
+                  <Td className="font-mono text-[11px]">{r.candidateVersion}</Td>
+                  <Td className="text-muted-foreground">{r.datasetName ?? "—"}</Td>
+                  <Td className="text-right tabular-nums">
+                    {r.mainScore === null ? (
+                      <span className="text-muted-foreground">—</span>
+                    ) : (
+                      `${r.mainScore.toFixed(1)}%`
+                    )}
+                  </Td>
+                  <Td className="text-right tabular-nums">
+                    {r.changeFromBaseline === null ? (
+                      <span className="text-muted-foreground">—</span>
+                    ) : (
+                      <span
+                        className={r.changeFromBaseline >= 0 ? "text-emerald-600" : "text-red-600"}
+                      >
+                        {r.changeFromBaseline >= 0 ? "+" : ""}
+                        {r.changeFromBaseline.toFixed(1)} pp
+                      </span>
+                    )}
+                  </Td>
+                  <Td>
+                    <RunStatusBadge status={r.status} />
+                  </Td>
+                  <Td className="text-right tabular-nums">
+                    {r.errorCount === 0 ? (
+                      <span className="text-muted-foreground">—</span>
+                    ) : (
+                      r.errorCount
+                    )}
+                  </Td>
+                  <Td className="whitespace-nowrap text-right text-muted-foreground">
+                    <Timestamp iso={r.startedAt} />
+                  </Td>
+                </TR>
+              ))}
+            </TBody>
+          </Table>
+        )}
       </div>
     </>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Scorers — read-only registry, aggregated from reported runs. Master-detail,
-// a table on the left, a detail aside on the right.
-//
-// A scorer's definition — what it measures, its type, scope, and score format —
-// lives in the customer's SDK code and is never reported to the server, so the
-// server-backed registry carries only the aggregates it can see (name, version,
-// score count, error rate). The detail aside surfaces those and names the SDK as
-// the source of truth for the rest, rather than fabricating descriptive text.
-// ---------------------------------------------------------------------------
-
-// +1 for the leading selection checkbox column.
-const SCORERS_COLUMN_COUNT = 5;
-
-const VALUE_TYPE_LABEL: Record<ScorerRegistryRow["valueType"], string> = {
-  numeric: "Numeric",
-  boolean: "Boolean",
-  categorical: "Categorical",
-  mixed: "Mixed",
-  unknown: "Unknown",
-};
-
-const DIRECTION_LABEL: Record<NonNullable<ScorerRegistryRow["direction"]>, string> = {
-  higher_is_better: "Higher is better",
-  lower_is_better: "Lower is better",
-  none: "No direction",
-};
-
-function ScorersTab({ projectId }: { projectId: string }) {
-  const { data, isLoading, error } = useScorers(projectId);
-  // Memoized so the derived id list (and therefore row selection) is stable
-  // across renders rather than churning on a fresh array identity.
-  const allScorers = React.useMemo(() => data?.data ?? [], [data]);
-  const [keyword, setKeyword] = React.useState("");
-  const scorers = React.useMemo(() => {
-    const q = keyword.trim().toLowerCase();
-    if (!q) return allScorers;
-    return allScorers.filter(
-      (s) => s.name.toLowerCase().includes(q) || s.version.toLowerCase().includes(q),
-    );
-  }, [allScorers, keyword]);
-
-  // A clicked scorer opens the detail panel (the right slide-in, no backdrop) rather
-  // than a persistent split-pane.
-  const [openKey, setOpenKey] = React.useState<string | null>(null);
-  const active = allScorers.find((s) => `${s.name}@${s.version}` === openKey) ?? null;
-
-  // Checkbox selection, independent of which scorer the panel is showing. The registry
-  // is derived from reported runs, so there is nothing to delete — the bar offers
-  // selection + Clear only.
-  const scorerKeys = React.useMemo(() => scorers.map((s) => `${s.name}@${s.version}`), [scorers]);
-  const sel = useRowSelection(scorerKeys);
+function LineagesTab({ projectId }: { projectId: string }) {
+  const router = useRouter();
+  const { data, isLoading, error } = useEvaluations(projectId);
+  const evals = data?.data ?? [];
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="border-b border-border bg-background px-3 py-1.5">
-        <div className="relative min-w-[12rem] max-w-md flex-1">
-          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            placeholder="Search scorers..."
-            value={keyword}
-            onChange={(e) => setKeyword(e.target.value)}
-            className="h-8 pl-8 text-[12px]"
-          />
-        </div>
-      </div>
-      <BulkActionBar count={sel.count} onClear={sel.clear} />
-      <div className="min-h-0 flex-1 overflow-auto">
+    <div className="min-h-0 flex-1 overflow-auto">
+      {isLoading ? (
+        <Centered>Loading evaluations...</Centered>
+      ) : error ? (
+        <Centered tone="destructive">Error loading evaluations</Centered>
+      ) : evals.length === 0 ? (
+        <Centered>No evaluations yet.</Centered>
+      ) : (
         <Table>
           <THead>
             <TRHead>
-              <SelectAllHeaderCell
-                checked={sel.allSelected}
-                indeterminate={sel.someSelected}
-                onToggle={sel.toggleAll}
-              />
-              <Th>Scorer</Th>
-              <Th className="w-[110px]">Output</Th>
-              <Th className="w-[120px] text-right">Scores</Th>
-              <Th className="w-[120px] text-right">Error rate</Th>
+              <Th>Evaluation</Th>
+              <Th>Dataset</Th>
+              <Th className="w-[80px] text-right">Runs</Th>
+              <Th className="w-[150px]">Latest candidate</Th>
+              <Th className="w-[120px] text-right">Latest score</Th>
+              <Th className="w-[150px] text-right">Last run</Th>
             </TRHead>
           </THead>
           <TBody>
-            {isLoading ? (
-              <Cell colSpan={SCORERS_COLUMN_COUNT}>
-                <EmptyState>Loading scorers...</EmptyState>
-              </Cell>
-            ) : error ? (
-              <Cell colSpan={SCORERS_COLUMN_COUNT}>
-                <EmptyState>Error loading scorers</EmptyState>
-              </Cell>
-            ) : allScorers.length === 0 ? (
-              <Cell colSpan={SCORERS_COLUMN_COUNT}>
-                <EmptyState>
-                  No scorers yet. Scorers are defined in your SDK code and appear here once a run
-                  reports them.
-                </EmptyState>
-              </Cell>
-            ) : scorers.length === 0 ? (
-              <Cell colSpan={SCORERS_COLUMN_COUNT}>
-                <EmptyState>No scorers match “{keyword}”.</EmptyState>
-              </Cell>
-            ) : (
-              scorers.map((s) => {
-                const key = `${s.name}@${s.version}`;
-                return (
-                  <TR
-                    key={key}
-                    interactive
-                    selected={key === openKey}
-                    onClick={() => setOpenKey(key)}
-                  >
-                    <SelectRowCell
-                      checked={sel.has(key)}
-                      onToggle={() => sel.toggle(key)}
-                      label={`Select ${s.name} ${s.version}`}
-                    />
-                    <Td>
-                      <span className="flex items-baseline gap-1.5">
-                        <span className="font-medium">{s.name}</span>
-                        <span className="text-[11px] text-muted-foreground">
-                          {fmtScorerVersion(s.version)}
-                        </span>
-                      </span>
-                    </Td>
-                    <Td>
-                      <Badge variant="outline">{VALUE_TYPE_LABEL[s.valueType]}</Badge>
-                    </Td>
-                    <Td className="text-right tabular-nums text-muted-foreground">
-                      {s.scoreCount}
-                    </Td>
-                    <Td className="text-right tabular-nums">
-                      {s.errorRate === 0 ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : (
-                        <span className={SENTIMENT_CLASS.bad}>
-                          {(s.errorRate * 100).toFixed(1)}%
-                        </span>
-                      )}
-                    </Td>
-                  </TR>
-                );
-              })
-            )}
+            {evals.map((e) => (
+              <TR
+                key={e.id}
+                interactive={!!e.latestRun}
+                onClick={() =>
+                  e.latestRun && router.push(`/projects/${projectId}/evaluations/${e.latestRun.id}`)
+                }
+              >
+                <Td className="font-medium">{e.name}</Td>
+                <Td className="text-muted-foreground">{e.datasetName ?? "—"}</Td>
+                <Td className="text-right tabular-nums text-muted-foreground">{e.runCount}</Td>
+                <Td className="font-mono text-[11px]">{e.latestRun?.candidateVersion ?? "—"}</Td>
+                <Td className="text-right tabular-nums">
+                  {e.latestRun?.mainScore == null ? (
+                    <span className="text-muted-foreground">—</span>
+                  ) : (
+                    `${e.latestRun.mainScore.toFixed(1)}%`
+                  )}
+                </Td>
+                <Td className="whitespace-nowrap text-right text-muted-foreground">
+                  {e.latestRun ? <Timestamp iso={e.latestRun.startedAt} /> : "—"}
+                </Td>
+              </TR>
+            ))}
           </TBody>
         </Table>
-      </div>
-
-      {active && (
-        <ScorerDetailPanel
-          key={`${active.name}@${active.version}`}
-          projectId={projectId}
-          scorer={active}
-          onClose={() => setOpenKey(null)}
-        />
       )}
     </div>
   );
 }
 
-/** Display a scorer version as "v1" — prefix a bare numeric version with "v"; leave a
- *  sentinel like "unversioned" or an already-prefixed "v3" untouched. */
-function fmtScorerVersion(v: string): string {
-  return /^\d/.test(v) ? `v${v}` : v;
+function Centered({ children, tone }: { children: React.ReactNode; tone?: "destructive" }) {
+  return (
+    <div className="flex h-64 items-center justify-center px-6 text-center">
+      <p className={cn("text-[13px]", tone ? "text-destructive" : "text-muted-foreground")}>
+        {children}
+      </p>
+    </div>
+  );
 }
 
-const OUTPUT_TYPE_LABEL: Record<"score" | "classification", string> = {
-  score: "Score",
-  classification: "Classification",
-};
-const LANGUAGE_LABEL: Record<"python" | "typescript", string> = {
-  python: "Python",
-  typescript: "TypeScript",
-};
-
-/** The scorer's type — declared by the SDK, or derived from which definition fields it
- *  reported (code source ⇒ code; model/messages ⇒ judge). Never guessed from the name. */
-function scorerKind(s: ScorerRegistryRow): "llm_judge" | "code" | null {
-  if (s.scorerType) return s.scorerType;
-  if (s.sourceCode) return "code";
-  if (s.model || s.messages) return "llm_judge";
-  return null;
-}
-
-/** The precise type shown at the top of the definition section and in the header:
- *  "LLM judge" for a judge, the language ("Python"/"TypeScript") for a code scorer. */
-function definitionTypeLabel(
-  s: ScorerRegistryRow,
-  kind: "llm_judge" | "code" | null,
-): string | null {
-  if (kind === "llm_judge") return "LLM judge";
-  if (kind === "code") return s.language ? LANGUAGE_LABEL[s.language] : "Code";
-  return null;
-}
-
-/** Output type (Score / Classification): the SDK's declared value wins; otherwise it's
- *  inferred from the declared/observed value type, and flagged as inferred. */
-function outputTypeOf(s: ScorerRegistryRow): { text: string; inferred: boolean } | null {
-  if (s.outputType) return { text: OUTPUT_TYPE_LABEL[s.outputType], inferred: false };
-  const vt =
-    s.declaredValueType ??
-    (s.valueType !== "unknown" && s.valueType !== "mixed" ? s.valueType : null);
-  if (vt === "categorical") return { text: "Classification", inferred: true };
-  if (vt === "numeric" || vt === "boolean") return { text: "Score", inferred: true };
-  return null;
-}
-
-/** For a field the SDK does not (yet) register — shown as a plain em dash. */
-function NotProvided() {
-  return <span className="text-muted-foreground">—</span>;
-}
-
-/** Bordered card with a muted header strip — mirrors the detector detail panel. */
-function ScorerCard({
-  title,
-  action,
-  children,
+function RunEvaluationDialog({
+  open,
+  onOpenChange,
 }: {
-  title: string;
-  action?: React.ReactNode;
-  children: React.ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }) {
   return (
-    <div className="border border-border">
-      <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/50 px-3 py-1.5">
-        <span className="text-[12px] font-medium text-muted-foreground">{title}</span>
-        {action}
-      </div>
-      <div className="p-3">{children}</div>
-    </div>
-  );
-}
-
-/** A labelled fact row inside a card. */
-function ScorerFact({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="flex items-start justify-between gap-6 py-0.5">
-      <dt className="shrink-0 text-[11px] text-muted-foreground">{label}</dt>
-      <dd className="min-w-0 text-right text-[12px]">{children}</dd>
-    </div>
-  );
-}
-
-/**
- * Read-only scorer detail — a bigger, detector-style subpage (mirrors DetectorPanel's
- * 70%-width right slide-in with bordered cards). It does NOT dim/blur the page behind it
- * and closes on Escape or ✕. A scorer is defined in the customer's SDK; TraceRoot shows
- * ONLY what the SDK reported (see offline-eval/sdk-ask/scorer-definition-reporting.md) —
- * anything unreported reads "Not provided by SDK", never invented from the name.
- */
-export function ScorerDetailPanel({
-  projectId,
-  scorer,
-  onClose,
-}: {
-  projectId: string;
-  scorer: ScorerRegistryRow;
-  onClose: () => void;
-}) {
-  React.useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.stopPropagation();
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [onClose]);
-
-  const kind = scorerKind(scorer);
-
-  return (
-    <div
-      role="dialog"
-      aria-label="Scorer detail"
-      className="animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 flex w-[70%] max-w-[980px] flex-col border-l border-border bg-background shadow-xl"
-    >
-      {/* Header — detector-panel style */}
-      <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border bg-muted/30 px-4">
-        <div className="flex min-w-0 items-center gap-2">
-          <Ruler className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <span className="text-[13px] font-medium">Scorer</span>
-          <span className="truncate text-[13px] text-muted-foreground">{scorer.name}</span>
-          <span className="shrink-0 text-[11px] text-muted-foreground">
-            {fmtScorerVersion(scorer.version)}
-          </span>
-          {definitionTypeLabel(scorer, kind) && (
-            <Badge variant="outline">{definitionTypeLabel(scorer, kind)}</Badge>
-          )}
-          <CopyButton
-            value={`${scorer.name}@${scorer.version}`}
-            className="h-5 w-5 text-muted-foreground hover:text-foreground"
-            iconClassName="h-3 w-3"
-            title="Copy scorer id"
-          />
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close"
-          className="rounded-sm text-muted-foreground hover:text-foreground"
-        >
-          <X className="h-4 w-4" />
-        </button>
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-auto text-[12px]">
-        <ScorerDetail projectId={projectId} scorer={scorer} kind={kind} />
-      </div>
-    </div>
-  );
-}
-
-function ScorerDetail({
-  projectId,
-  scorer,
-  kind,
-}: {
-  projectId: string;
-  scorer: ScorerRegistryRow;
-  kind: "llm_judge" | "code" | null;
-}) {
-  const maxCount = scorer.distribution?.reduce((m, d) => Math.max(m, d.count), 0) ?? 0;
-  const family = useScorer(projectId, scorer.name);
-  const versions = family.data?.versions ?? [];
-  const ot = outputTypeOf(scorer);
-  const metadataText =
-    scorer.metadata != null &&
-    (typeof scorer.metadata !== "object" || Object.keys(scorer.metadata).length > 0)
-      ? JSON.stringify(scorer.metadata, null, 2)
-      : null;
-
-  const typeLabel = definitionTypeLabel(scorer, kind);
-  return (
-    <div className="flex flex-col gap-3 p-4">
-      {/* Definition — leads with the exact type: LLM judge, Python, or TypeScript. */}
-      <div className="flex items-baseline gap-2">
-        <h3 className="text-[13px] font-semibold">Definition</h3>
-        <span className="text-[13px] font-medium text-muted-foreground">{typeLabel ?? "—"}</span>
-      </div>
-      {/* Type-specific body */}
-      {kind === "code" ? (
-        <ScorerCard
-          title="Source"
-          action={
-            scorer.sourceCode ? (
-              <CopyButton
-                value={scorer.sourceCode}
-                className="h-5 w-5 text-muted-foreground hover:text-foreground"
-                iconClassName="h-3 w-3"
-                title="Copy code"
-              />
-            ) : undefined
-          }
-        >
-          {scorer.sourceCode ? (
-            <HighlightedCode
-              code={scorer.sourceCode}
-              className="max-h-[45vh] overflow-auto whitespace-pre font-mono text-[11px] leading-relaxed"
-            />
-          ) : (
-            <NotProvided />
-          )}
-        </ScorerCard>
-      ) : kind === "llm_judge" ? (
-        // One "Prompt" card: the model sits in the header; messages are role-labelled
-        // rows separated by dividers (no card-in-card nesting).
-        <ScorerCard
-          title="Prompt"
-          action={
-            scorer.model ? (
-              <span className="font-mono text-[11px] text-muted-foreground">{scorer.model}</span>
-            ) : (
-              <span className="text-[11px] text-muted-foreground">— no model</span>
-            )
-          }
-        >
-          {scorer.messages && scorer.messages.length > 0 ? (
-            <div className="divide-y divide-border">
-              {scorer.messages.map((m, i) => (
-                <div key={i} className="py-2 first:pt-0 last:pb-0">
-                  <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                    {m.role}
-                  </div>
-                  <pre className="max-h-[30vh] overflow-auto whitespace-pre-wrap font-mono text-[11px] leading-relaxed">
-                    {m.content}
-                  </pre>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <NotProvided />
-          )}
-        </ScorerCard>
-      ) : (
-        <ScorerCard title="Definition">
-          <p className="text-[11px] leading-relaxed text-muted-foreground">
-            The SDK hasn&apos;t reported this scorer&apos;s definition — an LLM judge&apos;s model
-            &amp; messages, or a code scorer&apos;s snippet.
-          </p>
-        </ScorerCard>
-      )}
-
-      {/* Shared configuration */}
-      <ScorerCard title="Configuration">
-        <dl>
-          <ScorerFact label="Output type">
-            {ot ? (
-              <>
-                {ot.text}
-                {ot.inferred && (
-                  <span className="ml-1 text-[11px] text-muted-foreground">(inferred)</span>
-                )}
-              </>
-            ) : (
-              <NotProvided />
-            )}
-          </ScorerFact>
-          <ScorerFact label="Pass threshold">
-            {scorer.threshold !== null ? (
-              <span className="tabular-nums">{scorer.threshold}</span>
-            ) : (
-              <NotProvided />
-            )}
-          </ScorerFact>
-          <ScorerFact label="Direction">
-            {scorer.direction ? DIRECTION_LABEL[scorer.direction] : <NotProvided />}
-          </ScorerFact>
-          <ScorerFact label="Description">
-            {scorer.description ? scorer.description : <NotProvided />}
-          </ScorerFact>
-        </dl>
-      </ScorerCard>
-
-      {/* Metadata */}
-      <ScorerCard title="Metadata">
-        {metadataText ? (
-          <HighlightedCode
-            code={metadataText}
-            className="max-h-[30vh] overflow-auto whitespace-pre font-mono text-[11px] leading-relaxed"
-          />
-        ) : (
-          <NotProvided />
-        )}
-      </ScorerCard>
-
-      {/* Observed usage — honest stats derived from reported scores. */}
-      <ScorerCard title="Observed usage">
-        <dl>
-          <ScorerFact label="Evaluations">
-            <span className="tabular-nums">{scorer.evaluationCount}</span>
-          </ScorerFact>
-          <ScorerFact label="Runs">
-            <span className="tabular-nums">{scorer.runCount}</span>
-          </ScorerFact>
-          <ScorerFact label="Scored results">
-            <span className="tabular-nums">{scorer.scoreCount.toLocaleString("en-US")}</span>
-          </ScorerFact>
-          {scorer.numeric && (
-            <>
-              <ScorerFact label="Mean">
-                <span className="tabular-nums">{scorer.numeric.mean.toFixed(3)}</span>
-              </ScorerFact>
-              <ScorerFact label="Range">
-                <span className="tabular-nums">
-                  {scorer.numeric.min.toFixed(2)} – {scorer.numeric.max.toFixed(2)}
-                </span>
-              </ScorerFact>
-            </>
-          )}
-          {scorer.passRate !== null && (
-            <ScorerFact label="Pass rate">
-              <span className="tabular-nums">{(scorer.passRate * 100).toFixed(1)}%</span>
-            </ScorerFact>
-          )}
-          <ScorerFact label="Error rate">
-            {scorer.errorCount === 0 ? (
-              <span className="tabular-nums text-muted-foreground">0%</span>
-            ) : (
-              <span className={cn("tabular-nums", SENTIMENT_CLASS.bad)}>
-                {(scorer.errorRate * 100).toFixed(1)}% ({scorer.errorCount} of {scorer.scoreCount})
-              </span>
-            )}
-          </ScorerFact>
-          <ScorerFact label="Last used">
-            {scorer.lastUsed ? (
-              <Timestamp iso={scorer.lastUsed} className="inline" />
-            ) : (
-              <span className="text-muted-foreground">—</span>
-            )}
-          </ScorerFact>
-        </dl>
-
-        {scorer.distribution && scorer.distribution.length > 0 && (
-          <div className="mt-3">
-            <div className="mb-1 text-[11px] text-muted-foreground">Score distribution</div>
-            <ul className="flex flex-col gap-1.5">
-              {scorer.distribution.map((d) => (
-                <li key={d.label} className="flex items-center gap-2 text-[11px]">
-                  <span className="w-24 shrink-0 truncate" title={d.label}>
-                    {d.label}
-                  </span>
-                  <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
-                    <span
-                      className="block h-full rounded-full bg-foreground/70"
-                      style={{ width: `${maxCount > 0 ? (d.count / maxCount) * 100 : 0}%` }}
-                    />
-                  </span>
-                  <span className="w-10 shrink-0 text-right tabular-nums text-muted-foreground">
-                    {d.count}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        {scorer.recentErrors.length > 0 && (
-          <div className="mt-3">
-            <div className="mb-1 text-[11px] text-muted-foreground">Recent scorer errors</div>
-            <ul className="flex flex-col gap-1.5">
-              {scorer.recentErrors.map((e, i) => (
-                <li
-                  key={i}
-                  className="rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 font-mono text-[11px] leading-relaxed text-amber-700 dark:text-amber-300"
-                >
-                  {e.message}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        {versions.length > 1 && (
-          <div className="mt-3">
-            <div className="mb-1 text-[11px] text-muted-foreground">Version history</div>
-            <ul className="flex flex-col gap-0.5">
-              {versions.map((v) => (
-                <li
-                  key={v.version}
-                  className={cn(
-                    "flex items-center justify-between gap-2 rounded px-1.5 py-0.5 text-[11px]",
-                    v.version === scorer.version && "bg-muted/60",
-                  )}
-                >
-                  <span className="flex items-center gap-1.5">
-                    <span className="font-medium">{fmtScorerVersion(v.version)}</span>
-                    {v.version === scorer.version && (
-                      <span className="text-[10px] text-muted-foreground">viewing</span>
-                    )}
-                  </span>
-                  <span className="tabular-nums text-muted-foreground">
-                    {v.scoreCount} scored{v.lastUsed ? " · " : ""}
-                    {v.lastUsed && <Timestamp iso={v.lastUsed} className="inline" />}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </ScorerCard>
-    </div>
-  );
-}
-
-function Cell({ colSpan, children }: { colSpan: number; children: React.ReactNode }) {
-  return (
-    <tr>
-      <td colSpan={colSpan}>{children}</td>
-    </tr>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle className="text-[13px] font-medium">Run evaluation</DialogTitle>
+        </DialogHeader>
+        <p className="text-[12px] leading-relaxed text-muted-foreground">
+          Evaluations run in your application or CI environment using the TraceRoot SDK, and report
+          their results back here. Nothing runs from the browser. Starter code will be shown here
+          once the evaluation SDK is available.
+        </p>
+        <DialogFooter>
+          <Button size="sm" className="h-7 text-[12px]" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -5,14 +5,16 @@ import { useRouter, useSearchParams } from "next/navigation";
 import {
   ChevronDown,
   ChevronRight,
-  Download,
   GitCompare,
   Layers,
   ListChecks,
   Ruler,
+  Search,
+  X,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -23,6 +25,9 @@ import {
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
 import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { CopyButton } from "@/components/ui/copy-button";
+import { HighlightedCode } from "@/features/offline-eval/components/syntax";
 import { useToast } from "@/components/ui/toast";
 import { cn } from "@/lib/utils";
 import {
@@ -35,12 +40,7 @@ import {
 } from "@/features/offline-eval/components";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { PassRate } from "../components/pass-rate";
-import {
-  changeSentiment,
-  pctFraction,
-  SENTIMENT_CLASS,
-  signedPoints,
-} from "@/features/offline-eval/utils";
+import { pctFraction, SENTIMENT_CLASS } from "@/features/offline-eval/utils";
 import {
   useDatasets,
   useEvaluationRuns,
@@ -120,7 +120,7 @@ export function EvaluationsView({ projectId }: { projectId: string }) {
 // Runs — the flat execution list.
 // ---------------------------------------------------------------------------
 
-const RUNS_COLUMN_COUNT = 11;
+const RUNS_COLUMN_COUNT = 10;
 
 /** Human elapsed duration; "—" when unknown (never 0). */
 function formatElapsed(ms: number | null | undefined): string {
@@ -141,10 +141,10 @@ function ScoreValue({ value }: { value: number | null }) {
   );
 }
 
-function ChangeValue({ value }: { value: number | null | undefined }) {
-  if (value === null || value === undefined)
-    return <span className="text-muted-foreground">—</span>;
-  return <span className={SENTIMENT_CLASS[changeSentiment(value)]}>{signedPoints(value)} pp</span>;
+/** Total run cost; "—" when no case reported a cost (never a misleading $0). */
+function formatCost(cost: number | null | undefined): React.ReactNode {
+  if (cost === null || cost === undefined) return <span className="text-muted-foreground">—</span>;
+  return `$${cost < 1 ? cost.toFixed(4) : cost.toFixed(2)}`;
 }
 
 /**
@@ -208,19 +208,7 @@ function RunTableRow({
       <Td className="text-right tabular-nums">
         <PassRate counts={r} />
       </Td>
-      <Td className="text-right tabular-nums">
-        <ChangeValue value={r.changeFromBaseline} />
-      </Td>
-      <Td className="text-right tabular-nums">
-        {/* Regressed TEST CASES; "—" when there's no trustworthy baseline to count against. */}
-        {r.regressedCaseCount === null || r.regressedCaseCount === undefined ? (
-          <span className="text-muted-foreground">—</span>
-        ) : r.regressedCaseCount === 0 ? (
-          <span className="text-muted-foreground">0</span>
-        ) : (
-          <span className={SENTIMENT_CLASS.bad}>{r.regressedCaseCount}</span>
-        )}
-      </Td>
+      <Td className="text-right tabular-nums text-muted-foreground">{formatCost(r.cost)}</Td>
       <Td>
         <RunStatusBadge status={r.status} />
       </Td>
@@ -275,27 +263,97 @@ function groupRunsByEvaluation(runs: RunRow[]): RunGroup[] {
   return [...map.values()];
 }
 
-/** Collapsed group summary: name, latest run + its candidate/score/change/status, and
- *  the earlier-run count. Expands to the (reused) run rows. Relocates the removed
- *  unique-evaluations tab's per-lineage aggregates. */
+/** Per-lineage aggregate across a group's runs — pooled where a total is meaningful
+ *  (passed, cost, errors, duration) and averaged for the score. */
+function aggregateGroup(runs: RunRow[]) {
+  let passedCount = 0,
+    failedCount = 0,
+    erroredCount = 0,
+    notScoredCount = 0,
+    errors = 0,
+    durationMs = 0,
+    hasDuration = false,
+    scoreSum = 0,
+    scoreN = 0,
+    cost = 0,
+    hasCost = false;
+  for (const r of runs) {
+    passedCount += r.passedCount ?? 0;
+    failedCount += r.failedCount ?? 0;
+    erroredCount += r.erroredCount ?? 0;
+    notScoredCount += r.notScoredCount ?? 0;
+    errors += r.errorCount ?? 0;
+    if (r.elapsedMs != null) {
+      durationMs += r.elapsedMs;
+      hasDuration = true;
+    }
+    if (r.mainScore != null) {
+      scoreSum += r.mainScore;
+      scoreN += 1;
+    }
+    if (r.cost != null) {
+      cost += r.cost;
+      hasCost = true;
+    }
+  }
+  return {
+    counts: { passedCount, failedCount, erroredCount, notScoredCount },
+    errors,
+    durationMs: hasDuration ? durationMs : null,
+    avgScore: scoreN > 0 ? scoreSum / scoreN : null,
+    cost: hasCost ? cost : null,
+  };
+}
+
+/** Tiny muted caption under an aggregate value, naming how it was rolled up. */
+function AggCaption({ children }: { children: React.ReactNode }) {
+  return <div className="text-[10px] font-normal text-muted-foreground">{children}</div>;
+}
+
+/** Collapsed group summary: the evaluation name + run count, and per-column aggregate
+ *  totals across the lineage aligned under the same columns as the run rows. Expands to
+ *  the (reused) run rows. */
 function GroupHeaderRow({
   group,
   isOpen,
   onToggle,
   projectId,
+  selected,
+  indeterminate,
+  onToggleSelect,
 }: {
   group: RunGroup;
   isOpen: boolean;
   onToggle: () => void;
   projectId: string;
+  selected: boolean;
+  indeterminate: boolean;
+  onToggleSelect: () => void;
 }) {
   const router = useRouter();
   const latest = group.runs[0];
   const earlier = group.runs.length - 1;
+  const agg = React.useMemo(() => aggregateGroup(group.runs), [group.runs]);
   return (
-    <tr className="border-b border-border bg-muted/40">
-      <td colSpan={RUNS_COLUMN_COUNT} className="px-2 py-1.5">
-        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[12px]">
+    <TR className="bg-muted/40 font-medium">
+      {/* Group selection: selects/deselects every run in the lineage at once. */}
+      <td
+        className="w-8 border-r border-border/50 px-3 py-1.5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Checkbox
+          checked={selected}
+          indeterminate={indeterminate}
+          onCheckedChange={onToggleSelect}
+          aria-label={
+            selected
+              ? `Deselect all runs in ${group.evaluationName}`
+              : `Select all runs in ${group.evaluationName}`
+          }
+        />
+      </td>
+      <Td>
+        <div className="flex items-center gap-1.5">
           <button
             type="button"
             onClick={onToggle}
@@ -311,7 +369,7 @@ function GroupHeaderRow({
           </button>
           <button
             type="button"
-            className="rounded font-medium hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            className="rounded hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             title="Scope to this evaluation"
             onClick={() =>
               router.push(`/projects/${projectId}/evaluations?evaluation=${group.evaluationId}`)
@@ -319,25 +377,47 @@ function GroupHeaderRow({
           >
             {group.evaluationName}
           </button>
-          <span className="text-muted-foreground">
-            {group.runs.length} run{group.runs.length === 1 ? "" : "s"}
-            {earlier > 0 && ` · ${earlier} earlier`}
-          </span>
-          <span className="h-3 w-px bg-border" aria-hidden />
-          <span className="text-muted-foreground">
-            latest Run #{latest.runNumber} ·{" "}
-            <span className="font-mono">{latest.candidateVersion}</span>
-          </span>
-          <RunStatusBadge status={latest.status} />
-          <span className="tabular-nums">
-            <ScoreValue value={latest.mainScore} />
-          </span>
-          <span className="tabular-nums">
-            <ChangeValue value={latest.changeFromBaseline} />
-          </span>
         </div>
-      </td>
-    </tr>
+        <div className="pl-6 text-[11px] font-normal text-muted-foreground">
+          {group.runs.length} run{group.runs.length === 1 ? "" : "s"}
+          {earlier > 0 && ` · ${earlier} earlier`}
+        </div>
+      </Td>
+      <Td className="text-muted-foreground">{group.datasetName}</Td>
+      <Td className="text-right tabular-nums">
+        <ScoreValue value={agg.avgScore} />
+        {agg.avgScore !== null && <AggCaption>avg</AggCaption>}
+      </Td>
+      <Td className="text-right font-normal tabular-nums">
+        <PassRate counts={agg.counts} />
+      </Td>
+      <Td className="text-right tabular-nums text-muted-foreground">
+        {formatCost(agg.cost)}
+        {agg.cost !== null && <AggCaption>total</AggCaption>}
+      </Td>
+      <Td>
+        <RunStatusBadge status={latest.status} />
+        <AggCaption>latest</AggCaption>
+      </Td>
+      <Td className="text-right tabular-nums">
+        {agg.errors === 0 ? (
+          <span className="text-muted-foreground">—</span>
+        ) : (
+          <>
+            {agg.errors}
+            <AggCaption>total</AggCaption>
+          </>
+        )}
+      </Td>
+      <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
+        {formatElapsed(agg.durationMs)}
+        {agg.durationMs !== null && <AggCaption>total</AggCaption>}
+      </Td>
+      <Td className="whitespace-nowrap text-right font-normal text-muted-foreground">
+        <Timestamp iso={latest.startedAt} />
+        <AggCaption>latest</AggCaption>
+      </Td>
+    </TR>
   );
 }
 
@@ -545,15 +625,6 @@ function RunsTab({ projectId }: { projectId: string }) {
         )}
 
         <span className="flex-1" aria-hidden />
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-          onClick={() => toast({ title: "Export coming soon", tone: "success" })}
-        >
-          <Download className="h-3.5 w-3.5" aria-hidden />
-          Download
-        </Button>
       </SearchFilterBar>
 
       {scopedEvalId && allRuns[0] && (
@@ -592,8 +663,7 @@ function RunsTab({ projectId }: { projectId: string }) {
               <Th>Dataset</Th>
               <Th className="w-[110px] text-right">Main score</Th>
               <Th className="w-[100px] text-right">Passed</Th>
-              <Th className="w-[100px] text-right">Change</Th>
-              <Th className="w-[100px] text-right">Regressions</Th>
+              <Th className="w-[100px] text-right">Cost</Th>
               <Th className="w-[150px]">Status</Th>
               <Th className="w-[80px] text-right">Errors</Th>
               <Th className="w-[90px] text-right">Duration</Th>
@@ -618,28 +688,36 @@ function RunsTab({ projectId }: { projectId: string }) {
                 </EmptyState>
               </Cell>
             ) : grouped ? (
-              groups.map((g) => (
-                <React.Fragment key={g.evaluationId}>
-                  <GroupHeaderRow
-                    group={g}
-                    isOpen={expanded.has(g.evaluationId)}
-                    onToggle={() => toggleGroup(g.evaluationId)}
-                    projectId={projectId}
-                  />
-                  {expanded.has(g.evaluationId) &&
-                    g.runs.map((r) => (
-                      <RunTableRow
-                        key={r.id}
-                        run={r}
-                        projectId={projectId}
-                        selected={sel.has(r.id)}
-                        onToggle={() => sel.toggle(r.id)}
-                        showEvaluation={false}
-                        indent
-                      />
-                    ))}
-                </React.Fragment>
-              ))
+              groups.map((g) => {
+                const groupIds = g.runs.map((r) => r.id);
+                const groupAll = groupIds.every((id) => sel.has(id));
+                const groupSome = !groupAll && groupIds.some((id) => sel.has(id));
+                return (
+                  <React.Fragment key={g.evaluationId}>
+                    <GroupHeaderRow
+                      group={g}
+                      isOpen={expanded.has(g.evaluationId)}
+                      onToggle={() => toggleGroup(g.evaluationId)}
+                      projectId={projectId}
+                      selected={groupAll}
+                      indeterminate={groupSome}
+                      onToggleSelect={() => sel.setMany(groupIds, !groupAll)}
+                    />
+                    {expanded.has(g.evaluationId) &&
+                      g.runs.map((r) => (
+                        <RunTableRow
+                          key={r.id}
+                          run={r}
+                          projectId={projectId}
+                          selected={sel.has(r.id)}
+                          onToggle={() => sel.toggle(r.id)}
+                          showEvaluation={false}
+                          indent
+                        />
+                      ))}
+                  </React.Fragment>
+                );
+              })
             ) : (
               runs.map((r) => (
                 <RunTableRow
@@ -690,133 +768,164 @@ function ScorersTab({ projectId }: { projectId: string }) {
   const { data, isLoading, error } = useScorers(projectId);
   // Memoized so the derived id list (and therefore row selection) is stable
   // across renders rather than churning on a fresh array identity.
-  const scorers = React.useMemo(() => data?.data ?? [], [data]);
-  const [selectedKey, setSelectedKey] = React.useState<string | null>(null);
-  const selected =
-    scorers.find((s) => `${s.name}@${s.version}` === selectedKey) ?? scorers[0] ?? null;
+  const allScorers = React.useMemo(() => data?.data ?? [], [data]);
+  const [keyword, setKeyword] = React.useState("");
+  const scorers = React.useMemo(() => {
+    const q = keyword.trim().toLowerCase();
+    if (!q) return allScorers;
+    return allScorers.filter(
+      (s) => s.name.toLowerCase().includes(q) || s.version.toLowerCase().includes(q),
+    );
+  }, [allScorers, keyword]);
 
-  // Checkbox selection, independent of which scorer the detail aside is showing.
-  // The registry is derived from reported runs, so there is nothing to delete —
-  // the bar offers selection + Clear only.
+  // A clicked scorer opens the detail panel (the right slide-in, no backdrop) rather
+  // than a persistent split-pane.
+  const [openKey, setOpenKey] = React.useState<string | null>(null);
+  const active = allScorers.find((s) => `${s.name}@${s.version}` === openKey) ?? null;
+
+  // Checkbox selection, independent of which scorer the panel is showing. The registry
+  // is derived from reported runs, so there is nothing to delete — the bar offers
+  // selection + Clear only.
   const scorerKeys = React.useMemo(() => scorers.map((s) => `${s.name}@${s.version}`), [scorers]);
   const sel = useRowSelection(scorerKeys);
 
   return (
-    <div className="flex min-h-0 flex-1">
-      {/* Left column: the selection bar stays pinned above the scrolling table. */}
-      <div className="flex min-w-0 flex-1 flex-col">
-        <BulkActionBar count={sel.count} onClear={sel.clear} />
-        <div className="min-h-0 flex-1 overflow-auto">
-          <Table>
-            <THead>
-              <TRHead>
-                <SelectAllHeaderCell
-                  checked={sel.allSelected}
-                  indeterminate={sel.someSelected}
-                  onToggle={sel.toggleAll}
-                />
-                <Th>Scorer</Th>
-                <Th className="w-[110px]">Output</Th>
-                <Th className="w-[120px] text-right">Scores</Th>
-                <Th className="w-[120px] text-right">Error rate</Th>
-              </TRHead>
-            </THead>
-            <TBody>
-              {isLoading ? (
-                <Cell colSpan={SCORERS_COLUMN_COUNT}>
-                  <EmptyState>Loading scorers...</EmptyState>
-                </Cell>
-              ) : error ? (
-                <Cell colSpan={SCORERS_COLUMN_COUNT}>
-                  <EmptyState>Error loading scorers</EmptyState>
-                </Cell>
-              ) : scorers.length === 0 ? (
-                <Cell colSpan={SCORERS_COLUMN_COUNT}>
-                  <EmptyState>
-                    No scorers yet. Scorers are defined in your SDK code and appear here once a run
-                    reports them.
-                  </EmptyState>
-                </Cell>
-              ) : (
-                scorers.map((s) => {
-                  const key = `${s.name}@${s.version}`;
-                  return (
-                    <TR
-                      key={key}
-                      interactive
-                      selected={key === `${selected?.name}@${selected?.version}`}
-                      onClick={() => setSelectedKey(key)}
-                    >
-                      <SelectRowCell
-                        checked={sel.has(key)}
-                        onToggle={() => sel.toggle(key)}
-                        label={`Select ${s.name} ${s.version}`}
-                      />
-                      <Td>
-                        <span className="flex items-baseline gap-1.5">
-                          <span className="font-medium">{s.name}</span>
-                          <span className="text-[11px] text-muted-foreground">{s.version}</span>
-                        </span>
-                      </Td>
-                      <Td>
-                        <Badge variant="outline">{VALUE_TYPE_LABEL[s.valueType]}</Badge>
-                      </Td>
-                      <Td className="text-right tabular-nums text-muted-foreground">
-                        {s.scoreCount}
-                      </Td>
-                      <Td className="text-right tabular-nums">
-                        {s.errorRate === 0 ? (
-                          <span className="text-muted-foreground">—</span>
-                        ) : (
-                          <span className={SENTIMENT_CLASS.bad}>
-                            {(s.errorRate * 100).toFixed(1)}%
-                          </span>
-                        )}
-                      </Td>
-                    </TR>
-                  );
-                })
-              )}
-            </TBody>
-          </Table>
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="border-b border-border bg-background px-3 py-1.5">
+        <div className="relative min-w-[12rem] max-w-md flex-1">
+          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search scorers..."
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            className="h-8 pl-8 text-[12px]"
+          />
         </div>
       </div>
+      <BulkActionBar count={sel.count} onClear={sel.clear} />
+      <div className="min-h-0 flex-1 overflow-auto">
+        <Table>
+          <THead>
+            <TRHead>
+              <SelectAllHeaderCell
+                checked={sel.allSelected}
+                indeterminate={sel.someSelected}
+                onToggle={sel.toggleAll}
+              />
+              <Th>Scorer</Th>
+              <Th className="w-[110px]">Output</Th>
+              <Th className="w-[120px] text-right">Scores</Th>
+              <Th className="w-[120px] text-right">Error rate</Th>
+            </TRHead>
+          </THead>
+          <TBody>
+            {isLoading ? (
+              <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                <EmptyState>Loading scorers...</EmptyState>
+              </Cell>
+            ) : error ? (
+              <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                <EmptyState>Error loading scorers</EmptyState>
+              </Cell>
+            ) : allScorers.length === 0 ? (
+              <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                <EmptyState>
+                  No scorers yet. Scorers are defined in your SDK code and appear here once a run
+                  reports them.
+                </EmptyState>
+              </Cell>
+            ) : scorers.length === 0 ? (
+              <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                <EmptyState>No scorers match “{keyword}”.</EmptyState>
+              </Cell>
+            ) : (
+              scorers.map((s) => {
+                const key = `${s.name}@${s.version}`;
+                return (
+                  <TR
+                    key={key}
+                    interactive
+                    selected={key === openKey}
+                    onClick={() => setOpenKey(key)}
+                  >
+                    <SelectRowCell
+                      checked={sel.has(key)}
+                      onToggle={() => sel.toggle(key)}
+                      label={`Select ${s.name} ${s.version}`}
+                    />
+                    <Td>
+                      <span className="flex items-baseline gap-1.5">
+                        <span className="font-medium">{s.name}</span>
+                        <span className="text-[11px] text-muted-foreground">{s.version}</span>
+                      </span>
+                    </Td>
+                    <Td>
+                      <Badge variant="outline">{VALUE_TYPE_LABEL[s.valueType]}</Badge>
+                    </Td>
+                    <Td className="text-right tabular-nums text-muted-foreground">
+                      {s.scoreCount}
+                    </Td>
+                    <Td className="text-right tabular-nums">
+                      {s.errorRate === 0 ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : (
+                        <span className={SENTIMENT_CLASS.bad}>
+                          {(s.errorRate * 100).toFixed(1)}%
+                        </span>
+                      )}
+                    </Td>
+                  </TR>
+                );
+              })
+            )}
+          </TBody>
+        </Table>
+      </div>
 
-      <aside
-        aria-label="Scorer detail"
-        className="w-[360px] shrink-0 overflow-auto border-l border-border"
-      >
-        {selected ? (
-          <ScorerDetail
-            key={`${selected.name}@${selected.version}`}
-            projectId={projectId}
-            scorer={selected}
-          />
-        ) : (
-          <EmptyState>Select a scorer to see what it reports.</EmptyState>
-        )}
-      </aside>
+      {active && (
+        <ScorerDetailPanel
+          key={`${active.name}@${active.version}`}
+          projectId={projectId}
+          scorer={active}
+          onClose={() => setOpenKey(null)}
+        />
+      )}
     </div>
   );
 }
 
-function ScorerSection({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <section className="border-t border-border px-3 py-2.5">
-      <h3 className="text-[11px] font-medium text-muted-foreground">{title}</h3>
-      <div className="mt-1.5">{children}</div>
-    </section>
-  );
+const SCORER_TYPE_LABEL: Record<"llm_judge" | "code", string> = {
+  llm_judge: "LLM judge",
+  code: "Code",
+};
+const OUTPUT_TYPE_LABEL: Record<"score" | "classification", string> = {
+  score: "Score",
+  classification: "Classification",
+};
+const LANGUAGE_LABEL: Record<"python" | "typescript", string> = {
+  python: "Python",
+  typescript: "TypeScript",
+};
+
+/** The scorer's type — declared by the SDK, or derived from which definition fields it
+ *  reported (code source ⇒ code; model/messages ⇒ judge). Never guessed from the name. */
+function scorerKind(s: ScorerRegistryRow): "llm_judge" | "code" | null {
+  if (s.scorerType) return s.scorerType;
+  if (s.sourceCode) return "code";
+  if (s.model || s.messages) return "llm_judge";
+  return null;
 }
 
-/** A labelled scalar for the config/stats rows. */
-function ScorerFact({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="flex items-center justify-between gap-3 py-0.5">
-      <dt className="text-[11px] text-muted-foreground">{label}</dt>
-      <dd className="text-[12px] tabular-nums">{children}</dd>
-    </div>
-  );
+/** Output type (Score / Classification): the SDK's declared value wins; otherwise it's
+ *  inferred from the declared/observed value type, and flagged as inferred. */
+function outputTypeOf(s: ScorerRegistryRow): { text: string; inferred: boolean } | null {
+  if (s.outputType) return { text: OUTPUT_TYPE_LABEL[s.outputType], inferred: false };
+  const vt =
+    s.declaredValueType ??
+    (s.valueType !== "unknown" && s.valueType !== "mixed" ? s.valueType : null);
+  if (vt === "categorical") return { text: "Classification", inferred: true };
+  if (vt === "numeric" || vt === "boolean") return { text: "Score", inferred: true };
+  return null;
 }
 
 /** For a field the SDK does not (yet) register — shown honestly, never fabricated. */
@@ -824,106 +933,264 @@ function NotProvided() {
   return <span className="italic text-muted-foreground">Not provided by SDK</span>;
 }
 
+/** Bordered card with a muted header strip — mirrors the detector detail panel. */
+function ScorerCard({
+  title,
+  action,
+  children,
+}: {
+  title: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="border border-border">
+      <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/50 px-3 py-1.5">
+        <span className="text-[12px] font-medium text-muted-foreground">{title}</span>
+        {action}
+      </div>
+      <div className="p-3">{children}</div>
+    </div>
+  );
+}
+
+/** A labelled fact row inside a card. */
+function ScorerFact({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-6 py-0.5">
+      <dt className="shrink-0 text-[11px] text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 text-right text-[12px]">{children}</dd>
+    </div>
+  );
+}
+
 /**
- * Scorer detail, organized around four questions — what it measures / reads / how it
- * works / where it's used. A scorer is defined in the customer's SDK; TraceRoot shows
- * ONLY what the SDK reported and what it observed from scores. Fields the SDK doesn't
- * register (type, capabilities, judge prompt/model, code refs, scope, description,
- * lifecycle) say "Not provided by SDK" rather than being invented from the name.
+ * Read-only scorer detail — a bigger, detector-style subpage (mirrors DetectorPanel's
+ * 70%-width right slide-in with bordered cards). It does NOT dim/blur the page behind it
+ * and closes on Escape or ✕. A scorer is defined in the customer's SDK; TraceRoot shows
+ * ONLY what the SDK reported (see offline-eval/sdk-ask/scorer-definition-reporting.md) —
+ * anything unreported reads "Not provided by SDK", never invented from the name.
  */
-function ScorerDetail({ projectId, scorer }: { projectId: string; scorer: ScorerRegistryRow }) {
+export function ScorerDetailPanel({
+  projectId,
+  scorer,
+  onClose,
+}: {
+  projectId: string;
+  scorer: ScorerRegistryRow;
+  onClose: () => void;
+}) {
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onClose]);
+
+  const kind = scorerKind(scorer);
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Scorer detail"
+      className="animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 flex w-[70%] max-w-[980px] flex-col border-l border-border bg-background shadow-xl"
+    >
+      {/* Header — detector-panel style */}
+      <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border bg-muted/30 px-4">
+        <div className="flex min-w-0 items-center gap-2">
+          <Ruler className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="text-[13px] font-medium">Scorer</span>
+          <span className="truncate text-[13px] text-muted-foreground">{scorer.name}</span>
+          <span className="shrink-0 text-[11px] text-muted-foreground">{scorer.version}</span>
+          {kind && <Badge variant="outline">{SCORER_TYPE_LABEL[kind]}</Badge>}
+          <Badge variant="outline">Defined in SDK</Badge>
+          <CopyButton
+            value={`${scorer.name}@${scorer.version}`}
+            className="h-5 w-5 text-muted-foreground hover:text-foreground"
+            iconClassName="h-3 w-3"
+            title="Copy scorer id"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded-sm text-muted-foreground hover:text-foreground"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto text-[12px]">
+        <ScorerDetail projectId={projectId} scorer={scorer} kind={kind} />
+      </div>
+    </div>
+  );
+}
+
+function ScorerDetail({
+  projectId,
+  scorer,
+  kind,
+}: {
+  projectId: string;
+  scorer: ScorerRegistryRow;
+  kind: "llm_judge" | "code" | null;
+}) {
   const maxCount = scorer.distribution?.reduce((m, d) => Math.max(m, d.count), 0) ?? 0;
   const family = useScorer(projectId, scorer.name);
   const versions = family.data?.versions ?? [];
-  const categories =
-    scorer.valueType === "categorical" && scorer.distribution
-      ? scorer.distribution.map((d) => d.label)
+  const ot = outputTypeOf(scorer);
+  const metadataText =
+    scorer.metadata != null &&
+    (typeof scorer.metadata !== "object" || Object.keys(scorer.metadata).length > 0)
+      ? JSON.stringify(scorer.metadata, null, 2)
       : null;
 
   return (
-    <div className="flex flex-col">
-      <div className="px-3 py-2.5">
-        <div className="flex flex-wrap items-baseline gap-1.5">
-          <h2 className="text-[13px] font-medium">{scorer.name}</h2>
-          <span className="text-[11px] text-muted-foreground">{scorer.version}</span>
-          <Badge variant="outline" className="ml-auto">
-            Defined in SDK
-          </Badge>
-        </div>
-      </div>
+    <div className="flex flex-col gap-3 p-4">
+      {/* Type-specific top half */}
+      {kind === "code" ? (
+        <ScorerCard
+          title={`Code${scorer.language ? ` · ${LANGUAGE_LABEL[scorer.language]}` : ""}`}
+          action={
+            scorer.sourceCode ? (
+              <CopyButton
+                value={scorer.sourceCode}
+                className="h-5 w-5 text-muted-foreground hover:text-foreground"
+                iconClassName="h-3 w-3"
+                title="Copy code"
+              />
+            ) : undefined
+          }
+        >
+          {scorer.sourceCode ? (
+            <HighlightedCode
+              code={scorer.sourceCode}
+              className="max-h-[45vh] overflow-auto whitespace-pre font-mono text-[11px] leading-relaxed"
+            />
+          ) : (
+            <NotProvided />
+          )}
+        </ScorerCard>
+      ) : kind === "llm_judge" ? (
+        <>
+          <ScorerCard title="Model">
+            {scorer.model ? (
+              <span className="font-mono text-[12px]">{scorer.model}</span>
+            ) : (
+              <NotProvided />
+            )}
+          </ScorerCard>
+          <ScorerCard title="Messages">
+            {scorer.messages && scorer.messages.length > 0 ? (
+              <div className="flex flex-col gap-2">
+                {scorer.messages.map((m, i) => (
+                  <div key={i} className="border border-border">
+                    <div className="border-b border-border bg-muted/30 px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                      {m.role}
+                    </div>
+                    <pre className="max-h-[30vh] overflow-auto whitespace-pre-wrap px-2 py-1.5 font-mono text-[11px] leading-relaxed">
+                      {m.content}
+                    </pre>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <NotProvided />
+            )}
+          </ScorerCard>
+        </>
+      ) : (
+        <ScorerCard title="Definition">
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            The SDK hasn&apos;t reported this scorer&apos;s type or definition — an LLM judge&apos;s
+            model &amp; messages, or a code scorer&apos;s snippet. <NotProvided />.
+          </p>
+        </ScorerCard>
+      )}
 
-      {/* 1 — What does it measure? */}
-      <ScorerSection title="What does it measure?">
+      {/* Shared configuration */}
+      <ScorerCard title="Configuration">
         <dl>
           <ScorerFact label="Output type">
-            {VALUE_TYPE_LABEL[scorer.declaredValueType ?? scorer.valueType]}
-            {scorer.declaredValueType === null && (
-              <span className="ml-1 text-[11px] text-muted-foreground">(inferred)</span>
+            {ot ? (
+              <>
+                {ot.text}
+                {ot.inferred && (
+                  <span className="ml-1 text-[11px] text-muted-foreground">(inferred)</span>
+                )}
+              </>
+            ) : (
+              <NotProvided />
+            )}
+          </ScorerFact>
+          <ScorerFact label="Pass threshold">
+            {scorer.threshold !== null ? (
+              <span className="tabular-nums">{scorer.threshold}</span>
+            ) : (
+              <NotProvided />
             )}
           </ScorerFact>
           <ScorerFact label="Direction">
             {scorer.direction ? DIRECTION_LABEL[scorer.direction] : <NotProvided />}
           </ScorerFact>
-          <ScorerFact label="Threshold">
-            {scorer.threshold !== null ? scorer.threshold : <NotProvided />}
-          </ScorerFact>
-          {categories && (
-            <ScorerFact label="Categories (observed)">{categories.join(", ")}</ScorerFact>
-          )}
           <ScorerFact label="Description">
-            <NotProvided />
-          </ScorerFact>
-          <ScorerFact label="Scope / target">
-            <NotProvided />
-          </ScorerFact>
-          <ScorerFact label="Expected output required">
-            <NotProvided />
+            {scorer.description ? scorer.description : <NotProvided />}
           </ScorerFact>
         </dl>
-      </ScorerSection>
+      </ScorerCard>
 
-      {/* 2 — What does it read? */}
-      <ScorerSection title="What does it read?">
-        <p className="text-[11px] leading-relaxed text-muted-foreground">
-          The SDK does not yet report a scorer&apos;s declared capabilities (which of input,
-          candidate output, expected output, metadata, tool calls or retrieval context it reads).{" "}
-          <NotProvided />.
-        </p>
-      </ScorerSection>
+      {/* Metadata */}
+      <ScorerCard title="Metadata">
+        {metadataText ? (
+          <HighlightedCode
+            code={metadataText}
+            className="max-h-[30vh] overflow-auto whitespace-pre font-mono text-[11px] leading-relaxed"
+          />
+        ) : (
+          <NotProvided />
+        )}
+      </ScorerCard>
 
-      {/* 3 — How does it work? */}
-      <ScorerSection title="How does it work?">
-        <p className="text-[11px] leading-relaxed text-muted-foreground">
-          The scorer&apos;s type (rule, LLM judge or human) and its definition — a judge&apos;s
-          rubric/prompt/model, or a code scorer&apos;s language/module/source reference — live in
-          the SDK and are not registered with TraceRoot. <NotProvided />.
-        </p>
-      </ScorerSection>
-
-      {/* 4 — Where is it used? */}
-      <ScorerSection title="Where is it used?">
+      {/* Observed usage — honest stats derived from reported scores. */}
+      <ScorerCard title="Observed usage">
         <dl>
-          <ScorerFact label="Evaluations">{scorer.evaluationCount}</ScorerFact>
-          <ScorerFact label="Runs">{scorer.runCount}</ScorerFact>
+          <ScorerFact label="Evaluations">
+            <span className="tabular-nums">{scorer.evaluationCount}</span>
+          </ScorerFact>
+          <ScorerFact label="Runs">
+            <span className="tabular-nums">{scorer.runCount}</span>
+          </ScorerFact>
           <ScorerFact label="Scored results">
-            {scorer.scoreCount.toLocaleString("en-US")}
+            <span className="tabular-nums">{scorer.scoreCount.toLocaleString("en-US")}</span>
           </ScorerFact>
           {scorer.numeric && (
             <>
-              <ScorerFact label="Mean">{scorer.numeric.mean.toFixed(3)}</ScorerFact>
+              <ScorerFact label="Mean">
+                <span className="tabular-nums">{scorer.numeric.mean.toFixed(3)}</span>
+              </ScorerFact>
               <ScorerFact label="Range">
-                {scorer.numeric.min.toFixed(2)} – {scorer.numeric.max.toFixed(2)}
+                <span className="tabular-nums">
+                  {scorer.numeric.min.toFixed(2)} – {scorer.numeric.max.toFixed(2)}
+                </span>
               </ScorerFact>
             </>
           )}
           {scorer.passRate !== null && (
-            <ScorerFact label="Pass rate">{(scorer.passRate * 100).toFixed(1)}%</ScorerFact>
+            <ScorerFact label="Pass rate">
+              <span className="tabular-nums">{(scorer.passRate * 100).toFixed(1)}%</span>
+            </ScorerFact>
           )}
           <ScorerFact label="Error rate">
             {scorer.errorCount === 0 ? (
-              <span className="text-muted-foreground">0%</span>
+              <span className="tabular-nums text-muted-foreground">0%</span>
             ) : (
-              <span className={SENTIMENT_CLASS.bad}>
+              <span className={cn("tabular-nums", SENTIMENT_CLASS.bad)}>
                 {(scorer.errorRate * 100).toFixed(1)}% ({scorer.errorCount} of {scorer.scoreCount})
               </span>
             )}
@@ -938,12 +1205,12 @@ function ScorerDetail({ projectId, scorer }: { projectId: string; scorer: Scorer
         </dl>
 
         {scorer.distribution && scorer.distribution.length > 0 && (
-          <div className="mt-2">
+          <div className="mt-3">
             <div className="mb-1 text-[11px] text-muted-foreground">Score distribution</div>
             <ul className="flex flex-col gap-1.5">
               {scorer.distribution.map((d) => (
                 <li key={d.label} className="flex items-center gap-2 text-[11px]">
-                  <span className="w-20 shrink-0 truncate" title={d.label}>
+                  <span className="w-24 shrink-0 truncate" title={d.label}>
                     {d.label}
                   </span>
                   <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
@@ -962,7 +1229,7 @@ function ScorerDetail({ projectId, scorer }: { projectId: string; scorer: Scorer
         )}
 
         {scorer.recentErrors.length > 0 && (
-          <div className="mt-2">
+          <div className="mt-3">
             <div className="mb-1 text-[11px] text-muted-foreground">Recent scorer errors</div>
             <ul className="flex flex-col gap-1.5">
               {scorer.recentErrors.map((e, i) => (
@@ -978,7 +1245,7 @@ function ScorerDetail({ projectId, scorer }: { projectId: string; scorer: Scorer
         )}
 
         {versions.length > 1 && (
-          <div className="mt-2">
+          <div className="mt-3">
             <div className="mb-1 text-[11px] text-muted-foreground">Version history</div>
             <ul className="flex flex-col gap-0.5">
               {versions.map((v) => (
@@ -1004,11 +1271,7 @@ function ScorerDetail({ projectId, scorer }: { projectId: string; scorer: Scorer
             </ul>
           </div>
         )}
-      </ScorerSection>
-
-      <div className="border-t border-border px-3 py-2 text-[11px] text-muted-foreground">
-        Source: SDK · Scorers are defined in your SDK code and can&apos;t be created or edited here.
-      </div>
+      </ScorerCard>
     </div>
   );
 }

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
-import { Download, FlaskConical, ListChecks, Ruler } from "lucide-react";
+import { Download, ListChecks, Ruler } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -35,7 +35,6 @@ import {
 import {
   useDatasets,
   useEvaluationRuns,
-  useEvaluations,
   useScorers,
   useDeleteRuns,
   type ScorerRegistryRow,
@@ -43,11 +42,14 @@ import {
 import { EVAL_RUN_STATUS_LABEL, type EvalRunStatus } from "../types";
 import { RunEvaluationDrawer } from "../components/run-evaluation-drawer";
 
-type Tab = "runs" | "evaluations" | "scorers";
+// Run-centric: the Evaluations page is one table of immutable runs. Scorers is the
+// SDK-authored catalog. There is no separate "unique evaluations", "all runs", or
+// "compare" tab — lineage is reached by grouping/filtering, and comparison is an
+// action that opens a shareable /evaluations/compare route.
+type Tab = "evaluations" | "scorers";
 
 const TABS: Array<{ id: Tab; label: string; icon: typeof ListChecks }> = [
-  { id: "runs", label: "Runs", icon: ListChecks },
-  { id: "evaluations", label: "Evaluations", icon: FlaskConical },
+  { id: "evaluations", label: "Evaluations", icon: ListChecks },
   { id: "scorers", label: "Scorers", icon: Ruler },
 ];
 
@@ -66,8 +68,7 @@ export function RunStatusBadge({ status }: { status: EvalRunStatus }) {
 const ALL = "__all__";
 
 export function EvaluationsView({ projectId }: { projectId: string }) {
-  const router = useRouter();
-  const [tab, setTab] = React.useState<Tab>("runs");
+  const [tab, setTab] = React.useState<Tab>("evaluations");
   const [runOpen, setRunOpen] = React.useState(false);
 
   return (
@@ -99,20 +100,14 @@ export function EvaluationsView({ projectId }: { projectId: string }) {
             );
           })}
         </div>
-        {tab !== "scorers" && (
+        {tab === "evaluations" && (
           <Button size="sm" className="h-7 text-[12px]" onClick={() => setRunOpen(true)}>
             Run evaluation
           </Button>
         )}
       </div>
 
-      {tab === "runs" && <RunsTab projectId={projectId} />}
-      {tab === "evaluations" && (
-        <EvaluationsTab
-          projectId={projectId}
-          onOpenRun={(runId) => router.push(`/projects/${projectId}/evaluations/${runId}`)}
-        />
-      )}
+      {tab === "evaluations" && <RunsTab projectId={projectId} />}
       {tab === "scorers" && <ScorersTab projectId={projectId} />}
 
       <RunEvaluationDrawer projectId={projectId} open={runOpen} onOpenChange={setRunOpen} />
@@ -124,7 +119,7 @@ export function EvaluationsView({ projectId }: { projectId: string }) {
 // Runs — the flat execution list.
 // ---------------------------------------------------------------------------
 
-const RUNS_COLUMN_COUNT = 11;
+const RUNS_COLUMN_COUNT = 10;
 
 /** Human elapsed duration; "—" when unknown (never 0). */
 function formatElapsed(ms: number | null | undefined): string {
@@ -253,8 +248,7 @@ function RunsTab({ projectId }: { projectId: string }) {
                 indeterminate={sel.someSelected}
                 onToggle={sel.toggleAll}
               />
-              <Th>Name</Th>
-              <Th className="w-[140px]">Candidate version</Th>
+              <Th>Evaluation / Run</Th>
               <Th>Dataset</Th>
               <Th className="w-[110px] text-right">Main score</Th>
               <Th className="w-[100px] text-right">Change</Th>
@@ -297,14 +291,18 @@ function RunsTab({ projectId }: { projectId: string }) {
                       onToggle={() => sel.toggle(r.id)}
                       label={`Select ${r.evaluationName} #${r.runNumber}`}
                     />
-                    <Td className="font-medium">
-                      {r.evaluationName}
-                      <span className="ml-1.5 font-normal text-muted-foreground">
-                        #{r.runNumber}
-                      </span>
+                    {/* Two-line identity: the evaluation lineage, then the immutable
+                        run + candidate. No opaque DB id in the visible name. */}
+                    <Td>
+                      <div className="font-medium">{r.evaluationName}</div>
+                      <div className="text-[11px] text-muted-foreground">
+                        Run #{r.runNumber} · <span className="font-mono">{r.candidateVersion}</span>
+                      </div>
                     </Td>
-                    <Td className="font-mono text-[11px]">{r.candidateVersion}</Td>
-                    <Td className="text-muted-foreground">{r.datasetName}</Td>
+                    <Td className="text-muted-foreground">
+                      <div>{r.datasetName}</div>
+                      <div className="text-[11px]">{r.datasetVersionLabel}</div>
+                    </Td>
                     <Td className="text-right tabular-nums">
                       {r.mainScore === null ? (
                         <span className="text-muted-foreground">—</span>
@@ -347,150 +345,6 @@ function RunsTab({ projectId }: { projectId: string }) {
                   </TR>
                 );
               })
-            )}
-          </TBody>
-        </Table>
-      </div>
-    </>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Evaluations — one row per purpose (lineage), from the server.
-// ---------------------------------------------------------------------------
-
-// +1 for the leading selection checkbox column.
-const SUITES_COLUMN_COUNT = 7;
-
-function EvaluationsTab({
-  projectId,
-  onOpenRun,
-}: {
-  projectId: string;
-  onOpenRun: (runId: string) => void;
-}) {
-  const { toast } = useToast();
-  const [keyword, setKeyword] = React.useState("");
-  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
-    DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0],
-  );
-  const [customStart, setCustomStart] = React.useState<Date | null>(null);
-  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
-
-  const { data, isLoading, error } = useEvaluations(projectId);
-  const suites = React.useMemo(() => {
-    const all = data?.data ?? [];
-    const q = keyword.trim().toLowerCase();
-    if (!q) return all;
-    return all.filter(
-      (s) => s.name.toLowerCase().includes(q) || (s.datasetName ?? "").toLowerCase().includes(q),
-    );
-  }, [data, keyword]);
-
-  // Row selection, matching the Runs tab. There is no delete API for an evaluation
-  // lineage, so the bar offers selection + Clear without a Delete action.
-  const suiteIds = React.useMemo(() => suites.map((s) => s.id), [suites]);
-  const sel = useRowSelection(suiteIds);
-
-  return (
-    <>
-      <SearchFilterBar
-        searchValue={keyword}
-        onSearchChange={setKeyword}
-        searchPlaceholder="Search evaluations..."
-        dateFilter={dateFilter}
-        customStartDate={customStart}
-        customEndDate={customEnd}
-        onDateFilterChange={setDateFilter}
-        onCustomRangeChange={(s, e) => {
-          setCustomStart(s);
-          setCustomEnd(e);
-        }}
-      >
-        <span className="flex-1" aria-hidden />
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-          onClick={() => toast({ title: "Export coming soon", tone: "success" })}
-        >
-          <Download className="h-3.5 w-3.5" aria-hidden />
-          Download
-        </Button>
-      </SearchFilterBar>
-
-      <BulkActionBar count={sel.count} onClear={sel.clear} />
-
-      <div className="min-h-0 flex-1 overflow-auto">
-        <Table>
-          <THead>
-            <TRHead>
-              <SelectAllHeaderCell
-                checked={sel.allSelected}
-                indeterminate={sel.someSelected}
-                onToggle={sel.toggleAll}
-              />
-              <Th>Evaluation</Th>
-              <Th>Dataset</Th>
-              <Th className="w-[90px] text-right">Runs</Th>
-              <Th className="w-[150px]">Latest candidate</Th>
-              <Th className="w-[130px] text-right">Latest score</Th>
-              <Th className="w-[130px] text-right">Last run</Th>
-            </TRHead>
-          </THead>
-          <TBody>
-            {isLoading ? (
-              <Cell colSpan={SUITES_COLUMN_COUNT}>
-                <EmptyState>Loading evaluations...</EmptyState>
-              </Cell>
-            ) : error ? (
-              <Cell colSpan={SUITES_COLUMN_COUNT}>
-                <EmptyState>Error loading evaluations</EmptyState>
-              </Cell>
-            ) : suites.length === 0 ? (
-              <Cell colSpan={SUITES_COLUMN_COUNT}>
-                <EmptyState>
-                  {keyword ? "No evaluations match your search." : "No evaluations yet."}
-                </EmptyState>
-              </Cell>
-            ) : (
-              suites.map((suite) => (
-                <TR
-                  key={suite.id}
-                  interactive
-                  selected={sel.has(suite.id)}
-                  onClick={() => suite.latestRun && onOpenRun(suite.latestRun.id)}
-                >
-                  <SelectRowCell
-                    checked={sel.has(suite.id)}
-                    onToggle={() => sel.toggle(suite.id)}
-                    label={`Select ${suite.name}`}
-                  />
-                  <Td className="font-medium">
-                    {suite.name}
-                    <span className="ml-1.5 font-mono text-[11px] font-normal text-muted-foreground">
-                      {suite.id}
-                    </span>
-                  </Td>
-                  <Td className="text-muted-foreground">{suite.datasetName ?? "—"}</Td>
-                  <Td className="text-right tabular-nums text-muted-foreground">
-                    {suite.runCount}
-                  </Td>
-                  <Td className="font-mono text-[11px]">
-                    {suite.latestRun?.candidateVersion ?? "—"}
-                  </Td>
-                  <Td className="text-right tabular-nums">
-                    {suite.latestRun?.mainScore == null ? (
-                      <span className="text-muted-foreground">—</span>
-                    ) : (
-                      pctFraction(suite.latestRun.mainScore)
-                    )}
-                  </Td>
-                  <Td className="whitespace-nowrap text-right text-muted-foreground">
-                    {suite.latestRun ? <Timestamp iso={suite.latestRun.startedAt} /> : "—"}
-                  </Td>
-                </TR>
-              ))
             )}
           </TBody>
         </Table>

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -18,6 +18,7 @@ import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
 import { useToast } from "@/components/ui/toast";
 import { cn } from "@/lib/utils";
 import { EmptyState, Timestamp } from "@/features/offline-eval/components";
+import { ProjectBreadcrumb } from "@/features/projects/components";
 import { changeSentiment, pct, SENTIMENT_CLASS, signed } from "@/features/offline-eval/utils";
 import {
   useDatasets,
@@ -58,6 +59,9 @@ export function EvaluationsView({ projectId }: { projectId: string }) {
 
   return (
     <div className="flex h-full flex-col text-[12px]">
+      {/* Populates the app's top breadcrumb bar (workspace / project). Without a
+          mounted ProjectBreadcrumb the header goes blank on this route. */}
+      <ProjectBreadcrumb projectId={projectId} current="Evaluations" />
       {/* Tab bar — same shape as the Traces page's Traces/Users/Sessions bar. */}
       <div className="flex items-center justify-between border-b border-border bg-background pr-3">
         <div className="flex">

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -856,7 +856,9 @@ function ScorersTab({ projectId }: { projectId: string }) {
                     <Td>
                       <span className="flex items-baseline gap-1.5">
                         <span className="font-medium">{s.name}</span>
-                        <span className="text-[11px] text-muted-foreground">{s.version}</span>
+                        <span className="text-[11px] text-muted-foreground">
+                          {fmtScorerVersion(s.version)}
+                        </span>
                       </span>
                     </Td>
                     <Td>
@@ -894,10 +896,12 @@ function ScorersTab({ projectId }: { projectId: string }) {
   );
 }
 
-const SCORER_TYPE_LABEL: Record<"llm_judge" | "code", string> = {
-  llm_judge: "LLM judge",
-  code: "Code",
-};
+/** Display a scorer version as "v1" — prefix a bare numeric version with "v"; leave a
+ *  sentinel like "unversioned" or an already-prefixed "v3" untouched. */
+function fmtScorerVersion(v: string): string {
+  return /^\d/.test(v) ? `v${v}` : v;
+}
+
 const OUTPUT_TYPE_LABEL: Record<"score" | "classification", string> = {
   score: "Score",
   classification: "Classification",
@@ -916,6 +920,17 @@ function scorerKind(s: ScorerRegistryRow): "llm_judge" | "code" | null {
   return null;
 }
 
+/** The precise type shown at the top of the definition section and in the header:
+ *  "LLM judge" for a judge, the language ("Python"/"TypeScript") for a code scorer. */
+function definitionTypeLabel(
+  s: ScorerRegistryRow,
+  kind: "llm_judge" | "code" | null,
+): string | null {
+  if (kind === "llm_judge") return "LLM judge";
+  if (kind === "code") return s.language ? LANGUAGE_LABEL[s.language] : "Code";
+  return null;
+}
+
 /** Output type (Score / Classification): the SDK's declared value wins; otherwise it's
  *  inferred from the declared/observed value type, and flagged as inferred. */
 function outputTypeOf(s: ScorerRegistryRow): { text: string; inferred: boolean } | null {
@@ -928,9 +943,9 @@ function outputTypeOf(s: ScorerRegistryRow): { text: string; inferred: boolean }
   return null;
 }
 
-/** For a field the SDK does not (yet) register — shown honestly, never fabricated. */
+/** For a field the SDK does not (yet) register — shown as a plain em dash. */
 function NotProvided() {
-  return <span className="italic text-muted-foreground">Not provided by SDK</span>;
+  return <span className="text-muted-foreground">—</span>;
 }
 
 /** Bordered card with a muted header strip — mirrors the detector detail panel. */
@@ -1005,9 +1020,12 @@ export function ScorerDetailPanel({
           <Ruler className="h-4 w-4 shrink-0 text-muted-foreground" />
           <span className="text-[13px] font-medium">Scorer</span>
           <span className="truncate text-[13px] text-muted-foreground">{scorer.name}</span>
-          <span className="shrink-0 text-[11px] text-muted-foreground">{scorer.version}</span>
-          {kind && <Badge variant="outline">{SCORER_TYPE_LABEL[kind]}</Badge>}
-          <Badge variant="outline">Defined in SDK</Badge>
+          <span className="shrink-0 text-[11px] text-muted-foreground">
+            {fmtScorerVersion(scorer.version)}
+          </span>
+          {definitionTypeLabel(scorer, kind) && (
+            <Badge variant="outline">{definitionTypeLabel(scorer, kind)}</Badge>
+          )}
           <CopyButton
             value={`${scorer.name}@${scorer.version}`}
             className="h-5 w-5 text-muted-foreground hover:text-foreground"
@@ -1051,12 +1069,18 @@ function ScorerDetail({
       ? JSON.stringify(scorer.metadata, null, 2)
       : null;
 
+  const typeLabel = definitionTypeLabel(scorer, kind);
   return (
     <div className="flex flex-col gap-3 p-4">
-      {/* Type-specific top half */}
+      {/* Definition — leads with the exact type: LLM judge, Python, or TypeScript. */}
+      <div className="flex items-baseline gap-2">
+        <h3 className="text-[13px] font-semibold">Definition</h3>
+        <span className="text-[13px] font-medium text-foreground">{typeLabel ?? "—"}</span>
+      </div>
+      {/* Type-specific body */}
       {kind === "code" ? (
         <ScorerCard
-          title={`Code${scorer.language ? ` · ${LANGUAGE_LABEL[scorer.language]}` : ""}`}
+          title="Source"
           action={
             scorer.sourceCode ? (
               <CopyButton
@@ -1257,7 +1281,7 @@ function ScorerDetail({
                   )}
                 >
                   <span className="flex items-center gap-1.5">
-                    <span className="font-medium">{v.version}</span>
+                    <span className="font-medium">{fmtScorerVersion(v.version)}</span>
                     {v.version === scorer.version && (
                       <span className="text-[10px] text-muted-foreground">viewing</span>
                     )}

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import * as React from "react";
-import { useRouter } from "next/navigation";
-import { Download, ListChecks, Ruler } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  ChevronDown,
+  ChevronRight,
+  Download,
+  GitCompare,
+  Layers,
+  ListChecks,
+  Ruler,
+} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -36,10 +44,11 @@ import {
   useDatasets,
   useEvaluationRuns,
   useScorers,
+  useScorer,
   useDeleteRuns,
   type ScorerRegistryRow,
 } from "../hooks";
-import { EVAL_RUN_STATUS_LABEL, type EvalRunStatus } from "../types";
+import { EVAL_RUN_STATUS_LABEL, type EvalRunStatus, type RunRow } from "../types";
 import { RunEvaluationDrawer } from "../components/run-evaluation-drawer";
 
 // Run-centric: the Evaluations page is one table of immutable runs. Scorers is the
@@ -132,8 +141,275 @@ function formatElapsed(ms: number | null | undefined): string {
   return `${m}m ${rem}s`;
 }
 
+function ScoreValue({ value }: { value: number | null }) {
+  return value === null ? (
+    <span className="text-muted-foreground">—</span>
+  ) : (
+    <>{pctFraction(value)}</>
+  );
+}
+
+function ChangeValue({ value }: { value: number | null | undefined }) {
+  if (value === null || value === undefined)
+    return <span className="text-muted-foreground">—</span>;
+  return <span className={SENTIMENT_CLASS[changeSentiment(value)]}>{signedPoints(value)} pp</span>;
+}
+
+/**
+ * One immutable run row. Shared by the flat table and grouped mode (there is no
+ * second run-table implementation). `showEvaluation=false` hides the lineage line
+ * inside an expanded group, where the group header already names it. Clicking the
+ * evaluation name scopes the list to that lineage (?evaluation=<id>).
+ */
+function RunTableRow({
+  run: r,
+  projectId,
+  selected,
+  onToggle,
+  showEvaluation = true,
+  indent = false,
+}: {
+  run: RunRow;
+  projectId: string;
+  selected: boolean;
+  onToggle: () => void;
+  showEvaluation?: boolean;
+  indent?: boolean;
+}) {
+  const router = useRouter();
+  return (
+    <TR
+      interactive
+      selected={selected}
+      onClick={() => router.push(`/projects/${projectId}/evaluations/${r.id}`)}
+    >
+      <SelectRowCell
+        checked={selected}
+        onToggle={onToggle}
+        label={`Select ${r.evaluationName} #${r.runNumber}`}
+      />
+      <Td className={cn(indent && "pl-6")}>
+        {showEvaluation && (
+          <button
+            type="button"
+            className="rounded font-medium hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            title="Scope to this evaluation"
+            onClick={(e) => {
+              e.stopPropagation();
+              router.push(`/projects/${projectId}/evaluations?evaluation=${r.evaluationId}`);
+            }}
+          >
+            {r.evaluationName}
+          </button>
+        )}
+        <div className="text-[11px] text-muted-foreground">
+          Run #{r.runNumber} · <span className="font-mono">{r.candidateVersion}</span>
+        </div>
+      </Td>
+      <Td className="text-muted-foreground">
+        <div>{r.datasetName}</div>
+        <div className="text-[11px]">{r.datasetVersionLabel}</div>
+      </Td>
+      <Td className="text-right tabular-nums">
+        <ScoreValue value={r.mainScore} />
+      </Td>
+      <Td className="text-right tabular-nums">
+        <ChangeValue value={r.changeFromBaseline} />
+      </Td>
+      <Td className="text-right tabular-nums">
+        {/* Regressed TEST CASES; "—" when there's no trustworthy baseline to count against. */}
+        {r.regressedCaseCount === null || r.regressedCaseCount === undefined ? (
+          <span className="text-muted-foreground">—</span>
+        ) : r.regressedCaseCount === 0 ? (
+          <span className="text-muted-foreground">0</span>
+        ) : (
+          <span className={SENTIMENT_CLASS.bad}>{r.regressedCaseCount}</span>
+        )}
+      </Td>
+      <Td>
+        <RunStatusBadge status={r.status} />
+      </Td>
+      <Td className="text-right tabular-nums">
+        {r.errorCount === 0 ? <span className="text-muted-foreground">—</span> : r.errorCount}
+      </Td>
+      <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
+        {formatElapsed(r.elapsedMs)}
+      </Td>
+      <Td className="whitespace-nowrap text-right text-muted-foreground">
+        <Timestamp iso={r.startedAt} />
+      </Td>
+    </TR>
+  );
+}
+
+/** Newest run per evaluation lineage (runs arrive newest-first), keeping the latest
+ *  even when it's running/failed — never silently substituting an older one. */
+function latestPerEvaluation(runs: RunRow[]): RunRow[] {
+  const seen = new Set<string>();
+  const out: RunRow[] = [];
+  for (const r of runs) {
+    if (!seen.has(r.evaluationId)) {
+      seen.add(r.evaluationId);
+      out.push(r);
+    }
+  }
+  return out;
+}
+
+interface RunGroup {
+  evaluationId: string;
+  evaluationName: string;
+  datasetName: string | null;
+  runs: RunRow[]; // newest first
+}
+
+/** Group by the STABLE evaluation id (not display-name text). First seen is the latest. */
+function groupRunsByEvaluation(runs: RunRow[]): RunGroup[] {
+  const map = new Map<string, RunGroup>();
+  for (const r of runs) {
+    const g = map.get(r.evaluationId);
+    if (g) g.runs.push(r);
+    else
+      map.set(r.evaluationId, {
+        evaluationId: r.evaluationId,
+        evaluationName: r.evaluationName,
+        datasetName: r.datasetName,
+        runs: [r],
+      });
+  }
+  return [...map.values()];
+}
+
+/** Collapsed group summary: name, latest run + its candidate/score/change/status, and
+ *  the earlier-run count. Expands to the (reused) run rows. Relocates the removed
+ *  unique-evaluations tab's per-lineage aggregates. */
+function GroupHeaderRow({
+  group,
+  isOpen,
+  onToggle,
+  projectId,
+}: {
+  group: RunGroup;
+  isOpen: boolean;
+  onToggle: () => void;
+  projectId: string;
+}) {
+  const router = useRouter();
+  const latest = group.runs[0];
+  const earlier = group.runs.length - 1;
+  return (
+    <tr className="border-b border-border bg-muted/40">
+      <td colSpan={RUNS_COLUMN_COUNT} className="px-2 py-1.5">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[12px]">
+          <button
+            type="button"
+            onClick={onToggle}
+            className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+            aria-label={isOpen ? "Collapse" : "Expand"}
+            aria-expanded={isOpen}
+          >
+            {isOpen ? (
+              <ChevronDown className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" />
+            )}
+          </button>
+          <button
+            type="button"
+            className="rounded font-medium hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            title="Scope to this evaluation"
+            onClick={() =>
+              router.push(`/projects/${projectId}/evaluations?evaluation=${group.evaluationId}`)
+            }
+          >
+            {group.evaluationName}
+          </button>
+          <span className="text-muted-foreground">
+            {group.runs.length} run{group.runs.length === 1 ? "" : "s"}
+            {earlier > 0 && ` · ${earlier} earlier`}
+          </span>
+          <span className="h-3 w-px bg-border" aria-hidden />
+          <span className="text-muted-foreground">
+            latest Run #{latest.runNumber} ·{" "}
+            <span className="font-mono">{latest.candidateVersion}</span>
+          </span>
+          <RunStatusBadge status={latest.status} />
+          <span className="tabular-nums">
+            <ScoreValue value={latest.mainScore} />
+          </span>
+          <span className="tabular-nums">
+            <ChangeValue value={latest.changeFromBaseline} />
+          </span>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+/** Compact lineage header shown when the list is scoped to one evaluation. */
+function LineageHeader({
+  run,
+  runCount,
+  projectId,
+}: {
+  run: RunRow;
+  runCount: number;
+  projectId: string;
+}) {
+  const router = useRouter();
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-border bg-muted/20 px-3 py-2 text-[12px]">
+      <ListChecks className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+      <span className="font-medium">{run.evaluationName}</span>
+      <span className="text-muted-foreground">
+        {run.datasetName ?? "—"} · {runCount} run{runCount === 1 ? "" : "s"} · latest
+      </span>
+      <RunStatusBadge status={run.status} />
+      <button
+        type="button"
+        onClick={() => router.push(`/projects/${projectId}/evaluations`)}
+        className="ml-auto rounded px-1.5 py-0.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        Clear filter
+      </button>
+    </div>
+  );
+}
+
+/** Small pill toggle for the restrained run-table controls. */
+function Toggle({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-[12px] transition-colors",
+        active
+          ? "border-foreground/30 bg-muted text-foreground"
+          : "border-input text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
 function RunsTab({ projectId }: { projectId: string }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  // Scoping the list to one evaluation lineage lives in the URL (?evaluation=<id>) so
+  // browser back/forward and sharing work.
+  const scopedEvalId = searchParams.get("evaluation");
+
   const { toast } = useToast();
   const [keyword, setKeyword] = React.useState("");
   const [datasetFilter, setDatasetFilter] = React.useState(ALL);
@@ -143,17 +419,30 @@ function RunsTab({ projectId }: { projectId: string }) {
   );
   const [customStart, setCustomStart] = React.useState<Date | null>(null);
   const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
+  const [latestOnly, setLatestOnly] = React.useState(false);
+  const [groupBy, setGroupBy] = React.useState(false);
+  const [expanded, setExpanded] = React.useState<Set<string>>(new Set());
 
   const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
   const { data, isLoading, error } = useEvaluationRuns(projectId, {
+    evaluation_id: scopedEvalId ?? undefined,
     search_query: keyword.trim() || undefined,
     dataset_id: datasetFilter === ALL ? undefined : datasetFilter,
     status: statusFilter === ALL ? undefined : statusFilter,
   });
-  const runs = React.useMemo(() => data?.data ?? [], [data]);
-  const filtered = keyword || datasetFilter !== ALL || statusFilter !== ALL;
+  const allRuns = React.useMemo(() => data?.data ?? [], [data]);
+  const filtered = !!keyword || datasetFilter !== ALL || statusFilter !== ALL;
 
-  // Row selection + bulk delete, matching the dataset cases table.
+  // Latest-only is a client-side convenience over the loaded page (newest-first);
+  // grouping is client-side on the stable evaluation id. When scoped to one lineage,
+  // grouping is meaningless (a single group) so it's suppressed.
+  const runs = React.useMemo(
+    () => (latestOnly ? latestPerEvaluation(allRuns) : allRuns),
+    [allRuns, latestOnly],
+  );
+  const grouped = groupBy && !scopedEvalId;
+  const groups = React.useMemo(() => (grouped ? groupRunsByEvaluation(runs) : []), [grouped, runs]);
+
   const runIds = React.useMemo(() => runs.map((r) => r.id), [runs]);
   const sel = useRowSelection(runIds);
   const deleteRuns = useDeleteRuns(projectId);
@@ -177,6 +466,31 @@ function RunsTab({ projectId }: { projectId: string }) {
       onError: () => toast({ title: "Could not delete runs", tone: "warning" }),
     });
   };
+
+  // Comparison is an action: select exactly two runs to compare. Newer → candidate,
+  // older → baseline (by start time); the compare page makes roles explicit + swappable.
+  const comparePair = React.useMemo(() => {
+    const chosen = runs.filter((r) => sel.has(r.id));
+    if (chosen.length !== 2) return null;
+    const [newer, older] = [...chosen].sort(
+      (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+    );
+    return { candidate: newer.id, baseline: older.id };
+  }, [runs, sel]);
+  const openCompare = () => {
+    if (!comparePair) return;
+    router.push(
+      `/projects/${projectId}/evaluations/compare?baseline=${comparePair.baseline}&candidate=${comparePair.candidate}`,
+    );
+  };
+
+  const toggleGroup = (id: string) =>
+    setExpanded((cur) => {
+      const next = new Set(cur);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
 
   return (
     <>
@@ -225,6 +539,16 @@ function RunsTab({ projectId }: { projectId: string }) {
           </SelectContent>
         </Select>
 
+        <Toggle active={latestOnly} onClick={() => setLatestOnly((v) => !v)}>
+          Latest only
+        </Toggle>
+        {!scopedEvalId && (
+          <Toggle active={groupBy} onClick={() => setGroupBy((v) => !v)}>
+            <Layers className="h-3.5 w-3.5" aria-hidden />
+            Group by evaluation
+          </Toggle>
+        )}
+
         <span className="flex-1" aria-hidden />
         <Button
           variant="ghost"
@@ -237,7 +561,28 @@ function RunsTab({ projectId }: { projectId: string }) {
         </Button>
       </SearchFilterBar>
 
-      <BulkActionBar count={sel.count} onDelete={deleteSelected} onClear={sel.clear} />
+      {scopedEvalId && allRuns[0] && (
+        <LineageHeader run={allRuns[0]} runCount={allRuns.length} projectId={projectId} />
+      )}
+
+      <BulkActionBar
+        count={sel.count}
+        onDelete={deleteSelected}
+        onClear={sel.clear}
+        extra={
+          comparePair && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 gap-1 px-1.5 text-[12px]"
+              onClick={openCompare}
+            >
+              <GitCompare className="h-3.5 w-3.5" aria-hidden />
+              Compare
+            </Button>
+          )
+        }
+      />
 
       <div className="min-h-0 flex-1 overflow-auto">
         <Table>
@@ -271,80 +616,44 @@ function RunsTab({ projectId }: { projectId: string }) {
             ) : runs.length === 0 ? (
               <Cell colSpan={RUNS_COLUMN_COUNT}>
                 <EmptyState>
-                  {filtered
+                  {filtered || scopedEvalId
                     ? "No runs match these filters."
                     : "No evaluation runs yet. Use Run evaluation for the SDK snippet."}
                 </EmptyState>
               </Cell>
+            ) : grouped ? (
+              groups.map((g) => (
+                <React.Fragment key={g.evaluationId}>
+                  <GroupHeaderRow
+                    group={g}
+                    isOpen={expanded.has(g.evaluationId)}
+                    onToggle={() => toggleGroup(g.evaluationId)}
+                    projectId={projectId}
+                  />
+                  {expanded.has(g.evaluationId) &&
+                    g.runs.map((r) => (
+                      <RunTableRow
+                        key={r.id}
+                        run={r}
+                        projectId={projectId}
+                        selected={sel.has(r.id)}
+                        onToggle={() => sel.toggle(r.id)}
+                        showEvaluation={false}
+                        indent
+                      />
+                    ))}
+                </React.Fragment>
+              ))
             ) : (
-              runs.map((r) => {
-                const errors = r.errorCount;
-                return (
-                  <TR
-                    key={r.id}
-                    interactive
-                    selected={sel.has(r.id)}
-                    onClick={() => router.push(`/projects/${projectId}/evaluations/${r.id}`)}
-                  >
-                    <SelectRowCell
-                      checked={sel.has(r.id)}
-                      onToggle={() => sel.toggle(r.id)}
-                      label={`Select ${r.evaluationName} #${r.runNumber}`}
-                    />
-                    {/* Two-line identity: the evaluation lineage, then the immutable
-                        run + candidate. No opaque DB id in the visible name. */}
-                    <Td>
-                      <div className="font-medium">{r.evaluationName}</div>
-                      <div className="text-[11px] text-muted-foreground">
-                        Run #{r.runNumber} · <span className="font-mono">{r.candidateVersion}</span>
-                      </div>
-                    </Td>
-                    <Td className="text-muted-foreground">
-                      <div>{r.datasetName}</div>
-                      <div className="text-[11px]">{r.datasetVersionLabel}</div>
-                    </Td>
-                    <Td className="text-right tabular-nums">
-                      {r.mainScore === null ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : (
-                        pctFraction(r.mainScore)
-                      )}
-                    </Td>
-                    <Td className="text-right tabular-nums">
-                      {r.changeFromBaseline === null ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : (
-                        <span className={SENTIMENT_CLASS[changeSentiment(r.changeFromBaseline)]}>
-                          {signedPoints(r.changeFromBaseline)} pp
-                        </span>
-                      )}
-                    </Td>
-                    <Td className="text-right tabular-nums">
-                      {/* Regressed TEST CASES (not score cells). "—" when there's no
-                          trustworthy baseline to count against. */}
-                      {r.regressedCaseCount === null || r.regressedCaseCount === undefined ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : r.regressedCaseCount === 0 ? (
-                        <span className="text-muted-foreground">0</span>
-                      ) : (
-                        <span className={SENTIMENT_CLASS.bad}>{r.regressedCaseCount}</span>
-                      )}
-                    </Td>
-                    <Td>
-                      <RunStatusBadge status={r.status} />
-                    </Td>
-                    <Td className="text-right tabular-nums">
-                      {errors === 0 ? <span className="text-muted-foreground">—</span> : errors}
-                    </Td>
-                    <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
-                      {formatElapsed(r.elapsedMs)}
-                    </Td>
-                    <Td className="whitespace-nowrap text-right text-muted-foreground">
-                      <Timestamp iso={r.startedAt} />
-                    </Td>
-                  </TR>
-                );
-              })
+              runs.map((r) => (
+                <RunTableRow
+                  key={r.id}
+                  run={r}
+                  projectId={projectId}
+                  selected={sel.has(r.id)}
+                  onToggle={() => sel.toggle(r.id)}
+                />
+              ))
             )}
           </TBody>
         </Table>
@@ -411,7 +720,7 @@ function ScorersTab({ projectId }: { projectId: string }) {
                   onToggle={sel.toggleAll}
                 />
                 <Th>Scorer</Th>
-                <Th className="w-[110px]">Type</Th>
+                <Th className="w-[110px]">Output</Th>
                 <Th className="w-[120px] text-right">Scores</Th>
                 <Th className="w-[120px] text-right">Error rate</Th>
               </TRHead>
@@ -482,7 +791,11 @@ function ScorersTab({ projectId }: { projectId: string }) {
         className="w-[360px] shrink-0 overflow-auto border-l border-border"
       >
         {selected ? (
-          <ScorerDetail key={`${selected.name}@${selected.version}`} scorer={selected} />
+          <ScorerDetail
+            key={`${selected.name}@${selected.version}`}
+            projectId={projectId}
+            scorer={selected}
+          />
         ) : (
           <EmptyState>Select a scorer to see what it reports.</EmptyState>
         )}
@@ -510,14 +823,26 @@ function ScorerFact({ label, children }: { label: string; children: React.ReactN
   );
 }
 
+/** For a field the SDK does not (yet) register — shown honestly, never fabricated. */
+function NotProvided() {
+  return <span className="italic text-muted-foreground">Not provided by SDK</span>;
+}
+
 /**
- * Scorer detail — everything TraceRoot has OBSERVED about a scorer (the SDK owns
- * its definition): value type + declared config, the score distribution, pass and
- * error rates with recent failures, and where it's used. All derived from the
- * scores it has reported.
+ * Scorer detail, organized around four questions — what it measures / reads / how it
+ * works / where it's used. A scorer is defined in the customer's SDK; TraceRoot shows
+ * ONLY what the SDK reported and what it observed from scores. Fields the SDK doesn't
+ * register (type, capabilities, judge prompt/model, code refs, scope, description,
+ * lifecycle) say "Not provided by SDK" rather than being invented from the name.
  */
-function ScorerDetail({ scorer }: { scorer: ScorerRegistryRow }) {
+function ScorerDetail({ projectId, scorer }: { projectId: string; scorer: ScorerRegistryRow }) {
   const maxCount = scorer.distribution?.reduce((m, d) => Math.max(m, d.count), 0) ?? 0;
+  const family = useScorer(projectId, scorer.name);
+  const versions = family.data?.versions ?? [];
+  const categories =
+    scorer.valueType === "categorical" && scorer.distribution
+      ? scorer.distribution.map((d) => d.label)
+      : null;
 
   return (
     <div className="flex flex-col">
@@ -526,39 +851,67 @@ function ScorerDetail({ scorer }: { scorer: ScorerRegistryRow }) {
           <h2 className="text-[13px] font-medium">{scorer.name}</h2>
           <span className="text-[11px] text-muted-foreground">{scorer.version}</span>
           <Badge variant="outline" className="ml-auto">
-            {VALUE_TYPE_LABEL[scorer.valueType]}
+            Defined in SDK
           </Badge>
         </div>
       </div>
 
-      <ScorerSection title="Config">
+      {/* 1 — What does it measure? */}
+      <ScorerSection title="What does it measure?">
         <dl>
-          <ScorerFact label="Value type">
+          <ScorerFact label="Output type">
             {VALUE_TYPE_LABEL[scorer.declaredValueType ?? scorer.valueType]}
             {scorer.declaredValueType === null && (
               <span className="ml-1 text-[11px] text-muted-foreground">(inferred)</span>
             )}
           </ScorerFact>
           <ScorerFact label="Direction">
-            {scorer.direction ? (
-              DIRECTION_LABEL[scorer.direction]
-            ) : (
-              <span className="text-muted-foreground">Not declared</span>
-            )}
+            {scorer.direction ? DIRECTION_LABEL[scorer.direction] : <NotProvided />}
           </ScorerFact>
           <ScorerFact label="Threshold">
-            {scorer.threshold !== null ? (
-              scorer.threshold
-            ) : (
-              <span className="text-muted-foreground">—</span>
-            )}
+            {scorer.threshold !== null ? scorer.threshold : <NotProvided />}
+          </ScorerFact>
+          {categories && (
+            <ScorerFact label="Categories (observed)">{categories.join(", ")}</ScorerFact>
+          )}
+          <ScorerFact label="Description">
+            <NotProvided />
+          </ScorerFact>
+          <ScorerFact label="Scope / target">
+            <NotProvided />
+          </ScorerFact>
+          <ScorerFact label="Expected output required">
+            <NotProvided />
           </ScorerFact>
         </dl>
       </ScorerSection>
 
-      <ScorerSection title="Scores">
+      {/* 2 — What does it read? */}
+      <ScorerSection title="What does it read?">
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          The SDK does not yet report a scorer&apos;s declared capabilities (which of input,
+          candidate output, expected output, metadata, tool calls or retrieval context it reads).{" "}
+          <NotProvided />.
+        </p>
+      </ScorerSection>
+
+      {/* 3 — How does it work? */}
+      <ScorerSection title="How does it work?">
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          The scorer&apos;s type (rule, LLM judge or human) and its definition — a judge&apos;s
+          rubric/prompt/model, or a code scorer&apos;s language/module/source reference — live in
+          the SDK and are not registered with TraceRoot. <NotProvided />.
+        </p>
+      </ScorerSection>
+
+      {/* 4 — Where is it used? */}
+      <ScorerSection title="Where is it used?">
         <dl>
-          <ScorerFact label="Reported">{scorer.scoreCount.toLocaleString("en-US")}</ScorerFact>
+          <ScorerFact label="Evaluations">{scorer.evaluationCount}</ScorerFact>
+          <ScorerFact label="Runs">{scorer.runCount}</ScorerFact>
+          <ScorerFact label="Scored results">
+            {scorer.scoreCount.toLocaleString("en-US")}
+          </ScorerFact>
           {scorer.numeric && (
             <>
               <ScorerFact label="Mean">{scorer.numeric.mean.toFixed(3)}</ScorerFact>
@@ -570,34 +923,6 @@ function ScorerDetail({ scorer }: { scorer: ScorerRegistryRow }) {
           {scorer.passRate !== null && (
             <ScorerFact label="Pass rate">{(scorer.passRate * 100).toFixed(1)}%</ScorerFact>
           )}
-        </dl>
-      </ScorerSection>
-
-      {scorer.distribution && scorer.distribution.length > 0 && (
-        <ScorerSection title="Distribution">
-          <ul className="flex flex-col gap-1.5">
-            {scorer.distribution.map((d) => (
-              <li key={d.label} className="flex items-center gap-2 text-[11px]">
-                <span className="w-20 shrink-0 truncate" title={d.label}>
-                  {d.label}
-                </span>
-                <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
-                  <span
-                    className="block h-full rounded-full bg-foreground/70"
-                    style={{ width: `${maxCount > 0 ? (d.count / maxCount) * 100 : 0}%` }}
-                  />
-                </span>
-                <span className="w-10 shrink-0 text-right tabular-nums text-muted-foreground">
-                  {d.count}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </ScorerSection>
-      )}
-
-      <ScorerSection title="Reliability">
-        <dl>
           <ScorerFact label="Error rate">
             {scorer.errorCount === 0 ? (
               <span className="text-muted-foreground">0%</span>
@@ -607,25 +932,6 @@ function ScorerDetail({ scorer }: { scorer: ScorerRegistryRow }) {
               </span>
             )}
           </ScorerFact>
-        </dl>
-        {scorer.recentErrors.length > 0 && (
-          <ul className="mt-2 flex flex-col gap-1.5">
-            {scorer.recentErrors.map((e, i) => (
-              <li
-                key={i}
-                className="rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 font-mono text-[11px] leading-relaxed text-amber-700 dark:text-amber-300"
-              >
-                {e.message}
-              </li>
-            ))}
-          </ul>
-        )}
-      </ScorerSection>
-
-      <ScorerSection title="Usage">
-        <dl>
-          <ScorerFact label="Evaluations">{scorer.evaluationCount}</ScorerFact>
-          <ScorerFact label="Runs">{scorer.runCount}</ScorerFact>
           <ScorerFact label="Last used">
             {scorer.lastUsed ? (
               <Timestamp iso={scorer.lastUsed} className="inline" />
@@ -634,7 +940,79 @@ function ScorerDetail({ scorer }: { scorer: ScorerRegistryRow }) {
             )}
           </ScorerFact>
         </dl>
+
+        {scorer.distribution && scorer.distribution.length > 0 && (
+          <div className="mt-2">
+            <div className="mb-1 text-[11px] text-muted-foreground">Score distribution</div>
+            <ul className="flex flex-col gap-1.5">
+              {scorer.distribution.map((d) => (
+                <li key={d.label} className="flex items-center gap-2 text-[11px]">
+                  <span className="w-20 shrink-0 truncate" title={d.label}>
+                    {d.label}
+                  </span>
+                  <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+                    <span
+                      className="block h-full rounded-full bg-foreground/70"
+                      style={{ width: `${maxCount > 0 ? (d.count / maxCount) * 100 : 0}%` }}
+                    />
+                  </span>
+                  <span className="w-10 shrink-0 text-right tabular-nums text-muted-foreground">
+                    {d.count}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {scorer.recentErrors.length > 0 && (
+          <div className="mt-2">
+            <div className="mb-1 text-[11px] text-muted-foreground">Recent scorer errors</div>
+            <ul className="flex flex-col gap-1.5">
+              {scorer.recentErrors.map((e, i) => (
+                <li
+                  key={i}
+                  className="rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 font-mono text-[11px] leading-relaxed text-amber-700 dark:text-amber-300"
+                >
+                  {e.message}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {versions.length > 1 && (
+          <div className="mt-2">
+            <div className="mb-1 text-[11px] text-muted-foreground">Version history</div>
+            <ul className="flex flex-col gap-0.5">
+              {versions.map((v) => (
+                <li
+                  key={v.version}
+                  className={cn(
+                    "flex items-center justify-between gap-2 rounded px-1.5 py-0.5 text-[11px]",
+                    v.version === scorer.version && "bg-muted/60",
+                  )}
+                >
+                  <span className="flex items-center gap-1.5">
+                    <span className="font-medium">{v.version}</span>
+                    {v.version === scorer.version && (
+                      <span className="text-[10px] text-muted-foreground">viewing</span>
+                    )}
+                  </span>
+                  <span className="tabular-nums text-muted-foreground">
+                    {v.scoreCount} scored{v.lastUsed ? " · " : ""}
+                    {v.lastUsed && <Timestamp iso={v.lastUsed} className="inline" />}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
       </ScorerSection>
+
+      <div className="border-t border-border px-3 py-2 text-[11px] text-muted-foreground">
+        Source: SDK · Scorers are defined in your SDK code and can&apos;t be created or edited here.
+      </div>
     </div>
   );
 }

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -34,6 +34,7 @@ import {
   BulkActionBar,
 } from "@/features/offline-eval/components";
 import { ProjectBreadcrumb } from "@/features/projects/components";
+import { PassRate } from "../components/pass-rate";
 import {
   changeSentiment,
   pctFraction,
@@ -49,7 +50,6 @@ import {
   type ScorerRegistryRow,
 } from "../hooks";
 import { EVAL_RUN_STATUS_LABEL, type EvalRunStatus, type RunRow } from "../types";
-import { RunEvaluationDrawer } from "../components/run-evaluation-drawer";
 
 // Run-centric: the Evaluations page is one table of immutable runs. Scorers is the
 // SDK-authored catalog. There is no separate "unique evaluations", "all runs", or
@@ -78,7 +78,6 @@ const ALL = "__all__";
 
 export function EvaluationsView({ projectId }: { projectId: string }) {
   const [tab, setTab] = React.useState<Tab>("evaluations");
-  const [runOpen, setRunOpen] = React.useState(false);
 
   return (
     <div className="flex h-full flex-col text-[12px]">
@@ -109,17 +108,10 @@ export function EvaluationsView({ projectId }: { projectId: string }) {
             );
           })}
         </div>
-        {tab === "evaluations" && (
-          <Button size="sm" className="h-7 text-[12px]" onClick={() => setRunOpen(true)}>
-            Run evaluation
-          </Button>
-        )}
       </div>
 
       {tab === "evaluations" && <RunsTab projectId={projectId} />}
       {tab === "scorers" && <ScorersTab projectId={projectId} />}
-
-      <RunEvaluationDrawer projectId={projectId} open={runOpen} onOpenChange={setRunOpen} />
     </div>
   );
 }
@@ -128,7 +120,7 @@ export function EvaluationsView({ projectId }: { projectId: string }) {
 // Runs — the flat execution list.
 // ---------------------------------------------------------------------------
 
-const RUNS_COLUMN_COUNT = 10;
+const RUNS_COLUMN_COUNT = 11;
 
 /** Human elapsed duration; "—" when unknown (never 0). */
 function formatElapsed(ms: number | null | undefined): string {
@@ -212,6 +204,9 @@ function RunTableRow({
       </Td>
       <Td className="text-right tabular-nums">
         <ScoreValue value={r.mainScore} />
+      </Td>
+      <Td className="text-right tabular-nums">
+        <PassRate counts={r} />
       </Td>
       <Td className="text-right tabular-nums">
         <ChangeValue value={r.changeFromBaseline} />
@@ -596,6 +591,7 @@ function RunsTab({ projectId }: { projectId: string }) {
               <Th>Evaluation / Run</Th>
               <Th>Dataset</Th>
               <Th className="w-[110px] text-right">Main score</Th>
+              <Th className="w-[100px] text-right">Passed</Th>
               <Th className="w-[100px] text-right">Change</Th>
               <Th className="w-[100px] text-right">Regressions</Th>
               <Th className="w-[150px]">Status</Th>
@@ -618,7 +614,7 @@ function RunsTab({ projectId }: { projectId: string }) {
                 <EmptyState>
                   {filtered || scopedEvalId
                     ? "No runs match these filters."
-                    : "No evaluation runs yet. Use Run evaluation for the SDK snippet."}
+                    : "No evaluation runs yet. Report a run from your SDK and it appears here."}
                 </EmptyState>
               </Cell>
             ) : grouped ? (

--- a/frontend/ui/src/features/offline-eval/components/badges.tsx
+++ b/frontend/ui/src/features/offline-eval/components/badges.tsx
@@ -1,21 +1,18 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
 import {
   RESULT_STATUS_LABEL,
   REVIEW_STATUS_LABEL,
-  scopeMeta,
   type ResultStatus,
   type ReviewStatus,
-  type Scope,
 } from "../types";
 import { RESULT_STATUS_VARIANT, REVIEW_STATUS_VARIANT } from "../utils";
 
 /**
- * Only two badges exist in v1: how a result turned out, and how much a case is
- * trusted. Everything else that used to be a chip is now plain text — badges
- * stop meaning anything once every cell has three.
+ * Two badges: how a result turned out, and whether a case has been reviewed.
+ * Span kind uses the real `SpanKindBadge` from @/features/traces, so a span
+ * reads the same here as in the trace viewer.
  */
 
 export function StatusBadge({ status }: { status: ResultStatus }) {
@@ -24,24 +21,4 @@ export function StatusBadge({ status }: { status: ResultStatus }) {
 
 export function ReviewBadge({ status }: { status: ReviewStatus }) {
   return <Badge variant={REVIEW_STATUS_VARIANT[status]}>{REVIEW_STATUS_LABEL[status]}</Badge>;
-}
-
-/**
- * Scope as quiet text, not a coloured chip. "Whole workflow" is the normal
- * case, so it should not draw the eye — only the narrow scopes are notable.
- */
-export function ScopeLabel({ scope, className }: { scope: Scope; className?: string }) {
-  const meta = scopeMeta(scope);
-  const isDefault = scope === "whole_workflow";
-  return (
-    <span
-      className={cn(
-        "text-[12px]",
-        isDefault ? "text-muted-foreground" : "text-foreground",
-        className,
-      )}
-    >
-      {meta.label}
-    </span>
-  );
 }

--- a/frontend/ui/src/features/offline-eval/components/badges.tsx
+++ b/frontend/ui/src/features/offline-eval/components/badges.tsx
@@ -1,111 +1,47 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { getSpanKindColor } from "@/features/traces/components/SpanKindIcon";
 import {
-  granularity,
-  goldenStatus,
-  type Granularity,
-  type GoldenStatus,
-  type RowOutcome,
-  type Severity,
+  RESULT_STATUS_LABEL,
+  REVIEW_STATUS_LABEL,
+  scopeMeta,
+  type ResultStatus,
+  type ReviewStatus,
+  type Scope,
 } from "../types";
-import { GOLDEN_VARIANT, OUTCOME_LABEL, OUTCOME_VARIANT, SEVERITY_VARIANT } from "../utils";
+import { RESULT_STATUS_VARIANT, REVIEW_STATUS_VARIANT } from "../utils";
 
-export function SeverityBadge({ severity }: { severity: Severity }) {
-  return (
-    <Badge variant={SEVERITY_VARIANT[severity]} className="capitalize">
-      {severity}
-    </Badge>
-  );
+/**
+ * Only two badges exist in v1: how a result turned out, and how much a case is
+ * trusted. Everything else that used to be a chip is now plain text — badges
+ * stop meaning anything once every cell has three.
+ */
+
+export function StatusBadge({ status }: { status: ResultStatus }) {
+  return <Badge variant={RESULT_STATUS_VARIANT[status]}>{RESULT_STATUS_LABEL[status]}</Badge>;
+}
+
+export function ReviewBadge({ status }: { status: ReviewStatus }) {
+  return <Badge variant={REVIEW_STATUS_VARIANT[status]}>{REVIEW_STATUS_LABEL[status]}</Badge>;
 }
 
 /**
- * Golden status with its definition attached — "Golden" is a claim about human
- * validation, and the tooltip is where that claim is stated rather than assumed.
+ * Scope as quiet text, not a coloured chip. "Whole workflow" is the normal
+ * case, so it should not draw the eye — only the narrow scopes are notable.
  */
-export function GoldenBadge({ status }: { status: GoldenStatus }) {
-  const meta = goldenStatus(status);
+export function ScopeLabel({ scope, className }: { scope: Scope; className?: string }) {
+  const meta = scopeMeta(scope);
+  const isDefault = scope === "whole_workflow";
   return (
-    <TooltipProvider delayDuration={150}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            tabIndex={0}
-            className="rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          >
-            <Badge variant={GOLDEN_VARIANT[status]}>{meta.label}</Badge>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="max-w-[260px]">
-          <p className="text-[11px] leading-snug">{meta.description}</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
-/**
- * Granularity chip, tinted with the same span-kind palette the trace viewer
- * uses, so "LLM response" reads violet here and violet in the span tree.
- */
-export function ScopeBadge({
-  scope,
-  className,
-  withTooltip = true,
-}: {
-  scope: Granularity;
-  className?: string;
-  withTooltip?: boolean;
-}) {
-  const meta = granularity(scope);
-  const color = getSpanKindColor(meta.spanKind);
-
-  const chip = (
     <span
       className={cn(
-        "inline-flex items-center gap-1 whitespace-nowrap rounded border px-1.5 py-0.5 text-[11px] font-medium leading-none",
-        color.surface,
-        color.glyph,
+        "text-[12px]",
+        isDefault ? "text-muted-foreground" : "text-foreground",
         className,
       )}
     >
       {meta.label}
-    </span>
-  );
-
-  if (!withTooltip) return chip;
-
-  return (
-    <TooltipProvider delayDuration={150}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            tabIndex={0}
-            className="rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          >
-            {chip}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="max-w-[260px]">
-          <p className="text-[11px] leading-snug">{meta.description}</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
-export function OutcomeBadge({ outcome }: { outcome: RowOutcome }) {
-  return <Badge variant={OUTCOME_VARIANT[outcome]}>{OUTCOME_LABEL[outcome]}</Badge>;
-}
-
-/** Key=value cohort chip. */
-export function CohortChip({ label, value }: { label: string; value: string }) {
-  return (
-    <span className="inline-flex items-center whitespace-nowrap rounded border border-border bg-muted/60 px-1.5 py-0.5 font-mono text-[11px] leading-none text-muted-foreground">
-      {label}={value}
     </span>
   );
 }

--- a/frontend/ui/src/features/offline-eval/components/badges.tsx
+++ b/frontend/ui/src/features/offline-eval/components/badges.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { getSpanKindColor } from "@/features/traces/components/SpanKindIcon";
+import {
+  granularity,
+  goldenStatus,
+  type Granularity,
+  type GoldenStatus,
+  type RowOutcome,
+  type Severity,
+} from "../types";
+import { GOLDEN_VARIANT, OUTCOME_LABEL, OUTCOME_VARIANT, SEVERITY_VARIANT } from "../utils";
+
+export function SeverityBadge({ severity }: { severity: Severity }) {
+  return (
+    <Badge variant={SEVERITY_VARIANT[severity]} className="capitalize">
+      {severity}
+    </Badge>
+  );
+}
+
+/**
+ * Golden status with its definition attached — "Golden" is a claim about human
+ * validation, and the tooltip is where that claim is stated rather than assumed.
+ */
+export function GoldenBadge({ status }: { status: GoldenStatus }) {
+  const meta = goldenStatus(status);
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            tabIndex={0}
+            className="rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <Badge variant={GOLDEN_VARIANT[status]}>{meta.label}</Badge>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-[260px]">
+          <p className="text-[11px] leading-snug">{meta.description}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+/**
+ * Granularity chip, tinted with the same span-kind palette the trace viewer
+ * uses, so "LLM response" reads violet here and violet in the span tree.
+ */
+export function ScopeBadge({
+  scope,
+  className,
+  withTooltip = true,
+}: {
+  scope: Granularity;
+  className?: string;
+  withTooltip?: boolean;
+}) {
+  const meta = granularity(scope);
+  const color = getSpanKindColor(meta.spanKind);
+
+  const chip = (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 whitespace-nowrap rounded border px-1.5 py-0.5 text-[11px] font-medium leading-none",
+        color.surface,
+        color.glyph,
+        className,
+      )}
+    >
+      {meta.label}
+    </span>
+  );
+
+  if (!withTooltip) return chip;
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            tabIndex={0}
+            className="rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            {chip}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-[260px]">
+          <p className="text-[11px] leading-snug">{meta.description}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export function OutcomeBadge({ outcome }: { outcome: RowOutcome }) {
+  return <Badge variant={OUTCOME_VARIANT[outcome]}>{OUTCOME_LABEL[outcome]}</Badge>;
+}
+
+/** Key=value cohort chip. */
+export function CohortChip({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="inline-flex items-center whitespace-nowrap rounded border border-border bg-muted/60 px-1.5 py-0.5 font-mono text-[11px] leading-none text-muted-foreground">
+      {label}={value}
+    </span>
+  );
+}

--- a/frontend/ui/src/features/offline-eval/components/badges.tsx
+++ b/frontend/ui/src/features/offline-eval/components/badges.tsx
@@ -2,12 +2,31 @@
 
 import { Badge } from "@/components/ui/badge";
 import {
+  EVAL_RESULT_STATUS_LABEL,
   RESULT_STATUS_LABEL,
   REVIEW_STATUS_LABEL,
+  type EvalResultStatus,
   type ResultStatus,
   type ReviewStatus,
 } from "../types";
 import { RESULT_STATUS_VARIANT, REVIEW_STATUS_VARIANT } from "../utils";
+
+/**
+ * Evaluation-result variants. "Errored" is amber rather than red so a broken
+ * run reads differently from a judged-and-failed one, and "Not scored" is a
+ * plain outline so it can never be mistaken for a score of zero.
+ */
+const EVAL_RESULT_VARIANT: Record<EvalResultStatus, "success" | "danger" | "warning" | "outline"> =
+  {
+    passed: "success",
+    failed: "danger",
+    errored: "warning",
+    not_scored: "outline",
+  };
+
+export function EvalResultBadge({ status }: { status: EvalResultStatus }) {
+  return <Badge variant={EVAL_RESULT_VARIANT[status]}>{EVAL_RESULT_STATUS_LABEL[status]}</Badge>;
+}
 
 /**
  * Two badges: how a result turned out, and whether a case has been reviewed.

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Maximize2, Minimize2 } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
@@ -172,17 +173,29 @@ export function LineNumberedTextarea({
   highlightJson?: boolean;
   "aria-label"?: string;
 }) {
-  const lines = Math.max(value === "" ? 1 : value.split("\n").length, minRows);
+  // Gutter numbers only the real content lines; the textarea can still be taller
+  // (minRows) with blank, unnumbered space below — the way a code editor looks.
+  // The field never wraps, so every line maps 1:1 to a gutter number; long lines
+  // scroll horizontally, and the color layer tracks that scroll.
+  const contentLines = value === "" ? 1 : value.split("\n").length;
+  const rows = Math.max(contentLines, minRows);
   const tokens = highlightJson ? tokenizeJson(value) : null;
+  const preRef = React.useRef<HTMLPreElement>(null);
+  const syncScroll = (e: React.UIEvent<HTMLTextAreaElement>) => {
+    if (preRef.current) {
+      preRef.current.style.transform = `translateX(${-e.currentTarget.scrollLeft}px)`;
+    }
+  };
   return (
     <div className="flex overflow-hidden rounded border border-input bg-background focus-within:ring-1 focus-within:ring-ring">
-      <Gutter count={lines} />
-      <div className="relative flex-1">
+      <Gutter count={contentLines} />
+      <div className="relative min-w-0 flex-1 overflow-hidden">
         {/* Colored layer sits exactly behind the transparent-text textarea. */}
         {tokens && (
           <pre
+            ref={preRef}
             aria-hidden
-            className="pointer-events-none absolute inset-0 m-0 overflow-hidden whitespace-pre-wrap break-words px-2 py-1.5 font-mono text-[12px] leading-relaxed"
+            className="pointer-events-none absolute inset-0 m-0 whitespace-pre px-2 py-1.5 font-mono text-[12px] leading-relaxed"
           >
             {tokens.map((t, i) => (
               <span key={i} className={t.cls || undefined}>
@@ -194,12 +207,14 @@ export function LineNumberedTextarea({
         <textarea
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          rows={lines}
+          onScroll={syncScroll}
+          rows={rows}
+          wrap="off"
           spellCheck={false}
           placeholder={placeholder}
           aria-label={ariaLabel}
           className={cn(
-            "relative block w-full resize-none whitespace-pre-wrap break-words bg-transparent px-2 py-1.5 font-mono text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none",
+            "relative block w-full resize-none overflow-x-auto whitespace-pre bg-transparent px-2 py-1.5 font-mono text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none",
             tokens && "text-transparent caret-foreground",
           )}
         />
@@ -276,10 +291,29 @@ export function ValueBlock({
   );
 }
 
+/** Picks the initial format from the content: a JSON object/array → json, else text. */
+function detectKind(text: string): ValueKind {
+  const trimmed = text.trim();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      JSON.parse(trimmed);
+      return "json";
+    } catch {
+      /* looks like JSON but isn't — fall through to text */
+    }
+  }
+  return "text";
+}
+
 /**
  * Editable counterpart to ValueBlock. The text is controlled by the caller;
  * switching the view kind reformats it best-effort (only when it parses as
  * JSON), so plain text is never mangled.
+ *
+ * Optional extras (all off by default, so existing callers are unchanged):
+ * `copyable` adds a copy button, `enlargeable` adds a taller/shorter toggle,
+ * `autoDetectKind` picks JSON vs text from the initial content, and `minRows`
+ * sets the resting height.
  */
 export function EditableValueBlock({
   label,
@@ -287,17 +321,41 @@ export function EditableValueBlock({
   onChange,
   defaultKind = "yaml",
   ariaLabel,
+  copyable = false,
+  enlargeable = false,
+  autoDetectKind = false,
+  minRows = 1,
+  boxed = false,
 }: {
   label: string;
   text: string;
   onChange: (text: string) => void;
   defaultKind?: ValueKind;
   ariaLabel?: string;
+  copyable?: boolean;
+  enlargeable?: boolean;
+  autoDetectKind?: boolean;
+  minRows?: number;
+  /** Wrap the block in a bordered card with a muted header strip (like FormCard). */
+  boxed?: boolean;
 }) {
   const [kind, setKind] = React.useState<ValueKind>(defaultKind);
   const [menuOpen, setMenuOpen] = React.useState(false);
+  const [enlarged, setEnlarged] = React.useState(false);
+  const userSetKind = React.useRef(false);
+  const detected = React.useRef(false);
+
+  // Detect JSON vs text once, when the value first arrives (e.g. after a dialog
+  // seeds it), unless the user has already chosen a format from the switcher.
+  React.useEffect(() => {
+    if (autoDetectKind && !userSetKind.current && !detected.current && text.trim() !== "") {
+      detected.current = true;
+      setKind(detectKind(text));
+    }
+  }, [autoDetectKind, text]);
 
   const changeKind = (next: ValueKind) => {
+    userSetKind.current = true;
     setKind(next);
     setMenuOpen(false);
     // Reformat only when the current text is valid JSON; otherwise leave it be.
@@ -309,44 +367,88 @@ export function EditableValueBlock({
     }
   };
 
+  // Rest at minRows and grow one line at a time with the content; enlarge opens
+  // it fully.
+  const effectiveMin = enlarged ? Math.max(minRows, 24) : minRows;
+
+  const controls = (
+    <div className="flex items-center gap-0.5">
+      {enlargeable && (
+        <button
+          type="button"
+          onClick={() => setEnlarged((v) => !v)}
+          title={enlarged ? "Shrink" : "Enlarge"}
+          aria-label={enlarged ? "Shrink field" : "Enlarge field"}
+          className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          {enlarged ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
+        </button>
+      )}
+      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            {KIND_LABEL[kind]}
+            <ChevronDown className="h-3 w-3" aria-hidden />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-28 p-1">
+          {KINDS.map((k) => (
+            <button
+              key={k}
+              type="button"
+              onClick={() => changeKind(k)}
+              className={cn(
+                "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
+                k === kind ? "bg-muted/70" : "hover:bg-muted/50",
+              )}
+            >
+              {KIND_LABEL[k]}
+            </button>
+          ))}
+        </PopoverContent>
+      </Popover>
+      {copyable && (
+        <CopyButton
+          value={text}
+          className="h-6 w-6 text-muted-foreground hover:text-foreground"
+          title="Copy"
+        />
+      )}
+    </div>
+  );
+
+  const field = (
+    <LineNumberedTextarea
+      value={text}
+      onChange={onChange}
+      minRows={effectiveMin}
+      highlightJson={kind === "json" || kind === "pretty"}
+      aria-label={ariaLabel ?? label}
+    />
+  );
+
+  if (boxed) {
+    return (
+      <div className="border border-border">
+        <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/50 px-3 py-1.5">
+          <span className="text-[12px] font-medium text-muted-foreground">{label}</span>
+          {controls}
+        </div>
+        <div className="p-3">{field}</div>
+      </div>
+    );
+  }
+
   return (
     <div>
-      <div className="mb-1 flex items-center justify-between">
+      <div className="mb-1 flex items-center justify-between gap-2">
         <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
-        <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            >
-              {KIND_LABEL[kind]}
-              <ChevronDown className="h-3 w-3" aria-hidden />
-            </button>
-          </PopoverTrigger>
-          <PopoverContent align="end" className="w-28 p-1">
-            {KINDS.map((k) => (
-              <button
-                key={k}
-                type="button"
-                onClick={() => changeKind(k)}
-                className={cn(
-                  "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
-                  k === kind ? "bg-muted/70" : "hover:bg-muted/50",
-                )}
-              >
-                {KIND_LABEL[k]}
-              </button>
-            ))}
-          </PopoverContent>
-        </Popover>
+        {controls}
       </div>
-      <LineNumberedTextarea
-        value={text}
-        onChange={onChange}
-        minRows={1}
-        highlightJson={kind === "json" || kind === "pretty"}
-        aria-label={ariaLabel ?? label}
-      />
+      {field}
     </div>
   );
 }

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import * as React from "react";
+import { ChevronDown, ChevronRight, ChevronsDownUp } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+/**
+ * Small code helpers for the datasets UI: a line-numbered editable field, and a
+ * read-only value block that can be shown as YAML / text / JSON / pretty JSON
+ * and minimised — the same shapes a trace value uses.
+ */
+
+export type ValueKind = "yaml" | "text" | "json" | "pretty";
+
+const KIND_LABEL: Record<ValueKind, string> = {
+  yaml: "YAML",
+  text: "Text",
+  json: "JSON",
+  pretty: "Pretty",
+};
+
+const KINDS: ValueKind[] = ["yaml", "text", "json", "pretty"];
+
+/** Minimal YAML for the flat values we hold. Empty → `null`, as requested. */
+function toYaml(value: unknown, indent = 0): string {
+  const pad = "  ".repeat(indent);
+  if (value === null || value === undefined || value === "") return `${pad}null`;
+  if (typeof value === "string") {
+    // Multi-line strings render as a block scalar; single lines inline.
+    if (value.includes("\n")) {
+      return `${pad}|\n${value
+        .split("\n")
+        .map((line) => `${pad}  ${line}`)
+        .join("\n")}`;
+    }
+    return `${pad}${value}`;
+  }
+  if (typeof value === "number" || typeof value === "boolean") return `${pad}${value}`;
+  if (Array.isArray(value)) {
+    if (value.length === 0) return `${pad}[]`;
+    return value.map((item) => `${pad}- ${String(item)}`).join("\n");
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) return `${pad}null`;
+  return entries.map(([k, v]) => `${pad}${k}: ${String(v)}`).join("\n");
+}
+
+/** Formats a value for a given view kind. */
+export function formatValue(value: unknown, kind: ValueKind): string {
+  switch (kind) {
+    case "text":
+      if (value === null || value === undefined || value === "") return "null";
+      return typeof value === "string" ? value : JSON.stringify(value);
+    case "json":
+      return JSON.stringify(value ?? null);
+    case "pretty":
+      return JSON.stringify(value ?? null, null, 2);
+    case "yaml":
+    default:
+      return toYaml(value);
+  }
+}
+
+function Gutter({ count }: { count: number }) {
+  return (
+    <div
+      aria-hidden
+      className="select-none border-r border-border bg-muted/40 px-2 py-1.5 text-right font-mono text-[12px] leading-relaxed text-muted-foreground/50"
+    >
+      {Array.from({ length: count }, (_, i) => (
+        <div key={i}>{i + 1}</div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Editable code field with a line-number gutter on the left. An empty value is
+ * a single line "1" with an empty body. Grows with the content (no scroll sync
+ * to keep the numbers aligned).
+ */
+export function LineNumberedTextarea({
+  value,
+  onChange,
+  minRows = 1,
+  placeholder,
+  "aria-label": ariaLabel,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  minRows?: number;
+  placeholder?: string;
+  "aria-label"?: string;
+}) {
+  const lines = Math.max(value === "" ? 1 : value.split("\n").length, minRows);
+  return (
+    <div className="flex overflow-hidden rounded border border-input bg-background focus-within:ring-1 focus-within:ring-ring">
+      <Gutter count={lines} />
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={lines}
+        spellCheck={false}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        className="flex-1 resize-none bg-transparent px-2 py-1.5 font-mono text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none"
+      />
+    </div>
+  );
+}
+
+/** Read-only line-numbered code, used inside a ValueBlock. */
+function CodeView({ text }: { text: string }) {
+  const lines = text === "" ? 1 : text.split("\n").length;
+  return (
+    <div className="flex overflow-x-auto rounded border border-border bg-muted/20">
+      <Gutter count={lines} />
+      <pre className="flex-1 whitespace-pre-wrap break-words px-2 py-1.5 font-mono text-[12px] leading-relaxed">
+        {text}
+      </pre>
+    </div>
+  );
+}
+
+/**
+ * A labelled value that can switch view kind (YAML / Text / JSON / Pretty) and
+ * be minimised — the controls sit on the right of the label.
+ */
+export function ValueBlock({
+  label,
+  value,
+  defaultKind = "yaml",
+}: {
+  label: string;
+  value: unknown;
+  defaultKind?: ValueKind;
+}) {
+  const [kind, setKind] = React.useState<ValueKind>(defaultKind);
+  const [minimized, setMinimized] = React.useState(false);
+  const [menuOpen, setMenuOpen] = React.useState(false);
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
+        <span className="flex items-center gap-1">
+          <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                {KIND_LABEL[kind]}
+                <ChevronDown className="h-3 w-3" aria-hidden />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-28 p-1">
+              {KINDS.map((k) => (
+                <button
+                  key={k}
+                  type="button"
+                  onClick={() => {
+                    setKind(k);
+                    setMenuOpen(false);
+                  }}
+                  className={cn(
+                    "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
+                    k === kind ? "bg-muted/70" : "hover:bg-muted/50",
+                  )}
+                >
+                  {KIND_LABEL[k]}
+                </button>
+              ))}
+            </PopoverContent>
+          </Popover>
+          <button
+            type="button"
+            onClick={() => setMinimized((m) => !m)}
+            aria-label={minimized ? `Expand ${label}` : `Minimize ${label}`}
+            className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            {minimized ? (
+              <ChevronRight className="h-3.5 w-3.5" aria-hidden />
+            ) : (
+              <ChevronsDownUp className="h-3.5 w-3.5" aria-hidden />
+            )}
+          </button>
+        </span>
+      </div>
+      {!minimized && <CodeView text={formatValue(value, kind)} />}
+    </div>
+  );
+}

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ChevronDown, ChevronRight, ChevronsDownUp } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
@@ -137,58 +137,117 @@ export function ValueBlock({
   defaultKind?: ValueKind;
 }) {
   const [kind, setKind] = React.useState<ValueKind>(defaultKind);
-  const [minimized, setMinimized] = React.useState(false);
   const [menuOpen, setMenuOpen] = React.useState(false);
 
   return (
     <div>
       <div className="mb-1 flex items-center justify-between">
         <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
-        <span className="flex items-center gap-1">
-          <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-            <PopoverTrigger asChild>
+        <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              {KIND_LABEL[kind]}
+              <ChevronDown className="h-3 w-3" aria-hidden />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-28 p-1">
+            {KINDS.map((k) => (
               <button
+                key={k}
                 type="button"
-                className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                onClick={() => {
+                  setKind(k);
+                  setMenuOpen(false);
+                }}
+                className={cn(
+                  "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
+                  k === kind ? "bg-muted/70" : "hover:bg-muted/50",
+                )}
               >
-                {KIND_LABEL[kind]}
-                <ChevronDown className="h-3 w-3" aria-hidden />
+                {KIND_LABEL[k]}
               </button>
-            </PopoverTrigger>
-            <PopoverContent align="end" className="w-28 p-1">
-              {KINDS.map((k) => (
-                <button
-                  key={k}
-                  type="button"
-                  onClick={() => {
-                    setKind(k);
-                    setMenuOpen(false);
-                  }}
-                  className={cn(
-                    "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
-                    k === kind ? "bg-muted/70" : "hover:bg-muted/50",
-                  )}
-                >
-                  {KIND_LABEL[k]}
-                </button>
-              ))}
-            </PopoverContent>
-          </Popover>
-          <button
-            type="button"
-            onClick={() => setMinimized((m) => !m)}
-            aria-label={minimized ? `Expand ${label}` : `Minimize ${label}`}
-            className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          >
-            {minimized ? (
-              <ChevronRight className="h-3.5 w-3.5" aria-hidden />
-            ) : (
-              <ChevronsDownUp className="h-3.5 w-3.5" aria-hidden />
-            )}
-          </button>
-        </span>
+            ))}
+          </PopoverContent>
+        </Popover>
       </div>
-      {!minimized && <CodeView text={formatValue(value, kind)} />}
+      <CodeView text={formatValue(value, kind)} />
+    </div>
+  );
+}
+
+/**
+ * Editable counterpart to ValueBlock. The text is controlled by the caller;
+ * switching the view kind reformats it best-effort (only when it parses as
+ * JSON), so plain text is never mangled.
+ */
+export function EditableValueBlock({
+  label,
+  text,
+  onChange,
+  defaultKind = "yaml",
+  ariaLabel,
+}: {
+  label: string;
+  text: string;
+  onChange: (text: string) => void;
+  defaultKind?: ValueKind;
+  ariaLabel?: string;
+}) {
+  const [kind, setKind] = React.useState<ValueKind>(defaultKind);
+  const [menuOpen, setMenuOpen] = React.useState(false);
+
+  const changeKind = (next: ValueKind) => {
+    setKind(next);
+    setMenuOpen(false);
+    // Reformat only when the current text is valid JSON; otherwise leave it be.
+    try {
+      const parsed = JSON.parse(text);
+      onChange(formatValue(parsed, next));
+    } catch {
+      /* not JSON — keep the text as typed */
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
+        <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              {KIND_LABEL[kind]}
+              <ChevronDown className="h-3 w-3" aria-hidden />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-28 p-1">
+            {KINDS.map((k) => (
+              <button
+                key={k}
+                type="button"
+                onClick={() => changeKind(k)}
+                className={cn(
+                  "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
+                  k === kind ? "bg-muted/70" : "hover:bg-muted/50",
+                )}
+              >
+                {KIND_LABEL[k]}
+              </button>
+            ))}
+          </PopoverContent>
+        </Popover>
+      </div>
+      <LineNumberedTextarea
+        value={text}
+        onChange={onChange}
+        minRows={2}
+        aria-label={ariaLabel ?? label}
+      />
     </div>
   );
 }

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -62,6 +62,82 @@ export function formatValue(value: unknown, kind: ValueKind): string {
   }
 }
 
+/** Trace-panel JSON token colors, mirrored so JSON reads the same everywhere. */
+const JSON_TOKEN_COLORS = {
+  key: "text-sky-600 dark:text-sky-400",
+  string: "text-green-700 dark:text-green-400",
+  number: "text-blue-600 dark:text-blue-400",
+  boolean: "text-purple-600 dark:text-purple-400",
+  null: "text-orange-600 dark:text-orange-400",
+  punctuation: "text-muted-foreground",
+};
+
+/**
+ * Splits valid JSON text into colored tokens, preserving every character so the
+ * result can sit exactly behind a textarea. Returns null when the text is empty
+ * or not valid JSON, so the field shows as plain text mid-edit.
+ */
+function tokenizeJson(text: string): { text: string; cls: string }[] | null {
+  if (text.trim() === "") return null;
+  try {
+    JSON.parse(text);
+  } catch {
+    return null;
+  }
+  const tokens: { text: string; cls: string }[] = [];
+  const n = text.length;
+  let i = 0;
+  while (i < n) {
+    const c = text[i];
+    if (c === '"') {
+      let j = i + 1;
+      while (j < n) {
+        if (text[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (text[j] === '"') {
+          j += 1;
+          break;
+        }
+        j += 1;
+      }
+      let k = j;
+      while (k < n && /\s/.test(text[k])) k += 1;
+      const isKey = text[k] === ":";
+      tokens.push({
+        text: text.slice(i, j),
+        cls: isKey ? JSON_TOKEN_COLORS.key : JSON_TOKEN_COLORS.string,
+      });
+      i = j;
+    } else if (c === "-" || (c >= "0" && c <= "9")) {
+      let j = i + 1;
+      while (j < n && /[0-9.eE+-]/.test(text[j])) j += 1;
+      tokens.push({ text: text.slice(i, j), cls: JSON_TOKEN_COLORS.number });
+      i = j;
+    } else if (text.startsWith("true", i) || text.startsWith("false", i)) {
+      const word = text.startsWith("true", i) ? "true" : "false";
+      tokens.push({ text: word, cls: JSON_TOKEN_COLORS.boolean });
+      i += word.length;
+    } else if (text.startsWith("null", i)) {
+      tokens.push({ text: "null", cls: JSON_TOKEN_COLORS.null });
+      i += 4;
+    } else if ("{}[],:".includes(c)) {
+      tokens.push({ text: c, cls: JSON_TOKEN_COLORS.punctuation });
+      i += 1;
+    } else if (/\s/.test(c)) {
+      let j = i + 1;
+      while (j < n && /\s/.test(text[j])) j += 1;
+      tokens.push({ text: text.slice(i, j), cls: "" });
+      i = j;
+    } else {
+      tokens.push({ text: c, cls: "" });
+      i += 1;
+    }
+  }
+  return tokens;
+}
+
 function Gutter({ count }: { count: number }) {
   return (
     <div
@@ -85,27 +161,49 @@ export function LineNumberedTextarea({
   onChange,
   minRows = 1,
   placeholder,
+  highlightJson = false,
   "aria-label": ariaLabel,
 }: {
   value: string;
   onChange: (value: string) => void;
   minRows?: number;
   placeholder?: string;
+  /** When true, JSON content is syntax-highlighted (trace-panel colors). */
+  highlightJson?: boolean;
   "aria-label"?: string;
 }) {
   const lines = Math.max(value === "" ? 1 : value.split("\n").length, minRows);
+  const tokens = highlightJson ? tokenizeJson(value) : null;
   return (
     <div className="flex overflow-hidden rounded border border-input bg-background focus-within:ring-1 focus-within:ring-ring">
       <Gutter count={lines} />
-      <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        rows={lines}
-        spellCheck={false}
-        placeholder={placeholder}
-        aria-label={ariaLabel}
-        className="flex-1 resize-none bg-transparent px-2 py-1.5 font-mono text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none"
-      />
+      <div className="relative flex-1">
+        {/* Colored layer sits exactly behind the transparent-text textarea. */}
+        {tokens && (
+          <pre
+            aria-hidden
+            className="pointer-events-none absolute inset-0 m-0 overflow-hidden whitespace-pre-wrap break-words px-2 py-1.5 font-mono text-[12px] leading-relaxed"
+          >
+            {tokens.map((t, i) => (
+              <span key={i} className={t.cls || undefined}>
+                {t.text}
+              </span>
+            ))}
+          </pre>
+        )}
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          rows={lines}
+          spellCheck={false}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          className={cn(
+            "relative block w-full resize-none whitespace-pre-wrap break-words bg-transparent px-2 py-1.5 font-mono text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none",
+            tokens && "text-transparent caret-foreground",
+          )}
+        />
+      </div>
     </div>
   );
 }
@@ -245,7 +343,8 @@ export function EditableValueBlock({
       <LineNumberedTextarea
         value={text}
         onChange={onChange}
-        minRows={2}
+        minRows={1}
+        highlightJson={kind === "json" || kind === "pretty"}
         aria-label={ariaLabel ?? label}
       />
     </div>

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ChevronDown, Maximize2, Minimize2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Maximize2, Minimize2 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
@@ -183,6 +183,7 @@ export function LineNumberedTextarea({
   minRows = 1,
   placeholder,
   highlightJson = false,
+  readOnly = false,
   "aria-label": ariaLabel,
 }: {
   value: string;
@@ -191,13 +192,20 @@ export function LineNumberedTextarea({
   placeholder?: string;
   /** When true, JSON content is syntax-highlighted (trace-panel colors). */
   highlightJson?: boolean;
+  /** Display only — selectable and syntax-coloured, but not editable. */
+  readOnly?: boolean;
   "aria-label"?: string;
 }) {
   // Keep a real trailing empty line so the last line is always clickable — click
   // it and type without pressing Enter first, and a 1-line value still shows an
   // empty line 2. The parent value never keeps that trailing newline: it's added
   // for display/editing and stripped from what onChange reports.
-  const textValue = value.endsWith("\n") ? value : value + "\n";
+  //
+  // The newline is appended *unconditionally*. Appending it only when the value
+  // didn't already end in one meant pressing Enter (which makes the value end in
+  // a newline) was cancelled out by the strip below, so the line count — and the
+  // box height — never grew.
+  const textValue = `${value}\n`;
   const rawLines = textValue.split("\n");
   const tokenLines = highlightJson ? tokenizeJsonByLine(textValue) : null;
   const totalLines = Math.max(rawLines.length, minRows);
@@ -233,13 +241,18 @@ export function LineNumberedTextarea({
       <textarea
         value={textValue}
         onChange={(e) => {
+          if (readOnly) return;
           const v = e.target.value;
           onChange(v.endsWith("\n") ? v.slice(0, -1) : v);
         }}
+        readOnly={readOnly}
         spellCheck={false}
         placeholder={placeholder}
         aria-label={ariaLabel}
-        className="absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent py-1.5 pr-2 font-mono text-[12px] leading-relaxed text-transparent caret-foreground placeholder:text-muted-foreground focus:outline-none"
+        className={cn(
+          "absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent py-1.5 pr-2 font-mono text-[12px] leading-relaxed text-transparent placeholder:text-muted-foreground focus:outline-none",
+          readOnly ? "cursor-default caret-transparent" : "caret-foreground",
+        )}
         style={{ paddingLeft: `calc(${gutterWidth} + 0.5rem)` }}
       />
     </div>
@@ -349,6 +362,7 @@ export function EditableValueBlock({
   autoDetectKind = false,
   minRows = 1,
   boxed = false,
+  readOnly = false,
 }: {
   label: string;
   text: string;
@@ -361,12 +375,22 @@ export function EditableValueBlock({
   minRows?: number;
   /** Wrap the block in a bordered card with a muted header strip (like FormCard). */
   boxed?: boolean;
+  /** Display only — same look and format switcher, but the text can't be edited. */
+  readOnly?: boolean;
 }) {
   const [kind, setKind] = React.useState<ValueKind>(defaultKind);
   const [menuOpen, setMenuOpen] = React.useState(false);
   const [enlarged, setEnlarged] = React.useState(false);
+  // Minimised via the header chevron, like the span detail panel's I/O sections.
+  const [open, setOpen] = React.useState(true);
   const userSetKind = React.useRef(false);
   const detected = React.useRef(false);
+  // Read-only fields reformat locally (the parent value never changes), so the
+  // format switcher still works without touching the source of truth.
+  const [display, setDisplay] = React.useState(text);
+  React.useEffect(() => {
+    if (readOnly) setDisplay(text);
+  }, [readOnly, text]);
 
   // Detect JSON vs text once, when the value first arrives (e.g. after a dialog
   // seeds it), unless the user has already chosen a format from the switcher.
@@ -383,8 +407,10 @@ export function EditableValueBlock({
     setMenuOpen(false);
     // Reformat only when the current text is valid JSON; otherwise leave it be.
     try {
-      const parsed = JSON.parse(text);
-      onChange(formatValue(parsed, next));
+      const parsed = JSON.parse(readOnly ? display : text);
+      const formatted = formatValue(parsed, next);
+      if (readOnly) setDisplay(formatted);
+      else onChange(formatted);
     } catch {
       /* not JSON — keep the text as typed */
     }
@@ -435,7 +461,7 @@ export function EditableValueBlock({
       </Popover>
       {copyable && (
         <CopyButton
-          value={text}
+          value={readOnly ? display : text}
           className="h-6 w-6 text-muted-foreground hover:text-foreground"
           title="Copy"
         />
@@ -445,22 +471,48 @@ export function EditableValueBlock({
 
   const field = (
     <LineNumberedTextarea
-      value={text}
+      value={readOnly ? display : text}
       onChange={onChange}
       minRows={effectiveMin}
       highlightJson={kind === "json" || kind === "pretty"}
+      readOnly={readOnly}
       aria-label={ariaLabel ?? label}
     />
+  );
+
+  // Chevron + label: the whole thing toggles, matching the span detail panel.
+  const heading = (size: "sm" | "xs") => (
+    <button
+      type="button"
+      onClick={() => setOpen((v) => !v)}
+      aria-expanded={open}
+      className={cn(
+        "flex items-center gap-1.5 rounded font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        size === "sm" ? "text-[12px]" : "text-[11px]",
+      )}
+    >
+      {open ? (
+        <ChevronDown className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      ) : (
+        <ChevronRight className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      )}
+      {label}
+    </button>
   );
 
   if (boxed) {
     return (
       <div className="border border-border">
-        <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/50 px-3 py-1.5">
-          <span className="text-[12px] font-medium text-muted-foreground">{label}</span>
+        <div
+          className={cn(
+            "flex items-center justify-between gap-2 bg-muted/50 px-3 py-1.5",
+            open && "border-b border-border",
+          )}
+        >
+          {heading("sm")}
           {controls}
         </div>
-        <div className="p-3">{field}</div>
+        {open && <div className="p-3">{field}</div>}
       </div>
     );
   }
@@ -468,10 +520,10 @@ export function EditableValueBlock({
   return (
     <div>
       <div className="mb-1 flex items-center justify-between gap-2">
-        <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
+        {heading("xs")}
         {controls}
       </div>
-      {field}
+      {open && field}
     </div>
   );
 }

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ChevronDown, ChevronRight, Maximize2, Minimize2 } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
@@ -333,7 +333,9 @@ function detectKind(text: string): ValueKind {
   if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
     try {
       JSON.parse(trimmed);
-      return "json";
+      // Already pretty-printed (multi-line) JSON should read as "Pretty", not
+      // "JSON" — otherwise the mode label contradicts the indented content.
+      return trimmed.includes("\n") ? "pretty" : "json";
     } catch {
       /* looks like JSON but isn't — fall through to text */
     }
@@ -347,9 +349,8 @@ function detectKind(text: string): ValueKind {
  * JSON), so plain text is never mangled.
  *
  * Optional extras (all off by default, so existing callers are unchanged):
- * `copyable` adds a copy button, `enlargeable` adds a taller/shorter toggle,
- * `autoDetectKind` picks JSON vs text from the initial content, and `minRows`
- * sets the resting height.
+ * `copyable` adds a copy button, `autoDetectKind` picks JSON vs text from the
+ * initial content, and `minRows` sets the resting height.
  */
 export function EditableValueBlock({
   label,
@@ -358,7 +359,6 @@ export function EditableValueBlock({
   defaultKind = "yaml",
   ariaLabel,
   copyable = false,
-  enlargeable = false,
   autoDetectKind = false,
   minRows = 1,
   boxed = false,
@@ -370,7 +370,6 @@ export function EditableValueBlock({
   defaultKind?: ValueKind;
   ariaLabel?: string;
   copyable?: boolean;
-  enlargeable?: boolean;
   autoDetectKind?: boolean;
   minRows?: number;
   /** Wrap the block in a bordered card with a muted header strip (like FormCard). */
@@ -380,11 +379,9 @@ export function EditableValueBlock({
 }) {
   const [kind, setKind] = React.useState<ValueKind>(defaultKind);
   const [menuOpen, setMenuOpen] = React.useState(false);
-  const [enlarged, setEnlarged] = React.useState(false);
   // Minimised via the header chevron, like the span detail panel's I/O sections.
   const [open, setOpen] = React.useState(true);
   const userSetKind = React.useRef(false);
-  const detected = React.useRef(false);
   // Read-only fields reformat locally (the parent value never changes), so the
   // format switcher still works without touching the source of truth.
   const [display, setDisplay] = React.useState(text);
@@ -392,11 +389,11 @@ export function EditableValueBlock({
     if (readOnly) setDisplay(text);
   }, [readOnly, text]);
 
-  // Detect JSON vs text once, when the value first arrives (e.g. after a dialog
-  // seeds it), unless the user has already chosen a format from the switcher.
+  // Follow the content's type — text vs JSON vs pretty JSON — whenever a new value
+  // is seeded (e.g. navigating between cases re-seeds this field), unless the user
+  // has pinned a format from the switcher. setKind is a no-op when unchanged.
   React.useEffect(() => {
-    if (autoDetectKind && !userSetKind.current && !detected.current && text.trim() !== "") {
-      detected.current = true;
+    if (autoDetectKind && !userSetKind.current && text.trim() !== "") {
       setKind(detectKind(text));
     }
   }, [autoDetectKind, text]);
@@ -416,23 +413,8 @@ export function EditableValueBlock({
     }
   };
 
-  // Rest at minRows and grow one line at a time with the content; enlarge opens
-  // it fully.
-  const effectiveMin = enlarged ? Math.max(minRows, 24) : minRows;
-
   const controls = (
     <div className="flex items-center gap-0.5">
-      {enlargeable && (
-        <button
-          type="button"
-          onClick={() => setEnlarged((v) => !v)}
-          title={enlarged ? "Shrink" : "Enlarge"}
-          aria-label={enlarged ? "Shrink field" : "Enlarge field"}
-          className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-        >
-          {enlarged ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
-        </button>
-      )}
       <Popover open={menuOpen} onOpenChange={setMenuOpen}>
         <PopoverTrigger asChild>
           <button
@@ -473,7 +455,7 @@ export function EditableValueBlock({
     <LineNumberedTextarea
       value={readOnly ? display : text}
       onChange={onChange}
-      minRows={effectiveMin}
+      minRows={minRows}
       highlightJson={kind === "json" || kind === "pretty"}
       readOnly={readOnly}
       aria-label={ariaLabel ?? label}

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -152,10 +152,30 @@ function Gutter({ count }: { count: number }) {
   );
 }
 
+/** Splits whole-text JSON tokens into per-line arrays (newlines are consumed). */
+function tokenizeJsonByLine(text: string): { text: string; cls: string }[][] | null {
+  const tokens = tokenizeJson(text);
+  if (!tokens) return null;
+  const lines: { text: string; cls: string }[][] = [[]];
+  for (const tok of tokens) {
+    const parts = tok.text.split("\n");
+    parts.forEach((part, idx) => {
+      if (idx > 0) lines.push([]);
+      if (part !== "") lines[lines.length - 1].push({ text: part, cls: tok.cls });
+    });
+  }
+  return lines;
+}
+
 /**
- * Editable code field with a line-number gutter on the left. An empty value is
- * a single line "1" with an empty body. Grows with the content (no scroll sync
- * to keep the numbers aligned).
+ * Editable code field with a line-number gutter on the left.
+ *
+ * A wrapping display layer (line numbers + optional JSON colors) sits under a
+ * transparent-text textarea. Because both wrap with the same font/width, a long
+ * line wraps onto the next visual row while keeping a single line number pinned
+ * to its top — the way a real code editor renders wrapped lines. The box rests
+ * at `minRows` (blank, unnumbered space below the content) and grows one line
+ * per Enter.
  */
 export function LineNumberedTextarea({
   value,
@@ -173,52 +193,55 @@ export function LineNumberedTextarea({
   highlightJson?: boolean;
   "aria-label"?: string;
 }) {
-  // Gutter numbers only the real content lines; the textarea can still be taller
-  // (minRows) with blank, unnumbered space below — the way a code editor looks.
-  // The field never wraps, so every line maps 1:1 to a gutter number; long lines
-  // scroll horizontally, and the color layer tracks that scroll.
-  const contentLines = value === "" ? 1 : value.split("\n").length;
-  const rows = Math.max(contentLines, minRows);
-  const tokens = highlightJson ? tokenizeJson(value) : null;
-  const preRef = React.useRef<HTMLPreElement>(null);
-  const syncScroll = (e: React.UIEvent<HTMLTextAreaElement>) => {
-    if (preRef.current) {
-      preRef.current.style.transform = `translateX(${-e.currentTarget.scrollLeft}px)`;
-    }
-  };
+  // Keep a real trailing empty line so the last line is always clickable — click
+  // it and type without pressing Enter first, and a 1-line value still shows an
+  // empty line 2. The parent value never keeps that trailing newline: it's added
+  // for display/editing and stripped from what onChange reports.
+  const textValue = value.endsWith("\n") ? value : value + "\n";
+  const rawLines = textValue.split("\n");
+  const tokenLines = highlightJson ? tokenizeJsonByLine(textValue) : null;
+  const totalLines = Math.max(rawLines.length, minRows);
+  const digits = Math.max(2, String(totalLines).length);
+  const gutterWidth = `calc(${digits}ch + 1rem)`;
+
   return (
-    <div className="flex overflow-hidden rounded border border-input bg-background focus-within:ring-1 focus-within:ring-ring">
-      <Gutter count={contentLines} />
-      <div className="relative min-w-0 flex-1 overflow-hidden">
-        {/* Colored layer sits exactly behind the transparent-text textarea. */}
-        {tokens && (
-          <pre
-            ref={preRef}
-            aria-hidden
-            className="pointer-events-none absolute inset-0 m-0 whitespace-pre px-2 py-1.5 font-mono text-[12px] leading-relaxed"
-          >
-            {tokens.map((t, i) => (
-              <span key={i} className={t.cls || undefined}>
-                {t.text}
-              </span>
-            ))}
-          </pre>
-        )}
-        <textarea
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onScroll={syncScroll}
-          rows={rows}
-          wrap="off"
-          spellCheck={false}
-          placeholder={placeholder}
-          aria-label={ariaLabel}
-          className={cn(
-            "relative block w-full resize-none overflow-x-auto whitespace-pre bg-transparent px-2 py-1.5 font-mono text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none",
-            tokens && "text-transparent caret-foreground",
-          )}
-        />
+    <div className="relative overflow-hidden rounded border border-input bg-background font-mono text-[12px] leading-relaxed focus-within:ring-1 focus-within:ring-ring">
+      {/* Display layer — line numbers + (highlighted) content, wraps per line. */}
+      <div aria-hidden className="pointer-events-none py-1.5">
+        {Array.from({ length: totalLines }).map((_, i) => (
+          <div key={i} className="flex items-start">
+            <span
+              className="shrink-0 select-none border-r border-border bg-muted/40 px-2 text-right text-muted-foreground/50"
+              style={{ width: gutterWidth }}
+            >
+              {i + 1}
+            </span>
+            <span className="min-w-0 flex-1 whitespace-pre-wrap break-words px-2">
+              {tokenLines
+                ? (tokenLines[i] ?? []).map((t, ti) => (
+                    <span key={ti} className={t.cls || undefined}>
+                      {t.text}
+                    </span>
+                  ))
+                : (rawLines[i] ?? "")}
+              {"​"}
+            </span>
+          </div>
+        ))}
       </div>
+      {/* Editing layer — transparent text lined up over the display layer. */}
+      <textarea
+        value={textValue}
+        onChange={(e) => {
+          const v = e.target.value;
+          onChange(v.endsWith("\n") ? v.slice(0, -1) : v);
+        }}
+        spellCheck={false}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        className="absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent py-1.5 pr-2 font-mono text-[12px] leading-relaxed text-transparent caret-foreground placeholder:text-muted-foreground focus:outline-none"
+        style={{ paddingLeft: `calc(${gutterWidth} + 0.5rem)` }}
+      />
     </div>
   );
 }

--- a/frontend/ui/src/features/offline-eval/components/dataset-actions-menu.tsx
+++ b/frontend/ui/src/features/offline-eval/components/dataset-actions-menu.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import * as React from "react";
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+/**
+ * The row actions menu — the exact three-dot dropdown the detectors table uses
+ * (Popover + MoreHorizontal trigger, Edit / Delete items), so it reads as one
+ * product.
+ */
+export function DatasetActionsMenu({
+  onEdit,
+  onDelete,
+}: {
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-5 w-6 p-0 text-muted-foreground hover:text-foreground"
+          onClick={(e) => e.stopPropagation()}
+          aria-label="Row actions"
+        >
+          <MoreHorizontal className="h-3.5 w-3.5" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-36 p-1">
+        <button
+          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] hover:bg-muted/60"
+          onClick={(e) => {
+            e.stopPropagation();
+            onEdit();
+            setOpen(false);
+          }}
+        >
+          <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
+          Edit
+        </button>
+        <button
+          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+            setOpen(false);
+          }}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          Delete
+        </button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/ui/src/features/offline-eval/components/dataset-form.tsx
+++ b/frontend/ui/src/features/offline-eval/components/dataset-form.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import * as React from "react";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+
+/**
+ * The shared dataset form — used by both the "New dataset" centered dialog and
+ * the "Edit dataset" side panel, so create and edit stay identical (the way
+ * Create Detector and the detector edit panel share fields).
+ *
+ * Schema toggles default off and are mostly illustrative for now: when enabled
+ * they reveal an editable JSON block for the schema's properties/required. We
+ * keep the shape visible so the concept is testable before the details are
+ * settled.
+ */
+
+export interface DatasetFormState {
+  name: string;
+  description: string;
+  metadata: string;
+  inputSchemaEnabled: boolean;
+  inputSchema: string;
+  expectedSchemaEnabled: boolean;
+  expectedSchema: string;
+}
+
+const DEFAULT_INPUT_SCHEMA = `{
+  "type": "object",
+  "properties": {
+    "input": { "type": "string" }
+  },
+  "required": ["input"]
+}`;
+
+const DEFAULT_EXPECTED_SCHEMA = `{
+  "type": "object",
+  "properties": {
+    "expected": { "type": "string" }
+  },
+  "required": ["expected"]
+}`;
+
+export function emptyDatasetForm(overrides: Partial<DatasetFormState> = {}): DatasetFormState {
+  return {
+    name: "",
+    description: "",
+    metadata: "",
+    inputSchemaEnabled: false,
+    inputSchema: DEFAULT_INPUT_SCHEMA,
+    expectedSchemaEnabled: false,
+    expectedSchema: DEFAULT_EXPECTED_SCHEMA,
+    ...overrides,
+  };
+}
+
+/** Bordered card matching the Create Detector form fields. */
+function Card({
+  label,
+  optional,
+  action,
+  children,
+}: {
+  label: string;
+  optional?: boolean;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="border border-border">
+      <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/50 px-3 py-1.5">
+        <span className="text-[12px] font-medium text-muted-foreground">
+          {label}
+          {optional && <span className="ml-1 font-normal text-muted-foreground/70">optional</span>}
+        </span>
+        {action}
+      </div>
+      <div className="p-3">{children}</div>
+    </div>
+  );
+}
+
+const jsonBlockClass =
+  "w-full resize-vertical border border-input bg-background px-3 py-2 font-mono text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring";
+
+export function DatasetFormFields({
+  state,
+  onChange,
+  className,
+}: {
+  state: DatasetFormState;
+  onChange: (next: DatasetFormState) => void;
+  className?: string;
+}) {
+  const set = <K extends keyof DatasetFormState>(key: K, value: DatasetFormState[K]) =>
+    onChange({ ...state, [key]: value });
+
+  return (
+    <div className={cn("flex flex-col gap-3", className)}>
+      <Card label="Name">
+        <Input
+          value={state.name}
+          onChange={(e) => set("name", e.target.value)}
+          placeholder="e.g. Billing routing"
+          className="h-7 text-[13px]"
+          required
+        />
+      </Card>
+
+      <Card label="Description" optional>
+        <textarea
+          value={state.description}
+          onChange={(e) => set("description", e.target.value)}
+          rows={2}
+          placeholder="What this collection of test cases is for"
+          className="resize-vertical w-full border border-input bg-background px-3 py-2 text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+      </Card>
+
+      <Card label="Metadata" optional>
+        <textarea
+          value={state.metadata}
+          onChange={(e) => set("metadata", e.target.value)}
+          rows={2}
+          placeholder={'{\n  "team": "support"\n}'}
+          className={jsonBlockClass}
+        />
+      </Card>
+
+      <SchemaCard
+        label="Input schema"
+        enabled={state.inputSchemaEnabled}
+        onToggle={(v) => set("inputSchemaEnabled", v)}
+        explanation="Describe the shape each test case's input must take. When on, rows are validated against this schema. Leave off to accept any input."
+        value={state.inputSchema}
+        onValueChange={(v) => set("inputSchema", v)}
+      />
+
+      <SchemaCard
+        label="Expected output schema"
+        enabled={state.expectedSchemaEnabled}
+        onToggle={(v) => set("expectedSchemaEnabled", v)}
+        explanation="Describe the shape of the expected answer. When on, expected values are validated against this schema. Leave off when a scorer judges the output directly."
+        value={state.expectedSchema}
+        onValueChange={(v) => set("expectedSchema", v)}
+      />
+    </div>
+  );
+}
+
+function SchemaCard({
+  label,
+  enabled,
+  onToggle,
+  explanation,
+  value,
+  onValueChange,
+}: {
+  label: string;
+  enabled: boolean;
+  onToggle: (v: boolean) => void;
+  explanation: string;
+  value: string;
+  onValueChange: (v: string) => void;
+}) {
+  return (
+    <Card label={label} action={<Switch checked={enabled} onCheckedChange={onToggle} />}>
+      <p className="text-[11px] leading-relaxed text-muted-foreground">{explanation}</p>
+      {enabled && (
+        <textarea
+          value={value}
+          onChange={(e) => onValueChange(e.target.value)}
+          rows={7}
+          spellCheck={false}
+          className={cn(jsonBlockClass, "mt-2")}
+          aria-label={`${label} JSON`}
+        />
+      )}
+    </Card>
+  );
+}

--- a/frontend/ui/src/features/offline-eval/components/dataset-form.tsx
+++ b/frontend/ui/src/features/offline-eval/components/dataset-form.tsx
@@ -73,7 +73,9 @@ function Card({
       <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/50 px-3 py-1.5">
         <span className="text-[12px] font-medium text-muted-foreground">
           {label}
-          {optional && <span className="ml-1 font-normal text-muted-foreground/70">optional</span>}
+          {optional && (
+            <span className="ml-1 font-normal text-muted-foreground/70">(optional)</span>
+          )}
         </span>
         {action}
       </div>
@@ -107,12 +109,11 @@ export function DatasetFormFields({
       </Card>
 
       <Card label="Description" optional>
-        <textarea
+        <Input
           value={state.description}
           onChange={(e) => set("description", e.target.value)}
-          rows={2}
           placeholder="What this collection of test cases is for"
-          className="resize-vertical w-full border border-input bg-background px-3 py-2 text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          className="h-7 text-[13px]"
         />
       </Card>
 

--- a/frontend/ui/src/features/offline-eval/components/dataset-form.tsx
+++ b/frontend/ui/src/features/offline-eval/components/dataset-form.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
+import { LineNumberedTextarea } from "./code";
 
 /**
  * The shared dataset form — used by both the "New dataset" centered dialog and
@@ -81,9 +82,6 @@ function Card({
   );
 }
 
-const jsonBlockClass =
-  "w-full resize-vertical border border-input bg-background px-3 py-2 font-mono text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring";
-
 export function DatasetFormFields({
   state,
   onChange,
@@ -119,12 +117,10 @@ export function DatasetFormFields({
       </Card>
 
       <Card label="Metadata" optional>
-        <textarea
+        <LineNumberedTextarea
           value={state.metadata}
-          onChange={(e) => set("metadata", e.target.value)}
-          rows={2}
-          placeholder={'{\n  "team": "support"\n}'}
-          className={jsonBlockClass}
+          onChange={(v) => set("metadata", v)}
+          aria-label="Metadata"
         />
       </Card>
 
@@ -168,14 +164,14 @@ function SchemaCard({
     <Card label={label} action={<Switch checked={enabled} onCheckedChange={onToggle} />}>
       <p className="text-[11px] leading-relaxed text-muted-foreground">{explanation}</p>
       {enabled && (
-        <textarea
-          value={value}
-          onChange={(e) => onValueChange(e.target.value)}
-          rows={7}
-          spellCheck={false}
-          className={cn(jsonBlockClass, "mt-2")}
-          aria-label={`${label} JSON`}
-        />
+        <div className="mt-2">
+          <LineNumberedTextarea
+            value={value}
+            onChange={onValueChange}
+            minRows={3}
+            aria-label={`${label} JSON`}
+          />
+        </div>
       )}
     </Card>
   );

--- a/frontend/ui/src/features/offline-eval/components/dataset-form.tsx
+++ b/frontend/ui/src/features/offline-eval/components/dataset-form.tsx
@@ -121,6 +121,7 @@ export function DatasetFormFields({
         <LineNumberedTextarea
           value={state.metadata}
           onChange={(v) => set("metadata", v)}
+          highlightJson
           aria-label="Metadata"
         />
       </Card>
@@ -170,6 +171,7 @@ function SchemaCard({
             value={value}
             onChange={onValueChange}
             minRows={3}
+            highlightJson
             aria-label={`${label} JSON`}
           />
         </div>

--- a/frontend/ui/src/features/offline-eval/components/form-kit.tsx
+++ b/frontend/ui/src/features/offline-eval/components/form-kit.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import * as React from "react";
+import {
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Creation UI, modelled on the existing "Create Detector" flow.
+ *
+ * Create Detector uses bordered "cards" — a `bg-muted/50` label strip over a
+ * padded body — inside a single flat form with a Save/Cancel footer. We render
+ * that exact field style inside the shared `Drawer` primitive so New Dataset and
+ * New Evaluation look native and open as an overlay rather than a new page.
+ */
+
+/** One labelled field, matching the detector form's bordered card. */
+export function FormCard({
+  label,
+  hint,
+  children,
+  className,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("border border-border", className)}>
+      <div className="flex items-center justify-between border-b border-border bg-muted/50 px-3 py-1.5">
+        <span className="text-[12px] font-medium text-muted-foreground">{label}</span>
+        {hint && <span className="text-[11px] text-muted-foreground">{hint}</span>}
+      </div>
+      <div className="p-3">{children}</div>
+    </div>
+  );
+}
+
+/** Collapsed <details> for advanced/optional fields, matching the app's density. */
+export function AdvancedSection({
+  label = "Advanced",
+  children,
+}: {
+  label?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <details className="group border border-border">
+      <summary className="flex cursor-pointer list-none items-center border-border bg-muted/50 px-3 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring group-open:border-b">
+        {label}
+      </summary>
+      <div className="flex flex-col gap-3 p-3">{children}</div>
+    </details>
+  );
+}
+
+/**
+ * The creation drawer shell: header + scrollable form body + Save/Cancel footer.
+ * The caller supplies the fields and the save handler.
+ */
+export function CreateDrawer({
+  title,
+  open,
+  onOpenChange,
+  onSave,
+  saveLabel = "Save",
+  saveDisabled,
+  children,
+  width = "w-[560px]",
+}: {
+  title: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: () => void;
+  saveLabel?: string;
+  saveDisabled?: boolean;
+  children: React.ReactNode;
+  width?: string;
+}) {
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent width={width}>
+        <DrawerHeader className="pr-10">
+          <DrawerTitle>{title}</DrawerTitle>
+        </DrawerHeader>
+        <DrawerBody className="flex flex-col gap-3">{children}</DrawerBody>
+        <DrawerFooter className="justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-[12px]"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button size="sm" className="h-7 text-[12px]" onClick={onSave} disabled={saveDisabled}>
+            {saveLabel}
+          </Button>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -2,7 +2,7 @@
  * Offline Evaluation feature components.
  */
 
-export { StatusBadge, ReviewBadge, ScopeLabel } from "./badges";
+export { StatusBadge, ReviewBadge } from "./badges";
 export {
   EvalPageHeader,
   PrototypeNotice,
@@ -12,7 +12,7 @@ export {
   QuietAction,
   EmptyState,
 } from "./page-chrome";
-export { StepTree, StepDetail } from "./step-tree";
+export { TraceInspector } from "./trace-inspector";
+export { CreateDrawer, FormCard, AdvancedSection } from "./form-kit";
+export { SaveTestCaseDrawer } from "./save-test-case-drawer";
 export { ReviewPanel, type ReviewTarget } from "./review-panel";
-export { SdkDrawer } from "./sdk-drawer";
-export { SaveTestCaseDialog, type SaveTarget } from "./save-test-case-dialog";

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -2,7 +2,7 @@
  * Offline Evaluation feature components.
  */
 
-export { StatusBadge, ReviewBadge } from "./badges";
+export { StatusBadge, ReviewBadge, EvalResultBadge } from "./badges";
 export { Timestamp } from "./timestamp";
 export { DatasetInfoChip } from "./dataset-info-chip";
 export {
@@ -17,7 +17,9 @@ export {
 export { TraceInspector } from "./trace-inspector";
 export { CreateDrawer, FormCard, AdvancedSection } from "./form-kit";
 export { SaveTestCaseDrawer } from "./save-test-case-drawer";
+export { RunEvaluationDrawer } from "./run-evaluation-drawer";
 export { ReviewPanel, type ReviewTarget } from "./review-panel";
+export { TestCaseReviewDrawer, type TestCaseReviewTarget } from "./test-case-review-drawer";
 export { useRowSelection, SelectAllHeaderCell, SelectRowCell, BulkActionBar } from "./selection";
 export { ScoreChart, DistributionBar, type ChartSeries } from "./score-chart";
 export { UploadControl } from "./upload-control";

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -16,3 +16,7 @@ export { TraceInspector } from "./trace-inspector";
 export { CreateDrawer, FormCard, AdvancedSection } from "./form-kit";
 export { SaveTestCaseDrawer } from "./save-test-case-drawer";
 export { ReviewPanel, type ReviewTarget } from "./review-panel";
+export { useRowSelection, SelectAllHeaderCell, SelectRowCell, BulkActionBar } from "./selection";
+export { ScoreChart, DistributionBar, type ChartSeries } from "./score-chart";
+export { UploadControl } from "./upload-control";
+export { useSeedTraceIO } from "./seed-trace-io";

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -2,22 +2,17 @@
  * Offline Evaluation feature components.
  */
 
-export { SeverityBadge, GoldenBadge, ScopeBadge, OutcomeBadge, CohortChip } from "./badges";
-export { DetectorContextBar, InheritedContextPanel } from "./detector-context";
-export { ContinuityStages, ContinuityStagesExplained } from "./continuity-stages";
-export {
-  ScopeFacetList,
-  ScopeSummary,
-  ScopeFacetLegend,
-  GranularityPicker,
-  granularityLabel,
-} from "./scope-facets";
-export { ProtoSpanTree, ProtoSpanDetail, IOBlock } from "./span-tree";
-export { AddTestCaseDialog, type AddTestCaseTarget } from "./add-test-case-dialog";
+export { StatusBadge, ReviewBadge, ScopeLabel } from "./badges";
 export {
   EvalPageHeader,
   PrototypeNotice,
-  EvalSection,
-  StatTile,
-  ExperimentalNote,
+  EvalBody,
+  DetailsSection,
+  DetailRow,
+  QuietAction,
+  EmptyState,
 } from "./page-chrome";
+export { StepTree, StepDetail } from "./step-tree";
+export { ReviewPanel, type ReviewTarget } from "./review-panel";
+export { SdkDrawer } from "./sdk-drawer";
+export { SaveTestCaseDialog, type SaveTarget } from "./save-test-case-dialog";

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -20,3 +20,7 @@ export { useRowSelection, SelectAllHeaderCell, SelectRowCell, BulkActionBar } fr
 export { ScoreChart, DistributionBar, type ChartSeries } from "./score-chart";
 export { UploadControl } from "./upload-control";
 export { useSeedTraceIO } from "./seed-trace-io";
+export { DatasetFormFields, emptyDatasetForm, type DatasetFormState } from "./dataset-form";
+export { DatasetActionsMenu } from "./dataset-actions-menu";
+export { NewDatasetDialog } from "./new-dataset-dialog";
+export { DatasetEditPanel } from "./dataset-edit-panel";

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -4,30 +4,22 @@
 
 export { StatusBadge, ReviewBadge, EvalResultBadge } from "./badges";
 export { Timestamp } from "./timestamp";
-export { DatasetInfoChip } from "./dataset-info-chip";
 export {
   EvalPageHeader,
-  PrototypeNotice,
   EvalBody,
   DetailsSection,
   DetailRow,
   QuietAction,
   EmptyState,
 } from "./page-chrome";
-export { TraceInspector } from "./trace-inspector";
 export { CreateDrawer, FormCard, AdvancedSection } from "./form-kit";
-export { SaveTestCaseDrawer } from "./save-test-case-drawer";
-export { RunEvaluationDrawer } from "./run-evaluation-drawer";
 export { ReviewPanel, type ReviewTarget } from "./review-panel";
 export { TestCaseReviewDrawer, type TestCaseReviewTarget } from "./test-case-review-drawer";
 export { useRowSelection, SelectAllHeaderCell, SelectRowCell, BulkActionBar } from "./selection";
-export { ScoreChart, DistributionBar, type ChartSeries } from "./score-chart";
 export { UploadControl } from "./upload-control";
 export { useSeedTraceIO } from "./seed-trace-io";
 export { DatasetFormFields, emptyDatasetForm, type DatasetFormState } from "./dataset-form";
 export { DatasetActionsMenu } from "./dataset-actions-menu";
-export { NewDatasetDialog } from "./new-dataset-dialog";
-export { DatasetEditPanel } from "./dataset-edit-panel";
 export {
   LineNumberedTextarea,
   ValueBlock,

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -2,37 +2,22 @@
  * Offline Evaluation feature components.
  */
 
-export { StatusBadge, ReviewBadge, EvalResultBadge } from "./badges";
-export { Timestamp } from "./timestamp";
-export { DatasetInfoChip } from "./dataset-info-chip";
+export { SeverityBadge, GoldenBadge, ScopeBadge, OutcomeBadge, CohortChip } from "./badges";
+export { DetectorContextBar, InheritedContextPanel } from "./detector-context";
+export { ContinuityStages, ContinuityStagesExplained } from "./continuity-stages";
+export {
+  ScopeFacetList,
+  ScopeSummary,
+  ScopeFacetLegend,
+  GranularityPicker,
+  granularityLabel,
+} from "./scope-facets";
+export { ProtoSpanTree, ProtoSpanDetail, IOBlock } from "./span-tree";
+export { AddTestCaseDialog, type AddTestCaseTarget } from "./add-test-case-dialog";
 export {
   EvalPageHeader,
-  EvalBody,
-  DetailsSection,
-  DetailRow,
-  QuietAction,
-  EmptyState,
+  PrototypeNotice,
+  EvalSection,
+  StatTile,
+  ExperimentalNote,
 } from "./page-chrome";
-export { TraceInspector } from "./trace-inspector";
-export { CreateDrawer, FormCard, AdvancedSection } from "./form-kit";
-export { SaveTestCaseDrawer } from "./save-test-case-drawer";
-export { RunEvaluationDrawer } from "./run-evaluation-drawer";
-export { ReviewPanel, type ReviewTarget } from "./review-panel";
-export { TestCaseReviewDrawer, type TestCaseReviewTarget } from "./test-case-review-drawer";
-export { useRowSelection, SelectAllHeaderCell, SelectRowCell, BulkActionBar } from "./selection";
-export { ScoreChart, DistributionBar, type ChartSeries } from "./score-chart";
-export { UploadControl } from "./upload-control";
-export { useSeedTraceIO } from "./seed-trace-io";
-export { DatasetFormFields, emptyDatasetForm, type DatasetFormState } from "./dataset-form";
-export { DatasetActionsMenu } from "./dataset-actions-menu";
-export { NewDatasetDialog } from "./new-dataset-dialog";
-export { DatasetEditPanel } from "./dataset-edit-panel";
-export {
-  LineNumberedTextarea,
-  ValueBlock,
-  EditableValueBlock,
-  formatValue,
-  seedFormat,
-  type SeedJsonPreference,
-  type ValueKind,
-} from "./code";

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -24,4 +24,10 @@ export { DatasetFormFields, emptyDatasetForm, type DatasetFormState } from "./da
 export { DatasetActionsMenu } from "./dataset-actions-menu";
 export { NewDatasetDialog } from "./new-dataset-dialog";
 export { DatasetEditPanel } from "./dataset-edit-panel";
-export { LineNumberedTextarea, ValueBlock, formatValue, type ValueKind } from "./code";
+export {
+  LineNumberedTextarea,
+  ValueBlock,
+  EditableValueBlock,
+  formatValue,
+  type ValueKind,
+} from "./code";

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -4,6 +4,7 @@
 
 export { StatusBadge, ReviewBadge } from "./badges";
 export { Timestamp } from "./timestamp";
+export { DatasetInfoChip } from "./dataset-info-chip";
 export {
   EvalPageHeader,
   PrototypeNotice,

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -33,5 +33,7 @@ export {
   ValueBlock,
   EditableValueBlock,
   formatValue,
+  seedFormat,
+  type SeedJsonPreference,
   type ValueKind,
 } from "./code";

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -24,3 +24,4 @@ export { DatasetFormFields, emptyDatasetForm, type DatasetFormState } from "./da
 export { DatasetActionsMenu } from "./dataset-actions-menu";
 export { NewDatasetDialog } from "./new-dataset-dialog";
 export { DatasetEditPanel } from "./dataset-edit-panel";
+export { LineNumberedTextarea, ValueBlock, formatValue, type ValueKind } from "./code";

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { StatusBadge, ReviewBadge } from "./badges";
+export { Timestamp } from "./timestamp";
 export {
   EvalPageHeader,
   PrototypeNotice,

--- a/frontend/ui/src/features/offline-eval/components/syntax.tsx
+++ b/frontend/ui/src/features/offline-eval/components/syntax.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * Minimal syntax colouring for the SDK snippets shown in the UI (the dataset
+ * hover card and the Run evaluation panel).
+ *
+ * Deliberately not a real parser: it colours strings, keyword tokens, call
+ * names, and object/keyword-argument keys, which is everything these short
+ * snippets contain. Same palette as the trace panel's JSON highlighting.
+ */
+
+export const CODE_COLORS = {
+  fn: "text-purple-600 dark:text-purple-400",
+  key: "text-blue-600 dark:text-blue-400",
+  string: "text-green-700 dark:text-green-400",
+  keyword: "text-sky-700 dark:text-sky-300",
+  comment: "text-muted-foreground",
+};
+
+/** Keywords worth colouring across both languages the snippets use. */
+const KEYWORDS = new Set([
+  "import",
+  "from",
+  "const",
+  "let",
+  "await",
+  "async",
+  "return",
+  "def",
+  "class",
+  "new",
+  "export",
+  "default",
+]);
+
+export interface CodeToken {
+  text: string;
+  cls: string;
+}
+
+export function tokenizeCode(code: string): CodeToken[] {
+  const out: CodeToken[] = [];
+  const push = (text: string, cls: string) => out.push({ text, cls });
+  const n = code.length;
+  let i = 0;
+  const nextNonSpace = (from: number) => {
+    let k = from;
+    while (k < n && /[^\S\n]/.test(code[k])) k++;
+    return code[k];
+  };
+
+  while (i < n) {
+    const ch = code[i];
+
+    // Comments run to the end of the line (# for Python, // for TypeScript).
+    if (ch === "#" || (ch === "/" && code[i + 1] === "/")) {
+      let j = i;
+      while (j < n && code[j] !== "\n") j++;
+      push(code.slice(i, j), CODE_COLORS.comment);
+      i = j;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      let j = i + 1;
+      while (j < n) {
+        if (code[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (code[j] === ch) {
+          j++;
+          break;
+        }
+        j++;
+      }
+      // A quoted token followed by ":" is a key, not a value.
+      push(code.slice(i, j), nextNonSpace(j) === ":" ? CODE_COLORS.key : CODE_COLORS.string);
+      i = j;
+      continue;
+    }
+
+    if (/[A-Za-z_$]/.test(ch)) {
+      let j = i + 1;
+      while (j < n && /[A-Za-z0-9_$]/.test(code[j])) j++;
+      const word = code.slice(i, j);
+      const nx = nextNonSpace(j);
+      push(
+        word,
+        KEYWORDS.has(word)
+          ? CODE_COLORS.keyword
+          : nx === "("
+            ? CODE_COLORS.fn
+            : nx === ":" || nx === "="
+              ? CODE_COLORS.key
+              : "",
+      );
+      i = j;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      let j = i + 1;
+      while (j < n && /\s/.test(code[j])) j++;
+      push(code.slice(i, j), "");
+      i = j;
+      continue;
+    }
+
+    push(ch, "");
+    i++;
+  }
+  return out;
+}
+
+/** A syntax-coloured code block. The caller supplies the surrounding chrome. */
+export function HighlightedCode({ code, className }: { code: string; className?: string }) {
+  return (
+    <pre className={className}>
+      {tokenizeCode(code).map((token, i) => (
+        <span key={i} className={token.cls || undefined}>
+          {token.text}
+        </span>
+      ))}
+    </pre>
+  );
+}

--- a/frontend/ui/src/features/offline-eval/components/timestamp.tsx
+++ b/frontend/ui/src/features/offline-eval/components/timestamp.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import * as React from "react";
+import { cn, parseAsUTC } from "@/lib/utils";
+import { formatStamp } from "../utils";
+
+/**
+ * Deterministic UTC render of `formatStamp`'s format. Server and browser both
+ * produce this identical string, so it is safe for SSR / first client paint.
+ */
+function formatStampUTC(iso: string): string {
+  const d = parseAsUTC(iso);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())} ${p(
+    d.getUTCHours(),
+  )}:${p(d.getUTCMinutes())}:${p(d.getUTCSeconds())}`;
+}
+
+/**
+ * Hydration-safe absolute timestamp.
+ *
+ * These screens render hardcoded fixtures during SSR, so `formatStamp` (local
+ * time) would mismatch between the UTC server and the browser's timezone. We
+ * render the deterministic UTC value on the server and first client render —
+ * which match exactly — then swap to the local-time format the rest of the app
+ * uses once mounted.
+ */
+export function Timestamp({ iso, className }: { iso: string; className?: string }) {
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+  return (
+    <span className={cn("whitespace-nowrap", className)}>
+      {mounted ? formatStamp(iso) : formatStampUTC(iso)}
+    </span>
+  );
+}

--- a/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
+++ b/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
@@ -15,6 +15,12 @@ interface ProjectBreadcrumbProps {
   projectId: string;
   /** Final breadcrumb text (e.g., "Settings", trace name). If provided, project becomes a link. */
   current?: string;
+  /**
+   * Intermediate segments between the project and `current`, for nested pages —
+   * e.g. `[{ label: "Datasets", href: ".../datasets" }]` on a dataset detail page,
+   * so the trail reads Workspace / Project / Datasets / <name>. Each is a link.
+   */
+  trail?: Array<{ label: string; href?: string }>;
 }
 
 /**
@@ -31,7 +37,7 @@ interface ProjectBreadcrumbProps {
  * <ProjectBreadcrumb projectId={projectId} current={trace?.name} />
  * ```
  */
-export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps) {
+export function ProjectBreadcrumb({ projectId, current, trail }: ProjectBreadcrumbProps) {
   const { setHeaderContent } = useLayout();
   const pathname = usePathname();
   const { data: project } = useProject(projectId);
@@ -39,6 +45,9 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
   const { data: workspace } = useWorkspace(project?.workspace_id || "", !!project?.workspace_id);
   const [createWorkspaceOpen, setCreateWorkspaceOpen] = useState(false);
   const [createProjectOpen, setCreateProjectOpen] = useState(false);
+  // Depend on the trail's content, not its array identity, so an inline-literal
+  // trail from a caller doesn't re-run the effect (and re-set the header) each render.
+  const trailKey = JSON.stringify(trail ?? []);
 
   useEffect(() => {
     const breadcrumbItems: BreadcrumbItem[] = [
@@ -57,7 +66,7 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
       },
       {
         label: project?.name || "...",
-        href: current ? `/projects/${projectId}/traces` : undefined,
+        href: current || trail?.length ? `/projects/${projectId}/traces` : undefined,
         options: workspace?.projects?.map((p) => ({
           id: p.id,
           label: p.name,
@@ -73,13 +82,19 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
       },
     ];
 
+    for (const segment of trail ?? []) {
+      breadcrumbItems.push({ label: segment.label, href: segment.href });
+    }
+
     if (current) {
       breadcrumbItems.push({ label: current });
     }
 
     setHeaderContent(<Breadcrumb items={breadcrumbItems} />);
     return () => setHeaderContent(null);
-  }, [setHeaderContent, project, workspace, workspaces, projectId, current, pathname]);
+    // trailKey encodes `trail`'s content (see above); listing trail itself would churn.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setHeaderContent, project, workspace, workspaces, projectId, current, trailKey, pathname]);
 
   return (
     <>

--- a/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
+++ b/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
-import { Breadcrumb, BreadcrumbItem } from "@/components/layout/breadcrumb";
+import { Breadcrumb, type BreadcrumbItem } from "@/components/layout/breadcrumb";
 import { useProject } from "../hooks";
 import { projectSwitchHref } from "../utils";
 import { CreateProjectDialog } from "./CreateProjectDialog";
@@ -18,9 +18,11 @@ interface ProjectBreadcrumbProps {
   /**
    * Intermediate segments between the project and `current`, for nested pages —
    * e.g. `[{ label: "Datasets", href: ".../datasets" }]` on a dataset detail page,
-   * so the trail reads Workspace / Project / Datasets / <name>. Each is a link.
+   * so the trail reads Workspace / Project / Datasets / <name>. A plain segment is
+   * a link; a segment with `options` renders as a dropdown selector (like the
+   * workspace/project segments), e.g. to switch between datasets.
    */
-  trail?: Array<{ label: string; href?: string }>;
+  trail?: BreadcrumbItem[];
 }
 
 /**
@@ -83,7 +85,7 @@ export function ProjectBreadcrumb({ projectId, current, trail }: ProjectBreadcru
     ];
 
     for (const segment of trail ?? []) {
-      breadcrumbItems.push({ label: segment.label, href: segment.href });
+      breadcrumbItems.push(segment);
     }
 
     if (current) {

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -2,6 +2,16 @@
 
 import type { ReactNode } from "react";
 import { useRouter } from "next/navigation";
+import {
+  Clock,
+  Users,
+  Layers,
+  ChevronRight,
+  AlertCircle,
+  GitBranch,
+  GitCommitHorizontal,
+  FileCode,
+} from "lucide-react";
 import { ChevronRight, GitBranch, GitCommitHorizontal, FileCode, Loader2 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
@@ -19,8 +29,7 @@ import {
   getTraceCostBreakdown,
 } from "../utils";
 import { SpanKindIcon } from "./SpanKindIcon";
-import { ContentRenderer } from "./ContentRenderer";
-import { ExpandableSection } from "@/components/ui/expandable-section";
+import { TraceIOSection } from "./TraceIOValue";
 import { useSpanIO } from "../hooks";
 
 interface SpanInfoPanelProps {
@@ -37,6 +46,17 @@ interface SpanInfoPanelProps {
    * the standard trace viewer is unaffected.
    */
   spanActions?: ReactNode;
+  /**
+   * Optional action rendered on the right of the header's title row, vertically
+   * centred against the name + timestamp block (e.g. offline-eval's "Save as
+   * test case"). Unset in production.
+   */
+  headerAction?: ReactNode;
+  /**
+   * Optional extra chips appended to the span-kind / latency badge row (e.g.
+   * offline-eval's "Dataset:" chip). Unset in production.
+   */
+  extraTags?: ReactNode;
 }
 
 /**
@@ -51,6 +71,8 @@ export function SpanInfoPanel({
   customStartDate,
   customEndDate,
   spanActions,
+  headerAction,
+  extraTags,
 }: SpanInfoPanelProps) {
   const router = useRouter();
 
@@ -106,36 +128,35 @@ export function SpanInfoPanel({
 
   // Show a spinner while a selected span's I/O is in flight; trace-level I/O is
   // already loaded so it never spins.
-  const renderIOContent = (content: string | null) =>
-    !isTrace && isLoadingIO ? (
-      <div className="flex items-center gap-2 py-3 text-xs text-muted-foreground">
-        <Loader2 className="h-3 w-3 animate-spin" />
-        Loading…
-      </div>
-    ) : (
-      <ContentRenderer key={selectionId} content={content} />
-    );
+  // A selected span's I/O is fetched on demand; trace-level I/O is already loaded.
+  const ioLoading = !isTrace && isLoadingIO;
 
   return (
     <div className="h-full overflow-y-auto">
       {/* Header */}
       <div className="sticky top-0 z-10 border-b border-border bg-background px-4 py-3">
-        <div className="mb-1 flex items-center gap-2">
-          <SpanKindIcon kind={kind} size="md" selected />
-          <h3 className="text-sm font-medium">{name}</h3>
-          <CopyButton
-            value={isTrace ? trace.trace_id : selection.span.span_id}
-            className="h-6 w-6 text-muted-foreground hover:text-foreground"
-            title="Copy ID"
-          />
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <div className="mb-1 flex items-center gap-2">
+              <SpanKindIcon kind={kind} size="md" selected />
+              <h3 className="text-sm font-medium">{name}</h3>
+              <CopyButton
+                value={isTrace ? trace.trace_id : selection.span.span_id}
+                className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                title="Copy ID"
+              />
+            </div>
+            <div className="text-xs text-muted-foreground">{formatDate(timestamp)}</div>
+          </div>
+          {headerAction && <div className="shrink-0">{headerAction}</div>}
         </div>
-        <div className="mb-3 text-xs text-muted-foreground">{formatDate(timestamp)}</div>
         {/* Row 1: LLM related badges */}
         <div className="flex flex-wrap items-center gap-2">
           <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
             <span className="text-muted-foreground">Span Kind:</span>
             <span className="font-medium">{kind.toLowerCase()}</span>
           </div>
+          {extraTags}
           <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
             <DOMAIN_ICONS.latency className="h-3 w-3 text-muted-foreground" />
             <span className="text-muted-foreground">Latency:</span>
@@ -323,32 +344,29 @@ export function SpanInfoPanel({
           </div>
         )}
 
-        {/* Input */}
-        <ExpandableSection
+        {/* Input / Output / Metadata — each with a header format switcher. The key
+            resets the chosen format when a different span/trace is selected. */}
+        <TraceIOSection
+          key={`${selectionId}:input`}
           title="Input"
-          defaultOpen={true}
+          content={input}
+          loading={ioLoading}
           onCopy={input ? () => copyToClipboard(input) : undefined}
-        >
-          {renderIOContent(input)}
-        </ExpandableSection>
-
-        {/* Output */}
-        <ExpandableSection
+        />
+        <TraceIOSection
+          key={`${selectionId}:output`}
           title="Output"
-          defaultOpen={true}
+          content={output}
+          loading={ioLoading}
           onCopy={output ? () => copyToClipboard(output) : undefined}
-        >
-          {renderIOContent(output)}
-        </ExpandableSection>
-
-        {/* Metadata */}
-        <ExpandableSection
+        />
+        <TraceIOSection
+          key={`${selectionId}:metadata`}
           title="Metadata"
-          defaultOpen={true}
+          content={metadata}
+          loading={ioLoading}
           onCopy={metadata ? () => copyToClipboard(metadata) : undefined}
-        >
-          {renderIOContent(metadata)}
-        </ExpandableSection>
+        />
       </div>
     </div>
   );

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronRight, GitBranch, GitCommitHorizontal, FileCode, Loader2 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
@@ -30,6 +31,12 @@ interface SpanInfoPanelProps {
   dateFilter?: { id: string; isCustom?: boolean };
   customStartDate?: Date | null;
   customEndDate?: Date | null;
+  /**
+   * Optional action bar rendered between the header and the content, e.g. the
+   * offline-eval "Save as test case" / "Review" buttons. Unset in production, so
+   * the standard trace viewer is unaffected.
+   */
+  spanActions?: ReactNode;
 }
 
 /**
@@ -43,6 +50,7 @@ export function SpanInfoPanel({
   dateFilter,
   customStartDate,
   customEndDate,
+  spanActions,
 }: SpanInfoPanelProps) {
   const router = useRouter();
 
@@ -260,6 +268,13 @@ export function SpanInfoPanel({
           </div>
         )}
       </div>
+
+      {/* Optional injected actions (offline-eval); absent in production. */}
+      {spanActions && (
+        <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2">
+          {spanActions}
+        </div>
+      )}
 
       {/* Content */}
       <div className="space-y-3 p-4">

--- a/frontend/ui/src/features/traces/components/TraceIOValue.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceIOValue.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { TraceIOSection } from "./TraceIOValue";
+
+afterEach(() => cleanup());
+
+async function pickFormat(label: string) {
+  fireEvent.click(screen.getByTitle("Change format"));
+  fireEvent.click(await screen.findByRole("button", { name: label }));
+}
+
+describe("TraceIOSection format switcher (in header)", () => {
+  it("shows a dash and no switcher when there is no content", () => {
+    render(<TraceIOSection title="Input" content={null} />);
+    expect(screen.getByText("-")).toBeDefined();
+    expect(screen.queryByTitle("Change format")).toBeNull();
+  });
+
+  it("shows the switcher in the header, defaulting to Pretty", () => {
+    render(<TraceIOSection title="Input" content={'{"a":1}'} />);
+    const trigger = screen.getByTitle("Change format");
+    expect(trigger.textContent).toContain("Pretty");
+  });
+
+  it("shows a loading state (and no switcher) while I/O is in flight", () => {
+    render(<TraceIOSection title="Output" content={"x"} loading />);
+    expect(screen.getByText("Loading…")).toBeDefined();
+    expect(screen.queryByTitle("Change format")).toBeNull();
+  });
+
+  it("switches a JSON object to compact JSON", async () => {
+    render(<TraceIOSection title="Input" content={'{"a":1}'} />);
+    await pickFormat("JSON");
+    expect(screen.getByText('{"a":1}')).toBeDefined();
+  });
+
+  it("keeps a genuine string as-is in Text mode", async () => {
+    render(<TraceIOSection title="Output" content={"hello world"} />);
+    await pickFormat("Text");
+    expect(screen.getByText("hello world")).toBeDefined();
+  });
+
+  it("renders YAML for an object", async () => {
+    render(<TraceIOSection title="Metadata" content={'{"env":"prod","n":2}'} />);
+    await pickFormat("YAML");
+    expect(screen.getByText(/env: prod/)).toBeDefined();
+    expect(screen.getByText(/n: 2/)).toBeDefined();
+  });
+});

--- a/frontend/ui/src/features/traces/components/TraceIOValue.tsx
+++ b/frontend/ui/src/features/traces/components/TraceIOValue.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronDown, Loader2 } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ExpandableSection } from "@/components/ui/expandable-section";
+import { cn } from "@/lib/utils";
+import { ContentRenderer } from "./ContentRenderer";
+
+/**
+ * A collapsible span I/O / metadata section with a format switcher in its header
+ * (beside the copy button), matching the editable fields' chrome. Formats: Pretty
+ * (the smart JSON tree / media renderer — the default), JSON (compact), Text (raw),
+ * and YAML. The value is parsed as JSON when possible; a non-JSON string is shown as-is.
+ */
+type IOFormat = "pretty" | "json" | "text" | "yaml";
+
+const FORMAT_LABEL: Record<IOFormat, string> = {
+  pretty: "Pretty",
+  json: "JSON",
+  text: "Text",
+  yaml: "YAML",
+};
+const FORMATS: IOFormat[] = ["pretty", "json", "text", "yaml"];
+
+function parseMaybe(content: string): unknown {
+  try {
+    return JSON.parse(content);
+  } catch {
+    return content;
+  }
+}
+
+function toText(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+/** Minimal YAML for the shapes span I/O holds (scalars, flat-ish objects/arrays). */
+function toYaml(value: unknown, indent = 0): string {
+  const pad = "  ".repeat(indent);
+  if (value === null || value === undefined) return `${pad}null`;
+  if (typeof value === "string") {
+    if (value.includes("\n")) {
+      return `${pad}|\n${value
+        .split("\n")
+        .map((line) => `${pad}  ${line}`)
+        .join("\n")}`;
+    }
+    return `${pad}${value}`;
+  }
+  if (typeof value === "number" || typeof value === "boolean") return `${pad}${value}`;
+  if (Array.isArray(value)) {
+    if (value.length === 0) return `${pad}[]`;
+    return value
+      .map((item) =>
+        item !== null && typeof item === "object"
+          ? `${pad}-\n${toYaml(item, indent + 1)}`
+          : `${pad}- ${toText(item)}`,
+      )
+      .join("\n");
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) return `${pad}{}`;
+  return entries
+    .map(([k, v]) =>
+      v !== null && typeof v === "object"
+        ? `${pad}${k}:\n${toYaml(v, indent + 1)}`
+        : `${pad}${k}: ${toText(v)}`,
+    )
+    .join("\n");
+}
+
+function formatValue(value: unknown, format: Exclude<IOFormat, "pretty">): string {
+  switch (format) {
+    case "json":
+      return JSON.stringify(value ?? null);
+    case "text":
+      return toText(value);
+    case "yaml":
+      return toYaml(value);
+  }
+}
+
+/** Header format dropdown. A non-`<button>` trigger, since it lives inside the
+ *  ExpandableSection header button; the header wrapper stops the toggle click. */
+function FormatSwitcher({
+  format,
+  onChange,
+}: {
+  format: IOFormat;
+  onChange: (f: IOFormat) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <span
+          role="button"
+          tabIndex={0}
+          title="Change format"
+          className="flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          {FORMAT_LABEL[format]}
+          <ChevronDown className="h-3 w-3" aria-hidden />
+        </span>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-28 p-1">
+        {FORMATS.map((f) => (
+          <button
+            key={f}
+            type="button"
+            onClick={() => {
+              onChange(f);
+              setOpen(false);
+            }}
+            className={cn(
+              "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
+              f === format ? "bg-muted/70" : "hover:bg-muted/50",
+            )}
+          >
+            {FORMAT_LABEL[f]}
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function TraceIOSection({
+  title,
+  content,
+  onCopy,
+  loading = false,
+  defaultOpen = true,
+}: {
+  title: string;
+  content: string | null;
+  onCopy?: () => void;
+  loading?: boolean;
+  defaultOpen?: boolean;
+}) {
+  const [format, setFormat] = useState<IOFormat>("pretty");
+  const parsed = useMemo(() => (content ? parseMaybe(content) : null), [content]);
+  const hasContent = content !== null && content !== "";
+
+  return (
+    <ExpandableSection
+      title={title}
+      defaultOpen={defaultOpen}
+      onCopy={onCopy}
+      headerAction={
+        hasContent && !loading ? <FormatSwitcher format={format} onChange={setFormat} /> : undefined
+      }
+    >
+      {loading ? (
+        <div className="flex items-center gap-2 py-3 text-xs text-muted-foreground">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          Loading…
+        </div>
+      ) : !hasContent ? (
+        <span className="text-[11px] text-muted-foreground">-</span>
+      ) : format === "pretty" ? (
+        <ContentRenderer content={content} />
+      ) : (
+        <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed">
+          {formatValue(parsed, format)}
+        </pre>
+      )}
+    </ExpandableSection>
+  );
+}

--- a/frontend/ui/src/lib/eval/scorer-registry.ts
+++ b/frontend/ui/src/lib/eval/scorer-registry.ts
@@ -1,0 +1,306 @@
+/**
+ * Pure scorer-registry aggregation. TraceRoot has no dedicated Scorer table — a
+ * scorer's definition lives in the customer's SDK. The catalog is therefore DERIVED,
+ * at read time, from what runs reported: the per-run `scorers` manifests (name +
+ * version + optional value_type/direction/threshold) and the denormalized Score rows.
+ *
+ * This module is intentionally Prisma-free (like comparison-db) so it is unit-testable
+ * and reusable by both the list route (all scorers) and the family/detail route (one
+ * scorer, scoped). It never fabricates fields the SDK didn't report — type,
+ * capabilities, prompt, code refs, scope, description and lifecycle are simply absent.
+ */
+import { parseScorers } from "./comparison-db";
+
+/** Inferred value type from which value column populated (vs the SDK's *declared* type). */
+export type InferredValueType = "numeric" | "boolean" | "categorical" | "mixed" | "unknown";
+
+export interface RawScore {
+  scorerName: string;
+  scorerVersion: string;
+  numericValue: number | null;
+  boolValue: boolean | null;
+  stringValue: string | null;
+  passed: boolean | null;
+  error: string | null;
+  createTime: Date;
+  runId: string | null;
+  evaluationId: string | null;
+}
+
+/** The SDK-reported scorer DEFINITION (see offline-eval/sdk-ask/scorer-definition-reporting.md).
+ *  Every field is optional — absent → "Not provided by SDK", never inferred/fabricated. */
+export interface ScorerDefinition {
+  /** Discriminator; drives the detail's top-half. */
+  scorerType: "llm_judge" | "code" | null;
+  outputType: "score" | "classification" | null;
+  description: string | null;
+  metadata: unknown | null;
+  // llm_judge
+  model: string | null;
+  messages: Array<{ role: string; content: string }> | null;
+  // code
+  language: "python" | "typescript" | null;
+  sourceCode: string | null;
+}
+
+function emptyDefinition(): ScorerDefinition {
+  return {
+    scorerType: null,
+    outputType: null,
+    description: null,
+    metadata: null,
+    model: null,
+    messages: null,
+    language: null,
+    sourceCode: null,
+  };
+}
+
+export interface ScorerRow extends ScorerDefinition {
+  name: string;
+  version: string;
+  scoreCount: number;
+  errorCount: number;
+  errorRate: number;
+  /** Inferred from observed values. */
+  valueType: InferredValueType;
+  /** Declared by the SDK manifest (may differ from inferred, or be absent). */
+  declaredValueType: string | null;
+  direction: string | null;
+  threshold: number | null;
+  numeric: { mean: number; min: number; max: number; count: number } | null;
+  passRate: number | null;
+  distribution: Array<{ label: string; count: number }> | null;
+  runCount: number;
+  evaluationCount: number;
+  lastUsed: string | null;
+  recentErrors: Array<{ message: string; at: string }>;
+  /** Always "SDK" — the catalog only ever shows what the SDK reported. */
+  source: "SDK";
+}
+
+interface Agg {
+  name: string;
+  version: string;
+  total: number;
+  errored: number;
+  numericValues: number[];
+  passedTrue: number;
+  passedTotal: number;
+  boolTrue: number;
+  boolFalse: number;
+  categories: Map<string, number>;
+  runIds: Set<string>;
+  evaluationIds: Set<string>;
+  lastUsed: number;
+  recentErrors: Array<{ message: string; at: string }>;
+  seenNumeric: boolean;
+  seenBool: boolean;
+  seenString: boolean;
+}
+
+function inferValueType(a: Agg): InferredValueType {
+  const kinds = [a.seenNumeric, a.seenBool, a.seenString].filter(Boolean).length;
+  if (kinds > 1) return "mixed";
+  if (a.seenNumeric) return "numeric";
+  if (a.seenBool) return "boolean";
+  if (a.seenString) return "categorical";
+  return "unknown";
+}
+
+/** Most-recent declared value_type/direction/threshold per (name, version), from the
+ *  ordered run manifests (later runs win). */
+function declaredByKey(runManifests: Array<{ scorers: unknown }>) {
+  const declared = new Map<
+    string,
+    { valueType: string | null; direction: string | null; threshold: number | null }
+  >();
+  for (const run of runManifests) {
+    for (const s of parseScorers(run.scorers)) {
+      if (s.valueType || s.direction || s.threshold !== null) {
+        declared.set(`${s.name}@${s.version}`, {
+          valueType: s.valueType ?? null,
+          direction: s.direction ?? null,
+          threshold: s.threshold ?? null,
+        });
+      }
+    }
+  }
+  return declared;
+}
+
+/** Latest-reported scorer DEFINITION per (name, version), read from the raw manifest.
+ *  A later run that reports any definition field wins (definition is part of identity;
+ *  changing it should bump the scorer version). Unknown fields are ignored. */
+function definitionByKey(runManifests: Array<{ scorers: unknown }>) {
+  const map = new Map<string, ScorerDefinition>();
+  for (const run of runManifests) {
+    if (!Array.isArray(run.scorers)) continue;
+    for (const raw of run.scorers) {
+      if (!raw || typeof raw !== "object") continue;
+      const o = raw as Record<string, unknown>;
+      if (typeof o.name !== "string") continue;
+      const version = typeof o.version === "string" ? o.version : "";
+      const def = emptyDefinition();
+      let any = false;
+      if (o.scorer_type === "llm_judge" || o.scorer_type === "code") {
+        def.scorerType = o.scorer_type;
+        any = true;
+      }
+      if (o.output_type === "score" || o.output_type === "classification") {
+        def.outputType = o.output_type;
+        any = true;
+      }
+      if (typeof o.description === "string") {
+        def.description = o.description;
+        any = true;
+      }
+      if (o.metadata !== undefined && o.metadata !== null) {
+        def.metadata = o.metadata;
+        any = true;
+      }
+      if (typeof o.model === "string") {
+        def.model = o.model;
+        any = true;
+      }
+      if (Array.isArray(o.messages)) {
+        const msgs = o.messages
+          .filter(
+            (m): m is { role: string; content: string } =>
+              !!m &&
+              typeof m === "object" &&
+              typeof (m as Record<string, unknown>).role === "string" &&
+              typeof (m as Record<string, unknown>).content === "string",
+          )
+          .map((m) => ({ role: m.role, content: m.content }));
+        if (msgs.length > 0) {
+          def.messages = msgs;
+          any = true;
+        }
+      }
+      if (o.language === "python" || o.language === "typescript") {
+        def.language = o.language;
+        any = true;
+      }
+      if (typeof o.source === "string") {
+        def.sourceCode = o.source;
+        any = true;
+      }
+      if (any) map.set(`${o.name}@${version}`, def);
+    }
+  }
+  return map;
+}
+
+/**
+ * Aggregate raw scores + run manifests into per-(name, version) registry rows, sorted
+ * by name then version. `runManifests` must be ordered oldest-first so the newest
+ * declaration wins.
+ */
+export function aggregateScorers(
+  scores: RawScore[],
+  runManifests: Array<{ scorers: unknown }>,
+): ScorerRow[] {
+  const declared = declaredByKey(runManifests);
+  const definitions = definitionByKey(runManifests);
+  const byKey = new Map<string, Agg>();
+
+  for (const s of scores) {
+    const key = `${s.scorerName}@${s.scorerVersion}`;
+    let a = byKey.get(key);
+    if (!a) {
+      a = {
+        name: s.scorerName,
+        version: s.scorerVersion,
+        total: 0,
+        errored: 0,
+        numericValues: [],
+        passedTrue: 0,
+        passedTotal: 0,
+        boolTrue: 0,
+        boolFalse: 0,
+        categories: new Map(),
+        runIds: new Set(),
+        evaluationIds: new Set(),
+        lastUsed: 0,
+        recentErrors: [],
+        seenNumeric: false,
+        seenBool: false,
+        seenString: false,
+      };
+      byKey.set(key, a);
+    }
+    a.total += 1;
+    const at = s.createTime.getTime();
+    if (at > a.lastUsed) a.lastUsed = at;
+    if (s.runId) a.runIds.add(s.runId);
+    if (s.evaluationId) a.evaluationIds.add(s.evaluationId);
+    if (s.error) {
+      // A scorer error contributes to error stats but is never a 0 score.
+      a.errored += 1;
+      a.recentErrors.push({ message: s.error, at: s.createTime.toISOString() });
+    } else if (s.boolValue !== null) {
+      a.seenBool = true;
+      if (s.boolValue) a.boolTrue += 1;
+      else a.boolFalse += 1;
+    } else if (s.numericValue !== null) {
+      a.seenNumeric = true;
+      a.numericValues.push(s.numericValue);
+    } else if (s.stringValue !== null) {
+      a.seenString = true;
+      a.categories.set(s.stringValue, (a.categories.get(s.stringValue) ?? 0) + 1);
+    }
+    if (s.passed !== null) {
+      a.passedTotal += 1;
+      if (s.passed) a.passedTrue += 1;
+    }
+  }
+
+  return [...byKey.values()]
+    .map((a): ScorerRow => {
+      const meta = declared.get(`${a.name}@${a.version}`) ?? null;
+      const nums = a.numericValues;
+      const numeric =
+        nums.length > 0
+          ? {
+              mean: nums.reduce((x, y) => x + y, 0) / nums.length,
+              min: Math.min(...nums),
+              max: Math.max(...nums),
+              count: nums.length,
+            }
+          : null;
+      let distribution: Array<{ label: string; count: number }> | null = null;
+      if (a.seenBool && !a.seenNumeric && !a.seenString) {
+        distribution = [
+          { label: "true", count: a.boolTrue },
+          { label: "false", count: a.boolFalse },
+        ];
+      } else if (a.categories.size > 0) {
+        distribution = [...a.categories.entries()]
+          .map(([label, count]) => ({ label, count }))
+          .sort((x, y) => y.count - x.count)
+          .slice(0, 8);
+      }
+      return {
+        ...(definitions.get(`${a.name}@${a.version}`) ?? emptyDefinition()),
+        name: a.name,
+        version: a.version,
+        scoreCount: a.total,
+        errorCount: a.errored,
+        errorRate: a.total > 0 ? a.errored / a.total : 0,
+        valueType: inferValueType(a),
+        declaredValueType: meta?.valueType ?? null,
+        direction: meta?.direction ?? null,
+        threshold: meta?.threshold ?? null,
+        numeric,
+        passRate: a.passedTotal > 0 ? a.passedTrue / a.passedTotal : null,
+        distribution,
+        runCount: a.runIds.size,
+        evaluationCount: a.evaluationIds.size,
+        lastUsed: a.lastUsed > 0 ? new Date(a.lastUsed).toISOString() : null,
+        recentErrors: a.recentErrors.sort((x, y) => (x.at < y.at ? 1 : -1)).slice(0, 3),
+        source: "SDK",
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version));
+}


### PR DESCRIPTION
## Summary

Fixes: #1658

Adds the Datasets surface: a routed list of the project's datasets and a detail page whose version selector reads as a timeline of the dataset's history. Every version is an immutable, pinned snapshot, so selecting an older version swaps the test-case table to that snapshot read-only and only the current version stays editable. There is no "run evaluation" button — runs come from the SDK — so empty states and the pull-code drawer point the user at a snippet instead of an in-UI create flow.

## How it works

The list opens a dataset on row click. On the detail page the version selector defaults to the current version; picking an older one loads its snapshot, shows an amber "Viewing v{n} · {label} — read only." banner naming the snapshot, and repopulates the test-case table with that version's cases without leaving the page. "Pull code" opens a slide-out with a single "Pull dataset" snippet in Python or TypeScript, ready to copy.

## What's included

### Routes
- `app/projects/[projectId]/datasets/page.tsx` — the list route.
- `app/projects/[projectId]/datasets/[datasetId]/page.tsx` — the detail route.
- `app/api/projects/[projectId]/evaluations/scorers/route.ts` — provides `GET`.
- `app/projects/[projectId]/evaluations/[runId]/page.tsx` — part of this change.
- `app/projects/[projectId]/evaluations/page.tsx` — part of this change.

### UI
- `features/evaluations/views/datasets-view.tsx` — dataset list: search + date filter, single-line/ellipsis-truncated rows (Name is the widest column), test-case and evaluation counts, a three-dot Edit/Delete menu, and New/Edit side panels. Empty and error rows are handled explicitly, and the empty state tells the user to save a span or trace as a test case.
- `features/evaluations/views/dataset-detail-view.tsx` — detail scaffold: the version selector (newest-first, current version labelled), the immutable version id with a copy button, the read-only banner for older snapshots, the Test cases / Evaluation history tabs, and the Pull code entry point. Loading, not-found, and empty states are all handled.
- `app/globals.css` — part of this change.
- `components/layout/sidebar.tsx` — provides `Sidebar`.
- `components/search-filter-bar.tsx` — provides `SearchFilterBar`.
- `components/ui/badge.tsx` — provides `BadgeProps`, `Badge`.
- `components/ui/checkbox.tsx` — provides `CheckboxProps`, `Checkbox`.
- `components/ui/drawer.tsx` — provides `DrawerContentProps`.
- `components/ui/expandable-section.tsx` — provides `ExpandableSection`.
- `components/ui/table.tsx` — provides `TH`, `TD`, `TD_NUM`, `TD_ID`.
- `components/ui/tabs.tsx` — provides `TabsProps`, `Tabs`, `TabsList`, `TabsTrigger`.
- `components/ui/toast.tsx` — provides `ToastTone`, `ToastOptions`, `useToast`, `ToastProvider`.
- `features/evaluations/components/delete-dataset-dialog.tsx` — provides `DeleteDatasetDialog`.
- `features/evaluations/views/evaluations-view.tsx` — provides `RunStatusBadge`, `EvaluationsView`, `formatElapsed`, `ScoreValue`.
- `features/offline-eval/components/badges.tsx` — provides `EvalResultBadge`, `StatusBadge`, `ReviewBadge`.
- `features/offline-eval/components/code.tsx` — provides `ValueKind`, `formatValue`, `LineNumberedTextarea`, `ValueBlock`.
- `features/offline-eval/components/form-kit.tsx` — provides `FormCard`, `AdvancedSection`, `CreateDrawer`.
- `features/offline-eval/components/index.ts` — Offline Evaluation feature components.
- `features/offline-eval/components/syntax.tsx` — provides `CODE_COLORS`, `CodeToken`, `tokenizeCode`, `HighlightedCode`.
- `features/projects/components/ProjectBreadcrumb.tsx` — provides `ProjectBreadcrumb`.
- `features/traces/components/SpanInfoPanel.tsx` — provides `SpanInfoPanel`.
- `features/traces/components/TraceIOValue.tsx` — provides `TraceIOSection`.

### Shared components
- `features/evaluations/components/pull-code-drawer.tsx` — the shared pull-code slide-out; the detail page passes a single "Pull dataset" option (Python/TypeScript toggle, copy button) and the drawer omits the option picker when there is only one.
- `features/offline-eval/components/dataset-actions-menu.tsx` — the per-row Edit/Delete menu.
- `features/offline-eval/components/dataset-form.tsx` — dataset name/description form fields shared by the panels.
- `features/offline-eval/components/timestamp.tsx` — hydration-safe "last updated" rendering.

### Hooks / data
- `features/evaluations/hooks.ts` — `useDatasets`, `useDataset` (version-aware), `useCreateDataset`, `useUpdateDataset`, `useDeleteDataset`.
- `features/evaluations/types.ts` — `DatasetRow` and the version/detail read-model shapes the views consume.
- `lib/eval/scorer-registry.ts` — Pure scorer-registry aggregation. TraceRoot has no dedicated Scorer table — a scorer's definition lives in the customer's SDK.

### Backend
- `backend/db/clickhouse/migrations/008_add_is_evaluation.sql` — Explicit classification flag for offline-evaluation traces/spans. This is deliberately NOT folded into `environment`. `environment` is a.

### Tests
- `features/evaluations/evaluations.smoke.test.tsx` — covers `evaluations.smoke`.
- `features/evaluations/run-detail-trace.smoke.test.tsx` — covers `run-detail-trace.smoke`.
- `features/evaluations/run-evaluation-drawer.smoke.test.tsx` — covers `run-evaluation-drawer.smoke`.
- `features/evaluations/scorer-detail.smoke.test.tsx` — covers `scorer-detail.smoke`.
- `features/traces/components/TraceIOValue.test.tsx` — covers `TraceIOValue`.

## Test plan

- [ ] The list shows the project's datasets; rows truncate to one line and open the detail on click.
- [ ] Searching narrows the list by name; clearing the search restores the full list.
- [ ] The version selector loads older snapshots read-only, while the current version stays editable.
- [ ] Switching to an older version repopulates the test-case table with that snapshot's cases and shows the read-only banner; switching back to current clears it.
- [ ] There is no "run evaluation" button; Pull code offers only the "Pull dataset" snippet, copyable in both languages.
- [ ] Loading, empty, and error states render on the list and the detail page.
