### PR TITLE
feat(datasets): test-case table and slide-in per-case panel

### DIFF
--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -115,6 +115,9 @@ export function DatasetDetailView({
   const save = useSaveTestCase(projectId, datasetId);
   const update = useUpdateTestCase(projectId, datasetId);
 
+  // Hold the stable lineage id (testCaseId), not the per-version row id — a
+  // save/review publishes a new version with fresh row ids, and the row id
+  // would go dead and unmount the panel out from under the user.
   const [openCaseId, setOpenCaseId] = React.useState<string | null>(null);
 
   // Deep link: /datasets/[id]?case=<testCaseId> opens that case's panel once (e.g.
@@ -126,11 +129,14 @@ export function DatasetDetailView({
     if (!caseParam || !data || handledCaseParam.current === caseParam) return;
     const match = data.testCases.find((c) => c.testCaseId === caseParam);
     if (match) {
-      setOpenCaseId(match.id);
+      setOpenCaseId(match.testCaseId);
       handledCaseParam.current = caseParam;
     }
   }, [searchParams, data]);
   const [reviewCaseId, setReviewCaseId] = React.useState<string | null>(null);
+  // Mirrors CasePanel's dirty flag so the table can prompt before discarding an
+  // unsaved edit on row-click, without lifting the whole edit buffer up.
+  const dirtyRef = React.useRef(false);
   const [keyword, setKeyword] = React.useState("");
   const [historyKeyword, setHistoryKeyword] = React.useState("");
   const [codeOpen, setCodeOpen] = React.useState(false);
@@ -165,8 +171,13 @@ export function DatasetDetailView({
     );
   }, [runs, historyKeyword]);
 
-  const openCase = openCaseId ? (cases.find((c) => c.id === openCaseId) ?? null) : null;
-  const reviewCase = reviewCaseId ? (cases.find((c) => c.id === reviewCaseId) ?? null) : null;
+  // Resolved against allCases (not the keyword-filtered `cases`) and keyed on the
+  // stable testCaseId — otherwise typing in the search box, or a save publishing
+  // a new version's row ids, would silently unmount the open panel.
+  const openCase = openCaseId ? (allCases.find((c) => c.testCaseId === openCaseId) ?? null) : null;
+  const reviewCase = reviewCaseId
+    ? (allCases.find((c) => c.testCaseId === reviewCaseId) ?? null)
+    : null;
 
   const reviewTarget = React.useMemo<TestCaseReviewTarget | null>(() => {
     if (!reviewCase || !dataset) return null;
@@ -189,11 +200,21 @@ export function DatasetDetailView({
         },
       },
       {
-        onSuccess: () =>
-          toast({ title: "Review saved — new dataset version published", tone: "success" }),
+        onSuccess: () => {
+          toast({ title: "Review saved — new dataset version published", tone: "success" });
+          // Follow the version just published rather than leaving the view
+          // pinned to whatever was selected before the save.
+          setSelectedVersionId(null);
+          setReviewCaseId(null);
+        },
+        onError: (e) =>
+          toast({
+            title: "Could not save this review",
+            description: String(e),
+            tone: "warning",
+          }),
       },
     );
-    setReviewCaseId(null);
   };
 
   const addEmptyRow = () => {
@@ -399,25 +420,45 @@ export function DatasetDetailView({
                     </TRHead>
                   </THead>
                   <TBody>
-                    {cases.map((tc) => (
-                      <TR
-                        key={tc.id}
-                        interactive
-                        selected={tc.id === openCaseId}
-                        onClick={() => setOpenCaseId(tc.id)}
-                      >
-                        <Td className="whitespace-nowrap text-muted-foreground">
-                          <Timestamp iso={tc.createTime} />
-                        </Td>
-                        <Td className="max-w-[320px] truncate" title={tc.input || undefined}>
-                          {orDash(tc.input || null)}
-                        </Td>
-                        <Td className="max-w-[320px] truncate" title={tc.expected ?? undefined}>
-                          {orDash(tc.expected)}
-                        </Td>
-                        <Td className="max-w-[240px] truncate">{metadataPreview(tc.metadata)}</Td>
-                      </TR>
-                    ))}
+                    {cases.map((tc) => {
+                      const openThisCase = () => {
+                        if (
+                          dirtyRef.current &&
+                          !window.confirm("Discard unsaved changes to this case?")
+                        ) {
+                          return;
+                        }
+                        setOpenCaseId(tc.testCaseId);
+                      };
+                      return (
+                        <TR
+                          key={tc.id}
+                          interactive
+                          selected={tc.testCaseId === openCaseId}
+                          tabIndex={0}
+                          role="button"
+                          aria-expanded={tc.testCaseId === openCaseId}
+                          onClick={openThisCase}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              openThisCase();
+                            }
+                          }}
+                        >
+                          <Td className="whitespace-nowrap text-muted-foreground">
+                            <Timestamp iso={tc.createTime} />
+                          </Td>
+                          <Td className="max-w-[320px] truncate" title={tc.input || undefined}>
+                            {orDash(tc.input || null)}
+                          </Td>
+                          <Td className="max-w-[320px] truncate" title={tc.expected ?? undefined}>
+                            {orDash(tc.expected)}
+                          </Td>
+                          <Td className="max-w-[240px] truncate">{metadataPreview(tc.metadata)}</Td>
+                        </TR>
+                      );
+                    })}
                   </TBody>
                 </Table>
               )}
@@ -505,15 +546,19 @@ export function DatasetDetailView({
           datasetId={datasetId}
           datasetName={dataset.name}
           readOnly={!isCurrentVersion}
+          dirtyRef={dirtyRef}
           onClose={() => setOpenCaseId(null)}
-          onReview={() => setReviewCaseId(openCase.id)}
+          onReview={() => setReviewCaseId(openCase.testCaseId)}
+          onSaved={() => setSelectedVersionId(null)}
           onNavigate={(dir) => {
-            const idx = cases.findIndex((c) => c.id === openCase.id);
+            const idx = cases.findIndex((c) => c.testCaseId === openCase.testCaseId);
             const next = dir === "up" ? idx - 1 : idx + 1;
-            if (next >= 0 && next < cases.length) setOpenCaseId(cases[next].id);
+            if (next >= 0 && next < cases.length) setOpenCaseId(cases[next].testCaseId);
           }}
-          canNavigateUp={cases.findIndex((c) => c.id === openCase.id) > 0}
-          canNavigateDown={cases.findIndex((c) => c.id === openCase.id) < cases.length - 1}
+          canNavigateUp={cases.findIndex((c) => c.testCaseId === openCase.testCaseId) > 0}
+          canNavigateDown={
+            cases.findIndex((c) => c.testCaseId === openCase.testCaseId) < cases.length - 1
+          }
         />
       )}
 
@@ -579,8 +624,10 @@ function CasePanel({
   datasetId,
   datasetName,
   readOnly = false,
+  dirtyRef,
   onClose,
   onReview,
+  onSaved,
   onNavigate,
   canNavigateUp,
   canNavigateDown,
@@ -592,8 +639,14 @@ function CasePanel({
   /** Viewing an older snapshot: fields and Save are disabled (editing branches
    * from the current version, not this one). */
   readOnly?: boolean;
+  /** Mirrors `dirty` for the parent, which can't see this component's state
+   * directly (e.g. to confirm before switching rows). */
+  dirtyRef: React.MutableRefObject<boolean>;
   onClose: () => void;
   onReview: () => void;
+  /** Called after a save publishes a new version, so the parent can stop
+   * pinning an older/explicit version selection and follow the new current. */
+  onSaved: () => void;
   onNavigate: (direction: "up" | "down") => void;
   canNavigateUp: boolean;
   canNavigateDown: boolean;
@@ -617,17 +670,27 @@ function CasePanel({
   const [expectedText, setExpectedText] = React.useState(testCase.expected ?? "");
   const [metadataText, setMetadataText] = React.useState(initialMetadata);
 
+  // Re-seed only when the case identity changes, not on every value change —
+  // otherwise a background refetch (60s staleTime, cross-tab sync) that pulls in
+  // a new server value stomps text the user is mid-way through typing.
   React.useEffect(() => {
     setInputText(testCase.input);
     setExpectedText(testCase.expected ?? "");
     setMetadataText(initialMetadata);
-  }, [testCase.id, testCase.input, testCase.expected, initialMetadata]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [testCase.testCaseId]);
 
   const dirty =
     !readOnly &&
     (inputText !== testCase.input ||
       expectedText !== (testCase.expected ?? "") ||
       metadataText !== initialMetadata);
+
+  React.useEffect(() => {
+    dirtyRef.current = dirty;
+  }, [dirty, dirtyRef]);
+
+  const confirmDiscard = () => !dirty || window.confirm("Discard unsaved changes to this case?");
 
   // Metadata only persists when it parses to an object; a half-typed edit keeps
   // the prior value rather than blowing it away.
@@ -643,6 +706,18 @@ function CasePanel({
     }
     return undefined; // leave stored metadata untouched
   };
+
+  // Surfaces the same parse failure `parseMetadata` swallows, so a half-typed
+  // edit is visibly unsaveable instead of silently dropped on Save.
+  const metadataInvalid = React.useMemo(() => {
+    if (metadataText.trim() === "") return false;
+    try {
+      const parsed = JSON.parse(metadataText);
+      return parsed === null || typeof parsed !== "object" || Array.isArray(parsed);
+    } catch {
+      return true;
+    }
+  }, [metadataText]);
 
   const saveEdits = () => {
     const patch: {
@@ -662,15 +737,63 @@ function CasePanel({
     update.mutate(
       { testCaseId: testCase.testCaseId, patch },
       {
-        onSuccess: () => toast({ title: "Saved — new dataset version published", tone: "success" }),
+        onSuccess: () => {
+          toast({ title: "Saved — new dataset version published", tone: "success" });
+          onSaved();
+        },
+        onError: (e) =>
+          toast({
+            title: "Could not save this test case",
+            description: String(e),
+            tone: "warning",
+          }),
       },
     );
   };
 
+  const panelRef = React.useRef<HTMLDivElement>(null);
+  const previousFocusRef = React.useRef<HTMLElement | null>(null);
+
+  // Move focus into the panel on open and restore it to whatever triggered the
+  // open (usually the table row) on close, matching the trace/span panel.
+  React.useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    panelRef.current?.focus();
+    return () => {
+      previousFocusRef.current?.focus?.();
+    };
+  }, []);
+
+  const guardedClose = () => {
+    if (confirmDiscard()) onClose();
+  };
+  const guardedNavigate = (direction: "up" | "down") => {
+    if (confirmDiscard()) onNavigate(direction);
+  };
+
+  // Close on Escape, unless a nested Radix overlay (the value-block format
+  // popover) already consumed it in the capture phase — defaultPrevented means
+  // "already handled, leave this panel open".
+  React.useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (e.defaultPrevented) return;
+      guardedClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onClose, dirty]);
+
   return (
     <div
+      ref={panelRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Test case ${caseDisplayId(testCase.testCaseId)}`}
+      tabIndex={-1}
       className={cn(
-        "animate-slide-in-right fixed bottom-0 right-0 z-50 flex flex-col border-l border-border bg-background shadow-xl transition-[width,top] duration-200",
+        "animate-slide-in-right fixed bottom-0 right-0 z-50 flex flex-col border-l border-border bg-background shadow-xl transition-[width,top] duration-200 focus:outline-none",
         fullscreen
           ? sidebarCollapsed
             ? "top-14 w-[calc(100%-3.5rem)]"
@@ -697,7 +820,7 @@ function CasePanel({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => onNavigate("up")}
+              onClick={() => guardedNavigate("up")}
               disabled={!canNavigateUp}
               className="h-7 w-7 p-0"
               title="Previous row"
@@ -707,7 +830,7 @@ function CasePanel({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => onNavigate("down")}
+              onClick={() => guardedNavigate("down")}
               disabled={!canNavigateDown}
               className="h-7 w-7 p-0"
               title="Next row"
@@ -736,7 +859,7 @@ function CasePanel({
               variant="ghost"
               size="sm"
               className="h-7 w-7 p-0"
-              onClick={onClose}
+              onClick={guardedClose}
               aria-label="Close"
             >
               <X className="h-4 w-4" />
@@ -862,6 +985,11 @@ function CasePanel({
             collapsible
             readOnly={readOnly}
           />
+          {metadataInvalid && (
+            <p className="text-[11px] leading-snug text-amber-700 dark:text-amber-300">
+              Metadata must be a JSON object — this edit won&apos;t be saved until it is.
+            </p>
+          )}
           <p className="text-[11px] leading-snug text-muted-foreground">
             Saving publishes a new dataset version — it changes what future runs are compared
             against and never rewrites a snapshot an earlier run used.
@@ -919,13 +1047,19 @@ function CasePanel({
             size="sm"
             variant="outline"
             className="h-8 flex-1 text-[12px]"
-            disabled={update.isPending}
+            disabled={update.isPending || metadataInvalid}
             onClick={saveEdits}
           >
             Save changes
           </Button>
         )}
-        <Button size="sm" className="h-8 flex-1 text-[12px]" onClick={onReview}>
+        <Button
+          size="sm"
+          className="h-8 flex-1 text-[12px]"
+          onClick={onReview}
+          disabled={readOnly}
+          title={readOnly ? "Switch to the current version to review this case" : undefined}
+        >
           Review
         </Button>
       </div>

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -675,15 +675,17 @@ function CasePanel({
   const [expectedText, setExpectedText] = React.useState(testCase.expected ?? "");
   const [metadataText, setMetadataText] = React.useState(initialMetadata);
 
-  // Re-seed only when the case identity changes, not on every value change —
-  // otherwise a background refetch (60s staleTime, cross-tab sync) that pulls in
-  // a new server value stomps text the user is mid-way through typing.
+  // Re-seed on the per-version ROW id, not the stable testCaseId. A save or a
+  // snapshot switch publishes a NEW version — same testCaseId, new row id and values —
+  // so keying on the row id refreshes the buffer to the just-saved/selected values
+  // (otherwise a successful metadata save looks lost). A same-version background
+  // refetch keeps the same row id, so it still can't stomp in-progress typing.
   React.useEffect(() => {
     setInputText(testCase.input);
     setExpectedText(testCase.expected ?? "");
     setMetadataText(initialMetadata);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [testCase.testCaseId]);
+  }, [testCase.id]);
 
   const dirty =
     !readOnly &&

--- a/frontend/ui/src/features/offline-eval/components/test-case-review-drawer.tsx
+++ b/frontend/ui/src/features/offline-eval/components/test-case-review-drawer.tsx
@@ -11,16 +11,17 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "@/components/ui/drawer";
-import { useToast } from "@/components/ui/toast";
 import type { ReviewStatus } from "../types";
 
 /**
- * Review test case — verifies that a dataset row is a good, reusable test case,
- * which is a different question from scoring one output. It deliberately does
- * NOT ask Pass / Fail / Quality (those belong to production annotation or
- * evaluation-result scoring). The reviewer confirms the case is rerunnable and
- * appropriate, may correct the expected outcome, and marks it Ready or Needs
- * work. Ready is advisory — it never blocks the case from an evaluation here.
+ * Review test case — the server-wired review drawer. Submitting persists
+ * through useUpdateTestCase; the caller owns the success/error toast.
+ * Reviewing verifies a row is a good, reusable test case, which is a different
+ * question from scoring one output. It deliberately does NOT ask Pass / Fail /
+ * Quality (those belong to production annotation or evaluation-result
+ * scoring). The reviewer confirms the case is rerunnable and appropriate, may
+ * correct the expected outcome, and marks it Ready or Needs work. Ready is
+ * advisory — it never blocks the case from an evaluation.
  */
 
 export interface TestCaseReviewTarget {
@@ -49,7 +50,6 @@ export function TestCaseReviewDrawer({
   onOpenChange: (open: boolean) => void;
   onSubmit: (result: { review: ReviewStatus; correctedExpected?: string }) => void;
 }) {
-  const { toast } = useToast();
   const [checked, setChecked] = React.useState<boolean[]>(() => CHECKS.map(() => false));
   const [corrected, setCorrected] = React.useState("");
 
@@ -62,17 +62,13 @@ export function TestCaseReviewDrawer({
   if (!target) return null;
 
   const expectedChanged = corrected.trim() !== "" && corrected.trim() !== (target.expected ?? "");
+  const allChecked = checked.every(Boolean);
 
+  // Closing is the caller's job: it happens once the save actually succeeds
+  // (see dataset-detail-view's submitReview), not synchronously here — the
+  // request may still be in flight, or may fail.
   const submit = (review: ReviewStatus) => {
     onSubmit({ review, correctedExpected: expectedChanged ? corrected.trim() : undefined });
-    toast({
-      title: review === "ready" ? "Marked Ready" : "Sent back for work",
-      description: expectedChanged
-        ? "Saved with a corrected expected outcome."
-        : "Saved in this page only.",
-      tone: "success",
-    });
-    onOpenChange(false);
   };
 
   return (
@@ -145,14 +141,15 @@ export function TestCaseReviewDrawer({
               className="h-7 text-[12px]"
             />
             <p className="mt-1.5 text-[11px] text-muted-foreground">
-              Changing this changes what future runs are evaluated against.
+              Changing this publishes a new dataset version — it changes what future runs are
+              evaluated against.
             </p>
           </div>
         </DrawerBody>
 
         <DrawerFooter>
           <span className="text-[11px] text-muted-foreground">
-            Ready is advisory — saved here only.
+            Ready is advisory — it never blocks the case from an evaluation.
           </span>
           <span className="flex gap-2">
             <Button
@@ -163,7 +160,13 @@ export function TestCaseReviewDrawer({
             >
               Needs work
             </Button>
-            <Button size="sm" className="h-7 text-[12px]" onClick={() => submit("ready")}>
+            <Button
+              size="sm"
+              className="h-7 text-[12px]"
+              onClick={() => submit("ready")}
+              disabled={!allChecked}
+              title={allChecked ? undefined : "Check every item above before marking ready"}
+            >
               Mark ready
             </Button>
           </span>


### PR DESCRIPTION
## Summary

Fixes: #1659

Adds the dataset detail's test-case table and its slide-in per-case panel. The table lists cases single-line and ellipsis-truncated (Input / Expected / Metadata); clicking a row slides in a panel from the right the way a trace opens. The panel splits into a Details tab — input, expected, recorded production output, and metadata as value blocks — and a Runs tab that shows this case's result across runs, so a single case's identity and its trajectory over time stay in one place. Editing any field publishes a new immutable dataset version, so an earlier run's snapshot is never rewritten.

## How it works

Rows carry title tooltips for the full value and open the case panel on click; the panel's up/down chevrons step between cases. Input and expected edit as native JSON when the value is JSON (parsed back on save rather than flattened to a string); metadata edits as JSON and only persists when it parses to an object. Saving a change publishes a new version and toasts "new dataset version published". On an older (read-only) snapshot the value blocks still render but the fields and Save are disabled, matching the version's pinned state.

## What's included

### UI
- `features/evaluations/views/dataset-detail-view.tsx` — the Test cases table (truncated Created / Input / Expected / Metadata cells with tooltips, "-" placeholders for empty values, row selection) and the `CasePanel` slide-in: a trace-style header with the row id + copy button and up/down/fullscreen/open-in-new-tab/close controls, the Source / Captured chips, a Details / Runs toggle, editable Input / Expected / Metadata value blocks plus a read-only "What happened in production" block, the per-case Runs history that links to the run view, and a Save action shown only when the case is dirty.

### Shared components
- `features/offline-eval/components/test-case-review-drawer.tsx` — the review drawer opened from the panel's Review action; submitting a review publishes a new version.

### Hooks / data

## Test plan

- [ ] Rows are single-line / truncated with a title tooltip; clicking a row opens the case panel like a trace.
- [ ] Editing input, expected, or metadata and saving creates a new dataset version and never rewrites an earlier snapshot.
- [ ] JSON input / expected round-trips through an edit without being flattened to an escaped string.
- [ ] Long values collapse in-field rather than flooding the panel, and expand in place.
- [ ] The Runs tab lists this case's results (score + status per run) and jumps to the correct run view.
- [ ] Switching the Details / Runs toggle keeps the same case open.
- [ ] On an older version the value blocks render but the fields and Save are disabled.
