### PR TITLE
feat(datasets): save a span as a test case

### DIFF
--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -62,7 +62,17 @@ async def list_traces(
         None,
         description="Only traces that started before this time (exclusive, ISO 8601)",
     ),
+    include_evaluations: bool = Query(
+        False,
+        description="Include offline-evaluation traces (environment=evaluation). "
+        "Excluded by default so evaluation runs do not appear in the production trace list.",
+    ),
 ):
+    """List recent traces for the API key's project (newest first).
+
+    Offline-evaluation traces are excluded by default; pass
+    ``include_evaluations=true`` to include them.
+    """
     """List recent traces for the API key's project (newest first)."""
     start_after, end_before = clamp_retention_window(auth.billing_plan, start_after, end_before)
     try:
@@ -72,6 +82,7 @@ async def list_traces(
             limit=limit,
             start_after=start_after,
             end_before=end_before,
+            include_evaluations=include_evaluations,
         )
     except Exception as e:
         logger.exception(f"Error listing traces: {e}")

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -78,6 +78,11 @@ async def list_traces(
     filters: str | None = Query(
         None, description="URL-encoded JSON array of {field, op, value} filter predicates"
     ),
+    include_evaluations: bool = Query(
+        False,
+        description="Include offline-evaluation traces (environment=evaluation), "
+        "which are excluded by default.",
+    ),
 ):
     """List traces for a project with pagination and filtering."""
     # Parse + validate filters before the DB try-block so a bad predicate surfaces as a
@@ -99,6 +104,7 @@ async def list_traces(
             end_before=end_before,
             search_query=search_query,
             filters=parsed_filters,
+            include_evaluations=include_evaluations,
         )
         return result
     except Exception as e:

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -391,8 +391,15 @@ class TraceReaderService:
         end_before: datetime | None = None,
         search_query: str | None = None,
         filters: list[Predicate] | None = None,
+        include_evaluations: bool = False,
     ) -> dict:
-        """List traces with aggregated metrics from spans."""
+        """List traces with aggregated metrics from spans.
+
+        Offline-evaluation traces (``environment = 'evaluation'``) are excluded by
+        default so they do not pollute the production/staging Traces list; pass
+        ``include_evaluations=True`` to include them. The predicate is trace-level and
+        shared by the page and count queries (below), so counts and pagination match.
+        """
         offset = page * limit
 
         # Build WHERE conditions
@@ -442,6 +449,12 @@ class TraceReaderService:
         # SHARED conditions so they land in both the page query and the count query;
         # the span sub-queries reuse start_after (above) as a span-scan lower bound.
         conditions.extend(build_conditions(filters or [], params))
+
+        # Exclude offline-evaluation traces by default (trace-level, NULL-safe so
+        # untagged production traces are always kept). Shared by page + count.
+        if not include_evaluations:
+            conditions.append("(t.environment IS NULL OR t.environment != {excluded_env:String})")
+            params["excluded_env"] = "evaluation"
 
         where_clause = " AND ".join(conditions)
 

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -450,11 +450,13 @@ class TraceReaderService:
         # the span sub-queries reuse start_after (above) as a span-scan lower bound.
         conditions.extend(build_conditions(filters or [], params))
 
-        # Exclude offline-evaluation traces by default (trace-level, NULL-safe so
-        # untagged production traces are always kept). Shared by page + count.
+        # Exclude offline-evaluation traces by default via the authoritative
+        # `is_evaluation` flag — NOT the environment name, which a real project may
+        # legitimately set to "evaluation" (that would hide its production traces
+        # while leaving mistagged eval runs visible). NULL-safe so untagged
+        # production traces are always kept. Shared by page + count.
         if not include_evaluations:
-            conditions.append("(t.environment IS NULL OR t.environment != {excluded_env:String})")
-            params["excluded_env"] = "evaluation"
+            conditions.append("(t.is_evaluation IS NULL OR t.is_evaluation = 0)")
 
         where_clause = " AND ".join(conditions)
 

--- a/frontend/packages/core/src/__tests__/eval-contract.test.ts
+++ b/frontend/packages/core/src/__tests__/eval-contract.test.ts
@@ -39,12 +39,16 @@ describe("UpsertResultRequestSchema.scores", () => {
   });
 
   it("rejects more scores than the per-result cap", () => {
-    const score = { scorer_name: "s", scorer_version: "1" };
-    const under = Array.from({ length: EVAL_SCORER_LIST_MAX }, () => score);
+    // DISTINCT scorer pairs — identical ones would trip the duplicate-(name,version)
+    // refine first, so this would test dedup rather than the per-result cap.
+    const scoreAt = (i: number) => ({ scorer_name: `s${i}`, scorer_version: "1" });
+    const under = Array.from({ length: EVAL_SCORER_LIST_MAX }, (_, i) => scoreAt(i));
     expect(UpsertResultRequestSchema.safeParse(result({ scores: under })).success).toBe(true);
-    expect(UpsertResultRequestSchema.safeParse(result({ scores: [...under, score] })).success).toBe(
-      false,
-    );
+    expect(
+      UpsertResultRequestSchema.safeParse(
+        result({ scores: [...under, scoreAt(EVAL_SCORER_LIST_MAX)] }),
+      ).success,
+    ).toBe(false);
   });
 });
 

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.ts
@@ -13,12 +13,15 @@ type RouteParams = {
 export async function GET(_req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
-  const { projectId, testCaseId } = await params;
+  const { projectId, datasetId, testCaseId } = await params;
   const accessResult = await requireProjectAccess(authResult.user.id, projectId);
   if (accessResult.error) return accessResult.error;
 
+  // A stable testCaseId can recur across datasets in the same project (it's only
+  // unique within a dataset lineage), so scope through the run's dataset — otherwise
+  // this tab would surface runs from a different dataset that reused the id.
   const results = await prisma.evaluationResult.findMany({
-    where: { projectId, testCaseId },
+    where: { projectId, testCaseId, run: { datasetId } },
     orderBy: { createTime: "desc" },
     select: {
       id: true,

--- a/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
@@ -92,10 +92,13 @@ describe("A2: upsert a dataset by client id", () => {
     expect((await readJson(again)).dataset_id).toBe("ds_01");
   });
 
-  it("hides a dataset id owned by another project (404)", async () => {
+  it("lets two projects reuse the same client dataset id (per-project keyspace)", async () => {
     await upsertDataset(req({ dataset_id: "ds_shared", name: "mine" }));
     const res = await upsertDataset(req({ dataset_id: "ds_shared", name: "theirs" }, OTHER_KEY));
-    expect(res.status).toBe(404);
+    // `clientDatasetId` is unique per project, not globally: the other project creates
+    // its OWN dataset under the same id rather than being blocked (or shown it exists).
+    expect(res.status).toBe(201);
+    expect(fakePrisma.dataset.rows).toHaveLength(2);
   });
 });
 

--- a/frontend/ui/src/app/api/public/evaluation-runs/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/route.ts
@@ -63,8 +63,12 @@ async function registerRun(
   projectId: string,
   req: RegisterRunRequest,
 ): Promise<RegisterOutcome> {
-  const dataset = await tx.dataset.findFirst({
-    where: { id: req.dataset_id, projectId },
+  // The SDK's `dataset_id` is the project-scoped client id, never the internal PK
+  // (which is an auto-generated cuid the caller never sees) — resolve it here and
+  // thread the internal `dataset.id` through the version, evaluation and run below.
+  // Looking up by the internal id would 404 every SDK-registered run.
+  const dataset = await tx.dataset.findUnique({
+    where: { projectId_clientDatasetId: { projectId, clientDatasetId: req.dataset_id } },
     select: { id: true, currentVersionId: true },
   });
   if (!dataset) return { httpError: { message: "Dataset not found", status: 404 } };
@@ -76,7 +80,7 @@ async function registerRun(
     };
   }
   const version = await tx.datasetVersion.findFirst({
-    where: { id: versionId, datasetId: req.dataset_id, projectId },
+    where: { id: versionId, datasetId: dataset.id, projectId },
     select: { id: true },
   });
   if (!version) return { httpError: { message: "Dataset version not found", status: 400 } };
@@ -107,7 +111,7 @@ async function registerRun(
     (await tx.evaluation.create({
       data: {
         projectId,
-        datasetId: req.dataset_id,
+        datasetId: dataset.id,
         name: req.evaluation_name,
         mainScoreName: req.main_score_name ?? "Score",
       },
@@ -156,7 +160,7 @@ async function registerRun(
     data: {
       evaluationId: evaluation.id,
       projectId,
-      datasetId: req.dataset_id,
+      datasetId: dataset.id,
       datasetVersionId: versionId,
       runNumber,
       candidateVersion: req.candidate_version,

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -34,7 +34,6 @@ import { Button } from "@/components/ui/button";
 import {
   SaveTestCaseDrawer,
   TraceEvaluationChip,
-  SpanDatasetChip,
 } from "@/features/evaluations/components/trace-integration";
 import { formatContentPreview } from "@/features/traces/utils";
 import { useSession as useAuthSession } from "@/lib/auth-client";
@@ -434,18 +433,11 @@ export default function TracesPage() {
               Save as test case
             </Button>
           )}
-          // Offline eval: a trace-level chip when this trace came from a run, and
-          // a per-span "Dataset:" chip marking a span already saved as a test case.
+          // Offline eval: show an Evaluation chip when this trace came from a run.
           spanExtraTags={(selection: TraceSelection) =>
             selection.type === "trace" ? (
               <TraceEvaluationChip projectId={projectId} traceId={selectedTraceId} />
-            ) : (
-              <SpanDatasetChip
-                projectId={projectId}
-                traceId={selectedTraceId}
-                spanId={selection.span.span_id}
-              />
-            )
+            ) : null
           }
           // Customer surface, so state the scope explicitly rather than inheriting it:
           // the reader already defaults to customer traffic, so this is defense in depth,

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -471,6 +471,13 @@ export default function TracesPage() {
               Save as test case
             </Button>
           )}
+          // Offline eval: while the "Save as test case" drawer is open, clicking a
+          // different span in the tree retargets the drawer to that span.
+          onSelectionChange={(selection: TraceSelection) => {
+            if (saveOpen) {
+              setSaveSpanId(selection.type === "span" ? selection.span.span_id : undefined);
+            }
+          }}
           // Offline eval: a trace-level chip when this trace came from a run, and
           // a per-span "Dataset:" chip marking a span already saved as a test case.
           spanExtraTags={(selection: TraceSelection) =>

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -34,7 +34,9 @@ import { Button } from "@/components/ui/button";
 import {
   SaveTestCaseDrawer,
   TraceEvaluationChip,
+  SpanDatasetChip,
 } from "@/features/evaluations/components/trace-integration";
+import { useTraceTestCases } from "@/features/evaluations/hooks";
 import { formatContentPreview } from "@/features/traces/utils";
 import { useSession as useAuthSession } from "@/lib/auth-client";
 
@@ -76,6 +78,9 @@ export default function TracesPage() {
   } = useListPageState({ retentionDays: retention.retentionDays });
 
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(traceIdFromUrl);
+  // Warm the span→dataset chip data as soon as a trace is selected, so the
+  // "Dataset:" chip is ready before the user opens a span (no per-span latency).
+  useTraceTestCases(projectId, selectedTraceId ?? "");
   // Save-as-test-case (offline eval): which span the drawer targets (undefined = root).
   const [saveOpen, setSaveOpen] = useState(false);
   const [saveSpanId, setSaveSpanId] = useState<string | undefined>(undefined);
@@ -433,11 +438,18 @@ export default function TracesPage() {
               Save as test case
             </Button>
           )}
-          // Offline eval: show an Evaluation chip when this trace came from a run.
+          // Offline eval: a trace-level chip when this trace came from a run, and
+          // a per-span "Dataset:" chip marking a span already saved as a test case.
           spanExtraTags={(selection: TraceSelection) =>
             selection.type === "trace" ? (
               <TraceEvaluationChip projectId={projectId} traceId={selectedTraceId} />
-            ) : null
+            ) : (
+              <SpanDatasetChip
+                projectId={projectId}
+                traceId={selectedTraceId}
+                spanId={selection.span.span_id}
+              />
+            )
           }
           // Customer surface, so state the scope explicitly rather than inheriting it:
           // the reader already defaults to customer traffic, so this is defense in depth,

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -90,19 +90,13 @@ export default function TracesPage() {
     `traceroot:traces:live:v1:${projectId}`,
     false,
   );
-  // Evaluation traces are excluded from the default list; this opt-in includes them.
-  const [includeEvaluations, setIncludeEvaluations] = useLocalStorage(
-    `traceroot:traces:include-evals:v1:${projectId}`,
-    false,
-  );
-
-  // Fetch traces with combined query options + user filter from URL
+  // Fetch traces with combined query options + user filter from URL.
+  // Evaluation traces are excluded from this default list.
   const { data, isLoading, error } = useTraces(
     projectId,
     {
       ...queryOptions,
       user_id: userId || undefined,
-      include_evaluations: includeEvaluations || undefined,
     },
     { refetchInterval: autoRefresh ? 5000 : false },
   );
@@ -230,33 +224,6 @@ export default function TracesPage() {
                   className={cn(
                     "block h-3 w-3 rounded-full bg-background shadow-sm transition-transform duration-200",
                     autoRefresh ? "translate-x-3" : "translate-x-0",
-                  )}
-                />
-              </span>
-            </button>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={includeEvaluations}
-              onClick={() => setIncludeEvaluations(!includeEvaluations)}
-              title={
-                includeEvaluations
-                  ? "Evaluation traces shown — click to hide"
-                  : "Evaluation traces are hidden — click to include them"
-              }
-              className="flex items-center gap-2 rounded-md border border-border px-2.5 py-1 text-[12px] text-foreground transition-colors hover:border-foreground/40 hover:bg-muted"
-            >
-              Eval traces
-              <span
-                className={cn(
-                  "relative inline-flex h-4 w-7 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200",
-                  includeEvaluations ? "bg-foreground" : "bg-input",
-                )}
-              >
-                <span
-                  className={cn(
-                    "block h-3 w-3 rounded-full bg-background shadow-sm transition-transform duration-200",
-                    includeEvaluations ? "translate-x-3" : "translate-x-0",
                   )}
                 />
               </span>

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -90,6 +90,11 @@ export default function TracesPage() {
     `traceroot:traces:live:v1:${projectId}`,
     false,
   );
+  // Evaluation traces are excluded from the default list; this opt-in includes them.
+  const [includeEvaluations, setIncludeEvaluations] = useLocalStorage(
+    `traceroot:traces:include-evals:v1:${projectId}`,
+    false,
+  );
 
   // Fetch traces with combined query options + user filter from URL
   const { data, isLoading, error } = useTraces(
@@ -97,6 +102,7 @@ export default function TracesPage() {
     {
       ...queryOptions,
       user_id: userId || undefined,
+      include_evaluations: includeEvaluations || undefined,
     },
     { refetchInterval: autoRefresh ? 5000 : false },
   );
@@ -224,6 +230,33 @@ export default function TracesPage() {
                   className={cn(
                     "block h-3 w-3 rounded-full bg-background shadow-sm transition-transform duration-200",
                     autoRefresh ? "translate-x-3" : "translate-x-0",
+                  )}
+                />
+              </span>
+            </button>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={includeEvaluations}
+              onClick={() => setIncludeEvaluations(!includeEvaluations)}
+              title={
+                includeEvaluations
+                  ? "Evaluation traces shown — click to hide"
+                  : "Evaluation traces are hidden — click to include them"
+              }
+              className="flex items-center gap-2 rounded-md border border-border px-2.5 py-1 text-[12px] text-foreground transition-colors hover:border-foreground/40 hover:bg-muted"
+            >
+              Eval traces
+              <span
+                className={cn(
+                  "relative inline-flex h-4 w-7 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200",
+                  includeEvaluations ? "bg-foreground" : "bg-input",
+                )}
+              >
+                <span
+                  className={cn(
+                    "block h-3 w-3 rounded-full bg-background shadow-sm transition-transform duration-200",
+                    includeEvaluations ? "translate-x-3" : "translate-x-0",
                   )}
                 />
               </span>

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -84,6 +84,14 @@ export default function TracesPage() {
   // Save-as-test-case (offline eval): which span the drawer targets (undefined = root).
   const [saveOpen, setSaveOpen] = useState(false);
   const [saveSpanId, setSaveSpanId] = useState<string | undefined>(undefined);
+  // Close the drawer (and drop its target span) whenever the selected trace changes —
+  // including closing the viewer entirely. Without this, the drawer reopens on the
+  // NEXT trace still targeting a span from the previous one (which won't resolve
+  // there), stuck with no way out but closing and reopening it.
+  useEffect(() => {
+    setSaveOpen(false);
+    setSaveSpanId(undefined);
+  }, [selectedTraceId]);
   // Persisted per-project so a live view survives reloads, navigation, and re-login.
   // Default false: a project the user never toggled behaves exactly as before.
   const [autoRefresh, setAutoRefresh] = useLocalStorage(

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.user-filter.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.user-filter.test.tsx
@@ -16,6 +16,10 @@ vi.mock("@/features/traces/hooks", () => ({
   // The page gates the onboarding empty state on a separate "has this project
   // ever traced" probe; exists: true is required so the filter bar (and the
   // user_id badge inside it) isn't suppressed by showGettingStarted.
+  // The page now hosts the "Save as test case" drawer, which lazily fetches the
+  // selected span's I/O. Unmocked, the factory omits it and the page throws
+  // "useSpanIO is not a function" before any assertion runs.
+  useSpanIO: () => ({ data: undefined, isLoading: false, error: null }),
   useTracesExist: () => ({ data: { exists: true }, isPending: false, error: null }),
   usePrefetchTraces: () => vi.fn(),
 }));

--- a/frontend/ui/src/components/ui/markdown-view.test.tsx
+++ b/frontend/ui/src/components/ui/markdown-view.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MarkdownView } from "./markdown-view";
+
+describe("MarkdownView", () => {
+  it("renders the inline emphasis set", () => {
+    const { container } = render(
+      <MarkdownView content="**bold** and *italic* and ~~struck~~ and `code`" />,
+    );
+    expect(container.querySelector("strong")?.textContent).toBe("bold");
+    expect(container.querySelector("em")?.textContent).toBe("italic");
+    expect(container.querySelector("del")?.textContent).toBe("struck");
+    expect(container.querySelector("code")?.textContent).toBe("code");
+  });
+
+  it("renders <u> as a real underline element", () => {
+    // Markdown has no underline syntax and raw HTML is not rendered, so this
+    // proves the remarkUnderline plugin is wired and mapping to <u>.
+    const { container } = render(<MarkdownView content="plain <u>under</u> plain" />);
+    const u = container.querySelector("u");
+    expect(u).not.toBeNull();
+    expect(u?.textContent).toBe("under");
+  });
+
+  it("leaves an unbalanced <u> alone instead of swallowing the rest", () => {
+    const { container } = render(<MarkdownView content="a <u> b" />);
+    expect(container.querySelector("u")).toBeNull();
+    expect(container.textContent).toContain("a");
+    expect(container.textContent).toContain("b");
+  });
+
+  it("syntax-highlights a python fenced block", () => {
+    const { container } = render(
+      <MarkdownView content={"```py\ndef f():\n    return True\n```"} />,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre?.textContent).toContain("def f():");
+    expect(pre?.textContent).toContain("return True");
+    // `def` is a keyword → coloured span; plain text would have no classed spans.
+    const classed = Array.from(pre?.querySelectorAll("span") ?? []).filter((s) => s.className);
+    expect(classed.length).toBeGreaterThan(0);
+    expect(screen.getByText("py")).toBeTruthy();
+  });
+
+  it("syntax-highlights a javascript fenced block", () => {
+    const { container } = render(<MarkdownView content={"```js\nconst x = null;\n```"} />);
+    expect(container.querySelector("pre")?.textContent).toContain("const x = null;");
+    expect(screen.getByText("js")).toBeTruthy();
+  });
+
+  it("renders an unlabelled fence as a block, not inline code", () => {
+    const { container } = render(<MarkdownView content={"```\nline one\nline two\n```"} />);
+    expect(container.querySelector("pre")?.textContent).toContain("line one");
+  });
+
+  it("renders gfm lists and tables", () => {
+    const { container } = render(<MarkdownView content={"- a\n- b\n\n| h |\n| - |\n| c |"} />);
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+    expect(container.querySelector("table")).not.toBeNull();
+    expect(container.querySelector("th")?.textContent).toBe("h");
+  });
+});

--- a/frontend/ui/src/components/ui/markdown-view.tsx
+++ b/frontend/ui/src/components/ui/markdown-view.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import * as React from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { cn } from "@/lib/utils";
+import { remarkUnderline } from "@/lib/remark-underline";
+import { highlightCode, normalizeLang } from "@/lib/code-highlight";
+
+/**
+ * Rendered markdown for span I/O values — the "Markdown" format in the trace panel's
+ * and the editable value block's format switchers. Model output is very often
+ * markdown, and reading it raw hides its structure.
+ *
+ * Supports the full CommonMark + GFM set (bold, italic, strikethrough, inline code,
+ * fenced code, lists, headings, links, quotes, tables) plus `<u>` underline via
+ * remarkUnderline. Fenced code is syntax-highlighted for Python and JavaScript
+ * (TypeScript/JSON alias onto them); other languages render plain.
+ *
+ * Typography is deliberately compact (11px) to match the surrounding I/O panels.
+ */
+
+function CodeBlock({ code, lang }: { code: string; lang: string | null }) {
+  const normalized = normalizeLang(lang);
+  const tokens = React.useMemo(() => highlightCode(code, normalized), [code, normalized]);
+  return (
+    <div className="my-1.5 overflow-hidden rounded border border-border">
+      {lang && (
+        <div className="border-b border-border bg-muted/50 px-2 py-0.5 font-mono text-[10px] text-muted-foreground">
+          {lang}
+        </div>
+      )}
+      <pre className="whitespace-pre-wrap break-words bg-background px-2 py-1.5 font-mono text-[11px] leading-relaxed">
+        {tokens.map((t, i) => (
+          <span key={i} className={t.cls}>
+            {t.text}
+          </span>
+        ))}
+      </pre>
+    </div>
+  );
+}
+
+const COMPONENTS: Components = {
+  p: ({ children }) => <p className="mb-1.5 last:mb-0">{children}</p>,
+  strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+  del: ({ children }) => <del className="text-muted-foreground line-through">{children}</del>,
+  a: ({ children, href }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-sky-600 underline underline-offset-2 dark:text-sky-400"
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children }) => (
+    <ul className="mb-1.5 list-disc space-y-0.5 pl-4 marker:text-muted-foreground last:mb-0">
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="mb-1.5 list-decimal space-y-0.5 pl-4 marker:text-muted-foreground last:mb-0">
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => <li>{children}</li>,
+  h1: ({ children }) => (
+    <h1 className="mb-1.5 mt-2 text-[13px] font-semibold first:mt-0">{children}</h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="mb-1.5 mt-2 text-[12px] font-semibold first:mt-0">{children}</h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="mb-1 mt-2 text-[11px] font-semibold first:mt-0">{children}</h3>
+  ),
+  h4: ({ children }) => (
+    <h4 className="mb-1 mt-2 text-[11px] font-semibold first:mt-0">{children}</h4>
+  ),
+  h5: ({ children }) => (
+    <h5 className="mb-1 mt-2 text-[11px] font-semibold first:mt-0">{children}</h5>
+  ),
+  h6: ({ children }) => (
+    <h6 className="mb-1 mt-2 text-[11px] font-semibold first:mt-0">{children}</h6>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="my-1.5 border-l-2 border-border pl-2 text-muted-foreground">
+      {children}
+    </blockquote>
+  ),
+  hr: () => <hr className="my-2 border-border" />,
+  table: ({ children }) => (
+    <div className="my-1.5 overflow-x-auto">
+      <table className="w-full border-collapse text-[11px]">{children}</table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="border border-border bg-muted/40 px-1.5 py-0.5 text-left font-medium">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td className="border border-border px-1.5 py-0.5 align-top">{children}</td>
+  ),
+  // Fenced blocks render through CodeBlock; `pre` just passes them through so the
+  // block isn't wrapped in a second <pre>.
+  pre: ({ children }) => <>{children}</>,
+  code: ({ className, children }) => {
+    const raw = String(children ?? "");
+    const match = /language-([\w+-]+)/.exec(className ?? "");
+    // An unlabelled fence has no language-* class, so fall back to a newline check.
+    const isBlock = !!match || raw.includes("\n");
+    if (isBlock) return <CodeBlock code={raw.replace(/\n$/, "")} lang={match?.[1] ?? null} />;
+    return <code className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">{children}</code>;
+  },
+};
+
+const PLUGINS = [remarkGfm, remarkUnderline];
+
+export function MarkdownView({ content, className }: { content: string; className?: string }) {
+  return (
+    <div className={cn("text-[11px] leading-relaxed [overflow-wrap:anywhere]", className)}>
+      <ReactMarkdown remarkPlugins={PLUGINS} components={COMPONENTS}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/frontend/ui/src/components/ui/table.tsx
+++ b/frontend/ui/src/components/ui/table.tsx
@@ -55,7 +55,15 @@ export function TR({ className, selected, interactive, onClick, onKeyDown, ...pr
       role={interactive && onClick ? "button" : undefined}
       onClick={onClick}
       onKeyDown={(e) => {
-        if (interactive && onClick && (e.key === "Enter" || e.key === " ")) {
+        // Only the row itself activates row navigation — a keypress on a nested
+        // action (a button/link inside the row) bubbles here, and activating the row
+        // too would fire both the action AND the navigation from one Enter/Space.
+        if (
+          interactive &&
+          onClick &&
+          e.target === e.currentTarget &&
+          (e.key === "Enter" || e.key === " ")
+        ) {
           e.preventDefault();
           onClick(e as unknown as React.MouseEvent<HTMLTableRowElement>);
         }

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -19,12 +19,7 @@ import { CopyButton } from "@/components/ui/copy-button";
 import { cn } from "@/lib/utils";
 import { getTrace } from "@/lib/api/traces";
 import { SpanKindIcon, useSpanIO } from "@/features/traces";
-import {
-  FormCard,
-  EditableValueBlock,
-  LineNumberedTextarea,
-  Timestamp,
-} from "@/features/offline-eval/components";
+import { FormCard, EditableValueBlock, Timestamp } from "@/features/offline-eval/components";
 import { tokenizeCode } from "@/features/offline-eval/components/syntax";
 import { useProject } from "@/features/projects/hooks";
 import {
@@ -42,9 +37,6 @@ import {
 
 /** Sentinel dataset-select value for "create a new dataset". */
 const NEW_DATASET = "__new__";
-
-/** How the optional expected outcome is set for a captured case. */
-type ExpectedMode = "none" | "recorded" | "corrected";
 
 /** Root = the span with no parent (the application / evaluation-item root). */
 function rootSpan(spans: Span[]): Span | undefined {
@@ -116,11 +108,12 @@ export function SaveTestCaseDrawer({
   const [input, setInput] = React.useState("");
   const [metadata, setMetadata] = React.useState("");
   const [attachSource, setAttachSource] = React.useState(true);
-  // Default to grading against the recorded output — the common case is capturing
-  // a good production run as the expected outcome. Switch to "Not required" or a
-  // corrected value as needed.
-  const [expectedMode, setExpectedMode] = React.useState<ExpectedMode>("recorded");
-  const [correctedExpected, setCorrectedExpected] = React.useState("");
+  // The single editable Output field. It seeds from the recorded output; editing it
+  // makes the edit the EXPECTED outcome future runs are graded against, while the
+  // untouched recorded output is still stored separately. Left as-is, expected ==
+  // recorded — but all three fields (input, expected, recorded_output) are persisted.
+  const [output, setOutput] = React.useState("");
+  const [outputEdited, setOutputEdited] = React.useState(false);
   const [duplicate, setDuplicate] = React.useState<{ datasetId: string } | null>(null);
   const [feedback, setFeedback] = React.useState<{
     tone: "error" | "success";
@@ -134,8 +127,7 @@ export function SaveTestCaseDrawer({
       setDatasetId("");
       setNewDatasetName("");
       setAttachSource(true);
-      setExpectedMode("recorded");
-      setCorrectedExpected("");
+      setOutputEdited(false);
       setDuplicate(null);
       setFeedback(null);
     }
@@ -161,11 +153,14 @@ export function SaveTestCaseDrawer({
   // per span on demand (getSpanIO), so read them from that hook, not the span.
   const { data: spanIO } = useSpanIO(projectId, traceId ?? "", span?.span_id ?? null);
 
-  // Input / recorded output / metadata follow the fetched span I/O (incl. nav).
+  // Input / output / metadata follow the fetched span I/O (incl. nav). Output reseeds
+  // from the recorded output on each span (nav resets any in-progress edit).
   React.useEffect(() => {
     if (open && spanIO) {
       setInput(spanIO.input ?? "");
       setMetadata(prettyJson(spanIO.metadata));
+      setOutput(spanIO.output ?? "");
+      setOutputEdited(false);
     }
   }, [open, spanIO]);
 
@@ -247,17 +242,13 @@ export function SaveTestCaseDrawer({
       } catch {
         /* non-JSON metadata → not persisted */
       }
-      const expected =
-        expectedMode === "recorded"
-          ? recordedOutput || null
-          : expectedMode === "corrected"
-            ? correctedExpected.trim() || null
-            : null;
+      // The Output field IS the expected outcome (edited or not); the recorded output
+      // is always stored separately. Unedited → expected == recorded output.
       const res = await save.mutateAsync({
         datasetId: dsId,
         body: {
           input,
-          expected,
+          expected: output.trim() || null,
           recorded_output: recordedOutput || null,
           metadata: metadataObj,
           review: "needs_review",
@@ -384,69 +375,35 @@ export function SaveTestCaseDrawer({
 
         <div>
           <EditableValueBlock
-            label="Recorded output"
-            text={recordedOutput}
-            onChange={() => {}}
+            label="Output"
+            text={output}
+            onChange={(v) => {
+              setOutput(v);
+              setOutputEdited(true);
+            }}
             copyable
-            // May become the expected outcome future runs are graded against, so
-            // it has to be readable at a glance → expand it like Input.
+            // Read and possibly hand-corrected — expand it like Input.
             seedJson="expanded"
             boxed
             minRows={2}
-            readOnly
           />
-          <p className="mt-1 text-[11px] text-muted-foreground">
-            What happened in production. Kept separate from the expected outcome.
+          <p className="mt-1 flex items-start gap-1.5 text-[11px] text-muted-foreground">
+            <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+            {outputEdited ? (
+              <span>
+                Edited — your version becomes the{" "}
+                <span className="font-medium text-foreground">expected outcome</span>; the original
+                recorded output is still stored.
+              </span>
+            ) : (
+              <span>
+                The recorded production output. Leave it to grade against it, or edit to set a
+                corrected <span className="font-medium text-foreground">expected outcome</span> —
+                the recorded output is kept either way.
+              </span>
+            )}
           </p>
         </div>
-
-        <FormCard label="Expected outcome">
-          <div className="flex flex-col gap-1" role="radiogroup" aria-label="Expected outcome">
-            {(
-              [
-                ["none", "Not required"],
-                ["recorded", "Use recorded output"],
-                ["corrected", "Enter a corrected outcome"],
-              ] as Array<[ExpectedMode, string]>
-            ).map(([value, label]) => (
-              <label
-                key={value}
-                className={cn(
-                  "flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-[12px]",
-                  expectedMode === value ? "text-foreground" : "text-muted-foreground",
-                )}
-              >
-                <input
-                  type="radio"
-                  name="expected-outcome"
-                  value={value}
-                  checked={expectedMode === value}
-                  onChange={() => setExpectedMode(value)}
-                  className="h-3.5 w-3.5 accent-foreground"
-                />
-                {label}
-              </label>
-            ))}
-          </div>
-
-          {expectedMode === "recorded" && (
-            <p className="mt-2 flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-300">
-              <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
-              This will become the outcome future runs are evaluated against.
-            </p>
-          )}
-          {expectedMode === "corrected" && (
-            <div className="mt-2">
-              <LineNumberedTextarea
-                value={correctedExpected}
-                onChange={setCorrectedExpected}
-                minRows={2}
-                placeholder="Corrected expected outcome"
-                aria-label="Corrected expected outcome"
-              />
-            </div>
-          )}
-        </FormCard>
 
         <EditableValueBlock
           label="Metadata"

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -14,7 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { CopyButton } from "@/components/ui/copy-button";
 import { cn } from "@/lib/utils";
 import { getTrace } from "@/lib/api/traces";
@@ -71,7 +71,7 @@ function boundaryHint(displayKind: string, spanName: string): string {
 }
 
 /**
- * "Save as test case" — a faithful port of the approved mock drawer, wired to the
+ * "Save as test case" — the capture drawer, wired to the
  * server. Opened from the existing trace viewer's span header. Self-contained: it
  * fetches the trace, walks its spans (up/down), lets you pick or create a
  * dataset, and persists via the server (which publishes a new dataset version).
@@ -112,8 +112,10 @@ export function SaveTestCaseDrawer({
   // makes the edit the EXPECTED outcome future runs are graded against, while the
   // untouched recorded output is still stored separately. Left as-is, expected ==
   // recorded — but all three fields (input, expected, recorded_output) are persisted.
+  // Whether it's been edited is DERIVED (see `outputEdited` below), not a flag set by
+  // the field's `onChange` — the field normalises JSON on seed (see EditableValueBlock),
+  // and that normalisation must never itself read as an edit.
   const [output, setOutput] = React.useState("");
-  const [outputEdited, setOutputEdited] = React.useState(false);
   const [duplicate, setDuplicate] = React.useState<{ datasetId: string } | null>(null);
   const [feedback, setFeedback] = React.useState<{
     tone: "error" | "success";
@@ -127,7 +129,6 @@ export function SaveTestCaseDrawer({
       setDatasetId("");
       setNewDatasetName("");
       setAttachSource(true);
-      setOutputEdited(false);
       setDuplicate(null);
       setFeedback(null);
     }
@@ -152,34 +153,84 @@ export function SaveTestCaseDrawer({
   // The trace-detail response OMITS span input/output/metadata — they are fetched
   // per span on demand (getSpanIO), so read them from that hook, not the span.
   const { data: spanIO } = useSpanIO(projectId, traceId ?? "", span?.span_id ?? null);
+  // True only once the fetched I/O actually belongs to the currently-selected span.
+  // Switching spans (nav, or a tree click) changes `span?.span_id`, and `spanIO` goes
+  // undefined until the new span's fetch lands — during that window this component's
+  // own `input`/`output`/`metadata` state must not sit on the PREVIOUS span's values,
+  // or a Save mid-fetch would persist them under the new span's id.
+  const spanIOReady = !!spanIO && !!span && spanIO.span_id === span.span_id;
+
+  // Bumped only in the SAME commit that a genuinely new span's I/O actually lands —
+  // passed as `collapseResetKey` to Input/Output/Metadata below instead of
+  // `span?.span_id`. `span?.span_id` changes as soon as the tree selection does,
+  // one (or more) renders before the corresponding fetch resolves and this state
+  // updates; EditableValueBlock's seed effect keys its "already normalised this
+  // seed" bookkeeping off `collapseResetKey` alone; pairing it with a stale
+  // `span?.span_id` would let a field lock in "seeded" before its real content
+  // (still the previous span's) had actually arrived, silently skipping the
+  // normalisation once it does.
+  const [seedGeneration, setSeedGeneration] = React.useState(0);
 
   // Input / output / metadata follow the fetched span I/O (incl. nav). Output reseeds
-  // from the recorded output on each span (nav resets any in-progress edit).
-  React.useEffect(() => {
-    if (open && spanIO) {
-      setInput(spanIO.input ?? "");
-      setMetadata(prettyJson(spanIO.metadata));
-      setOutput(spanIO.output ?? "");
-      setOutputEdited(false);
-    }
-  }, [open, spanIO]);
-
-  // Reset the duplicate note whenever the selected span changes.
-  React.useEffect(() => {
-    if (open) setDuplicate(null);
-  }, [open, span?.span_id]);
-
-  // Non-modal: Escape closes this panel without touching the trace behind it.
+  // from the recorded output on each span (nav resets any in-progress edit). Cleared
+  // while the current span's I/O hasn't arrived (or belongs to a previous span) rather
+  // than left stale — see `spanIOReady`.
   React.useEffect(() => {
     if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.stopPropagation();
-        onOpenChange(false);
-      }
+    if (spanIOReady && spanIO) {
+      setInput(spanIO.input ?? "");
+      setMetadata(prettyJson(spanIO.metadata));
+      // Normalised here (once) so the Output field never needs to write a
+      // re-serialised value back up just to canonicalise it — see `outputEdited`.
+      setOutput(prettyJson(spanIO.output));
+      setSeedGeneration((g) => g + 1);
+    } else {
+      setInput("");
+      setMetadata("");
+      setOutput("");
+    }
+  }, [open, spanIO, spanIOReady]);
+
+  // Reset the duplicate note whenever the selected span changes, or the target
+  // dataset changes (picking a different dataset after a duplicate note must let
+  // the user save into it, not keep pointing at the dataset that already had it).
+  React.useEffect(() => {
+    if (open) setDuplicate(null);
+  }, [open, span?.span_id, datasetId]);
+
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const headingRef = React.useRef<HTMLHeadingElement>(null);
+
+  // Focus the panel on open (it gets none by default — the opener stays focused)
+  // and restore focus to whatever had it (the "Save as test case" button) on close.
+  React.useEffect(() => {
+    if (!open) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    headingRef.current?.focus();
+    return () => {
+      previouslyFocused?.focus?.();
     };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open]);
+
+  // Non-modal: Escape closes this panel without touching the trace behind it — but
+  // must not swallow Escape meant for a nested Radix layer (the Dataset select, a
+  // field's format-switcher popover). Listening on the drawer's own root in the
+  // BUBBLE phase (not window/capture) gets this right for free: a layer that
+  // consumes Escape calls preventDefault() from `document`'s CAPTURE-phase listener,
+  // which always runs before any bubble-phase listener; a layer that's portaled
+  // outside this subtree (as Radix content is) never reaches this listener at all.
+  // `stopPropagation` only shields the trace viewer's own Escape-to-close underneath.
+  React.useEffect(() => {
+    if (!open) return;
+    const root = rootRef.current;
+    if (!root) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      e.stopPropagation();
+      onOpenChange(false);
+    };
+    root.addEventListener("keydown", onKey);
+    return () => root.removeEventListener("keydown", onKey);
   }, [open, onOpenChange]);
 
   const createDataset = useCreateDataset(projectId);
@@ -208,7 +259,12 @@ export function SaveTestCaseDrawer({
   const creatingNew = datasetId === NEW_DATASET;
   const dataset = datasets.find((item) => item.id === datasetId);
   const displayKind = isRoot ? "trace" : (span?.span_kind ?? "SPAN");
-  const recordedOutput = spanIO?.output ?? "";
+  // Normalised the same way the Output field's seed is (see the effect above), so
+  // this is byte-for-byte what an untouched Output field holds.
+  const recordedOutput = spanIOReady ? prettyJson(spanIO?.output) : "";
+  // Derived, not a flag `onChange` sets — a same-content reformat (the field's own
+  // JSON pretty-print on seed) must never itself read as an edit.
+  const outputEdited = output !== recordedOutput;
   const currentIndex = span ? spans.findIndex((s) => s.span_id === span.span_id) : -1;
   const canNavigateUp = currentIndex > 0;
   const canNavigateDown = currentIndex >= 0 && currentIndex < spans.length - 1;
@@ -216,8 +272,28 @@ export function SaveTestCaseDrawer({
   const inferredReason: CaptureReason =
     span?.status === "ERROR" ? (displayKind === "TOOL" ? "failed_tool" : "error") : "manual";
 
+  // Metadata must parse to a JSON object (or be empty) to be persisted at all — see
+  // CreateTestCaseRequestSchema.metadata. Validated here (surfaced below) rather than
+  // only at submit time, so an array/scalar/invalid value blocks Save instead of
+  // silently vanishing from a "Saved" response.
+  const metadataError = (() => {
+    const trimmed = metadata.trim();
+    if (trimmed === "") return null;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return null;
+      return 'Metadata must be a JSON object, e.g. {"key": "value"}.';
+    } catch {
+      return "Metadata isn't valid JSON.";
+    }
+  })();
+
   const canSave =
-    !!span && (creatingNew ? newDatasetName.trim() !== "" : datasetId !== "") && !save.isPending;
+    !!span &&
+    spanIOReady &&
+    !metadataError &&
+    (creatingNew ? newDatasetName.trim() !== "" : datasetId !== "") &&
+    !save.isPending;
 
   const navigate = (dir: "up" | "down") => {
     if (currentIndex < 0) return;
@@ -235,13 +311,11 @@ export function SaveTestCaseDrawer({
         dsId = created.dataset.id;
         setDatasetId(dsId);
       }
-      let metadataObj: Record<string, unknown> | null = null;
-      try {
-        const parsed = metadata.trim() ? JSON.parse(metadata) : null;
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) metadataObj = parsed;
-      } catch {
-        /* non-JSON metadata → not persisted */
-      }
+      // canSave already required metadataError === null, so this is either empty or a
+      // valid JSON object — never silently dropped.
+      const metadataObj: Record<string, unknown> | null = metadata.trim()
+        ? (JSON.parse(metadata) as Record<string, unknown>)
+        : null;
       // The Output field IS the expected outcome (edited or not); the recorded output
       // is always stored separately. Unedited → expected == recorded output.
       const res = await save.mutateAsync({
@@ -271,9 +345,21 @@ export function SaveTestCaseDrawer({
   };
 
   return (
-    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
+    <div
+      ref={rootRef}
+      role="dialog"
+      aria-labelledby="save-test-case-title"
+      className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl"
+    >
       <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
-        <h2 className="text-[13px] font-semibold">Save as test case</h2>
+        <h2
+          id="save-test-case-title"
+          ref={headingRef}
+          tabIndex={-1}
+          className="text-[13px] font-semibold focus:outline-none"
+        >
+          Save as test case
+        </h2>
         <button
           type="button"
           onClick={() => onOpenChange(false)}
@@ -286,7 +372,13 @@ export function SaveTestCaseDrawer({
 
       <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-auto px-4 py-3">
         <FormCard label="Dataset">
-          <Select value={datasetId} onValueChange={setDatasetId}>
+          <Select
+            value={datasetId}
+            onValueChange={(value) => {
+              setDatasetId(value);
+              setDuplicate(null);
+            }}
+          >
             <SelectTrigger className="h-7 text-[13px]">
               <SelectValue placeholder="Select dataset" />
             </SelectTrigger>
@@ -372,24 +464,21 @@ export function SaveTestCaseDrawer({
           boxed
           minRows={2}
           collapsible
-          collapseResetKey={span?.span_id}
+          collapseResetKey={String(seedGeneration)}
         />
 
         <div>
           <EditableValueBlock
             label="Output"
             text={output}
-            onChange={(v) => {
-              setOutput(v);
-              setOutputEdited(true);
-            }}
+            onChange={setOutput}
             copyable
             // Read and possibly hand-corrected — expand it like Input.
             seedJson="expanded"
             boxed
             minRows={2}
             collapsible
-            collapseResetKey={span?.span_id}
+            collapseResetKey={String(seedGeneration)}
           />
           <p className="mt-1 flex items-start gap-1.5 text-[11px] text-muted-foreground">
             <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
@@ -409,19 +498,22 @@ export function SaveTestCaseDrawer({
           </p>
         </div>
 
-        <EditableValueBlock
-          label="Metadata"
-          text={metadata}
-          onChange={setMetadata}
-          copyable
-          // Incidental context, usually one or two short keys → keep it inline
-          // (seedFormat expands it anyway once it stops fitting on one line).
-          seedJson="compact"
-          boxed
-          minRows={2}
-          collapsible
-          collapseResetKey={span?.span_id}
-        />
+        <div>
+          <EditableValueBlock
+            label="Metadata"
+            text={metadata}
+            onChange={setMetadata}
+            copyable
+            // Incidental context, usually one or two short keys → keep it inline
+            // (seedFormat expands it anyway once it stops fitting on one line).
+            seedJson="compact"
+            boxed
+            minRows={2}
+            collapsible
+            collapseResetKey={String(seedGeneration)}
+          />
+          {metadataError && <p className="mt-1 text-[11px] text-destructive">{metadataError}</p>}
+        </div>
 
         <div className="border border-border">
           <div className="flex items-center justify-between border-b border-border bg-muted/50 px-3 py-1.5">
@@ -532,14 +624,14 @@ export function TraceEvaluationChip({
 
 type Lang = "python" | "typescript";
 
-/** e.g. "Billing routing" → "billing-routing". Matches the mock's slug. */
+/** e.g. "Billing routing" → "billing-routing". */
 function slugify(name: string): string {
   return name.trim().toLowerCase().replace(/\s+/g, "-");
 }
 
 /**
- * A 4-line initDataset snippet, Braintrust-style, for one language — identical in
- * shape to the mock's DatasetInfoChip. Indents differ on purpose: 4 spaces for
+ * A 4-line initDataset snippet for one language — identical in shape to the
+ * DatasetInfoChip. Indents differ on purpose: 4 spaces for
  * Python (PEP 8), 2 for TypeScript (Prettier).
  */
 function sdkSnippet(lang: Lang, projectName: string, datasetSlug: string, version: string): string {
@@ -618,46 +710,61 @@ export function SpanDatasetChip({
   const matches = (data?.data ?? []).filter((c) => c.sourceSpanId === spanId);
   if (matches.length === 0) return null;
   return (
-    <TooltipProvider delayDuration={150}>
+    <>
       {matches.map((c) => (
-        <Tooltip key={`${c.datasetId}:${c.testCaseId}`}>
-          <TooltipTrigger asChild>
-            <Link
-              href={`/projects/${projectId}/datasets/${c.datasetId}`}
+        // A Popover, not a Tooltip: the card's language toggle and copy button are
+        // interactive, and `role="tooltip"` content is unreachable by keyboard and
+        // (per ARIA) forbidden from holding focusable children. Popover opens on
+        // click/Enter/Space, so it works for keyboard and touch alike; the trigger
+        // itself is a button, and the dataset link lives inside the card instead of
+        // being the trigger, so there's still a keyboard path to both.
+        <Popover key={`${c.datasetId}:${c.testCaseId}`}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
               className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors hover:bg-muted"
               title={`In dataset ${c.datasetName}`}
             >
               <Database className="h-3 w-3 text-muted-foreground" aria-hidden />
               <span className="text-muted-foreground">Dataset:</span>
               <span className="font-medium">{c.datasetName}</span>
-            </Link>
-          </TooltipTrigger>
-          <TooltipContent
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
             align="start"
             className="w-[540px] max-w-[92vw] border bg-popover px-3 pb-2 pt-3 text-xs text-popover-foreground shadow-md"
           >
-            <div className="mb-2">
-              <div className="font-semibold">{c.datasetName}</div>
-              <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-0.5 text-muted-foreground">
-                <span>
-                  Version <span className="font-mono">{c.datasetVersionLabel}</span>
-                </span>
-                <span className="inline-flex items-center gap-1">
-                  Updated <Timestamp iso={c.datasetUpdatedAt} />
-                </span>
-                <span>
-                  {c.caseCount} {c.caseCount === 1 ? "case" : "cases"}
-                </span>
+            <div className="mb-2 flex items-start justify-between gap-2">
+              <div>
+                <div className="font-semibold">{c.datasetName}</div>
+                <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-0.5 text-muted-foreground">
+                  <span>
+                    Version <span className="font-mono">{c.datasetVersionLabel}</span>
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    Updated <Timestamp iso={c.datasetUpdatedAt} />
+                  </span>
+                  <span>
+                    {c.caseCount} {c.caseCount === 1 ? "case" : "cases"}
+                  </span>
+                </div>
               </div>
+              <Link
+                href={`/projects/${projectId}/datasets/${c.datasetId}`}
+                className="inline-flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                Open
+                <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
+              </Link>
             </div>
             <DatasetSdkSnippet
               projectName={projectName}
               datasetName={c.datasetName}
               version={c.datasetVersionLabel}
             />
-          </TooltipContent>
-        </Tooltip>
+          </PopoverContent>
+        </Popover>
       ))}
-    </TooltipProvider>
+    </>
   );
 }

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -617,7 +617,9 @@ function DatasetSdkSnippet({
         </div>
         <CopyButton value={code} className="h-6 w-6" iconClassName="h-3.5 w-3.5" title="Copy" />
       </div>
-      <pre className="max-h-48 overflow-auto whitespace-pre px-2.5 py-2 font-mono text-xs leading-relaxed">
+      {/* pb-6 so the horizontal scrollbar at the pre's bottom doesn't overlap the
+          last line (it scrolls in both axes with a small max height). */}
+      <pre className="max-h-48 overflow-auto whitespace-pre px-2.5 pb-6 pt-2 font-mono text-xs leading-relaxed">
         {tokenizeCode(code).map((t, i) => (
           <span key={i} className={t.cls || undefined}>
             {t.text}

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -51,7 +51,11 @@ function rootSpan(spans: Span[]): Span | undefined {
   return spans.find((s) => !s.parent_span_id) ?? spans[0];
 }
 
-/** Pretty-print JSON so metadata shows expanded and indented; leave other text. */
+/**
+ * Normalise a captured JSON blob (2-space indent); leave non-JSON text alone.
+ * The field's own `seedJson` preference decides the final shape it opens in —
+ * this just guarantees the seed is valid, canonical JSON when it is JSON.
+ */
 function prettyJson(raw: string | null | undefined): string {
   if (!raw) return "";
   try {
@@ -363,7 +367,8 @@ export function SaveTestCaseDrawer({
           text={input}
           onChange={setInput}
           copyable
-          autoDetectKind
+          // Read + hand-edited most, and usually the most nested → expand it.
+          seedJson="expanded"
           boxed
           minRows={2}
         />
@@ -374,7 +379,9 @@ export function SaveTestCaseDrawer({
             text={recordedOutput}
             onChange={() => {}}
             copyable
-            autoDetectKind
+            // May become the expected outcome future runs are graded against, so
+            // it has to be readable at a glance → expand it like Input.
+            seedJson="expanded"
             boxed
             minRows={2}
             readOnly
@@ -437,7 +444,9 @@ export function SaveTestCaseDrawer({
           text={metadata}
           onChange={setMetadata}
           copyable
-          autoDetectKind
+          // Incidental context, usually one or two short keys → keep it inline
+          // (seedFormat expands it anyway once it stops fitting on one line).
+          seedJson="compact"
           boxed
           minRows={2}
         />

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -152,17 +152,28 @@ export function SaveTestCaseDrawer({
   // The trace-detail response OMITS span input/output/metadata — they are fetched
   // per span on demand (getSpanIO), so read them from that hook, not the span.
   const { data: spanIO } = useSpanIO(projectId, traceId ?? "", span?.span_id ?? null);
+  // True only once the fetched I/O actually belongs to the selected span. Switching
+  // spans leaves `spanIO` on the PREVIOUS span's values until the new fetch lands, so
+  // this gates both seeding and Save — otherwise a click made immediately after
+  // navigating would publish the new span's id with the previous span's input/output.
+  const spanIOReady = !!spanIO && !!span && spanIO.span_id === span.span_id;
 
   // Input / output / metadata follow the fetched span I/O (incl. nav). Output reseeds
-  // from the recorded output on each span (nav resets any in-progress edit).
+  // from the recorded output on each span (nav resets any in-progress edit). Cleared
+  // while the current span's I/O hasn't arrived rather than left on the previous span.
   React.useEffect(() => {
-    if (open && spanIO) {
+    if (!open) return;
+    if (spanIOReady && spanIO) {
       setInput(spanIO.input ?? "");
       setMetadata(prettyJson(spanIO.metadata));
       setOutput(spanIO.output ?? "");
       setOutputEdited(false);
+    } else {
+      setInput("");
+      setMetadata("");
+      setOutput("");
     }
-  }, [open, spanIO]);
+  }, [open, spanIOReady, spanIO]);
 
   // Reset the duplicate note whenever the selected span changes.
   React.useEffect(() => {
@@ -217,7 +228,9 @@ export function SaveTestCaseDrawer({
     span?.status === "ERROR" ? (displayKind === "TOOL" ? "failed_tool" : "error") : "manual";
 
   const canSave =
-    !!span && (creatingNew ? newDatasetName.trim() !== "" : datasetId !== "") && !save.isPending;
+    spanIOReady &&
+    (creatingNew ? newDatasetName.trim() !== "" : datasetId !== "") &&
+    !save.isPending;
 
   const navigate = (dir: "up" | "down") => {
     if (currentIndex < 0) return;

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -116,7 +116,10 @@ export function SaveTestCaseDrawer({
   const [input, setInput] = React.useState("");
   const [metadata, setMetadata] = React.useState("");
   const [attachSource, setAttachSource] = React.useState(true);
-  const [expectedMode, setExpectedMode] = React.useState<ExpectedMode>("none");
+  // Default to grading against the recorded output — the common case is capturing
+  // a good production run as the expected outcome. Switch to "Not required" or a
+  // corrected value as needed.
+  const [expectedMode, setExpectedMode] = React.useState<ExpectedMode>("recorded");
   const [correctedExpected, setCorrectedExpected] = React.useState("");
   const [duplicate, setDuplicate] = React.useState<{ datasetId: string } | null>(null);
   const [feedback, setFeedback] = React.useState<{
@@ -131,7 +134,7 @@ export function SaveTestCaseDrawer({
       setDatasetId("");
       setNewDatasetName("");
       setAttachSource(true);
-      setExpectedMode("none");
+      setExpectedMode("recorded");
       setCorrectedExpected("");
       setDuplicate(null);
       setFeedback(null);

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -25,7 +25,8 @@ import {
   LineNumberedTextarea,
   Timestamp,
 } from "@/features/offline-eval/components";
-import { datasetInitCode, datasetInitCodeTs } from "@/features/offline-eval/utils";
+import { tokenizeCode } from "@/features/offline-eval/components/syntax";
+import { useProject } from "@/features/projects/hooks";
 import {
   CAPTURE_REASON_LABEL,
   SPAN_KIND_LABEL,
@@ -548,15 +549,42 @@ export function TraceEvaluationChip({
   );
 }
 
-/** Small SDK-snippet card with a Python / TypeScript toggle (one shown at a time). */
-function DatasetSdkSnippet({ datasetName }: { datasetName: string }) {
-  const [lang, setLang] = React.useState<"python" | "typescript">("python");
-  const code = lang === "python" ? datasetInitCode(datasetName) : datasetInitCodeTs(datasetName);
+type Lang = "python" | "typescript";
+
+/** e.g. "Billing routing" → "billing-routing". Matches the mock's slug. */
+function slugify(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, "-");
+}
+
+/**
+ * A 4-line initDataset snippet, Braintrust-style, for one language — identical in
+ * shape to the mock's DatasetInfoChip. Indents differ on purpose: 4 spaces for
+ * Python (PEP 8), 2 for TypeScript (Prettier).
+ */
+function sdkSnippet(lang: Lang, projectName: string, datasetSlug: string, version: string): string {
+  if (lang === "python") {
+    return `traceroot.init_dataset("${projectName}", {\n    "dataset": "${datasetSlug}",\n    "version": "${version}",\n})`;
+  }
+  return `traceroot.initDataset("${projectName}", {\n  dataset: "${datasetSlug}",\n  version: "${version}",\n});`;
+}
+
+/** SDK init snippet with a Python / TypeScript toggle — one shown at a time. */
+function DatasetSdkSnippet({
+  projectName,
+  datasetName,
+  version,
+}: {
+  projectName: string;
+  datasetName: string;
+  version: string;
+}) {
+  const [lang, setLang] = React.useState<Lang>("python");
+  const code = sdkSnippet(lang, projectName, slugify(datasetName), version);
   return (
     <div className="overflow-hidden rounded border border-border">
       <div className="flex items-center justify-between border-b border-border bg-muted/50 px-1.5 py-1">
         <div className="flex items-center gap-0.5">
-          {(["python", "typescript"] as const).map((l) => (
+          {(["python", "typescript"] as Lang[]).map((l) => (
             <button
               key={l}
               type="button"
@@ -575,7 +603,11 @@ function DatasetSdkSnippet({ datasetName }: { datasetName: string }) {
         <CopyButton value={code} className="h-6 w-6" iconClassName="h-3.5 w-3.5" title="Copy" />
       </div>
       <pre className="max-h-48 overflow-auto whitespace-pre px-2.5 py-2 font-mono text-xs leading-relaxed">
-        {code}
+        {tokenizeCode(code).map((t, i) => (
+          <span key={i} className={t.cls || undefined}>
+            {t.text}
+          </span>
+        ))}
       </pre>
     </div>
   );
@@ -598,6 +630,8 @@ export function SpanDatasetChip({
   spanId: string;
 }) {
   const { data } = useTraceTestCases(projectId, traceId);
+  const { data: project } = useProject(projectId);
+  const projectName = project?.name ?? "your-project";
   const matches = (data?.data ?? []).filter((c) => c.sourceSpanId === spanId);
   if (matches.length === 0) return null;
   return (
@@ -633,7 +667,11 @@ export function SpanDatasetChip({
                 </span>
               </div>
             </div>
-            <DatasetSdkSnippet datasetName={c.datasetName} />
+            <DatasetSdkSnippet
+              projectName={projectName}
+              datasetName={c.datasetName}
+              version={c.datasetVersionLabel}
+            />
           </TooltipContent>
         </Tooltip>
       ))}

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -2,8 +2,8 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
-import { Database, X } from "lucide-react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { ArrowDown, ArrowUp, ArrowUpRight, Database, Info, Plus, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -13,23 +13,64 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
 import { getTrace } from "@/lib/api/traces";
 import { SpanKindIcon } from "@/features/traces";
-import { FormCard } from "@/features/offline-eval/components";
+import {
+  FormCard,
+  EditableValueBlock,
+  LineNumberedTextarea,
+} from "@/features/offline-eval/components";
+import {
+  CAPTURE_REASON_LABEL,
+  SPAN_KIND_LABEL,
+  type CaptureReason,
+} from "@/features/offline-eval/types";
 import type { Span } from "@/types/api";
-import { useDatasets, useSaveTestCase, useTraceEvaluationResults } from "../hooks";
+import { useDatasets, useCreateDataset, useTraceEvaluationResults } from "../hooks";
 
-/** Root = the span with no parent (the evaluation-item / application root). */
+/** Sentinel dataset-select value for "create a new dataset". */
+const NEW_DATASET = "__new__";
+
+/** How the optional expected outcome is set for a captured case. */
+type ExpectedMode = "none" | "recorded" | "corrected";
+
+/** Root = the span with no parent (the application / evaluation-item root). */
 function rootSpan(spans: Span[]): Span | undefined {
   return spans.find((s) => !s.parent_span_id) ?? spans[0];
 }
 
+/** Pretty-print JSON so metadata shows expanded and indented; leave other text. */
+function prettyJson(raw: string | null | undefined): string {
+  if (!raw) return "";
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+/** One short line explaining what a case sourced from this span actually tests. */
+function boundaryHint(displayKind: string, spanName: string): string {
+  const name = spanName.toLowerCase();
+  if (displayKind === "trace" || displayKind === "AGENT")
+    return "This tests the application from this input.";
+  if (displayKind === "LLM") return "This tests this model or prompt step.";
+  if (displayKind === "TOOL")
+    return "This tests the tool using these arguments. To test whether the agent selected the correct tool, choose its parent agent or LLM span.";
+  if (/retriev|search|recall|policy|vector|embed/.test(name))
+    return "This tests retrieval from this query.";
+  return "This tests this step from its input.";
+}
+
 /**
- * Save a real trace/span as a server-backed test case. Opened from the existing
- * trace viewer's span header. For a child span it saves a component-level case;
- * for the trace root (no spanId) it fetches the trace and saves the application
- * scope. Never treats the produced output as the expected answer, and surfaces
- * duplicates instead of silently creating a second case.
+ * "Save as test case" — a faithful port of the approved mock drawer, wired to the
+ * server. Opened from the existing trace viewer's span header. Self-contained: it
+ * fetches the trace, walks its spans (up/down), lets you pick or create a
+ * dataset, and persists via the server (which publishes a new dataset version).
+ * The span's input becomes the proposed test input; its output is shown read-only
+ * ("Recorded output") and is never treated as the expected answer.
  */
 export function SaveTestCaseDrawer({
   projectId,
@@ -40,12 +81,13 @@ export function SaveTestCaseDrawer({
 }: {
   projectId: string;
   traceId: string | null;
-  /** Undefined = the trace root / application scope. */
+  /** Initial span; undefined = the trace root / application scope. */
   spanId?: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const { data: datasetsData } = useDatasets(projectId);
+  const qc = useQueryClient();
+  const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
   const datasets = datasetsData?.data ?? [];
 
   const { data: trace } = useQuery({
@@ -54,34 +96,54 @@ export function SaveTestCaseDrawer({
     enabled: open && !!traceId,
   });
 
-  const span = React.useMemo(() => {
-    if (!trace) return undefined;
-    return spanId ? trace.spans.find((s) => s.span_id === spanId) : rootSpan(trace.spans);
-  }, [trace, spanId]);
-  const isRoot = !spanId;
-
   const [datasetId, setDatasetId] = React.useState("");
-  const [setExpected, setSetExpected] = React.useState(false);
-  const [expected, setExpectedValue] = React.useState("");
-  const [duplicateIn, setDuplicateIn] = React.useState<string | null>(null);
+  const [newDatasetName, setNewDatasetName] = React.useState("");
+  const [selectedSpanId, setSelectedSpanId] = React.useState<string | undefined>(spanId);
+  const [input, setInput] = React.useState("");
+  const [metadata, setMetadata] = React.useState("");
+  const [attachSource, setAttachSource] = React.useState(true);
+  const [expectedMode, setExpectedMode] = React.useState<ExpectedMode>("none");
+  const [correctedExpected, setCorrectedExpected] = React.useState("");
+  const [duplicate, setDuplicate] = React.useState<{ datasetId: string } | null>(null);
   const [feedback, setFeedback] = React.useState<{
     tone: "error" | "success";
     text: string;
   } | null>(null);
 
+  // Reset the dataset choice and toggles only when the panel opens, so the
+  // selected dataset persists while walking between spans with up/down.
   React.useEffect(() => {
     if (open) {
-      setDatasetId((prev) => prev || (datasets[0]?.id ?? ""));
-      setSetExpected(false);
-      setExpectedValue("");
-      setDuplicateIn(null);
+      setDatasetId("");
+      setNewDatasetName("");
+      setSelectedSpanId(spanId);
+      setAttachSource(true);
+      setExpectedMode("none");
+      setCorrectedExpected("");
+      setDuplicate(null);
       setFeedback(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  const save = useSaveTestCase(projectId, datasetId);
+  const spans = React.useMemo(() => trace?.spans ?? [], [trace]);
+  const root = trace ? rootSpan(spans) : undefined;
+  const span = React.useMemo(() => {
+    if (!trace) return undefined;
+    return selectedSpanId ? spans.find((s) => s.span_id === selectedSpanId) : root;
+  }, [trace, selectedSpanId, spans, root]);
+  const isRoot = !!span && !span.parent_span_id;
 
+  // Input / recorded output / metadata follow the selected span (incl. nav).
+  React.useEffect(() => {
+    if (open && span) {
+      setInput(span.input ?? "");
+      setMetadata(prettyJson(span.metadata));
+      setDuplicate(null);
+    }
+  }, [open, span]);
+
+  // Non-modal: Escape closes this panel without touching the trace behind it.
   React.useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
@@ -94,46 +156,103 @@ export function SaveTestCaseDrawer({
     return () => window.removeEventListener("keydown", onKey, true);
   }, [open, onOpenChange]);
 
+  const createDataset = useCreateDataset(projectId);
+  const save = useMutation({
+    mutationFn: async (vars: { datasetId: string; body: Record<string, unknown> }) => {
+      const res = await fetch(`/api/projects/${projectId}/datasets/${vars.datasetId}/test-cases`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(vars.body),
+      });
+      if (!res.ok) {
+        const detail = await res.json().catch(() => null);
+        throw new Error(detail?.error ?? `Save failed: ${res.status}`);
+      }
+      return res.json() as Promise<{ duplicate: boolean; testCaseId?: string; versionId?: string }>;
+    },
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["datasets"] }),
+  });
+
   if (!open || !traceId) return null;
 
-  const handleSave = () => {
-    if (!span || !datasetId) return;
-    save.mutate(
-      {
-        input: span.input ?? "",
-        // The observed output is never auto-treated as the expected answer.
-        expected: setExpected && expected.trim() ? expected.trim() : null,
-        recorded_output: span.output ?? null,
-        review: "needs_review",
-        capture_reason: span.status === "ERROR" ? "error" : "manual",
-        source_trace_id: traceId,
-        source_span_id: span.span_id,
-        source_span_name: span.name,
-        source_span_kind: isRoot ? "trace" : span.span_kind,
-      },
-      {
-        onSuccess: (res) => {
-          if (res.duplicate) {
-            setDuplicateIn(datasetId);
-            return;
-          }
-          setFeedback({ tone: "success", text: "Saved — published as a new dataset version." });
-          setTimeout(() => onOpenChange(false), 700);
+  const creatingNew = datasetId === NEW_DATASET;
+  const dataset = datasets.find((item) => item.id === datasetId);
+  const displayKind = isRoot ? "trace" : (span?.span_kind ?? "SPAN");
+  const recordedOutput = span?.output ?? "";
+  const currentIndex = span ? spans.findIndex((s) => s.span_id === span.span_id) : -1;
+  const canNavigateUp = currentIndex > 0;
+  const canNavigateDown = currentIndex >= 0 && currentIndex < spans.length - 1;
+
+  const inferredReason: CaptureReason =
+    span?.status === "ERROR" ? (displayKind === "TOOL" ? "failed_tool" : "error") : "manual";
+
+  const canSave =
+    !!span && (creatingNew ? newDatasetName.trim() !== "" : datasetId !== "") && !save.isPending;
+
+  const navigate = (dir: "up" | "down") => {
+    if (currentIndex < 0) return;
+    const next = dir === "up" ? currentIndex - 1 : currentIndex + 1;
+    if (next >= 0 && next < spans.length) setSelectedSpanId(spans[next].span_id);
+  };
+
+  const handleSave = async () => {
+    if (!span || !canSave) return;
+    setFeedback(null);
+    try {
+      let dsId = datasetId;
+      if (creatingNew) {
+        const created = await createDataset.mutateAsync({ name: newDatasetName.trim() });
+        dsId = created.dataset.id;
+        setDatasetId(dsId);
+      }
+      let metadataObj: Record<string, unknown> | null = null;
+      try {
+        const parsed = metadata.trim() ? JSON.parse(metadata) : null;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) metadataObj = parsed;
+      } catch {
+        /* non-JSON metadata → not persisted */
+      }
+      const expected =
+        expectedMode === "recorded"
+          ? recordedOutput || null
+          : expectedMode === "corrected"
+            ? correctedExpected.trim() || null
+            : null;
+      const res = await save.mutateAsync({
+        datasetId: dsId,
+        body: {
+          input,
+          expected,
+          recorded_output: recordedOutput || null,
+          metadata: metadataObj,
+          review: "needs_review",
+          capture_reason: inferredReason,
+          source_trace_id: attachSource ? traceId : null,
+          source_span_id: attachSource ? span.span_id : null,
+          source_span_name: attachSource ? span.name : null,
+          source_span_kind: attachSource ? displayKind : null,
         },
-        onError: () => setFeedback({ tone: "error", text: "Could not save test case." }),
-      },
-    );
+      });
+      if (res.duplicate) {
+        setDuplicate({ datasetId: dsId });
+        return;
+      }
+      setFeedback({ tone: "success", text: "Saved — published as a new dataset version." });
+      setTimeout(() => onOpenChange(false), 700);
+    } catch {
+      setFeedback({ tone: "error", text: "Could not save test case." });
+    }
   };
 
   return (
-    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background text-[12px] shadow-xl">
+    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
       <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
         <h2 className="text-[13px] font-semibold">Save as test case</h2>
         <button
           type="button"
           onClick={() => onOpenChange(false)}
           aria-label="Close"
-          className="rounded-sm text-muted-foreground opacity-70 hover:opacity-100"
+          className="rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
         >
           <X className="h-4 w-4" />
         </button>
@@ -143,97 +262,206 @@ export function SaveTestCaseDrawer({
         <FormCard label="Dataset">
           <Select value={datasetId} onValueChange={setDatasetId}>
             <SelectTrigger className="h-7 text-[13px]">
-              <SelectValue placeholder={datasets.length ? "Select dataset" : "No datasets yet"} />
+              <SelectValue placeholder="Select dataset" />
             </SelectTrigger>
             <SelectContent>
-              {datasets.map((d) => (
-                <SelectItem key={d.id} value={d.id} className="text-[12px]">
-                  {d.name}
+              {datasets.map((item) => (
+                <SelectItem key={item.id} value={item.id} className="text-[12px]">
+                  {item.name}
                 </SelectItem>
               ))}
+              <SelectItem
+                value={NEW_DATASET}
+                icon={<Plus className="h-4 w-4" />}
+                className="mt-1 border-t border-border text-[12px]"
+              >
+                New dataset
+              </SelectItem>
             </SelectContent>
           </Select>
-          {duplicateIn && (
+          {creatingNew && (
+            <Input
+              value={newDatasetName}
+              onChange={(event) => setNewDatasetName(event.target.value)}
+              placeholder="New dataset name"
+              autoFocus
+              className="mt-2 h-7 text-[13px]"
+            />
+          )}
+          {duplicate && (
             <p className="mt-1.5 text-[11px] text-muted-foreground">
-              This span is already a test case in this dataset.{" "}
-              <Link
-                href={`/projects/${projectId}/datasets/${duplicateIn}`}
-                className="font-medium text-foreground underline underline-offset-2"
-              >
-                Open existing test case
-              </Link>
+              This span is already a test case in this dataset. Open it instead of adding another
+              row.
             </p>
           )}
         </FormCard>
 
-        <FormCard label={isRoot ? "Application (trace root)" : "Selected span"}>
-          {span ? (
-            <div className="flex items-center gap-2">
-              <SpanKindIcon kind={isRoot ? "AGENT" : span.span_kind} inTree />
-              <span className="text-[13px] font-medium">{span.name}</span>
-              <span className="text-[11px] text-muted-foreground">
-                {isRoot ? "workflow-level case" : "component-level case"}
-              </span>
-            </div>
-          ) : (
-            <p className="text-[11px] text-muted-foreground">Loading trace…</p>
-          )}
+        <FormCard label="Selected span">
+          <div className="flex items-center gap-2">
+            <SpanKindIcon kind={displayKind} inTree />
+            <span className="text-[13px] font-medium">{span?.name ?? "Loading trace…"}</span>
+            <span className="text-[11px] text-muted-foreground">
+              {SPAN_KIND_LABEL[displayKind as keyof typeof SPAN_KIND_LABEL] ?? displayKind}
+            </span>
+            <span className="ml-auto flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => navigate("up")}
+                disabled={!canNavigateUp}
+                aria-label="Previous span"
+                className="rounded border border-border p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+              >
+                <ArrowUp className="h-3.5 w-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => navigate("down")}
+                disabled={!canNavigateDown}
+                aria-label="Next span"
+                className="rounded border border-border p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+              >
+                <ArrowDown className="h-3.5 w-3.5" />
+              </button>
+            </span>
+          </div>
+          <p className="mt-2 flex items-start gap-1.5 text-[11px] text-muted-foreground">
+            <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+            {boundaryHint(displayKind, span?.name ?? "")}
+          </p>
+          <p className="mt-1.5 text-[11px] text-muted-foreground">
+            Capture reason:{" "}
+            <span className="font-medium text-foreground">
+              {CAPTURE_REASON_LABEL[inferredReason]}
+            </span>
+          </p>
         </FormCard>
 
-        <div>
-          <p className="mb-1 text-[11px] text-muted-foreground">Input</p>
-          <div className="max-h-40 overflow-auto rounded border border-border bg-muted/20 px-2.5 py-2 font-mono text-[11px] leading-relaxed">
-            {span?.input || <span className="text-muted-foreground">—</span>}
-          </div>
-        </div>
+        <EditableValueBlock
+          label="Input"
+          text={input}
+          onChange={setInput}
+          copyable
+          autoDetectKind
+          boxed
+          minRows={2}
+        />
 
         <div>
-          <p className="mb-1 text-[11px] text-muted-foreground">
-            Recorded output{" "}
-            <span className="font-normal">— what happened, kept separate from expected</span>
+          <EditableValueBlock
+            label="Recorded output"
+            text={recordedOutput}
+            onChange={() => {}}
+            copyable
+            autoDetectKind
+            boxed
+            minRows={2}
+            readOnly
+          />
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            What happened in production. Kept separate from the expected outcome.
           </p>
-          <div className="max-h-40 overflow-auto rounded border border-border bg-muted/20 px-2.5 py-2 font-mono text-[11px] leading-relaxed">
-            {span?.output || <span className="text-muted-foreground">—</span>}
-          </div>
         </div>
 
         <FormCard label="Expected outcome">
-          <label className="flex cursor-pointer items-center gap-2 text-[12px]">
-            <input
-              type="checkbox"
-              checked={setExpected}
-              onChange={(e) => setSetExpected(e.target.checked)}
-              className="h-3.5 w-3.5 accent-foreground"
-            />
-            Set an expected outcome (optional)
-          </label>
-          {setExpected && (
-            <Input
-              value={expected}
-              onChange={(e) => setExpectedValue(e.target.value)}
-              placeholder="Expected outcome"
-              className="mt-2 h-7 text-[12px]"
-            />
+          <div className="flex flex-col gap-1" role="radiogroup" aria-label="Expected outcome">
+            {(
+              [
+                ["none", "Not required"],
+                ["recorded", "Use recorded output"],
+                ["corrected", "Enter a corrected outcome"],
+              ] as Array<[ExpectedMode, string]>
+            ).map(([value, label]) => (
+              <label
+                key={value}
+                className={cn(
+                  "flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-[12px]",
+                  expectedMode === value ? "text-foreground" : "text-muted-foreground",
+                )}
+              >
+                <input
+                  type="radio"
+                  name="expected-outcome"
+                  value={value}
+                  checked={expectedMode === value}
+                  onChange={() => setExpectedMode(value)}
+                  className="h-3.5 w-3.5 accent-foreground"
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+
+          {expectedMode === "recorded" && (
+            <p className="mt-2 flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-300">
+              <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+              This will become the outcome future runs are evaluated against.
+            </p>
           )}
-          <p className="mt-1.5 text-[11px] text-muted-foreground">
-            The recorded output is never used as the expected answer automatically.
-          </p>
+          {expectedMode === "corrected" && (
+            <div className="mt-2">
+              <LineNumberedTextarea
+                value={correctedExpected}
+                onChange={setCorrectedExpected}
+                minRows={2}
+                placeholder="Corrected expected outcome"
+                aria-label="Corrected expected outcome"
+              />
+            </div>
+          )}
         </FormCard>
 
+        <EditableValueBlock
+          label="Metadata"
+          text={metadata}
+          onChange={setMetadata}
+          copyable
+          autoDetectKind
+          boxed
+          minRows={2}
+        />
+
+        <div className="border border-border">
+          <div className="flex items-center justify-between border-b border-border bg-muted/50 px-3 py-1.5">
+            <span className="text-[12px] font-medium text-muted-foreground">Source</span>
+            <Switch checked={attachSource} onCheckedChange={setAttachSource} />
+          </div>
+          {attachSource ? (
+            <div className="p-3">
+              <dl className="flex flex-col gap-1 text-[11px]">
+                <div className="flex justify-between gap-3">
+                  <dt className="text-muted-foreground">Source trace</dt>
+                  <dd className="font-mono text-muted-foreground">{traceId}</dd>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <dt className="text-muted-foreground">Source span</dt>
+                  <dd className="font-mono text-muted-foreground">{span?.span_id ?? "—"}</dd>
+                </div>
+              </dl>
+            </div>
+          ) : (
+            <div className="p-3">
+              <p className="text-[11px] text-muted-foreground">
+                Added as a manual case — no source trace or span is linked.
+              </p>
+            </div>
+          )}
+        </div>
+
         <p className="text-[11px] text-muted-foreground">
-          This case will start as <span className="font-medium text-foreground">Needs review</span>{" "}
-          and publishes a new dataset version.
+          This case will start as <span className="font-medium text-foreground">Needs review</span>.
+          Review it from the dataset row.
         </p>
       </div>
 
       <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border px-4 py-3">
         {feedback && (
           <span
-            className={
+            className={cn(
+              "mr-auto text-[11px]",
               feedback.tone === "error"
-                ? "mr-auto text-[11px] text-destructive"
-                : "mr-auto text-[11px] text-emerald-600 dark:text-emerald-400"
-            }
+                ? "text-destructive"
+                : "text-emerald-600 dark:text-emerald-400",
+            )}
           >
             {feedback.text}
           </span>
@@ -246,14 +474,23 @@ export function SaveTestCaseDrawer({
         >
           Cancel
         </Button>
-        <Button
-          size="sm"
-          className="h-7 text-[12px]"
-          onClick={handleSave}
-          disabled={!span || !datasetId || save.isPending}
-        >
-          {save.isPending ? "Saving…" : "Save to dataset"}
-        </Button>
+        {duplicate ? (
+          <Link
+            href={`/projects/${projectId}/datasets/${duplicate.datasetId}`}
+            className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
+            Open existing test case
+          </Link>
+        ) : (
+          <Button size="sm" className="h-7 text-[12px]" onClick={handleSave} disabled={!canSave}>
+            {creatingNew
+              ? "Create dataset & save"
+              : datasetId
+                ? `Save to ${dataset?.name ?? "dataset"}`
+                : "Save"}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -70,13 +70,69 @@ function boundaryHint(displayKind: string, spanName: string): string {
   return "This tests this step from its input.";
 }
 
+/** Collapse threshold — mirrors the span-detail I/O renderer's STRING_TRUNCATE_AT. */
+const COLLAPSE_AT = 500;
+
+/**
+ * Caps a long editable field behind a "…expand (N more characters)" control — the same
+ * organizing the span-detail I/O panel uses — so a big Input/Output/Metadata value
+ * doesn't flood the save panel. Short values render untouched. Expand-only; re-collapses
+ * when the selected span changes (via `resetKey`), matching the span-detail behavior.
+ */
+function CollapsibleField({
+  text,
+  resetKey,
+  children,
+}: {
+  text: string;
+  resetKey?: string;
+  children: React.ReactNode;
+}) {
+  const [expanded, setExpanded] = React.useState(false);
+  React.useEffect(() => {
+    setExpanded(false);
+  }, [resetKey]);
+
+  if (text.length <= COLLAPSE_AT) return <>{children}</>;
+  if (expanded) {
+    return (
+      <div>
+        {children}
+        <button
+          type="button"
+          onClick={() => setExpanded(false)}
+          className="mt-1 text-[11px] text-muted-foreground hover:text-foreground"
+        >
+          collapse
+        </button>
+      </div>
+    );
+  }
+  const hidden = text.length - COLLAPSE_AT;
+  return (
+    <div>
+      <div className="relative max-h-40 overflow-hidden">
+        {children}
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-background to-transparent" />
+      </div>
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        className="mt-1 text-[11px] text-muted-foreground hover:text-foreground"
+      >
+        …expand ({hidden.toLocaleString()} more characters)
+      </button>
+    </div>
+  );
+}
+
 /**
  * "Save as test case" — a faithful port of the approved mock drawer, wired to the
  * server. Opened from the existing trace viewer's span header. Self-contained: it
  * fetches the trace, walks its spans (up/down), lets you pick or create a
  * dataset, and persists via the server (which publishes a new dataset version).
- * The span's input becomes the proposed test input; its output is shown read-only
- * ("Recorded output") and is never treated as the expected answer.
+ * The span's input becomes the proposed test input; the single editable Output field
+ * seeds from the recorded output and, when edited, becomes the expected outcome.
  */
 export function SaveTestCaseDrawer({
   projectId,
@@ -362,31 +418,35 @@ export function SaveTestCaseDrawer({
           </p>
         </FormCard>
 
-        <EditableValueBlock
-          label="Input"
-          text={input}
-          onChange={setInput}
-          copyable
-          // Read + hand-edited most, and usually the most nested → expand it.
-          seedJson="expanded"
-          boxed
-          minRows={2}
-        />
-
-        <div>
+        <CollapsibleField text={input} resetKey={span?.span_id}>
           <EditableValueBlock
-            label="Output"
-            text={output}
-            onChange={(v) => {
-              setOutput(v);
-              setOutputEdited(true);
-            }}
+            label="Input"
+            text={input}
+            onChange={setInput}
             copyable
-            // Read and possibly hand-corrected — expand it like Input.
+            // Read + hand-edited most, and usually the most nested → expand it.
             seedJson="expanded"
             boxed
             minRows={2}
           />
+        </CollapsibleField>
+
+        <div>
+          <CollapsibleField text={output} resetKey={span?.span_id}>
+            <EditableValueBlock
+              label="Output"
+              text={output}
+              onChange={(v) => {
+                setOutput(v);
+                setOutputEdited(true);
+              }}
+              copyable
+              // Read and possibly hand-corrected — expand it like Input.
+              seedJson="expanded"
+              boxed
+              minRows={2}
+            />
+          </CollapsibleField>
           <p className="mt-1 flex items-start gap-1.5 text-[11px] text-muted-foreground">
             <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
             {outputEdited ? (
@@ -405,17 +465,19 @@ export function SaveTestCaseDrawer({
           </p>
         </div>
 
-        <EditableValueBlock
-          label="Metadata"
-          text={metadata}
-          onChange={setMetadata}
-          copyable
-          // Incidental context, usually one or two short keys → keep it inline
-          // (seedFormat expands it anyway once it stops fitting on one line).
-          seedJson="compact"
-          boxed
-          minRows={2}
-        />
+        <CollapsibleField text={metadata} resetKey={span?.span_id}>
+          <EditableValueBlock
+            label="Metadata"
+            text={metadata}
+            onChange={setMetadata}
+            copyable
+            // Incidental context, usually one or two short keys → keep it inline
+            // (seedFormat expands it anyway once it stops fitting on one line).
+            seedJson="compact"
+            boxed
+            minRows={2}
+          />
+        </CollapsibleField>
 
         <div className="border border-border">
           <div className="flex items-center justify-between border-b border-border bg-muted/50 px-3 py-1.5">

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -70,62 +70,6 @@ function boundaryHint(displayKind: string, spanName: string): string {
   return "This tests this step from its input.";
 }
 
-/** Collapse threshold — mirrors the span-detail I/O renderer's STRING_TRUNCATE_AT. */
-const COLLAPSE_AT = 500;
-
-/**
- * Caps a long editable field behind a "…expand (N more characters)" control — the same
- * organizing the span-detail I/O panel uses — so a big Input/Output/Metadata value
- * doesn't flood the save panel. Short values render untouched. Expand-only; re-collapses
- * when the selected span changes (via `resetKey`), matching the span-detail behavior.
- */
-function CollapsibleField({
-  text,
-  resetKey,
-  children,
-}: {
-  text: string;
-  resetKey?: string;
-  children: React.ReactNode;
-}) {
-  const [expanded, setExpanded] = React.useState(false);
-  React.useEffect(() => {
-    setExpanded(false);
-  }, [resetKey]);
-
-  if (text.length <= COLLAPSE_AT) return <>{children}</>;
-  if (expanded) {
-    return (
-      <div>
-        {children}
-        <button
-          type="button"
-          onClick={() => setExpanded(false)}
-          className="mt-1 text-[11px] text-muted-foreground hover:text-foreground"
-        >
-          collapse
-        </button>
-      </div>
-    );
-  }
-  const hidden = text.length - COLLAPSE_AT;
-  return (
-    <div>
-      <div className="relative max-h-40 overflow-hidden">
-        {children}
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-background to-transparent" />
-      </div>
-      <button
-        type="button"
-        onClick={() => setExpanded(true)}
-        className="mt-1 text-[11px] text-muted-foreground hover:text-foreground"
-      >
-        …expand ({hidden.toLocaleString()} more characters)
-      </button>
-    </div>
-  );
-}
-
 /**
  * "Save as test case" — a faithful port of the approved mock drawer, wired to the
  * server. Opened from the existing trace viewer's span header. Self-contained: it
@@ -418,35 +362,35 @@ export function SaveTestCaseDrawer({
           </p>
         </FormCard>
 
-        <CollapsibleField text={input} resetKey={span?.span_id}>
+        <EditableValueBlock
+          label="Input"
+          text={input}
+          onChange={setInput}
+          copyable
+          // Read + hand-edited most, and usually the most nested → expand it.
+          seedJson="expanded"
+          boxed
+          minRows={2}
+          collapsible
+          collapseResetKey={span?.span_id}
+        />
+
+        <div>
           <EditableValueBlock
-            label="Input"
-            text={input}
-            onChange={setInput}
+            label="Output"
+            text={output}
+            onChange={(v) => {
+              setOutput(v);
+              setOutputEdited(true);
+            }}
             copyable
-            // Read + hand-edited most, and usually the most nested → expand it.
+            // Read and possibly hand-corrected — expand it like Input.
             seedJson="expanded"
             boxed
             minRows={2}
+            collapsible
+            collapseResetKey={span?.span_id}
           />
-        </CollapsibleField>
-
-        <div>
-          <CollapsibleField text={output} resetKey={span?.span_id}>
-            <EditableValueBlock
-              label="Output"
-              text={output}
-              onChange={(v) => {
-                setOutput(v);
-                setOutputEdited(true);
-              }}
-              copyable
-              // Read and possibly hand-corrected — expand it like Input.
-              seedJson="expanded"
-              boxed
-              minRows={2}
-            />
-          </CollapsibleField>
           <p className="mt-1 flex items-start gap-1.5 text-[11px] text-muted-foreground">
             <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
             {outputEdited ? (
@@ -465,19 +409,19 @@ export function SaveTestCaseDrawer({
           </p>
         </div>
 
-        <CollapsibleField text={metadata} resetKey={span?.span_id}>
-          <EditableValueBlock
-            label="Metadata"
-            text={metadata}
-            onChange={setMetadata}
-            copyable
-            // Incidental context, usually one or two short keys → keep it inline
-            // (seedFormat expands it anyway once it stops fitting on one line).
-            seedJson="compact"
-            boxed
-            minRows={2}
-          />
-        </CollapsibleField>
+        <EditableValueBlock
+          label="Metadata"
+          text={metadata}
+          onChange={setMetadata}
+          copyable
+          // Incidental context, usually one or two short keys → keep it inline
+          // (seedFormat expands it anyway once it stops fitting on one line).
+          seedJson="compact"
+          boxed
+          minRows={2}
+          collapsible
+          collapseResetKey={span?.span_id}
+        />
 
         <div className="border border-border">
           <div className="flex items-center justify-between border-b border-border bg-muted/50 px-3 py-1.5">

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -2,8 +2,8 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { ArrowDown, ArrowUp, ArrowUpRight, Database, Info, Plus, X } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { Database, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -13,70 +13,23 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { CopyButton } from "@/components/ui/copy-button";
-import { cn } from "@/lib/utils";
 import { getTrace } from "@/lib/api/traces";
-import { SpanKindIcon, useSpanIO } from "@/features/traces";
-import { FormCard, EditableValueBlock, Timestamp } from "@/features/offline-eval/components";
-import { tokenizeCode } from "@/features/offline-eval/components/syntax";
-import { useProject } from "@/features/projects/hooks";
-import {
-  CAPTURE_REASON_LABEL,
-  SPAN_KIND_LABEL,
-  type CaptureReason,
-} from "@/features/offline-eval/types";
+import { SpanKindIcon } from "@/features/traces";
+import { FormCard } from "@/features/offline-eval/components";
 import type { Span } from "@/types/api";
-import {
-  useDatasets,
-  useCreateDataset,
-  useTraceEvaluationResults,
-  useTraceTestCases,
-} from "../hooks";
+import { useDatasets, useSaveTestCase, useTraceEvaluationResults } from "../hooks";
 
-/** Sentinel dataset-select value for "create a new dataset". */
-const NEW_DATASET = "__new__";
-
-/** Root = the span with no parent (the application / evaluation-item root). */
+/** Root = the span with no parent (the evaluation-item / application root). */
 function rootSpan(spans: Span[]): Span | undefined {
   return spans.find((s) => !s.parent_span_id) ?? spans[0];
 }
 
 /**
- * Normalise a captured JSON blob (2-space indent); leave non-JSON text alone.
- * The field's own `seedJson` preference decides the final shape it opens in —
- * this just guarantees the seed is valid, canonical JSON when it is JSON.
- */
-function prettyJson(raw: string | null | undefined): string {
-  if (!raw) return "";
-  try {
-    return JSON.stringify(JSON.parse(raw), null, 2);
-  } catch {
-    return raw;
-  }
-}
-
-/** One short line explaining what a case sourced from this span actually tests. */
-function boundaryHint(displayKind: string, spanName: string): string {
-  const name = spanName.toLowerCase();
-  if (displayKind === "trace" || displayKind === "AGENT")
-    return "This tests the application from this input.";
-  if (displayKind === "LLM") return "This tests this model or prompt step.";
-  if (displayKind === "TOOL")
-    return "This tests the tool using these arguments. To test whether the agent selected the correct tool, choose its parent agent or LLM span.";
-  if (/retriev|search|recall|policy|vector|embed/.test(name))
-    return "This tests retrieval from this query.";
-  return "This tests this step from its input.";
-}
-
-/**
- * "Save as test case" — the capture drawer, wired to the
- * server. Opened from the existing trace viewer's span header. Self-contained: it
- * fetches the trace, walks its spans (up/down), lets you pick or create a
- * dataset, and persists via the server (which publishes a new dataset version).
- * The span's input becomes the proposed test input; the single editable Output field
- * seeds from the recorded output and, when edited, becomes the expected outcome.
+ * Save a real trace/span as a server-backed test case. Opened from the existing
+ * trace viewer's span header. For a child span it saves a component-level case;
+ * for the trace root (no spanId) it fetches the trace and saves the application
+ * scope. Never treats the produced output as the expected answer, and surfaces
+ * duplicates instead of silently creating a second case.
  */
 export function SaveTestCaseDrawer({
   projectId,
@@ -87,13 +40,12 @@ export function SaveTestCaseDrawer({
 }: {
   projectId: string;
   traceId: string | null;
-  /** Initial span; undefined = the trace root / application scope. */
+  /** Undefined = the trace root / application scope. */
   spanId?: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const qc = useQueryClient();
-  const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
+  const { data: datasetsData } = useDatasets(projectId);
   const datasets = datasetsData?.data ?? [];
 
   const { data: trace } = useQuery({
@@ -102,74 +54,34 @@ export function SaveTestCaseDrawer({
     enabled: open && !!traceId,
   });
 
+  const span = React.useMemo(() => {
+    if (!trace) return undefined;
+    return spanId ? trace.spans.find((s) => s.span_id === spanId) : rootSpan(trace.spans);
+  }, [trace, spanId]);
+  const isRoot = !spanId;
+
   const [datasetId, setDatasetId] = React.useState("");
-  const [newDatasetName, setNewDatasetName] = React.useState("");
-  const [selectedSpanId, setSelectedSpanId] = React.useState<string | undefined>(spanId);
-  const [input, setInput] = React.useState("");
-  const [metadata, setMetadata] = React.useState("");
-  const [attachSource, setAttachSource] = React.useState(true);
-  // The single editable Output field. It seeds from the recorded output; editing it
-  // makes the edit the EXPECTED outcome future runs are graded against, while the
-  // untouched recorded output is still stored separately. Left as-is, expected ==
-  // recorded — but all three fields (input, expected, recorded_output) are persisted.
-  const [output, setOutput] = React.useState("");
-  const [outputEdited, setOutputEdited] = React.useState(false);
-  const [duplicate, setDuplicate] = React.useState<{ datasetId: string } | null>(null);
+  const [setExpected, setSetExpected] = React.useState(false);
+  const [expected, setExpectedValue] = React.useState("");
+  const [duplicateIn, setDuplicateIn] = React.useState<string | null>(null);
   const [feedback, setFeedback] = React.useState<{
     tone: "error" | "success";
     text: string;
   } | null>(null);
 
-  // Reset the dataset choice and toggles only when the panel opens, so the
-  // selected dataset persists while walking between spans with up/down.
   React.useEffect(() => {
     if (open) {
-      setDatasetId("");
-      setNewDatasetName("");
-      setAttachSource(true);
-      setOutputEdited(false);
-      setDuplicate(null);
+      setDatasetId((prev) => prev || (datasets[0]?.id ?? ""));
+      setSetExpected(false);
+      setExpectedValue("");
+      setDuplicateIn(null);
       setFeedback(null);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  // Follow the tree: when the parent retargets the span — a click on a different
-  // span in the span tree while this drawer is open — select it here too. The
-  // drawer's own up/down nav sets internal state without changing this prop, so
-  // it keeps working; only a genuine tree selection re-syncs.
-  React.useEffect(() => {
-    setSelectedSpanId(spanId);
-  }, [spanId]);
+  const save = useSaveTestCase(projectId, datasetId);
 
-  const spans = React.useMemo(() => trace?.spans ?? [], [trace]);
-  const root = trace ? rootSpan(spans) : undefined;
-  const span = React.useMemo(() => {
-    if (!trace) return undefined;
-    return selectedSpanId ? spans.find((s) => s.span_id === selectedSpanId) : root;
-  }, [trace, selectedSpanId, spans, root]);
-  const isRoot = !!span && !span.parent_span_id;
-
-  // The trace-detail response OMITS span input/output/metadata — they are fetched
-  // per span on demand (getSpanIO), so read them from that hook, not the span.
-  const { data: spanIO } = useSpanIO(projectId, traceId ?? "", span?.span_id ?? null);
-
-  // Input / output / metadata follow the fetched span I/O (incl. nav). Output reseeds
-  // from the recorded output on each span (nav resets any in-progress edit).
-  React.useEffect(() => {
-    if (open && spanIO) {
-      setInput(spanIO.input ?? "");
-      setMetadata(prettyJson(spanIO.metadata));
-      setOutput(spanIO.output ?? "");
-      setOutputEdited(false);
-    }
-  }, [open, spanIO]);
-
-  // Reset the duplicate note whenever the selected span changes.
-  React.useEffect(() => {
-    if (open) setDuplicate(null);
-  }, [open, span?.span_id]);
-
-  // Non-modal: Escape closes this panel without touching the trace behind it.
   React.useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
@@ -182,103 +94,46 @@ export function SaveTestCaseDrawer({
     return () => window.removeEventListener("keydown", onKey, true);
   }, [open, onOpenChange]);
 
-  const createDataset = useCreateDataset(projectId);
-  const save = useMutation({
-    mutationFn: async (vars: { datasetId: string; body: Record<string, unknown> }) => {
-      const res = await fetch(`/api/projects/${projectId}/datasets/${vars.datasetId}/test-cases`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(vars.body),
-      });
-      if (!res.ok) {
-        const detail = await res.json().catch(() => null);
-        throw new Error(detail?.error ?? `Save failed: ${res.status}`);
-      }
-      return res.json() as Promise<{ duplicate: boolean; testCaseId?: string; versionId?: string }>;
-    },
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ["datasets"] });
-      // Refresh the span→dataset chips so the just-saved span is marked at once.
-      void qc.invalidateQueries({ queryKey: ["evaluations", "trace-test-cases"] });
-    },
-  });
-
   if (!open || !traceId) return null;
 
-  const creatingNew = datasetId === NEW_DATASET;
-  const dataset = datasets.find((item) => item.id === datasetId);
-  const displayKind = isRoot ? "trace" : (span?.span_kind ?? "SPAN");
-  const recordedOutput = spanIO?.output ?? "";
-  const currentIndex = span ? spans.findIndex((s) => s.span_id === span.span_id) : -1;
-  const canNavigateUp = currentIndex > 0;
-  const canNavigateDown = currentIndex >= 0 && currentIndex < spans.length - 1;
-
-  const inferredReason: CaptureReason =
-    span?.status === "ERROR" ? (displayKind === "TOOL" ? "failed_tool" : "error") : "manual";
-
-  const canSave =
-    !!span && (creatingNew ? newDatasetName.trim() !== "" : datasetId !== "") && !save.isPending;
-
-  const navigate = (dir: "up" | "down") => {
-    if (currentIndex < 0) return;
-    const next = dir === "up" ? currentIndex - 1 : currentIndex + 1;
-    if (next >= 0 && next < spans.length) setSelectedSpanId(spans[next].span_id);
-  };
-
-  const handleSave = async () => {
-    if (!span || !canSave) return;
-    setFeedback(null);
-    try {
-      let dsId = datasetId;
-      if (creatingNew) {
-        const created = await createDataset.mutateAsync({ name: newDatasetName.trim() });
-        dsId = created.dataset.id;
-        setDatasetId(dsId);
-      }
-      let metadataObj: Record<string, unknown> | null = null;
-      try {
-        const parsed = metadata.trim() ? JSON.parse(metadata) : null;
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) metadataObj = parsed;
-      } catch {
-        /* non-JSON metadata → not persisted */
-      }
-      // The Output field IS the expected outcome (edited or not); the recorded output
-      // is always stored separately. Unedited → expected == recorded output.
-      const res = await save.mutateAsync({
-        datasetId: dsId,
-        body: {
-          input,
-          expected: output.trim() || null,
-          recorded_output: recordedOutput || null,
-          metadata: metadataObj,
-          review: "needs_review",
-          capture_reason: inferredReason,
-          source_trace_id: attachSource ? traceId : null,
-          source_span_id: attachSource ? span.span_id : null,
-          source_span_name: attachSource ? span.name : null,
-          source_span_kind: attachSource ? displayKind : null,
+  const handleSave = () => {
+    if (!span || !datasetId) return;
+    save.mutate(
+      {
+        input: span.input ?? "",
+        // The observed output is never auto-treated as the expected answer.
+        expected: setExpected && expected.trim() ? expected.trim() : null,
+        recorded_output: span.output ?? null,
+        review: "needs_review",
+        capture_reason: span.status === "ERROR" ? "error" : "manual",
+        source_trace_id: traceId,
+        source_span_id: span.span_id,
+        source_span_name: span.name,
+        source_span_kind: isRoot ? "trace" : span.span_kind,
+      },
+      {
+        onSuccess: (res) => {
+          if (res.duplicate) {
+            setDuplicateIn(datasetId);
+            return;
+          }
+          setFeedback({ tone: "success", text: "Saved — published as a new dataset version." });
+          setTimeout(() => onOpenChange(false), 700);
         },
-      });
-      if (res.duplicate) {
-        setDuplicate({ datasetId: dsId });
-        return;
-      }
-      setFeedback({ tone: "success", text: "Saved — published as a new dataset version." });
-      setTimeout(() => onOpenChange(false), 700);
-    } catch {
-      setFeedback({ tone: "error", text: "Could not save test case." });
-    }
+        onError: () => setFeedback({ tone: "error", text: "Could not save test case." }),
+      },
+    );
   };
 
   return (
-    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
+    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background text-[12px] shadow-xl">
       <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
         <h2 className="text-[13px] font-semibold">Save as test case</h2>
         <button
           type="button"
           onClick={() => onOpenChange(false)}
           aria-label="Close"
-          className="rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+          className="rounded-sm text-muted-foreground opacity-70 hover:opacity-100"
         >
           <X className="h-4 w-4" />
         </button>
@@ -288,183 +143,97 @@ export function SaveTestCaseDrawer({
         <FormCard label="Dataset">
           <Select value={datasetId} onValueChange={setDatasetId}>
             <SelectTrigger className="h-7 text-[13px]">
-              <SelectValue placeholder="Select dataset" />
+              <SelectValue placeholder={datasets.length ? "Select dataset" : "No datasets yet"} />
             </SelectTrigger>
             <SelectContent>
-              {datasets.map((item) => (
-                <SelectItem key={item.id} value={item.id} className="text-[12px]">
-                  {item.name}
+              {datasets.map((d) => (
+                <SelectItem key={d.id} value={d.id} className="text-[12px]">
+                  {d.name}
                 </SelectItem>
               ))}
-              <SelectItem
-                value={NEW_DATASET}
-                icon={<Plus className="h-4 w-4" />}
-                className="mt-1 border-t border-border text-[12px]"
-              >
-                New dataset
-              </SelectItem>
             </SelectContent>
           </Select>
-          {creatingNew && (
-            <Input
-              value={newDatasetName}
-              onChange={(event) => setNewDatasetName(event.target.value)}
-              placeholder="New dataset name"
-              autoFocus
-              className="mt-2 h-7 text-[13px]"
-            />
-          )}
-          {duplicate && (
+          {duplicateIn && (
             <p className="mt-1.5 text-[11px] text-muted-foreground">
-              This span is already a test case in this dataset. Open it instead of adding another
-              row.
+              This span is already a test case in this dataset.{" "}
+              <Link
+                href={`/projects/${projectId}/datasets/${duplicateIn}`}
+                className="font-medium text-foreground underline underline-offset-2"
+              >
+                Open existing test case
+              </Link>
             </p>
           )}
         </FormCard>
 
-        <FormCard label="Selected span">
-          <div className="flex items-center gap-2">
-            <SpanKindIcon kind={displayKind} inTree />
-            <span className="text-[13px] font-medium">{span?.name ?? "Loading trace…"}</span>
-            <span className="text-[11px] text-muted-foreground">
-              {SPAN_KIND_LABEL[displayKind as keyof typeof SPAN_KIND_LABEL] ?? displayKind}
-            </span>
-            <span className="ml-auto flex items-center gap-1">
-              <button
-                type="button"
-                onClick={() => navigate("up")}
-                disabled={!canNavigateUp}
-                aria-label="Previous span"
-                className="rounded border border-border p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
-              >
-                <ArrowUp className="h-3.5 w-3.5" />
-              </button>
-              <button
-                type="button"
-                onClick={() => navigate("down")}
-                disabled={!canNavigateDown}
-                aria-label="Next span"
-                className="rounded border border-border p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
-              >
-                <ArrowDown className="h-3.5 w-3.5" />
-              </button>
-            </span>
+        <FormCard label={isRoot ? "Application (trace root)" : "Selected span"}>
+          {span ? (
+            <div className="flex items-center gap-2">
+              <SpanKindIcon kind={isRoot ? "AGENT" : span.span_kind} inTree />
+              <span className="text-[13px] font-medium">{span.name}</span>
+              <span className="text-[11px] text-muted-foreground">
+                {isRoot ? "workflow-level case" : "component-level case"}
+              </span>
+            </div>
+          ) : (
+            <p className="text-[11px] text-muted-foreground">Loading trace…</p>
+          )}
+        </FormCard>
+
+        <div>
+          <p className="mb-1 text-[11px] text-muted-foreground">Input</p>
+          <div className="max-h-40 overflow-auto rounded border border-border bg-muted/20 px-2.5 py-2 font-mono text-[11px] leading-relaxed">
+            {span?.input || <span className="text-muted-foreground">—</span>}
           </div>
-          <p className="mt-2 flex items-start gap-1.5 text-[11px] text-muted-foreground">
-            <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
-            {boundaryHint(displayKind, span?.name ?? "")}
+        </div>
+
+        <div>
+          <p className="mb-1 text-[11px] text-muted-foreground">
+            Recorded output{" "}
+            <span className="font-normal">— what happened, kept separate from expected</span>
           </p>
+          <div className="max-h-40 overflow-auto rounded border border-border bg-muted/20 px-2.5 py-2 font-mono text-[11px] leading-relaxed">
+            {span?.output || <span className="text-muted-foreground">—</span>}
+          </div>
+        </div>
+
+        <FormCard label="Expected outcome">
+          <label className="flex cursor-pointer items-center gap-2 text-[12px]">
+            <input
+              type="checkbox"
+              checked={setExpected}
+              onChange={(e) => setSetExpected(e.target.checked)}
+              className="h-3.5 w-3.5 accent-foreground"
+            />
+            Set an expected outcome (optional)
+          </label>
+          {setExpected && (
+            <Input
+              value={expected}
+              onChange={(e) => setExpectedValue(e.target.value)}
+              placeholder="Expected outcome"
+              className="mt-2 h-7 text-[12px]"
+            />
+          )}
           <p className="mt-1.5 text-[11px] text-muted-foreground">
-            Capture reason:{" "}
-            <span className="font-medium text-foreground">
-              {CAPTURE_REASON_LABEL[inferredReason]}
-            </span>
+            The recorded output is never used as the expected answer automatically.
           </p>
         </FormCard>
 
-        <EditableValueBlock
-          label="Input"
-          text={input}
-          onChange={setInput}
-          copyable
-          // Read + hand-edited most, and usually the most nested → expand it.
-          seedJson="expanded"
-          boxed
-          minRows={2}
-          collapsible
-          collapseResetKey={span?.span_id}
-        />
-
-        <div>
-          <EditableValueBlock
-            label="Output"
-            text={output}
-            onChange={(v) => {
-              setOutput(v);
-              setOutputEdited(true);
-            }}
-            copyable
-            // Read and possibly hand-corrected — expand it like Input.
-            seedJson="expanded"
-            boxed
-            minRows={2}
-            collapsible
-            collapseResetKey={span?.span_id}
-          />
-          <p className="mt-1 flex items-start gap-1.5 text-[11px] text-muted-foreground">
-            <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
-            {outputEdited ? (
-              <span>
-                Edited — your version becomes the{" "}
-                <span className="font-medium text-foreground">expected outcome</span>; the original
-                recorded output is still stored.
-              </span>
-            ) : (
-              <span>
-                The recorded production output. Leave it to grade against it, or edit to set a
-                corrected <span className="font-medium text-foreground">expected outcome</span> —
-                the recorded output is kept either way.
-              </span>
-            )}
-          </p>
-        </div>
-
-        <EditableValueBlock
-          label="Metadata"
-          text={metadata}
-          onChange={setMetadata}
-          copyable
-          // Incidental context, usually one or two short keys → keep it inline
-          // (seedFormat expands it anyway once it stops fitting on one line).
-          seedJson="compact"
-          boxed
-          minRows={2}
-          collapsible
-          collapseResetKey={span?.span_id}
-        />
-
-        <div className="border border-border">
-          <div className="flex items-center justify-between border-b border-border bg-muted/50 px-3 py-1.5">
-            <span className="text-[12px] font-medium text-muted-foreground">Source</span>
-            <Switch checked={attachSource} onCheckedChange={setAttachSource} />
-          </div>
-          {attachSource ? (
-            <div className="p-3">
-              <dl className="flex flex-col gap-1 text-[11px]">
-                <div className="flex justify-between gap-3">
-                  <dt className="text-muted-foreground">Source trace</dt>
-                  <dd className="font-mono text-muted-foreground">{traceId}</dd>
-                </div>
-                <div className="flex justify-between gap-3">
-                  <dt className="text-muted-foreground">Source span</dt>
-                  <dd className="font-mono text-muted-foreground">{span?.span_id ?? "—"}</dd>
-                </div>
-              </dl>
-            </div>
-          ) : (
-            <div className="p-3">
-              <p className="text-[11px] text-muted-foreground">
-                Added as a manual case — no source trace or span is linked.
-              </p>
-            </div>
-          )}
-        </div>
-
         <p className="text-[11px] text-muted-foreground">
-          This case will start as <span className="font-medium text-foreground">Needs review</span>.
-          Review it from the dataset row.
+          This case will start as <span className="font-medium text-foreground">Needs review</span>{" "}
+          and publishes a new dataset version.
         </p>
       </div>
 
       <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border px-4 py-3">
         {feedback && (
           <span
-            className={cn(
-              "mr-auto text-[11px]",
+            className={
               feedback.tone === "error"
-                ? "text-destructive"
-                : "text-emerald-600 dark:text-emerald-400",
-            )}
+                ? "mr-auto text-[11px] text-destructive"
+                : "mr-auto text-[11px] text-emerald-600 dark:text-emerald-400"
+            }
           >
             {feedback.text}
           </span>
@@ -477,23 +246,14 @@ export function SaveTestCaseDrawer({
         >
           Cancel
         </Button>
-        {duplicate ? (
-          <Link
-            href={`/projects/${projectId}/datasets/${duplicate.datasetId}`}
-            className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-          >
-            <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
-            Open existing test case
-          </Link>
-        ) : (
-          <Button size="sm" className="h-7 text-[12px]" onClick={handleSave} disabled={!canSave}>
-            {creatingNew
-              ? "Create dataset & save"
-              : datasetId
-                ? `Save to ${dataset?.name ?? "dataset"}`
-                : "Save"}
-          </Button>
-        )}
+        <Button
+          size="sm"
+          className="h-7 text-[12px]"
+          onClick={handleSave}
+          disabled={!span || !datasetId || save.isPending}
+        >
+          {save.isPending ? "Saving…" : "Save to dataset"}
+        </Button>
       </div>
     </div>
   );
@@ -527,137 +287,5 @@ export function TraceEvaluationChip({
         Run #{run.runNumber} · {run.candidateVersion}
       </span>
     </Link>
-  );
-}
-
-type Lang = "python" | "typescript";
-
-/** e.g. "Billing routing" → "billing-routing". */
-function slugify(name: string): string {
-  return name.trim().toLowerCase().replace(/\s+/g, "-");
-}
-
-/**
- * A 4-line initDataset snippet for one language — identical in shape to the
- * DatasetInfoChip. Indents differ on purpose: 4 spaces for
- * Python (PEP 8), 2 for TypeScript (Prettier).
- */
-function sdkSnippet(lang: Lang, projectName: string, datasetSlug: string, version: string): string {
-  if (lang === "python") {
-    return `traceroot.init_dataset("${projectName}", {\n    "dataset": "${datasetSlug}",\n    "version": "${version}",\n})`;
-  }
-  return `traceroot.initDataset("${projectName}", {\n  dataset: "${datasetSlug}",\n  version: "${version}",\n});`;
-}
-
-/** SDK init snippet with a Python / TypeScript toggle — one shown at a time. */
-function DatasetSdkSnippet({
-  projectName,
-  datasetName,
-  version,
-}: {
-  projectName: string;
-  datasetName: string;
-  version: string;
-}) {
-  const [lang, setLang] = React.useState<Lang>("python");
-  const code = sdkSnippet(lang, projectName, slugify(datasetName), version);
-  return (
-    <div className="overflow-hidden rounded border border-border">
-      <div className="flex items-center justify-between border-b border-border bg-muted/50 px-1.5 py-1">
-        <div className="flex items-center gap-0.5">
-          {(["python", "typescript"] as Lang[]).map((l) => (
-            <button
-              key={l}
-              type="button"
-              onClick={() => setLang(l)}
-              className={cn(
-                "rounded px-1.5 py-0.5 text-xs font-medium transition-colors",
-                lang === l
-                  ? "bg-background text-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              {l === "python" ? "Python" : "TypeScript"}
-            </button>
-          ))}
-        </div>
-        <CopyButton value={code} className="h-6 w-6" iconClassName="h-3.5 w-3.5" title="Copy" />
-      </div>
-      {/* pb-6 so the horizontal scrollbar at the pre's bottom doesn't overlap the
-          last line (it scrolls in both axes with a small max height). */}
-      <pre className="max-h-48 overflow-auto whitespace-pre px-2.5 pb-6 pt-2 font-mono text-xs leading-relaxed">
-        {tokenizeCode(code).map((t, i) => (
-          <span key={i} className={t.cls || undefined}>
-            {t.text}
-          </span>
-        ))}
-      </pre>
-    </div>
-  );
-}
-
-/**
- * "Dataset:" chip shown on a span that already backs a test case — the trace-
- * viewer marker for a span that's been saved to a dataset. Renders one chip per
- * dataset the span belongs to (current version only), each linking to it, with a
- * hover card carrying the dataset's version, last-updated, case count, and a
- * copyable SDK snippet. Nothing renders when the span isn't a saved case.
- */
-export function SpanDatasetChip({
-  projectId,
-  traceId,
-  spanId,
-}: {
-  projectId: string;
-  traceId: string;
-  spanId: string;
-}) {
-  const { data } = useTraceTestCases(projectId, traceId);
-  const { data: project } = useProject(projectId);
-  const projectName = project?.name ?? "your-project";
-  const matches = (data?.data ?? []).filter((c) => c.sourceSpanId === spanId);
-  if (matches.length === 0) return null;
-  return (
-    <TooltipProvider delayDuration={150}>
-      {matches.map((c) => (
-        <Tooltip key={`${c.datasetId}:${c.testCaseId}`}>
-          <TooltipTrigger asChild>
-            <Link
-              href={`/projects/${projectId}/datasets/${c.datasetId}`}
-              className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors hover:bg-muted"
-              title={`In dataset ${c.datasetName}`}
-            >
-              <Database className="h-3 w-3 text-muted-foreground" aria-hidden />
-              <span className="text-muted-foreground">Dataset:</span>
-              <span className="font-medium">{c.datasetName}</span>
-            </Link>
-          </TooltipTrigger>
-          <TooltipContent
-            align="start"
-            className="w-[540px] max-w-[92vw] border bg-popover px-3 pb-2 pt-3 text-xs text-popover-foreground shadow-md"
-          >
-            <div className="mb-2">
-              <div className="font-semibold">{c.datasetName}</div>
-              <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-0.5 text-muted-foreground">
-                <span>
-                  Version <span className="font-mono">{c.datasetVersionLabel}</span>
-                </span>
-                <span className="inline-flex items-center gap-1">
-                  Updated <Timestamp iso={c.datasetUpdatedAt} />
-                </span>
-                <span>
-                  {c.caseCount} {c.caseCount === 1 ? "case" : "cases"}
-                </span>
-              </div>
-            </div>
-            <DatasetSdkSnippet
-              projectName={projectName}
-              datasetName={c.datasetName}
-              version={c.datasetVersionLabel}
-            />
-          </TooltipContent>
-        </Tooltip>
-      ))}
-    </TooltipProvider>
   );
 }

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -14,6 +14,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { CopyButton } from "@/components/ui/copy-button";
 import { cn } from "@/lib/utils";
 import { getTrace } from "@/lib/api/traces";
 import { SpanKindIcon, useSpanIO } from "@/features/traces";
@@ -21,14 +23,21 @@ import {
   FormCard,
   EditableValueBlock,
   LineNumberedTextarea,
+  Timestamp,
 } from "@/features/offline-eval/components";
+import { datasetInitCode, datasetInitCodeTs } from "@/features/offline-eval/utils";
 import {
   CAPTURE_REASON_LABEL,
   SPAN_KIND_LABEL,
   type CaptureReason,
 } from "@/features/offline-eval/types";
 import type { Span } from "@/types/api";
-import { useDatasets, useCreateDataset, useTraceEvaluationResults } from "../hooks";
+import {
+  useDatasets,
+  useCreateDataset,
+  useTraceEvaluationResults,
+  useTraceTestCases,
+} from "../hooks";
 
 /** Sentinel dataset-select value for "create a new dataset". */
 const NEW_DATASET = "__new__";
@@ -178,7 +187,11 @@ export function SaveTestCaseDrawer({
       }
       return res.json() as Promise<{ duplicate: boolean; testCaseId?: string; versionId?: string }>;
     },
-    onSuccess: () => void qc.invalidateQueries({ queryKey: ["datasets"] }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["datasets"] });
+      // Refresh the span→dataset chips so the just-saved span is marked at once.
+      void qc.invalidateQueries({ queryKey: ["evaluations", "trace-test-cases"] });
+    },
   });
 
   if (!open || !traceId) return null;
@@ -532,5 +545,98 @@ export function TraceEvaluationChip({
         Run #{run.runNumber} · {run.candidateVersion}
       </span>
     </Link>
+  );
+}
+
+/** Small SDK-snippet card with a Python / TypeScript toggle (one shown at a time). */
+function DatasetSdkSnippet({ datasetName }: { datasetName: string }) {
+  const [lang, setLang] = React.useState<"python" | "typescript">("python");
+  const code = lang === "python" ? datasetInitCode(datasetName) : datasetInitCodeTs(datasetName);
+  return (
+    <div className="overflow-hidden rounded border border-border">
+      <div className="flex items-center justify-between border-b border-border bg-muted/50 px-1.5 py-1">
+        <div className="flex items-center gap-0.5">
+          {(["python", "typescript"] as const).map((l) => (
+            <button
+              key={l}
+              type="button"
+              onClick={() => setLang(l)}
+              className={cn(
+                "rounded px-1.5 py-0.5 text-xs font-medium transition-colors",
+                lang === l
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {l === "python" ? "Python" : "TypeScript"}
+            </button>
+          ))}
+        </div>
+        <CopyButton value={code} className="h-6 w-6" iconClassName="h-3.5 w-3.5" title="Copy" />
+      </div>
+      <pre className="max-h-48 overflow-auto whitespace-pre px-2.5 py-2 font-mono text-xs leading-relaxed">
+        {code}
+      </pre>
+    </div>
+  );
+}
+
+/**
+ * "Dataset:" chip shown on a span that already backs a test case — the trace-
+ * viewer marker for a span that's been saved to a dataset. Renders one chip per
+ * dataset the span belongs to (current version only), each linking to it, with a
+ * hover card carrying the dataset's version, last-updated, case count, and a
+ * copyable SDK snippet. Nothing renders when the span isn't a saved case.
+ */
+export function SpanDatasetChip({
+  projectId,
+  traceId,
+  spanId,
+}: {
+  projectId: string;
+  traceId: string;
+  spanId: string;
+}) {
+  const { data } = useTraceTestCases(projectId, traceId);
+  const matches = (data?.data ?? []).filter((c) => c.sourceSpanId === spanId);
+  if (matches.length === 0) return null;
+  return (
+    <TooltipProvider delayDuration={150}>
+      {matches.map((c) => (
+        <Tooltip key={`${c.datasetId}:${c.testCaseId}`}>
+          <TooltipTrigger asChild>
+            <Link
+              href={`/projects/${projectId}/datasets/${c.datasetId}`}
+              className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors hover:bg-muted"
+              title={`In dataset ${c.datasetName}`}
+            >
+              <Database className="h-3 w-3 text-muted-foreground" aria-hidden />
+              <span className="text-muted-foreground">Dataset:</span>
+              <span className="font-medium">{c.datasetName}</span>
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent
+            align="start"
+            className="w-[540px] max-w-[92vw] border bg-popover px-3 pb-2 pt-3 text-xs text-popover-foreground shadow-md"
+          >
+            <div className="mb-2">
+              <div className="font-semibold">{c.datasetName}</div>
+              <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-0.5 text-muted-foreground">
+                <span>
+                  Version <span className="font-mono">{c.datasetVersionLabel}</span>
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  Updated <Timestamp iso={c.datasetUpdatedAt} />
+                </span>
+                <span>
+                  {c.caseCount} {c.caseCount === 1 ? "case" : "cases"}
+                </span>
+              </div>
+            </div>
+            <DatasetSdkSnippet datasetName={c.datasetName} />
+          </TooltipContent>
+        </Tooltip>
+      ))}
+    </TooltipProvider>
   );
 }

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -16,7 +16,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import { getTrace } from "@/lib/api/traces";
-import { SpanKindIcon } from "@/features/traces";
+import { SpanKindIcon, useSpanIO } from "@/features/traces";
 import {
   FormCard,
   EditableValueBlock,
@@ -134,14 +134,22 @@ export function SaveTestCaseDrawer({
   }, [trace, selectedSpanId, spans, root]);
   const isRoot = !!span && !span.parent_span_id;
 
-  // Input / recorded output / metadata follow the selected span (incl. nav).
+  // The trace-detail response OMITS span input/output/metadata — they are fetched
+  // per span on demand (getSpanIO), so read them from that hook, not the span.
+  const { data: spanIO } = useSpanIO(projectId, traceId ?? "", span?.span_id ?? null);
+
+  // Input / recorded output / metadata follow the fetched span I/O (incl. nav).
   React.useEffect(() => {
-    if (open && span) {
-      setInput(span.input ?? "");
-      setMetadata(prettyJson(span.metadata));
-      setDuplicate(null);
+    if (open && spanIO) {
+      setInput(spanIO.input ?? "");
+      setMetadata(prettyJson(spanIO.metadata));
     }
-  }, [open, span]);
+  }, [open, spanIO]);
+
+  // Reset the duplicate note whenever the selected span changes.
+  React.useEffect(() => {
+    if (open) setDuplicate(null);
+  }, [open, span?.span_id]);
 
   // Non-modal: Escape closes this panel without touching the trace behind it.
   React.useEffect(() => {
@@ -178,7 +186,7 @@ export function SaveTestCaseDrawer({
   const creatingNew = datasetId === NEW_DATASET;
   const dataset = datasets.find((item) => item.id === datasetId);
   const displayKind = isRoot ? "trace" : (span?.span_kind ?? "SPAN");
-  const recordedOutput = span?.output ?? "";
+  const recordedOutput = spanIO?.output ?? "";
   const currentIndex = span ? spans.findIndex((s) => s.span_id === span.span_id) : -1;
   const canNavigateUp = currentIndex > 0;
   const canNavigateDown = currentIndex >= 0 && currentIndex < spans.length - 1;

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -130,15 +130,21 @@ export function SaveTestCaseDrawer({
     if (open) {
       setDatasetId("");
       setNewDatasetName("");
-      setSelectedSpanId(spanId);
       setAttachSource(true);
       setExpectedMode("none");
       setCorrectedExpected("");
       setDuplicate(null);
       setFeedback(null);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
+
+  // Follow the tree: when the parent retargets the span — a click on a different
+  // span in the span tree while this drawer is open — select it here too. The
+  // drawer's own up/down nav sets internal state without changing this prop, so
+  // it keeps working; only a genuine tree selection re-syncs.
+  React.useEffect(() => {
+    setSelectedSpanId(spanId);
+  }, [spanId]);
 
   const spans = React.useMemo(() => trace?.spans ?? [], [trace]);
   const root = trace ? rootSpan(spans) : undefined;

--- a/frontend/ui/src/features/evaluations/save-test-case-format.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-test-case-format.smoke.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+/**
+ * Per-field seed formats in the real Save-as-test-case drawer.
+ *
+ * The mode a captured value opens in is a property of the FIELD, not of however
+ * the instrumented app serialised it: Input and Recorded output expand (they are
+ * read and edited closely, and the recorded output may become the expected
+ * outcome), while Metadata stays on one line (incidental context). The seeded
+ * text is normalised to match, so what is saved is canonical.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("@/lib/api/traces", () => ({
+  getTrace: vi.fn(async () => ({
+    trace_id: "t1",
+    spans: [
+      {
+        span_id: "root",
+        parent_span_id: null,
+        name: "support-ticket-triage",
+        span_kind: "AGENT",
+        status: "OK",
+        metadata: null,
+      },
+    ],
+  })),
+}));
+
+// The span I/O the drawer seeds from: COMPACT JSON input/output and PRETTY
+// metadata — i.e. the opposite of the intended presentation, so the assertions
+// prove the field's preference wins over the captured serialisation.
+// Stable identity: the drawer re-seeds its fields whenever the span-I/O object
+// changes, so a fresh literal per render would clobber the normalised value.
+const spanIO = vi.hoisted(() => ({
+  data: {
+    input: '{"message":"I was charged twice","channel":"email"}',
+    output: '{"route":"billing"}',
+    metadata: '{\n  "suite": "smoke"\n}',
+  },
+}));
+vi.mock("@/features/traces", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/traces")>();
+  return { ...actual, useSpanIO: () => spanIO };
+});
+
+import { SaveTestCaseDrawer } from "./components/trace-integration";
+
+beforeEach(() => {
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      data: [{ id: "ds1", name: "Billing routing", caseCount: 2, versionCount: 1 }],
+      meta: { page: 0, limit: 200, total: 1 },
+    }),
+  })) as unknown as typeof fetch;
+});
+afterEach(() => cleanup());
+
+function mount() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <SaveTestCaseDrawer projectId="p1" traceId="t1" open onOpenChange={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+/**
+ * The field's value. LineNumberedTextarea appends a trailing newline purely so
+ * the last line's gutter renders (the stored value never keeps it), so trim it.
+ */
+const valueOf = (label: string) =>
+  (screen.getByLabelText(label) as HTMLTextAreaElement).value.trimEnd();
+
+describe("save-as-test-case seed formats", () => {
+  it("expands Input even though it was captured compact", async () => {
+    mount();
+    await screen.findByText("support-ticket-triage");
+    const input = valueOf("Input");
+    expect(input).toContain("\n"); // pretty, not the captured one-liner
+    expect(input).toContain('  "message": "I was charged twice"');
+  });
+
+  it("keeps Metadata on one line even though it was captured indented", async () => {
+    mount();
+    await screen.findByText("support-ticket-triage");
+    expect(valueOf("Metadata")).toBe('{"suite":"smoke"}');
+  });
+
+  it("expands Recorded output — it may become the expected outcome", async () => {
+    mount();
+    await screen.findByText("support-ticket-triage");
+    const output = valueOf("Recorded output");
+    expect(output).toContain("\n");
+    expect(output).toContain('  "route": "billing"');
+  });
+});

--- a/frontend/ui/src/features/evaluations/save-test-case-format.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-test-case-format.smoke.test.tsx
@@ -90,10 +90,10 @@ describe("save-as-test-case seed formats", () => {
     expect(valueOf("Metadata")).toBe('{"suite":"smoke"}');
   });
 
-  it("expands Recorded output — it may become the expected outcome", async () => {
+  it("expands Output — the editable field that becomes the expected outcome", async () => {
     mount();
     await screen.findByText("support-ticket-triage");
-    const output = valueOf("Recorded output");
+    const output = valueOf("Output");
     expect(output).toContain("\n");
     expect(output).toContain('  "route": "billing"');
   });

--- a/frontend/ui/src/features/evaluations/save-test-case-format.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-test-case-format.smoke.test.tsx
@@ -35,6 +35,9 @@ vi.mock("@/lib/api/traces", () => ({
 // changes, so a fresh literal per render would clobber the normalised value.
 const spanIO = vi.hoisted(() => ({
   data: {
+    // Must match the selected span's id — the drawer only treats the I/O as ready
+    // (seeds fields, enables Save) when spanIO.span_id === span.span_id.
+    span_id: "root",
     input: '{"message":"I was charged twice","channel":"email"}',
     output: '{"route":"billing"}',
     metadata: '{\n  "suite": "smoke"\n}',

--- a/frontend/ui/src/features/evaluations/save-test-case-span-sync.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-test-case-span-sync.smoke.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+/**
+ * While the Save-as-test-case drawer is open, clicking a different span in the
+ * trace tree retargets the drawer to that span. The page keeps `spanId` in sync
+ * with the tree selection (via TraceViewerPanel's onSelectionChange); the drawer
+ * follows that prop, so its "Selected span" updates without reopening.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("@/lib/api/traces", () => ({
+  getTrace: vi.fn(async () => ({
+    trace_id: "t1",
+    spans: [
+      {
+        span_id: "root",
+        parent_span_id: null,
+        name: "triage-agent",
+        span_kind: "AGENT",
+        status: "OK",
+        metadata: null,
+      },
+      {
+        span_id: "llm",
+        parent_span_id: "root",
+        name: "anthropic.messages",
+        span_kind: "LLM",
+        status: "OK",
+        metadata: null,
+      },
+    ],
+  })),
+}));
+
+// Distinct I/O per span, so the "Selected span" swap is observable.
+vi.mock("@/features/traces", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/traces")>();
+  return {
+    ...actual,
+    useSpanIO: (_p: string, _t: string, spanId: string | null) => ({
+      data:
+        spanId === "llm"
+          ? { input: "llm-input", metadata: null }
+          : { input: "root-input", metadata: null },
+    }),
+  };
+});
+
+import { SaveTestCaseDrawer } from "./components/trace-integration";
+
+beforeEach(() => {
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      data: [{ id: "ds1", name: "Billing routing", caseCount: 2, versionCount: 1 }],
+      meta: { page: 0, limit: 200, total: 1 },
+    }),
+  })) as unknown as typeof fetch;
+});
+afterEach(() => cleanup());
+
+function renderDrawer(spanId: string | undefined) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <SaveTestCaseDrawer
+        projectId="p1"
+        traceId="t1"
+        spanId={spanId}
+        open
+        onOpenChange={() => {}}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("drawer follows the tree selection", () => {
+  it("retargets the selected span when the spanId prop changes while open", async () => {
+    const { rerender } = renderDrawer("root");
+    expect(await screen.findByText("triage-agent")).toBeDefined();
+
+    // Simulate a click on the LLM span in the tree (page pushes the new spanId).
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    rerender(
+      <QueryClientProvider client={qc}>
+        <SaveTestCaseDrawer projectId="p1" traceId="t1" spanId="llm" open onOpenChange={() => {}} />
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByText("anthropic.messages")).toBeDefined();
+    expect(screen.queryByText("triage-agent")).toBeNull();
+  });
+});

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -111,7 +111,11 @@ export function DatasetDetailView({
   // null = the current version. Selecting an older version loads its snapshot
   // (read-only — editing always branches from the current version).
   const [selectedVersionId, setSelectedVersionId] = React.useState<string | null>(null);
-  const { data, isLoading, error, refetch } = useDataset(projectId, datasetId, selectedVersionId);
+  const { data, isLoading, error, refetch, isFetching } = useDataset(
+    projectId,
+    datasetId,
+    selectedVersionId,
+  );
   const save = useSaveTestCase(projectId, datasetId);
   const update = useUpdateTestCase(projectId, datasetId);
 
@@ -148,7 +152,10 @@ export function DatasetDetailView({
   // to `undefined === null` -> false on the server, which would otherwise lock
   // the page read-only before the first row can ever be added.
   const hasVersions = versions.length > 0;
-  const isCurrentVersion = !hasVersions || (data?.isCurrentVersion ?? true);
+  // While a newly-selected version is still loading, `data` reflects the PREVIOUS
+  // snapshot, so treat the page as non-current (read-only) until the fetch settles —
+  // otherwise a click mid-fetch would edit/publish against the wrong version.
+  const isCurrentVersion = (!hasVersions || (data?.isCurrentVersion ?? true)) && !isFetching;
   const allCases = React.useMemo(() => data?.testCases ?? [], [data]);
 
   const cases = React.useMemo(() => {
@@ -349,7 +356,9 @@ export function DatasetDetailView({
                 {selectedVersion?.label ? ` · ${selectedVersion.label}` : ""} — read only.{" "}
                 <button
                   type="button"
-                  onClick={() => setSelectedVersionId(data.currentVersion?.id ?? null)}
+                  // null = follow the LIVE current pointer. Pinning the current version's
+                  // id would strand the page on a now-historical version after the next edit.
+                  onClick={() => setSelectedVersionId(null)}
                   className="underline underline-offset-2"
                 >
                   Back to current
@@ -675,15 +684,17 @@ function CasePanel({
   const [expectedText, setExpectedText] = React.useState(testCase.expected ?? "");
   const [metadataText, setMetadataText] = React.useState(initialMetadata);
 
-  // Re-seed only when the case identity changes, not on every value change —
-  // otherwise a background refetch (60s staleTime, cross-tab sync) that pulls in
-  // a new server value stomps text the user is mid-way through typing.
+  // Re-seed on the per-version ROW id, not the stable testCaseId. A save or a
+  // snapshot switch publishes a NEW version — same testCaseId, new row id and values —
+  // so keying on the row id refreshes the buffer to the just-saved/selected values
+  // (otherwise a successful metadata save looks lost). A same-version background
+  // refetch keeps the same row id, so it still can't stomp in-progress typing.
   React.useEffect(() => {
     setInputText(testCase.input);
     setExpectedText(testCase.expected ?? "");
     setMetadataText(initialMetadata);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [testCase.testCaseId]);
+  }, [testCase.id]);
 
   const dirty =
     !readOnly &&

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -296,6 +296,11 @@ export function DatasetDetailView({
               <span className="font-mono text-xs font-normal text-muted-foreground">
                 {dataset.id}
               </span>
+              <CopyButton
+                value={dataset.id}
+                className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                title="Copy dataset ID"
+              />
             </span>
           }
         />

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -111,7 +111,11 @@ export function DatasetDetailView({
   // null = the current version. Selecting an older version loads its snapshot
   // (read-only — editing always branches from the current version).
   const [selectedVersionId, setSelectedVersionId] = React.useState<string | null>(null);
-  const { data, isLoading, error, refetch } = useDataset(projectId, datasetId, selectedVersionId);
+  const { data, isLoading, error, refetch, isFetching } = useDataset(
+    projectId,
+    datasetId,
+    selectedVersionId,
+  );
   const save = useSaveTestCase(projectId, datasetId);
   const update = useUpdateTestCase(projectId, datasetId);
 
@@ -148,7 +152,10 @@ export function DatasetDetailView({
   // to `undefined === null` -> false on the server, which would otherwise lock
   // the page read-only before the first row can ever be added.
   const hasVersions = versions.length > 0;
-  const isCurrentVersion = !hasVersions || (data?.isCurrentVersion ?? true);
+  // While a newly-selected version is still loading, `data` reflects the PREVIOUS
+  // snapshot, so treat the page as non-current (read-only) until the fetch settles —
+  // otherwise a click mid-fetch would edit/publish against the wrong version.
+  const isCurrentVersion = (!hasVersions || (data?.isCurrentVersion ?? true)) && !isFetching;
   const allCases = React.useMemo(() => data?.testCases ?? [], [data]);
 
   const cases = React.useMemo(() => {
@@ -189,15 +196,16 @@ export function DatasetDetailView({
     };
   }, [reviewCase, dataset]);
 
-  const submitReview = (result: { review: ReviewStatus; correctedExpected?: string }) => {
+  const submitReview = async (result: { review: ReviewStatus; correctedExpected?: string }) => {
     if (!reviewCase) return;
-    update.mutate(
-      {
-        testCaseId: reviewCase.testCaseId,
-        patch: {
-          review: result.review,
-          ...(result.correctedExpected ? { expected: result.correctedExpected } : {}),
-        },
+    // Return the promise so the drawer only reports success / closes once the publish
+    // actually lands, and stays open (input intact) on failure. The drawer owns the
+    // success toast + close; a rejection there keeps the reviewer's work.
+    await update.mutateAsync({
+      testCaseId: reviewCase.testCaseId,
+      patch: {
+        review: result.review,
+        ...(result.correctedExpected ? { expected: result.correctedExpected } : {}),
       },
       {
         onSuccess: () => {
@@ -349,7 +357,9 @@ export function DatasetDetailView({
                 {selectedVersion?.label ? ` · ${selectedVersion.label}` : ""} — read only.{" "}
                 <button
                   type="button"
-                  onClick={() => setSelectedVersionId(data.currentVersion?.id ?? null)}
+                  // null = follow the LIVE current pointer. Pinning the current version's
+                  // id would strand the page on a now-historical version after the next edit.
+                  onClick={() => setSelectedVersionId(null)}
                   className="underline underline-offset-2"
                 >
                   Back to current
@@ -675,15 +685,17 @@ function CasePanel({
   const [expectedText, setExpectedText] = React.useState(testCase.expected ?? "");
   const [metadataText, setMetadataText] = React.useState(initialMetadata);
 
-  // Re-seed only when the case identity changes, not on every value change —
-  // otherwise a background refetch (60s staleTime, cross-tab sync) that pulls in
-  // a new server value stomps text the user is mid-way through typing.
+  // Re-seed on the per-version ROW id, not the stable testCaseId. A save or a
+  // snapshot switch publishes a NEW version — same testCaseId, new row id and values —
+  // so keying on the row id refreshes the buffer to the just-saved/selected values
+  // (otherwise a successful metadata save looks lost). A same-version background
+  // refetch keeps the same row id, so it still can't stomp in-progress typing.
   React.useEffect(() => {
     setInputText(testCase.input);
     setExpectedText(testCase.expected ?? "");
     setMetadataText(initialMetadata);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [testCase.testCaseId]);
+  }, [testCase.id]);
 
   const dirty =
     !readOnly &&

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -957,7 +957,7 @@ function ScorerDetail({
           {scorer.sourceCode ? (
             <HighlightedCode
               code={scorer.sourceCode}
-              className="max-h-[45vh] overflow-auto whitespace-pre font-mono text-[11px] leading-relaxed"
+              className="max-h-[45vh] overflow-auto whitespace-pre font-mono text-[12px] leading-relaxed"
             />
           ) : (
             <NotProvided />
@@ -970,6 +970,7 @@ function ScorerDetail({
               value={systemPrompt}
               onChange={() => {}}
               readOnly
+              fontClassName="text-[12px] leading-[20px]"
               aria-label="System prompt"
             />
           ) : (

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -24,7 +24,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { SearchFilterBar } from "@/components/search-filter-bar";
-import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
+import { DATE_FILTER_OPTIONS, toTimestampBounds, type DateFilterOption } from "@/lib/date-filter";
 import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
 import { Input } from "@/components/ui/input";
 import { CopyButton } from "@/components/ui/copy-button";
@@ -432,11 +432,20 @@ function RunsTab({ projectId }: { projectId: string }) {
   const [expanded, setExpanded] = React.useState<Set<string>>(new Set());
 
   const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
+  // Resolve the selected range to actual bounds and send them to the query — the date
+  // control was previously read for display only, so it never narrowed the runs list.
+  const { startAfter, endBefore } = toTimestampBounds(
+    dateFilter.id,
+    customStart ?? undefined,
+    customEnd ?? undefined,
+  );
   const { data, isLoading, error } = useEvaluationRuns(projectId, {
     evaluation_id: scopedEvalId ?? undefined,
     search_query: keyword.trim() || undefined,
     dataset_id: datasetFilter === ALL ? undefined : datasetFilter,
     status: statusFilter === ALL ? undefined : statusFilter,
+    started_after: startAfter,
+    started_before: endBefore,
   });
   const allRuns = React.useMemo(() => data?.data ?? [], [data]);
   const filtered = !!keyword || datasetFilter !== ALL || statusFilter !== ALL;

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -572,12 +572,16 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
         open={reviewOpen}
         onOpenChange={setReviewOpen}
         onSave={(review) =>
-          humanScore.mutate({
-            verdict: review.verdict,
-            quality: review.quality ?? null,
-            comment: review.comment ?? null,
-            reviewer: review.reviewer,
-          })
+          // Return the promise so the panel awaits persistence — a failed human-score
+          // request is no longer shown as saved.
+          humanScore
+            .mutateAsync({
+              verdict: review.verdict,
+              quality: review.quality ?? null,
+              comment: review.comment ?? null,
+              reviewer: review.reviewer,
+            })
+            .then(() => {})
         }
       />
 

--- a/frontend/ui/src/features/offline-eval/components/code.review.test.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.review.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+/**
+ * EditableValueBlock's `seedJson` re-seed effect. It must normalise a freshly
+ * seeded value exactly once (per `collapseResetKey`) and then leave the field
+ * alone — the effect keeps `text` in its dependency array so it can seed once
+ * real content arrives, but re-running it on every keystroke would fight the
+ * user's own typing (any in-progress edit that happens to parse as JSON gets
+ * pretty-printed out from under the cursor).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { render, cleanup, fireEvent, screen } from "@testing-library/react";
+import * as React from "react";
+import { EditableValueBlock } from "./code";
+
+afterEach(cleanup);
+
+/** Mirrors how a real caller (e.g. the Save-as-test-case drawer) wires this up:
+ *  the block's own value lives in the parent, `onChange` writes it back, and a
+ *  new seed is applied to that same state in lockstep with `collapseResetKey`
+ *  (the drawer's `seedGeneration` bumps together with `setInput`/`setOutput`/
+ *  `setMetadata`, in the very same effect, so the two always change in one
+ *  commit — never `collapseResetKey` alone, one render ahead of the text). */
+function Harness({ seedText, collapseResetKey }: { seedText: string; collapseResetKey?: string }) {
+  const [text, setText] = React.useState(seedText);
+  const prevKeyRef = React.useRef(collapseResetKey);
+  if (prevKeyRef.current !== collapseResetKey) {
+    prevKeyRef.current = collapseResetKey;
+    if (text !== seedText) setText(seedText);
+  }
+  return (
+    <EditableValueBlock
+      label="Output"
+      text={text}
+      onChange={setText}
+      seedJson="expanded"
+      collapseResetKey={collapseResetKey}
+    />
+  );
+}
+
+describe("EditableValueBlock — seedJson re-seeding", () => {
+  it("pretty-prints the initial (compact JSON) seed", () => {
+    render(<Harness seedText='{"a":1}' />);
+    const textarea = screen.getByLabelText("Output") as HTMLTextAreaElement;
+    expect(textarea.value).toBe('{\n  "a": 1\n}\n');
+  });
+
+  it("does not rewrite a further edit that also happens to parse as JSON", () => {
+    render(<Harness seedText='{"a":1}' />);
+    const textarea = screen.getByLabelText("Output") as HTMLTextAreaElement;
+    // The initial seed already landed (asserted above); now the user replaces the
+    // whole value with a different, still-valid, compact JSON value.
+    fireEvent.change(textarea, { target: { value: "[1,2]\n" } });
+    // A re-seed would pretty-print this to "[\n  1,\n  2\n]" and move the caret —
+    // it must instead stay exactly what was typed.
+    expect(textarea.value).toBe("[1,2]\n");
+  });
+
+  it("re-seeds once more when collapseResetKey changes (a genuinely new source)", () => {
+    const { rerender } = render(<Harness seedText='{"a":1}' collapseResetKey="span-1" />);
+    let textarea = screen.getByLabelText("Output") as HTMLTextAreaElement;
+    expect(textarea.value).toBe('{\n  "a": 1\n}\n');
+
+    rerender(<Harness seedText='{"b":2}' collapseResetKey="span-2" />);
+    textarea = screen.getByLabelText("Output") as HTMLTextAreaElement;
+    expect(textarea.value).toBe('{\n  "b": 2\n}\n');
+  });
+});

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
-import { CopyButton } from "@/components/ui/copy-button";
+import { ChevronDown } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
@@ -63,82 +62,6 @@ export function formatValue(value: unknown, kind: ValueKind): string {
   }
 }
 
-/** Trace-panel JSON token colors, mirrored so JSON reads the same everywhere. */
-const JSON_TOKEN_COLORS = {
-  key: "text-sky-600 dark:text-sky-400",
-  string: "text-green-700 dark:text-green-400",
-  number: "text-blue-600 dark:text-blue-400",
-  boolean: "text-purple-600 dark:text-purple-400",
-  null: "text-orange-600 dark:text-orange-400",
-  punctuation: "text-muted-foreground",
-};
-
-/**
- * Splits valid JSON text into colored tokens, preserving every character so the
- * result can sit exactly behind a textarea. Returns null when the text is empty
- * or not valid JSON, so the field shows as plain text mid-edit.
- */
-function tokenizeJson(text: string): { text: string; cls: string }[] | null {
-  if (text.trim() === "") return null;
-  try {
-    JSON.parse(text);
-  } catch {
-    return null;
-  }
-  const tokens: { text: string; cls: string }[] = [];
-  const n = text.length;
-  let i = 0;
-  while (i < n) {
-    const c = text[i];
-    if (c === '"') {
-      let j = i + 1;
-      while (j < n) {
-        if (text[j] === "\\") {
-          j += 2;
-          continue;
-        }
-        if (text[j] === '"') {
-          j += 1;
-          break;
-        }
-        j += 1;
-      }
-      let k = j;
-      while (k < n && /\s/.test(text[k])) k += 1;
-      const isKey = text[k] === ":";
-      tokens.push({
-        text: text.slice(i, j),
-        cls: isKey ? JSON_TOKEN_COLORS.key : JSON_TOKEN_COLORS.string,
-      });
-      i = j;
-    } else if (c === "-" || (c >= "0" && c <= "9")) {
-      let j = i + 1;
-      while (j < n && /[0-9.eE+-]/.test(text[j])) j += 1;
-      tokens.push({ text: text.slice(i, j), cls: JSON_TOKEN_COLORS.number });
-      i = j;
-    } else if (text.startsWith("true", i) || text.startsWith("false", i)) {
-      const word = text.startsWith("true", i) ? "true" : "false";
-      tokens.push({ text: word, cls: JSON_TOKEN_COLORS.boolean });
-      i += word.length;
-    } else if (text.startsWith("null", i)) {
-      tokens.push({ text: "null", cls: JSON_TOKEN_COLORS.null });
-      i += 4;
-    } else if ("{}[],:".includes(c)) {
-      tokens.push({ text: c, cls: JSON_TOKEN_COLORS.punctuation });
-      i += 1;
-    } else if (/\s/.test(c)) {
-      let j = i + 1;
-      while (j < n && /\s/.test(text[j])) j += 1;
-      tokens.push({ text: text.slice(i, j), cls: "" });
-      i = j;
-    } else {
-      tokens.push({ text: c, cls: "" });
-      i += 1;
-    }
-  }
-  return tokens;
-}
-
 function Gutter({ count }: { count: number }) {
   return (
     <div
@@ -152,108 +75,36 @@ function Gutter({ count }: { count: number }) {
   );
 }
 
-/** Splits whole-text JSON tokens into per-line arrays (newlines are consumed). */
-function tokenizeJsonByLine(text: string): { text: string; cls: string }[][] | null {
-  const tokens = tokenizeJson(text);
-  if (!tokens) return null;
-  const lines: { text: string; cls: string }[][] = [[]];
-  for (const tok of tokens) {
-    const parts = tok.text.split("\n");
-    parts.forEach((part, idx) => {
-      if (idx > 0) lines.push([]);
-      if (part !== "") lines[lines.length - 1].push({ text: part, cls: tok.cls });
-    });
-  }
-  return lines;
-}
-
 /**
- * Editable code field with a line-number gutter on the left.
- *
- * A wrapping display layer (line numbers + optional JSON colors) sits under a
- * transparent-text textarea. Because both wrap with the same font/width, a long
- * line wraps onto the next visual row while keeping a single line number pinned
- * to its top — the way a real code editor renders wrapped lines. The box rests
- * at `minRows` (blank, unnumbered space below the content) and grows one line
- * per Enter.
+ * Editable code field with a line-number gutter on the left. An empty value is
+ * a single line "1" with an empty body. Grows with the content (no scroll sync
+ * to keep the numbers aligned).
  */
 export function LineNumberedTextarea({
   value,
   onChange,
   minRows = 1,
   placeholder,
-  highlightJson = false,
-  readOnly = false,
   "aria-label": ariaLabel,
 }: {
   value: string;
   onChange: (value: string) => void;
   minRows?: number;
   placeholder?: string;
-  /** When true, JSON content is syntax-highlighted (trace-panel colors). */
-  highlightJson?: boolean;
-  /** Display only — selectable and syntax-coloured, but not editable. */
-  readOnly?: boolean;
   "aria-label"?: string;
 }) {
-  // Keep a real trailing empty line so the last line is always clickable — click
-  // it and type without pressing Enter first, and a 1-line value still shows an
-  // empty line 2. The parent value never keeps that trailing newline: it's added
-  // for display/editing and stripped from what onChange reports.
-  //
-  // The newline is appended *unconditionally*. Appending it only when the value
-  // didn't already end in one meant pressing Enter (which makes the value end in
-  // a newline) was cancelled out by the strip below, so the line count — and the
-  // box height — never grew.
-  const textValue = `${value}\n`;
-  const rawLines = textValue.split("\n");
-  const tokenLines = highlightJson ? tokenizeJsonByLine(textValue) : null;
-  const totalLines = Math.max(rawLines.length, minRows);
-  const digits = Math.max(2, String(totalLines).length);
-  const gutterWidth = `calc(${digits}ch + 1rem)`;
-
+  const lines = Math.max(value === "" ? 1 : value.split("\n").length, minRows);
   return (
-    <div className="relative overflow-hidden rounded border border-input bg-background font-mono text-[12px] leading-relaxed focus-within:ring-1 focus-within:ring-ring">
-      {/* Display layer — line numbers + (highlighted) content, wraps per line. */}
-      <div aria-hidden className="pointer-events-none py-1.5">
-        {Array.from({ length: totalLines }).map((_, i) => (
-          <div key={i} className="flex items-start">
-            <span
-              className="shrink-0 select-none border-r border-border bg-muted/40 px-2 text-right text-muted-foreground/50"
-              style={{ width: gutterWidth }}
-            >
-              {i + 1}
-            </span>
-            <span className="min-w-0 flex-1 whitespace-pre-wrap break-words px-2">
-              {tokenLines
-                ? (tokenLines[i] ?? []).map((t, ti) => (
-                    <span key={ti} className={t.cls || undefined}>
-                      {t.text}
-                    </span>
-                  ))
-                : (rawLines[i] ?? "")}
-              {"​"}
-            </span>
-          </div>
-        ))}
-      </div>
-      {/* Editing layer — transparent text lined up over the display layer. */}
+    <div className="flex overflow-hidden rounded border border-input bg-background focus-within:ring-1 focus-within:ring-ring">
+      <Gutter count={lines} />
       <textarea
-        value={textValue}
-        onChange={(e) => {
-          if (readOnly) return;
-          const v = e.target.value;
-          onChange(v.endsWith("\n") ? v.slice(0, -1) : v);
-        }}
-        readOnly={readOnly}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={lines}
         spellCheck={false}
         placeholder={placeholder}
         aria-label={ariaLabel}
-        className={cn(
-          "absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent py-1.5 pr-2 font-mono text-[12px] leading-relaxed text-transparent placeholder:text-muted-foreground focus:outline-none",
-          readOnly ? "cursor-default caret-transparent" : "caret-foreground",
-        )}
-        style={{ paddingLeft: `calc(${gutterWidth} + 0.5rem)` }}
+        className="flex-1 resize-none bg-transparent px-2 py-1.5 font-mono text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none"
       />
     </div>
   );
@@ -323,189 +174,6 @@ export function ValueBlock({
         </Popover>
       </div>
       <CodeView text={formatValue(value, kind)} />
-    </div>
-  );
-}
-
-/** Picks the initial format from the content: a JSON object/array → json, else text. */
-function detectKind(text: string): ValueKind {
-  const trimmed = text.trim();
-  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
-    try {
-      JSON.parse(trimmed);
-      // Already pretty-printed (multi-line) JSON should read as "Pretty", not
-      // "JSON" — otherwise the mode label contradicts the indented content.
-      return trimmed.includes("\n") ? "pretty" : "json";
-    } catch {
-      /* looks like JSON but isn't — fall through to text */
-    }
-  }
-  return "text";
-}
-
-/**
- * Editable counterpart to ValueBlock. The text is controlled by the caller;
- * switching the view kind reformats it best-effort (only when it parses as
- * JSON), so plain text is never mangled.
- *
- * Optional extras (all off by default, so existing callers are unchanged):
- * `copyable` adds a copy button, `autoDetectKind` picks JSON vs text from the
- * initial content, and `minRows` sets the resting height.
- */
-export function EditableValueBlock({
-  label,
-  text,
-  onChange,
-  defaultKind = "yaml",
-  ariaLabel,
-  copyable = false,
-  autoDetectKind = false,
-  minRows = 1,
-  boxed = false,
-  readOnly = false,
-}: {
-  label: string;
-  text: string;
-  onChange: (text: string) => void;
-  defaultKind?: ValueKind;
-  ariaLabel?: string;
-  copyable?: boolean;
-  autoDetectKind?: boolean;
-  minRows?: number;
-  /** Wrap the block in a bordered card with a muted header strip (like FormCard). */
-  boxed?: boolean;
-  /** Display only — same look and format switcher, but the text can't be edited. */
-  readOnly?: boolean;
-}) {
-  const [kind, setKind] = React.useState<ValueKind>(defaultKind);
-  const [menuOpen, setMenuOpen] = React.useState(false);
-  // Minimised via the header chevron, like the span detail panel's I/O sections.
-  const [open, setOpen] = React.useState(true);
-  const userSetKind = React.useRef(false);
-  // Read-only fields reformat locally (the parent value never changes), so the
-  // format switcher still works without touching the source of truth.
-  const [display, setDisplay] = React.useState(text);
-  React.useEffect(() => {
-    if (readOnly) setDisplay(text);
-  }, [readOnly, text]);
-
-  // Follow the content's type — text vs JSON vs pretty JSON — whenever a new value
-  // is seeded (e.g. navigating between cases re-seeds this field), unless the user
-  // has pinned a format from the switcher. setKind is a no-op when unchanged.
-  React.useEffect(() => {
-    if (autoDetectKind && !userSetKind.current && text.trim() !== "") {
-      setKind(detectKind(text));
-    }
-  }, [autoDetectKind, text]);
-
-  const changeKind = (next: ValueKind) => {
-    userSetKind.current = true;
-    setKind(next);
-    setMenuOpen(false);
-    // Reformat only when the current text is valid JSON; otherwise leave it be.
-    try {
-      const parsed = JSON.parse(readOnly ? display : text);
-      const formatted = formatValue(parsed, next);
-      if (readOnly) setDisplay(formatted);
-      else onChange(formatted);
-    } catch {
-      /* not JSON — keep the text as typed */
-    }
-  };
-
-  const controls = (
-    <div className="flex items-center gap-0.5">
-      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          >
-            {KIND_LABEL[kind]}
-            <ChevronDown className="h-3 w-3" aria-hidden />
-          </button>
-        </PopoverTrigger>
-        <PopoverContent align="end" className="w-28 p-1">
-          {KINDS.map((k) => (
-            <button
-              key={k}
-              type="button"
-              onClick={() => changeKind(k)}
-              className={cn(
-                "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
-                k === kind ? "bg-muted/70" : "hover:bg-muted/50",
-              )}
-            >
-              {KIND_LABEL[k]}
-            </button>
-          ))}
-        </PopoverContent>
-      </Popover>
-      {copyable && (
-        <CopyButton
-          value={readOnly ? display : text}
-          className="h-6 w-6 text-muted-foreground hover:text-foreground"
-          title="Copy"
-        />
-      )}
-    </div>
-  );
-
-  const field = (
-    <LineNumberedTextarea
-      value={readOnly ? display : text}
-      onChange={onChange}
-      minRows={minRows}
-      highlightJson={kind === "json" || kind === "pretty"}
-      readOnly={readOnly}
-      aria-label={ariaLabel ?? label}
-    />
-  );
-
-  // Chevron + label: the whole thing toggles, matching the span detail panel.
-  const heading = (size: "sm" | "xs") => (
-    <button
-      type="button"
-      onClick={() => setOpen((v) => !v)}
-      aria-expanded={open}
-      className={cn(
-        "flex items-center gap-1.5 rounded font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-        size === "sm" ? "text-[12px]" : "text-[11px]",
-      )}
-    >
-      {open ? (
-        <ChevronDown className="h-3.5 w-3.5 shrink-0" aria-hidden />
-      ) : (
-        <ChevronRight className="h-3.5 w-3.5 shrink-0" aria-hidden />
-      )}
-      {label}
-    </button>
-  );
-
-  if (boxed) {
-    return (
-      <div className="border border-border">
-        <div
-          className={cn(
-            "flex items-center justify-between gap-2 bg-muted/50 px-3 py-1.5",
-            open && "border-b border-border",
-          )}
-        >
-          {heading("sm")}
-          {controls}
-        </div>
-        {open && <div className="p-3">{field}</div>}
-      </div>
-    );
-  }
-
-  return (
-    <div>
-      <div className="mb-1 flex items-center justify-between gap-2">
-        {heading("xs")}
-        {controls}
-      </div>
-      {open && field}
     </div>
   );
 }

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -177,3 +177,77 @@ export function ValueBlock({
     </div>
   );
 }
+
+/**
+ * Editable counterpart to ValueBlock. The text is controlled by the caller;
+ * switching the view kind reformats it best-effort (only when it parses as
+ * JSON), so plain text is never mangled.
+ */
+export function EditableValueBlock({
+  label,
+  text,
+  onChange,
+  defaultKind = "yaml",
+  ariaLabel,
+}: {
+  label: string;
+  text: string;
+  onChange: (text: string) => void;
+  defaultKind?: ValueKind;
+  ariaLabel?: string;
+}) {
+  const [kind, setKind] = React.useState<ValueKind>(defaultKind);
+  const [menuOpen, setMenuOpen] = React.useState(false);
+
+  const changeKind = (next: ValueKind) => {
+    setKind(next);
+    setMenuOpen(false);
+    // Reformat only when the current text is valid JSON; otherwise leave it be.
+    try {
+      const parsed = JSON.parse(text);
+      onChange(formatValue(parsed, next));
+    } catch {
+      /* not JSON — keep the text as typed */
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
+        <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              {KIND_LABEL[kind]}
+              <ChevronDown className="h-3 w-3" aria-hidden />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-28 p-1">
+            {KINDS.map((k) => (
+              <button
+                key={k}
+                type="button"
+                onClick={() => changeKind(k)}
+                className={cn(
+                  "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
+                  k === kind ? "bg-muted/70" : "hover:bg-muted/50",
+                )}
+              >
+                {KIND_LABEL[k]}
+              </button>
+            ))}
+          </PopoverContent>
+        </Popover>
+      </div>
+      <LineNumberedTextarea
+        value={text}
+        onChange={onChange}
+        minRows={1}
+        aria-label={ariaLabel ?? label}
+      />
+    </div>
+  );
+}

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Maximize2, Minimize2 } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
@@ -62,6 +63,82 @@ export function formatValue(value: unknown, kind: ValueKind): string {
   }
 }
 
+/** Trace-panel JSON token colors, mirrored so JSON reads the same everywhere. */
+const JSON_TOKEN_COLORS = {
+  key: "text-sky-600 dark:text-sky-400",
+  string: "text-green-700 dark:text-green-400",
+  number: "text-blue-600 dark:text-blue-400",
+  boolean: "text-purple-600 dark:text-purple-400",
+  null: "text-orange-600 dark:text-orange-400",
+  punctuation: "text-muted-foreground",
+};
+
+/**
+ * Splits valid JSON text into colored tokens, preserving every character so the
+ * result can sit exactly behind a textarea. Returns null when the text is empty
+ * or not valid JSON, so the field shows as plain text mid-edit.
+ */
+function tokenizeJson(text: string): { text: string; cls: string }[] | null {
+  if (text.trim() === "") return null;
+  try {
+    JSON.parse(text);
+  } catch {
+    return null;
+  }
+  const tokens: { text: string; cls: string }[] = [];
+  const n = text.length;
+  let i = 0;
+  while (i < n) {
+    const c = text[i];
+    if (c === '"') {
+      let j = i + 1;
+      while (j < n) {
+        if (text[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (text[j] === '"') {
+          j += 1;
+          break;
+        }
+        j += 1;
+      }
+      let k = j;
+      while (k < n && /\s/.test(text[k])) k += 1;
+      const isKey = text[k] === ":";
+      tokens.push({
+        text: text.slice(i, j),
+        cls: isKey ? JSON_TOKEN_COLORS.key : JSON_TOKEN_COLORS.string,
+      });
+      i = j;
+    } else if (c === "-" || (c >= "0" && c <= "9")) {
+      let j = i + 1;
+      while (j < n && /[0-9.eE+-]/.test(text[j])) j += 1;
+      tokens.push({ text: text.slice(i, j), cls: JSON_TOKEN_COLORS.number });
+      i = j;
+    } else if (text.startsWith("true", i) || text.startsWith("false", i)) {
+      const word = text.startsWith("true", i) ? "true" : "false";
+      tokens.push({ text: word, cls: JSON_TOKEN_COLORS.boolean });
+      i += word.length;
+    } else if (text.startsWith("null", i)) {
+      tokens.push({ text: "null", cls: JSON_TOKEN_COLORS.null });
+      i += 4;
+    } else if ("{}[],:".includes(c)) {
+      tokens.push({ text: c, cls: JSON_TOKEN_COLORS.punctuation });
+      i += 1;
+    } else if (/\s/.test(c)) {
+      let j = i + 1;
+      while (j < n && /\s/.test(text[j])) j += 1;
+      tokens.push({ text: text.slice(i, j), cls: "" });
+      i = j;
+    } else {
+      tokens.push({ text: c, cls: "" });
+      i += 1;
+    }
+  }
+  return tokens;
+}
+
 function Gutter({ count }: { count: number }) {
   return (
     <div
@@ -85,27 +162,52 @@ export function LineNumberedTextarea({
   onChange,
   minRows = 1,
   placeholder,
+  highlightJson = false,
   "aria-label": ariaLabel,
 }: {
   value: string;
   onChange: (value: string) => void;
   minRows?: number;
   placeholder?: string;
+  /** When true, JSON content is syntax-highlighted (trace-panel colors). */
+  highlightJson?: boolean;
   "aria-label"?: string;
 }) {
-  const lines = Math.max(value === "" ? 1 : value.split("\n").length, minRows);
+  // Gutter numbers only the real content lines; the textarea can still be taller
+  // (minRows) with blank, unnumbered space below — the way a code editor looks.
+  const contentLines = value === "" ? 1 : value.split("\n").length;
+  const rows = Math.max(contentLines, minRows);
+  const tokens = highlightJson ? tokenizeJson(value) : null;
   return (
     <div className="flex overflow-hidden rounded border border-input bg-background focus-within:ring-1 focus-within:ring-ring">
-      <Gutter count={lines} />
-      <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        rows={lines}
-        spellCheck={false}
-        placeholder={placeholder}
-        aria-label={ariaLabel}
-        className="flex-1 resize-none bg-transparent px-2 py-1.5 font-mono text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none"
-      />
+      <Gutter count={contentLines} />
+      <div className="relative flex-1">
+        {/* Colored layer sits exactly behind the transparent-text textarea. */}
+        {tokens && (
+          <pre
+            aria-hidden
+            className="pointer-events-none absolute inset-0 m-0 overflow-hidden whitespace-pre-wrap break-words px-2 py-1.5 font-mono text-[12px] leading-relaxed"
+          >
+            {tokens.map((t, i) => (
+              <span key={i} className={t.cls || undefined}>
+                {t.text}
+              </span>
+            ))}
+          </pre>
+        )}
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          rows={rows}
+          spellCheck={false}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          className={cn(
+            "relative block w-full resize-none whitespace-pre-wrap break-words bg-transparent px-2 py-1.5 font-mono text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none",
+            tokens && "text-transparent caret-foreground",
+          )}
+        />
+      </div>
     </div>
   );
 }
@@ -178,10 +280,29 @@ export function ValueBlock({
   );
 }
 
+/** Picks the initial format from the content: a JSON object/array → json, else text. */
+function detectKind(text: string): ValueKind {
+  const trimmed = text.trim();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      JSON.parse(trimmed);
+      return "json";
+    } catch {
+      /* looks like JSON but isn't — fall through to text */
+    }
+  }
+  return "text";
+}
+
 /**
  * Editable counterpart to ValueBlock. The text is controlled by the caller;
  * switching the view kind reformats it best-effort (only when it parses as
  * JSON), so plain text is never mangled.
+ *
+ * Optional extras (all off by default, so existing callers are unchanged):
+ * `copyable` adds a copy button, `enlargeable` adds a taller/shorter toggle,
+ * `autoDetectKind` picks JSON vs text from the initial content, and `minRows`
+ * sets the resting height.
  */
 export function EditableValueBlock({
   label,
@@ -189,17 +310,38 @@ export function EditableValueBlock({
   onChange,
   defaultKind = "yaml",
   ariaLabel,
+  copyable = false,
+  enlargeable = false,
+  autoDetectKind = false,
+  minRows = 1,
 }: {
   label: string;
   text: string;
   onChange: (text: string) => void;
   defaultKind?: ValueKind;
   ariaLabel?: string;
+  copyable?: boolean;
+  enlargeable?: boolean;
+  autoDetectKind?: boolean;
+  minRows?: number;
 }) {
   const [kind, setKind] = React.useState<ValueKind>(defaultKind);
   const [menuOpen, setMenuOpen] = React.useState(false);
+  const [enlarged, setEnlarged] = React.useState(false);
+  const userSetKind = React.useRef(false);
+  const detected = React.useRef(false);
+
+  // Detect JSON vs text once, when the value first arrives (e.g. after a dialog
+  // seeds it), unless the user has already chosen a format from the switcher.
+  React.useEffect(() => {
+    if (autoDetectKind && !userSetKind.current && !detected.current && text.trim() !== "") {
+      detected.current = true;
+      setKind(detectKind(text));
+    }
+  }, [autoDetectKind, text]);
 
   const changeKind = (next: ValueKind) => {
+    userSetKind.current = true;
     setKind(next);
     setMenuOpen(false);
     // Reformat only when the current text is valid JSON; otherwise leave it be.
@@ -213,39 +355,64 @@ export function EditableValueBlock({
 
   return (
     <div>
-      <div className="mb-1 flex items-center justify-between">
+      <div className="mb-1 flex items-center justify-between gap-2">
         <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
-        <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-          <PopoverTrigger asChild>
+        <div className="flex items-center gap-0.5">
+          {enlargeable && (
             <button
               type="button"
-              className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              onClick={() => setEnlarged((v) => !v)}
+              title={enlarged ? "Shrink" : "Enlarge"}
+              aria-label={enlarged ? "Shrink field" : "Enlarge field"}
+              className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
-              {KIND_LABEL[kind]}
-              <ChevronDown className="h-3 w-3" aria-hidden />
+              {enlarged ? (
+                <Minimize2 className="h-3.5 w-3.5" />
+              ) : (
+                <Maximize2 className="h-3.5 w-3.5" />
+              )}
             </button>
-          </PopoverTrigger>
-          <PopoverContent align="end" className="w-28 p-1">
-            {KINDS.map((k) => (
+          )}
+          <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+            <PopoverTrigger asChild>
               <button
-                key={k}
                 type="button"
-                onClick={() => changeKind(k)}
-                className={cn(
-                  "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
-                  k === kind ? "bg-muted/70" : "hover:bg-muted/50",
-                )}
+                className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
-                {KIND_LABEL[k]}
+                {KIND_LABEL[kind]}
+                <ChevronDown className="h-3 w-3" aria-hidden />
               </button>
-            ))}
-          </PopoverContent>
-        </Popover>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-28 p-1">
+              {KINDS.map((k) => (
+                <button
+                  key={k}
+                  type="button"
+                  onClick={() => changeKind(k)}
+                  className={cn(
+                    "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
+                    k === kind ? "bg-muted/70" : "hover:bg-muted/50",
+                  )}
+                >
+                  {KIND_LABEL[k]}
+                </button>
+              ))}
+            </PopoverContent>
+          </Popover>
+          {copyable && (
+            <CopyButton
+              value={text}
+              className="h-6 w-6 text-muted-foreground hover:text-foreground"
+              title="Copy"
+            />
+          )}
+        </div>
       </div>
       <LineNumberedTextarea
         value={text}
         onChange={onChange}
-        minRows={1}
+        minRows={enlarged ? Math.max(minRows, 24) : minRows}
+        highlightJson={kind === "json" || kind === "pretty"}
         aria-label={ariaLabel ?? label}
       />
     </div>

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -213,7 +213,7 @@ export function LineNumberedTextarea({
   const gutterWidth = `calc(${digits}ch + 1rem)`;
 
   return (
-    <div className="relative overflow-hidden rounded border border-input bg-background font-mono text-[12px] leading-relaxed focus-within:ring-1 focus-within:ring-ring">
+    <div className="relative overflow-hidden rounded border border-input bg-background font-mono text-[11px] leading-relaxed focus-within:ring-1 focus-within:ring-ring">
       {/* Display layer — line numbers + (highlighted) content, wraps per line. */}
       <div aria-hidden className="pointer-events-none py-1.5">
         {Array.from({ length: totalLines }).map((_, i) => (
@@ -250,7 +250,8 @@ export function LineNumberedTextarea({
         placeholder={placeholder}
         aria-label={ariaLabel}
         className={cn(
-          "absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent py-1.5 pr-2 font-mono text-[12px] leading-relaxed text-transparent placeholder:text-muted-foreground focus:outline-none",
+          // Must match the display layer's font metrics exactly — the two are overlaid.
+          "absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent py-1.5 pr-2 font-mono text-[11px] leading-relaxed text-transparent placeholder:text-muted-foreground focus:outline-none",
           readOnly ? "cursor-default caret-transparent" : "caret-foreground",
         )}
         style={{ paddingLeft: `calc(${gutterWidth} + 0.5rem)` }}
@@ -483,7 +484,7 @@ export function EditableValueBlock({
   };
 
   const controls = (
-    <div className="flex items-center gap-0.5">
+    <div className="flex items-center gap-1">
       <Popover open={menuOpen} onOpenChange={setMenuOpen}>
         <PopoverTrigger asChild>
           <button
@@ -511,9 +512,12 @@ export function EditableValueBlock({
         </PopoverContent>
       </Popover>
       {copyable && (
+        // Sized to the read-only I/O section's copy affordance (16px box, 12px
+        // icon) so the header strip is the same height as ExpandableSection's.
         <CopyButton
           value={readOnly ? display : text}
-          className="h-6 w-6 text-muted-foreground hover:text-foreground"
+          className="h-4 w-4 text-muted-foreground hover:text-foreground"
+          iconClassName="h-3 w-3"
           title="Copy"
         />
       )}

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -270,12 +270,12 @@ export function LineNumberedTextarea({
           <div className="flex items-start">
             <span
               aria-hidden
-              className="shrink-0 select-none border-r border-border bg-muted/40 px-2 text-right text-muted-foreground/50"
+              className="shrink-0 select-none border-r border-border bg-muted/40 px-2 pt-2 text-right text-muted-foreground/50"
               style={{ width: gutterWidth }}
             >
               {"​"}
             </span>
-            <span className="min-w-0 flex-1 whitespace-pre-wrap break-words px-2">
+            <span className="min-w-0 flex-1 whitespace-pre-wrap break-words px-2 pt-2">
               <button
                 type="button"
                 onClick={onExpand}
@@ -623,7 +623,7 @@ export function EditableValueBlock({
               <button
                 type="button"
                 onClick={() => setFieldExpanded(true)}
-                className="mt-1 cursor-pointer text-[11px] text-muted-foreground hover:text-foreground"
+                className="mt-2 cursor-pointer text-[11px] text-muted-foreground hover:text-foreground"
               >
                 …expand ({(collapseValue.length - COLLAPSE_AT).toLocaleString()} more characters)
               </button>

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -538,32 +538,40 @@ export function EditableValueBlock({
       onClick={() => setOpen((v) => !v)}
       aria-expanded={open}
       className={cn(
-        "flex items-center gap-1.5 rounded font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-        size === "sm" ? "text-[12px]" : "text-[11px]",
+        "flex items-center gap-1.5 rounded font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        // Boxed matches the span detail panel's read-only I/O sections
+        // (ExpandableSection): foreground label, muted chevron. The inline
+        // variant keeps its lighter form-label look.
+        size === "sm"
+          ? "text-xs text-foreground"
+          : "text-[11px] text-muted-foreground hover:text-foreground",
       )}
     >
       {open ? (
-        <ChevronDown className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        <ChevronDown
+          className={cn("h-3.5 w-3.5 shrink-0", size === "sm" && "text-muted-foreground")}
+          aria-hidden
+        />
       ) : (
-        <ChevronRight className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        <ChevronRight
+          className={cn("h-3.5 w-3.5 shrink-0", size === "sm" && "text-muted-foreground")}
+          aria-hidden
+        />
       )}
       {label}
     </button>
   );
 
+  // Boxed chrome mirrors ExpandableSection (the read-only span I/O sections) so an
+  // editable Input/Output/Metadata field sits beside them without a style seam.
   if (boxed) {
     return (
-      <div className="border border-border">
-        <div
-          className={cn(
-            "flex items-center justify-between gap-2 bg-muted/50 px-3 py-1.5",
-            open && "border-b border-border",
-          )}
-        >
+      <div className="overflow-hidden rounded-md border border-border">
+        <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/50 px-2.5 py-1.5">
           {heading("sm")}
           {controls}
         </div>
-        {open && <div className="p-3">{field}</div>}
+        {open && <div className="bg-background px-2.5 py-2">{field}</div>}
       </div>
     );
   }

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ChevronDown, Maximize2, Minimize2 } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
@@ -183,6 +183,7 @@ export function LineNumberedTextarea({
   minRows = 1,
   placeholder,
   highlightJson = false,
+  readOnly = false,
   "aria-label": ariaLabel,
 }: {
   value: string;
@@ -191,19 +192,31 @@ export function LineNumberedTextarea({
   placeholder?: string;
   /** When true, JSON content is syntax-highlighted (trace-panel colors). */
   highlightJson?: boolean;
+  /** Display only — selectable and syntax-coloured, but not editable. */
+  readOnly?: boolean;
   "aria-label"?: string;
 }) {
-  const rawLines = value === "" ? [""] : value.split("\n");
-  const tokenLines = highlightJson ? tokenizeJsonByLine(value) : null;
-  const padLines = Math.max(0, minRows - rawLines.length);
-  const digits = Math.max(2, String(rawLines.length).length);
+  // Keep a real trailing empty line so the last line is always clickable — click
+  // it and type without pressing Enter first, and a 1-line value still shows an
+  // empty line 2. The parent value never keeps that trailing newline: it's added
+  // for display/editing and stripped from what onChange reports.
+  //
+  // The newline is appended *unconditionally*. Appending it only when the value
+  // didn't already end in one meant pressing Enter (which makes the value end in
+  // a newline) was cancelled out by the strip below, so the line count — and the
+  // box height — never grew.
+  const textValue = `${value}\n`;
+  const rawLines = textValue.split("\n");
+  const tokenLines = highlightJson ? tokenizeJsonByLine(textValue) : null;
+  const totalLines = Math.max(rawLines.length, minRows);
+  const digits = Math.max(2, String(totalLines).length);
   const gutterWidth = `calc(${digits}ch + 1rem)`;
 
   return (
     <div className="relative overflow-hidden rounded border border-input bg-background font-mono text-[12px] leading-relaxed focus-within:ring-1 focus-within:ring-ring">
       {/* Display layer — line numbers + (highlighted) content, wraps per line. */}
       <div aria-hidden className="pointer-events-none py-1.5">
-        {rawLines.map((line, i) => (
+        {Array.from({ length: totalLines }).map((_, i) => (
           <div key={i} className="flex items-start">
             <span
               className="shrink-0 select-none border-r border-border bg-muted/40 px-2 text-right text-muted-foreground/50"
@@ -218,31 +231,28 @@ export function LineNumberedTextarea({
                       {t.text}
                     </span>
                   ))
-                : line}
+                : (rawLines[i] ?? "")}
               {"​"}
             </span>
-          </div>
-        ))}
-        {Array.from({ length: padLines }).map((_, k) => (
-          <div key={`pad-${k}`} className="flex items-start">
-            <span
-              className="shrink-0 border-r border-border bg-muted/40 px-2"
-              style={{ width: gutterWidth }}
-            >
-              {"​"}
-            </span>
-            <span className="flex-1 px-2">{"​"}</span>
           </div>
         ))}
       </div>
       {/* Editing layer — transparent text lined up over the display layer. */}
       <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
+        value={textValue}
+        onChange={(e) => {
+          if (readOnly) return;
+          const v = e.target.value;
+          onChange(v.endsWith("\n") ? v.slice(0, -1) : v);
+        }}
+        readOnly={readOnly}
         spellCheck={false}
         placeholder={placeholder}
         aria-label={ariaLabel}
-        className="absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent py-1.5 pr-2 font-mono text-[12px] leading-relaxed text-transparent caret-foreground placeholder:text-muted-foreground focus:outline-none"
+        className={cn(
+          "absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent py-1.5 pr-2 font-mono text-[12px] leading-relaxed text-transparent placeholder:text-muted-foreground focus:outline-none",
+          readOnly ? "cursor-default caret-transparent" : "caret-foreground",
+        )}
         style={{ paddingLeft: `calc(${gutterWidth} + 0.5rem)` }}
       />
     </div>
@@ -337,9 +347,8 @@ function detectKind(text: string): ValueKind {
  * JSON), so plain text is never mangled.
  *
  * Optional extras (all off by default, so existing callers are unchanged):
- * `copyable` adds a copy button, `enlargeable` adds a taller/shorter toggle,
- * `autoDetectKind` picks JSON vs text from the initial content, and `minRows`
- * sets the resting height.
+ * `copyable` adds a copy button, `autoDetectKind` picks JSON vs text from the
+ * initial content, and `minRows` sets the resting height.
  */
 export function EditableValueBlock({
   label,
@@ -348,10 +357,10 @@ export function EditableValueBlock({
   defaultKind = "yaml",
   ariaLabel,
   copyable = false,
-  enlargeable = false,
   autoDetectKind = false,
   minRows = 1,
   boxed = false,
+  readOnly = false,
 }: {
   label: string;
   text: string;
@@ -359,17 +368,25 @@ export function EditableValueBlock({
   defaultKind?: ValueKind;
   ariaLabel?: string;
   copyable?: boolean;
-  enlargeable?: boolean;
   autoDetectKind?: boolean;
   minRows?: number;
   /** Wrap the block in a bordered card with a muted header strip (like FormCard). */
   boxed?: boolean;
+  /** Display only — same look and format switcher, but the text can't be edited. */
+  readOnly?: boolean;
 }) {
   const [kind, setKind] = React.useState<ValueKind>(defaultKind);
   const [menuOpen, setMenuOpen] = React.useState(false);
-  const [enlarged, setEnlarged] = React.useState(false);
+  // Minimised via the header chevron, like the span detail panel's I/O sections.
+  const [open, setOpen] = React.useState(true);
   const userSetKind = React.useRef(false);
   const detected = React.useRef(false);
+  // Read-only fields reformat locally (the parent value never changes), so the
+  // format switcher still works without touching the source of truth.
+  const [display, setDisplay] = React.useState(text);
+  React.useEffect(() => {
+    if (readOnly) setDisplay(text);
+  }, [readOnly, text]);
 
   // Detect JSON vs text once, when the value first arrives (e.g. after a dialog
   // seeds it), unless the user has already chosen a format from the switcher.
@@ -386,30 +403,17 @@ export function EditableValueBlock({
     setMenuOpen(false);
     // Reformat only when the current text is valid JSON; otherwise leave it be.
     try {
-      const parsed = JSON.parse(text);
-      onChange(formatValue(parsed, next));
+      const parsed = JSON.parse(readOnly ? display : text);
+      const formatted = formatValue(parsed, next);
+      if (readOnly) setDisplay(formatted);
+      else onChange(formatted);
     } catch {
       /* not JSON — keep the text as typed */
     }
   };
 
-  // Rest at minRows and grow one line at a time with the content; enlarge opens
-  // it fully.
-  const effectiveMin = enlarged ? Math.max(minRows, 24) : minRows;
-
   const controls = (
     <div className="flex items-center gap-0.5">
-      {enlargeable && (
-        <button
-          type="button"
-          onClick={() => setEnlarged((v) => !v)}
-          title={enlarged ? "Shrink" : "Enlarge"}
-          aria-label={enlarged ? "Shrink field" : "Enlarge field"}
-          className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-        >
-          {enlarged ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
-        </button>
-      )}
       <Popover open={menuOpen} onOpenChange={setMenuOpen}>
         <PopoverTrigger asChild>
           <button
@@ -438,7 +442,7 @@ export function EditableValueBlock({
       </Popover>
       {copyable && (
         <CopyButton
-          value={text}
+          value={readOnly ? display : text}
           className="h-6 w-6 text-muted-foreground hover:text-foreground"
           title="Copy"
         />
@@ -448,22 +452,48 @@ export function EditableValueBlock({
 
   const field = (
     <LineNumberedTextarea
-      value={text}
+      value={readOnly ? display : text}
       onChange={onChange}
-      minRows={effectiveMin}
+      minRows={minRows}
       highlightJson={kind === "json" || kind === "pretty"}
+      readOnly={readOnly}
       aria-label={ariaLabel ?? label}
     />
+  );
+
+  // Chevron + label: the whole thing toggles, matching the span detail panel.
+  const heading = (size: "sm" | "xs") => (
+    <button
+      type="button"
+      onClick={() => setOpen((v) => !v)}
+      aria-expanded={open}
+      className={cn(
+        "flex items-center gap-1.5 rounded font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        size === "sm" ? "text-[12px]" : "text-[11px]",
+      )}
+    >
+      {open ? (
+        <ChevronDown className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      ) : (
+        <ChevronRight className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      )}
+      {label}
+    </button>
   );
 
   if (boxed) {
     return (
       <div className="border border-border">
-        <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/50 px-3 py-1.5">
-          <span className="text-[12px] font-medium text-muted-foreground">{label}</span>
+        <div
+          className={cn(
+            "flex items-center justify-between gap-2 bg-muted/50 px-3 py-1.5",
+            open && "border-b border-border",
+          )}
+        >
+          {heading("sm")}
           {controls}
         </div>
-        <div className="p-3">{field}</div>
+        {open && <div className="p-3">{field}</div>}
       </div>
     );
   }
@@ -471,10 +501,10 @@ export function EditableValueBlock({
   return (
     <div>
       <div className="mb-1 flex items-center justify-between gap-2">
-        <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
+        {heading("xs")}
         {controls}
       </div>
-      {field}
+      {open && field}
     </div>
   );
 }

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -152,10 +152,30 @@ function Gutter({ count }: { count: number }) {
   );
 }
 
+/** Splits whole-text JSON tokens into per-line arrays (newlines are consumed). */
+function tokenizeJsonByLine(text: string): { text: string; cls: string }[][] | null {
+  const tokens = tokenizeJson(text);
+  if (!tokens) return null;
+  const lines: { text: string; cls: string }[][] = [[]];
+  for (const tok of tokens) {
+    const parts = tok.text.split("\n");
+    parts.forEach((part, idx) => {
+      if (idx > 0) lines.push([]);
+      if (part !== "") lines[lines.length - 1].push({ text: part, cls: tok.cls });
+    });
+  }
+  return lines;
+}
+
 /**
- * Editable code field with a line-number gutter on the left. An empty value is
- * a single line "1" with an empty body. Grows with the content (no scroll sync
- * to keep the numbers aligned).
+ * Editable code field with a line-number gutter on the left.
+ *
+ * A wrapping display layer (line numbers + optional JSON colors) sits under a
+ * transparent-text textarea. Because both wrap with the same font/width, a long
+ * line wraps onto the next visual row while keeping a single line number pinned
+ * to its top — the way a real code editor renders wrapped lines. The box rests
+ * at `minRows` (blank, unnumbered space below the content) and grows one line
+ * per Enter.
  */
 export function LineNumberedTextarea({
   value,
@@ -173,41 +193,58 @@ export function LineNumberedTextarea({
   highlightJson?: boolean;
   "aria-label"?: string;
 }) {
-  // Gutter numbers only the real content lines; the textarea can still be taller
-  // (minRows) with blank, unnumbered space below — the way a code editor looks.
-  const contentLines = value === "" ? 1 : value.split("\n").length;
-  const rows = Math.max(contentLines, minRows);
-  const tokens = highlightJson ? tokenizeJson(value) : null;
+  const rawLines = value === "" ? [""] : value.split("\n");
+  const tokenLines = highlightJson ? tokenizeJsonByLine(value) : null;
+  const padLines = Math.max(0, minRows - rawLines.length);
+  const digits = Math.max(2, String(rawLines.length).length);
+  const gutterWidth = `calc(${digits}ch + 1rem)`;
+
   return (
-    <div className="flex overflow-hidden rounded border border-input bg-background focus-within:ring-1 focus-within:ring-ring">
-      <Gutter count={contentLines} />
-      <div className="relative flex-1">
-        {/* Colored layer sits exactly behind the transparent-text textarea. */}
-        {tokens && (
-          <pre
-            aria-hidden
-            className="pointer-events-none absolute inset-0 m-0 overflow-hidden whitespace-pre-wrap break-words px-2 py-1.5 font-mono text-[12px] leading-relaxed"
-          >
-            {tokens.map((t, i) => (
-              <span key={i} className={t.cls || undefined}>
-                {t.text}
-              </span>
-            ))}
-          </pre>
-        )}
-        <textarea
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          rows={rows}
-          spellCheck={false}
-          placeholder={placeholder}
-          aria-label={ariaLabel}
-          className={cn(
-            "relative block w-full resize-none whitespace-pre-wrap break-words bg-transparent px-2 py-1.5 font-mono text-[12px] leading-relaxed placeholder:text-muted-foreground focus:outline-none",
-            tokens && "text-transparent caret-foreground",
-          )}
-        />
+    <div className="relative overflow-hidden rounded border border-input bg-background font-mono text-[12px] leading-relaxed focus-within:ring-1 focus-within:ring-ring">
+      {/* Display layer — line numbers + (highlighted) content, wraps per line. */}
+      <div aria-hidden className="pointer-events-none py-1.5">
+        {rawLines.map((line, i) => (
+          <div key={i} className="flex items-start">
+            <span
+              className="shrink-0 select-none border-r border-border bg-muted/40 px-2 text-right text-muted-foreground/50"
+              style={{ width: gutterWidth }}
+            >
+              {i + 1}
+            </span>
+            <span className="min-w-0 flex-1 whitespace-pre-wrap break-words px-2">
+              {tokenLines
+                ? (tokenLines[i] ?? []).map((t, ti) => (
+                    <span key={ti} className={t.cls || undefined}>
+                      {t.text}
+                    </span>
+                  ))
+                : line}
+              {"​"}
+            </span>
+          </div>
+        ))}
+        {Array.from({ length: padLines }).map((_, k) => (
+          <div key={`pad-${k}`} className="flex items-start">
+            <span
+              className="shrink-0 border-r border-border bg-muted/40 px-2"
+              style={{ width: gutterWidth }}
+            >
+              {"​"}
+            </span>
+            <span className="flex-1 px-2">{"​"}</span>
+          </div>
+        ))}
       </div>
+      {/* Editing layer — transparent text lined up over the display layer. */}
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        spellCheck={false}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        className="absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent py-1.5 pr-2 font-mono text-[12px] leading-relaxed text-transparent caret-foreground placeholder:text-muted-foreground focus:outline-none"
+        style={{ paddingLeft: `calc(${gutterWidth} + 0.5rem)` }}
+      />
     </div>
   );
 }
@@ -314,7 +351,6 @@ export function EditableValueBlock({
   enlargeable = false,
   autoDetectKind = false,
   minRows = 1,
-  growRows,
   boxed = false,
 }: {
   label: string;
@@ -326,12 +362,6 @@ export function EditableValueBlock({
   enlargeable?: boolean;
   autoDetectKind?: boolean;
   minRows?: number;
-  /**
-   * When set, the field rests at `minRows` until the content grows past it, then
-   * springs to (at least) `growRows` — a small default that opens up once the
-   * value no longer fits.
-   */
-  growRows?: number;
   /** Wrap the block in a bordered card with a muted header strip (like FormCard). */
   boxed?: boolean;
 }) {
@@ -363,11 +393,9 @@ export function EditableValueBlock({
     }
   };
 
-  // Rest at minRows; once the content outgrows it, spring to growRows; enlarge
-  // opens it fully. LineNumberedTextarea still grows past this with more content.
-  const contentLines = text === "" ? 1 : text.split("\n").length;
-  const restingMin = growRows != null && contentLines > minRows ? growRows : minRows;
-  const effectiveMin = enlarged ? Math.max(restingMin, 24) : restingMin;
+  // Rest at minRows and grow one line at a time with the content; enlarge opens
+  // it fully.
+  const effectiveMin = enlarged ? Math.max(minRows, 24) : minRows;
 
   const controls = (
     <div className="flex items-center gap-0.5">

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -194,6 +194,7 @@ export function LineNumberedTextarea({
   collapsed = false,
   collapseAt = 500,
   onExpand,
+  fontClassName = "text-[11px] leading-[18px]",
   "aria-label": ariaLabel,
 }: {
   value: string;
@@ -211,6 +212,9 @@ export function LineNumberedTextarea({
   collapsed?: boolean;
   collapseAt?: number;
   onExpand?: () => void;
+  /** Override the font size + line-height. The line-height must be a whole pixel
+   *  so the display and textarea layers stay aligned. Defaults to 11px / 18px. */
+  fontClassName?: string;
   "aria-label"?: string;
 }) {
   const isCollapsed = collapsed && value.length > collapseAt;
@@ -237,7 +241,12 @@ export function LineNumberedTextarea({
     // line-height (e.g. leading-relaxed → 17.875px at 11px) is rounded per block
     // box in the display layer but flows continuously in the textarea, so the two
     // drift apart as lines accumulate and the textarea's last line gets clipped.
-    <div className="relative overflow-hidden rounded border border-input bg-background font-mono text-[11px] leading-[18px] focus-within:ring-1 focus-within:ring-ring">
+    <div
+      className={cn(
+        "relative overflow-hidden rounded border border-input bg-background font-mono focus-within:ring-1 focus-within:ring-ring",
+        fontClassName,
+      )}
+    >
       {/* Display layer — line numbers + (highlighted) content, wraps per line.
           Collapsed has no textarea overlay, so it must take pointer events (the
           inline expand control lives here). */}
@@ -304,7 +313,8 @@ export function LineNumberedTextarea({
           className={cn(
             // Must match the display layer's font metrics exactly — the two are
             // overlaid, so the line-height is the same whole pixel value.
-            "absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent pb-2 pr-2 pt-1.5 font-mono text-[11px] leading-[18px] text-transparent placeholder:text-muted-foreground focus:outline-none",
+            "absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent pb-2 pr-2 pt-1.5 font-mono text-transparent placeholder:text-muted-foreground focus:outline-none",
+            fontClassName,
             readOnly ? "cursor-default caret-transparent" : "caret-foreground",
           )}
           style={{ paddingLeft: `calc(${gutterWidth} + 0.5rem)` }}

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -333,12 +333,66 @@ function detectKind(text: string): ValueKind {
   if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
     try {
       JSON.parse(trimmed);
-      return "json";
+      // Already pretty-printed (multi-line) JSON should read as "Pretty", not
+      // "JSON" — otherwise the mode label contradicts the indented content.
+      return trimmed.includes("\n") ? "pretty" : "json";
     } catch {
       /* looks like JSON but isn't — fall through to text */
     }
   }
   return "text";
+}
+
+/** Longest single-line JSON that still reads well inline. */
+const COMPACT_MAX_CHARS = 100;
+
+/** True when no member is itself an object/array, so one line stays readable. */
+function isFlat(value: unknown): boolean {
+  const members = Array.isArray(value)
+    ? value
+    : value && typeof value === "object"
+      ? Object.values(value as Record<string, unknown>)
+      : [];
+  return members.every((v) => v === null || typeof v !== "object");
+}
+
+/** How a field wants a JSON value presented when it is first seeded. */
+export type SeedJsonPreference = "expanded" | "compact";
+
+/**
+ * The format a freshly-captured value should be shown (and stored) in.
+ *
+ * Without this, the mode is whatever the instrumented app happened to emit —
+ * the same logical value reads as Pretty or compact depending on whether
+ * upstream used an indent. Seeding makes it a property of the FIELD instead:
+ * values you read and edit closely (input, recorded output) expand; incidental
+ * ones (metadata) stay on one line.
+ *
+ * `compact` is honoured only while the value actually fits on a line — a large
+ * or nested value falls back to Pretty, since a one-liner is only better while
+ * it stays one line. Non-JSON text is returned untouched (never mangled).
+ */
+export function seedFormat(
+  text: string,
+  prefer: SeedJsonPreference,
+): { kind: ValueKind; text: string } {
+  const trimmed = text.trim();
+  if (trimmed === "" || !(trimmed.startsWith("{") || trimmed.startsWith("["))) {
+    return { kind: "text", text };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return { kind: "text", text }; // looks like JSON but isn't
+  }
+  if (prefer === "compact") {
+    const compact = formatValue(parsed, "json");
+    if (compact.length <= COMPACT_MAX_CHARS && isFlat(parsed)) {
+      return { kind: "json", text: compact };
+    }
+  }
+  return { kind: "pretty", text: formatValue(parsed, "pretty") };
 }
 
 /**
@@ -358,6 +412,7 @@ export function EditableValueBlock({
   ariaLabel,
   copyable = false,
   autoDetectKind = false,
+  seedJson,
   minRows = 1,
   boxed = false,
   readOnly = false,
@@ -369,6 +424,12 @@ export function EditableValueBlock({
   ariaLabel?: string;
   copyable?: boolean;
   autoDetectKind?: boolean;
+  /**
+   * Present (and normalise) a seeded JSON value per this field's role rather
+   * than following however it was serialised upstream. Supersedes
+   * `autoDetectKind`. See `seedFormat`.
+   */
+  seedJson?: SeedJsonPreference;
   minRows?: number;
   /** Wrap the block in a bordered card with a muted header strip (like FormCard). */
   boxed?: boolean;
@@ -380,7 +441,6 @@ export function EditableValueBlock({
   // Minimised via the header chevron, like the span detail panel's I/O sections.
   const [open, setOpen] = React.useState(true);
   const userSetKind = React.useRef(false);
-  const detected = React.useRef(false);
   // Read-only fields reformat locally (the parent value never changes), so the
   // format switcher still works without touching the source of truth.
   const [display, setDisplay] = React.useState(text);
@@ -388,14 +448,24 @@ export function EditableValueBlock({
     if (readOnly) setDisplay(text);
   }, [readOnly, text]);
 
-  // Detect JSON vs text once, when the value first arrives (e.g. after a dialog
-  // seeds it), unless the user has already chosen a format from the switcher.
+  // Pick the format whenever a new value is seeded (e.g. navigating between cases
+  // re-seeds this field), unless the user has pinned one from the switcher.
+  // `seedJson` chooses by FIELD ROLE and normalises the text once so the stored
+  // value is canonical; `autoDetectKind` just follows the content. setKind is a
+  // no-op when unchanged, and the text guard stops the normalise from looping.
   React.useEffect(() => {
-    if (autoDetectKind && !userSetKind.current && !detected.current && text.trim() !== "") {
-      detected.current = true;
-      setKind(detectKind(text));
+    if (userSetKind.current || text.trim() === "") return;
+    if (seedJson) {
+      const seeded = seedFormat(text, seedJson);
+      setKind(seeded.kind);
+      if (seeded.text !== text) {
+        if (readOnly) setDisplay(seeded.text);
+        else onChange(seeded.text);
+      }
+      return;
     }
-  }, [autoDetectKind, text]);
+    if (autoDetectKind) setKind(detectKind(text));
+  }, [autoDetectKind, seedJson, text, readOnly, onChange]);
 
   const changeKind = (next: ValueKind) => {
     userSetKind.current = true;

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -191,6 +191,9 @@ export function LineNumberedTextarea({
   placeholder,
   highlightJson = false,
   readOnly = false,
+  collapsed = false,
+  collapseAt = 500,
+  onExpand,
   "aria-label": ariaLabel,
 }: {
   value: string;
@@ -201,18 +204,28 @@ export function LineNumberedTextarea({
   highlightJson?: boolean;
   /** Display only — selectable and syntax-coloured, but not editable. */
   readOnly?: boolean;
+  /** Clip a long value to `collapseAt` chars and show an inline "…expand" as the
+   *  last line INSIDE the box (like the span-detail I/O). Editing is suspended while
+   *  collapsed — the transparent textarea isn't mounted — so the inline control is
+   *  clickable. Expanding is the caller's to handle via `onExpand`. */
+  collapsed?: boolean;
+  collapseAt?: number;
+  onExpand?: () => void;
   "aria-label"?: string;
 }) {
+  const isCollapsed = collapsed && value.length > collapseAt;
+  const shown = isCollapsed ? value.slice(0, collapseAt) : value;
   // Keep a real trailing empty line so the last line is always clickable — click
   // it and type without pressing Enter first, and a 1-line value still shows an
   // empty line 2. The parent value never keeps that trailing newline: it's added
-  // for display/editing and stripped from what onChange reports.
+  // for display/editing and stripped from what onChange reports. (When collapsed
+  // there's no editing, so no trailing line is needed.)
   //
   // The newline is appended *unconditionally*. Appending it only when the value
   // didn't already end in one meant pressing Enter (which makes the value end in
   // a newline) was cancelled out by the strip below, so the line count — and the
   // box height — never grew.
-  const textValue = `${value}\n`;
+  const textValue = isCollapsed ? shown : `${value}\n`;
   const rawLines = textValue.split("\n");
   const tokenLines = highlightJson ? tokenizeJsonByLine(textValue) : null;
   const totalLines = Math.max(rawLines.length, minRows);
@@ -225,8 +238,13 @@ export function LineNumberedTextarea({
     // box in the display layer but flows continuously in the textarea, so the two
     // drift apart as lines accumulate and the textarea's last line gets clipped.
     <div className="relative overflow-hidden rounded border border-input bg-background font-mono text-[11px] leading-[18px] focus-within:ring-1 focus-within:ring-ring">
-      {/* Display layer — line numbers + (highlighted) content, wraps per line. */}
-      <div aria-hidden className="pointer-events-none pb-2 pt-1.5">
+      {/* Display layer — line numbers + (highlighted) content, wraps per line.
+          Collapsed has no textarea overlay, so it must take pointer events (the
+          inline expand control lives here). */}
+      <div
+        aria-hidden={!isCollapsed}
+        className={cn("pb-2 pt-1.5", !isCollapsed && "pointer-events-none")}
+      >
         {Array.from({ length: totalLines }).map((_, i) => (
           <div key={i} className="flex items-start">
             <span
@@ -247,27 +265,51 @@ export function LineNumberedTextarea({
             </span>
           </div>
         ))}
-      </div>
-      {/* Editing layer — transparent text lined up over the display layer. */}
-      <textarea
-        value={textValue}
-        onChange={(e) => {
-          if (readOnly) return;
-          const v = e.target.value;
-          onChange(v.endsWith("\n") ? v.slice(0, -1) : v);
-        }}
-        readOnly={readOnly}
-        spellCheck={false}
-        placeholder={placeholder}
-        aria-label={ariaLabel}
-        className={cn(
-          // Must match the display layer's font metrics exactly — the two are
-          // overlaid, so the line-height is the same whole pixel value.
-          "absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent pb-2 pr-2 pt-1.5 font-mono text-[11px] leading-[18px] text-transparent placeholder:text-muted-foreground focus:outline-none",
-          readOnly ? "cursor-default caret-transparent" : "caret-foreground",
+        {/* Inline "…expand" as the final line, sitting with the text inside the box. */}
+        {isCollapsed && (
+          <div className="flex items-start">
+            <span
+              aria-hidden
+              className="shrink-0 select-none border-r border-border bg-muted/40 px-2 text-right text-muted-foreground/50"
+              style={{ width: gutterWidth }}
+            >
+              {"​"}
+            </span>
+            <span className="min-w-0 flex-1 whitespace-pre-wrap break-words px-2">
+              <button
+                type="button"
+                onClick={onExpand}
+                className="cursor-pointer align-baseline text-muted-foreground hover:text-foreground"
+              >
+                …expand ({(value.length - collapseAt).toLocaleString()} more characters)
+              </button>
+            </span>
+          </div>
         )}
-        style={{ paddingLeft: `calc(${gutterWidth} + 0.5rem)` }}
-      />
+      </div>
+      {/* Editing layer — transparent text lined up over the display layer. Omitted
+          while collapsed so the inline expand control above stays clickable. */}
+      {!isCollapsed && (
+        <textarea
+          value={textValue}
+          onChange={(e) => {
+            if (readOnly) return;
+            const v = e.target.value;
+            onChange(v.endsWith("\n") ? v.slice(0, -1) : v);
+          }}
+          readOnly={readOnly}
+          spellCheck={false}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          className={cn(
+            // Must match the display layer's font metrics exactly — the two are
+            // overlaid, so the line-height is the same whole pixel value.
+            "absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent pb-2 pr-2 pt-1.5 font-mono text-[11px] leading-[18px] text-transparent placeholder:text-muted-foreground focus:outline-none",
+            readOnly ? "cursor-default caret-transparent" : "caret-foreground",
+          )}
+          style={{ paddingLeft: `calc(${gutterWidth} + 0.5rem)` }}
+        />
+      )}
     </div>
   );
 }
@@ -561,13 +603,34 @@ export function EditableValueBlock({
     </div>
   );
 
+  // A long value clips to an in-field "…expand" control that sits INSIDE the code
+  // block, inline with the text (like the span-detail I/O renderer) — not a button
+  // below the card. Expand-only; re-collapses when `collapseResetKey` changes.
+  const collapseValue = readOnly ? display : text;
+  const isCollapsed = collapsible && collapseValue.length > COLLAPSE_AT && !fieldExpanded;
+
   // Markdown is a rendered preview of the text, so it replaces the editable field;
   // switching back to any other format returns to editing the same raw value.
   const field =
     kind === "markdown" ? (
       <div>
         <div className="rounded border border-input bg-background px-2 py-1.5">
-          <MarkdownView content={readOnly ? display : text} />
+          {isCollapsed ? (
+            <div>
+              <div className="max-h-40 overflow-hidden">
+                <MarkdownView content={readOnly ? display : text} />
+              </div>
+              <button
+                type="button"
+                onClick={() => setFieldExpanded(true)}
+                className="mt-1 cursor-pointer text-[11px] text-muted-foreground hover:text-foreground"
+              >
+                …expand ({(collapseValue.length - COLLAPSE_AT).toLocaleString()} more characters)
+              </button>
+            </div>
+          ) : (
+            <MarkdownView content={readOnly ? display : text} />
+          )}
         </div>
         {!readOnly && (
           <p className="mt-1 text-[10px] text-muted-foreground">
@@ -582,42 +645,11 @@ export function EditableValueBlock({
         minRows={minRows}
         highlightJson={kind === "json" || kind === "pretty"}
         readOnly={readOnly}
+        collapsed={isCollapsed}
+        collapseAt={COLLAPSE_AT}
+        onExpand={() => setFieldExpanded(true)}
         aria-label={ariaLabel ?? label}
       />
-    );
-
-  // A long value collapses behind an in-field "…expand" control INSIDE the body —
-  // below the header, clipping only the value (not the whole card). Same threshold
-  // and styling as the span-detail I/O renderer. Short values render untouched.
-  const collapseValue = readOnly ? display : text;
-  const body =
-    !collapsible || collapseValue.length <= COLLAPSE_AT ? (
-      field
-    ) : fieldExpanded ? (
-      <div>
-        {field}
-        <button
-          type="button"
-          onClick={() => setFieldExpanded(false)}
-          className="mt-1 text-[11px] text-muted-foreground hover:text-foreground"
-        >
-          collapse
-        </button>
-      </div>
-    ) : (
-      <div>
-        <div className="relative max-h-40 overflow-hidden">
-          {field}
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-background to-transparent" />
-        </div>
-        <button
-          type="button"
-          onClick={() => setFieldExpanded(true)}
-          className="mt-1 text-[11px] text-muted-foreground hover:text-foreground"
-        >
-          …expand ({(collapseValue.length - COLLAPSE_AT).toLocaleString()} more characters)
-        </button>
-      </div>
     );
 
   // Chevron + label: the whole thing toggles, matching the span detail panel.
@@ -665,7 +697,7 @@ export function EditableValueBlock({
           {heading("sm")}
           {controls}
         </div>
-        {open && <div className="bg-background px-2.5 py-2">{body}</div>}
+        {open && <div className="bg-background px-2.5 py-2">{field}</div>}
       </div>
     );
   }
@@ -676,7 +708,7 @@ export function EditableValueBlock({
         {heading("xs")}
         {controls}
       </div>
-      {open && body}
+      {open && field}
     </div>
   );
 }

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { MarkdownView } from "@/components/ui/markdown-view";
 import { cn } from "@/lib/utils";
 
 /**
@@ -12,16 +13,17 @@ import { cn } from "@/lib/utils";
  * and minimised — the same shapes a trace value uses.
  */
 
-export type ValueKind = "yaml" | "text" | "json" | "pretty";
+export type ValueKind = "yaml" | "text" | "json" | "pretty" | "markdown";
 
 const KIND_LABEL: Record<ValueKind, string> = {
   yaml: "YAML",
   text: "Text",
   json: "JSON",
   pretty: "Pretty",
+  markdown: "Markdown",
 };
 
-const KINDS: ValueKind[] = ["yaml", "text", "json", "pretty"];
+const KINDS: ValueKind[] = ["yaml", "text", "json", "pretty", "markdown"];
 
 /** Minimal YAML for the flat values we hold. Empty → `null`, as requested. */
 function toYaml(value: unknown, indent = 0): string {
@@ -50,6 +52,11 @@ function toYaml(value: unknown, indent = 0): string {
 /** Formats a value for a given view kind. */
 export function formatValue(value: unknown, kind: ValueKind): string {
   switch (kind) {
+    // Markdown is a *rendering* of the raw text, so it carries the value through
+    // verbatim (an empty value stays empty rather than becoming the string "null").
+    case "markdown":
+      if (value === null || value === undefined) return "";
+      return typeof value === "string" ? value : JSON.stringify(value);
     case "text":
       if (value === null || value === undefined || value === "") return "null";
       return typeof value === "string" ? value : JSON.stringify(value);
@@ -323,7 +330,13 @@ export function ValueBlock({
           </PopoverContent>
         </Popover>
       </div>
-      <CodeView text={formatValue(value, kind)} />
+      {kind === "markdown" ? (
+        <div className="rounded border border-input bg-background px-2 py-1.5">
+          <MarkdownView content={formatValue(value, kind)} />
+        </div>
+      ) : (
+        <CodeView text={formatValue(value, kind)} />
+      )}
     </div>
   );
 }
@@ -472,6 +485,9 @@ export function EditableValueBlock({
     userSetKind.current = true;
     setKind(next);
     setMenuOpen(false);
+    // Markdown renders the text as-is rather than re-serializing it, so switching
+    // to it must never rewrite the stored value.
+    if (next === "markdown") return;
     // Reformat only when the current text is valid JSON; otherwise leave it be.
     try {
       const parsed = JSON.parse(readOnly ? display : text);
@@ -524,16 +540,30 @@ export function EditableValueBlock({
     </div>
   );
 
-  const field = (
-    <LineNumberedTextarea
-      value={readOnly ? display : text}
-      onChange={onChange}
-      minRows={minRows}
-      highlightJson={kind === "json" || kind === "pretty"}
-      readOnly={readOnly}
-      aria-label={ariaLabel ?? label}
-    />
-  );
+  // Markdown is a rendered preview of the text, so it replaces the editable field;
+  // switching back to any other format returns to editing the same raw value.
+  const field =
+    kind === "markdown" ? (
+      <div>
+        <div className="rounded border border-input bg-background px-2 py-1.5">
+          <MarkdownView content={readOnly ? display : text} />
+        </div>
+        {!readOnly && (
+          <p className="mt-1 text-[10px] text-muted-foreground">
+            Preview — switch to Text to edit.
+          </p>
+        )}
+      </div>
+    ) : (
+      <LineNumberedTextarea
+        value={readOnly ? display : text}
+        onChange={onChange}
+        minRows={minRows}
+        highlightJson={kind === "json" || kind === "pretty"}
+        readOnly={readOnly}
+        aria-label={ariaLabel ?? label}
+      />
+    );
 
   // Chevron + label: the whole thing toggles, matching the span detail panel.
   const heading = (size: "sm" | "xs") => (

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -423,6 +423,9 @@ export function seedFormat(
  * `copyable` adds a copy button, `autoDetectKind` picks JSON vs text from the
  * initial content, and `minRows` sets the resting height.
  */
+/** A long value collapses behind an in-field "…expand" control past this length. */
+const COLLAPSE_AT = 500;
+
 export function EditableValueBlock({
   label,
   text,
@@ -435,6 +438,8 @@ export function EditableValueBlock({
   minRows = 1,
   boxed = false,
   readOnly = false,
+  collapsible = false,
+  collapseResetKey,
 }: {
   label: string;
   text: string;
@@ -454,11 +459,22 @@ export function EditableValueBlock({
   boxed?: boolean;
   /** Display only — same look and format switcher, but the text can't be edited. */
   readOnly?: boolean;
+  /** Cap a long value behind an in-field "…expand (N more)" control that sits below
+   *  the header and clips only the value body (not the whole card). Off by default. */
+  collapsible?: boolean;
+  /** Re-collapse when this changes (e.g. the source span switched). Editing never
+   *  re-collapses — only a new key does. Unneeded when the block is remounted by `key`. */
+  collapseResetKey?: string;
 }) {
   const [kind, setKind] = React.useState<ValueKind>(defaultKind);
   const [menuOpen, setMenuOpen] = React.useState(false);
   // Minimised via the header chevron, like the span detail panel's I/O sections.
   const [open, setOpen] = React.useState(true);
+  // A long value is clipped behind an in-field "…expand" control; reset on key change.
+  const [fieldExpanded, setFieldExpanded] = React.useState(false);
+  React.useEffect(() => {
+    setFieldExpanded(false);
+  }, [collapseResetKey]);
   const userSetKind = React.useRef(false);
   // Read-only fields reformat locally (the parent value never changes), so the
   // format switcher still works without touching the source of truth.
@@ -570,6 +586,40 @@ export function EditableValueBlock({
       />
     );
 
+  // A long value collapses behind an in-field "…expand" control INSIDE the body —
+  // below the header, clipping only the value (not the whole card). Same threshold
+  // and styling as the span-detail I/O renderer. Short values render untouched.
+  const collapseValue = readOnly ? display : text;
+  const body =
+    !collapsible || collapseValue.length <= COLLAPSE_AT ? (
+      field
+    ) : fieldExpanded ? (
+      <div>
+        {field}
+        <button
+          type="button"
+          onClick={() => setFieldExpanded(false)}
+          className="mt-1 text-[11px] text-muted-foreground hover:text-foreground"
+        >
+          collapse
+        </button>
+      </div>
+    ) : (
+      <div>
+        <div className="relative max-h-40 overflow-hidden">
+          {field}
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-background to-transparent" />
+        </div>
+        <button
+          type="button"
+          onClick={() => setFieldExpanded(true)}
+          className="mt-1 text-[11px] text-muted-foreground hover:text-foreground"
+        >
+          …expand ({(collapseValue.length - COLLAPSE_AT).toLocaleString()} more characters)
+        </button>
+      </div>
+    );
+
   // Chevron + label: the whole thing toggles, matching the span detail panel.
   const heading = (size: "sm" | "xs") => (
     <button
@@ -615,7 +665,7 @@ export function EditableValueBlock({
           {heading("sm")}
           {controls}
         </div>
-        {open && <div className="bg-background px-2.5 py-2">{field}</div>}
+        {open && <div className="bg-background px-2.5 py-2">{body}</div>}
       </div>
     );
   }
@@ -626,7 +676,7 @@ export function EditableValueBlock({
         {heading("xs")}
         {controls}
       </div>
-      {open && field}
+      {open && body}
     </div>
   );
 }

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -605,7 +605,12 @@ export function EditableValueBlock({
   // editable Input/Output/Metadata field sits beside them without a style seam.
   if (boxed) {
     return (
-      <div className="overflow-hidden rounded-md border border-border">
+      // `shrink-0` is required, not cosmetic: these fields stack in flex-column
+      // scroll panes (the dataset case panel, the Save-as-test-case drawer), and
+      // the `overflow-hidden` below sets the flex item's automatic min-size to 0 —
+      // so without it the flex column shrinks the field to fit and clips its
+      // content instead of letting the pane scroll.
+      <div className="shrink-0 overflow-hidden rounded-md border border-border">
         <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/50 px-2.5 py-1.5">
           {heading("sm")}
           {controls}

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -25,6 +25,9 @@ const KIND_LABEL: Record<ValueKind, string> = {
 
 const KINDS: ValueKind[] = ["yaml", "text", "json", "pretty", "markdown"];
 
+/** Sentinel for "no seed normalised yet" — see `seededKeyRef` in EditableValueBlock. */
+const UNSEEDED = Symbol("unseeded");
+
 /** Minimal YAML for the flat values we hold. Empty → `null`, as requested. */
 function toYaml(value: unknown, indent = 0): string {
   const pad = "  ".repeat(indent);
@@ -535,14 +538,27 @@ export function EditableValueBlock({
     if (readOnly) setDisplay(text);
   }, [readOnly, text]);
 
+  // Marks the seed (identified by `collapseResetKey`) the `seedJson` branch below has
+  // already normalised, so it runs once per seed rather than on every keystroke — see
+  // that effect. Distinct from any real key (including `undefined`, the default when
+  // the caller passes none) so the very first seed is never mistaken for "already done".
+  const seededKeyRef = React.useRef<string | undefined | typeof UNSEEDED>(UNSEEDED);
+
   // Pick the format whenever a new value is seeded (e.g. navigating between cases
   // re-seeds this field), unless the user has pinned one from the switcher.
   // `seedJson` chooses by FIELD ROLE and normalises the text once so the stored
-  // value is canonical; `autoDetectKind` just follows the content. setKind is a
-  // no-op when unchanged, and the text guard stops the normalise from looping.
+  // value is canonical; `autoDetectKind` just follows the content.
   React.useEffect(() => {
     if (userSetKind.current || text.trim() === "") return;
     if (seedJson) {
+      // `text` must stay a dep so this runs once real content arrives, but re-running
+      // it on every keystroke would fight the user's own typing: `seedFormat`
+      // pretty-prints anything that parses as JSON, and the caller's `onChange` below
+      // then rewrites the (controlled) field out from under the cursor. `collapseResetKey`
+      // — set by the caller to the source's identity (e.g. the span id) — marks a
+      // genuinely new seed; skip once we've already normalised for the current one.
+      if (seededKeyRef.current === collapseResetKey) return;
+      seededKeyRef.current = collapseResetKey;
       const seeded = seedFormat(text, seedJson);
       setKind(seeded.kind);
       if (seeded.text !== text) {
@@ -552,7 +568,7 @@ export function EditableValueBlock({
       return;
     }
     if (autoDetectKind) setKind(detectKind(text));
-  }, [autoDetectKind, seedJson, text, readOnly, onChange]);
+  }, [autoDetectKind, seedJson, text, readOnly, onChange, collapseResetKey]);
 
   const changeKind = (next: ValueKind) => {
     userSetKind.current = true;

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -220,9 +220,13 @@ export function LineNumberedTextarea({
   const gutterWidth = `calc(${digits}ch + 1rem)`;
 
   return (
-    <div className="relative overflow-hidden rounded border border-input bg-background font-mono text-[11px] leading-relaxed focus-within:ring-1 focus-within:ring-ring">
+    // The line-height is pinned to a whole pixel on BOTH layers. A fractional
+    // line-height (e.g. leading-relaxed → 17.875px at 11px) is rounded per block
+    // box in the display layer but flows continuously in the textarea, so the two
+    // drift apart as lines accumulate and the textarea's last line gets clipped.
+    <div className="relative overflow-hidden rounded border border-input bg-background font-mono text-[11px] leading-[18px] focus-within:ring-1 focus-within:ring-ring">
       {/* Display layer — line numbers + (highlighted) content, wraps per line. */}
-      <div aria-hidden className="pointer-events-none py-1.5">
+      <div aria-hidden className="pointer-events-none pb-2 pt-1.5">
         {Array.from({ length: totalLines }).map((_, i) => (
           <div key={i} className="flex items-start">
             <span
@@ -257,8 +261,9 @@ export function LineNumberedTextarea({
         placeholder={placeholder}
         aria-label={ariaLabel}
         className={cn(
-          // Must match the display layer's font metrics exactly — the two are overlaid.
-          "absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent py-1.5 pr-2 font-mono text-[11px] leading-relaxed text-transparent placeholder:text-muted-foreground focus:outline-none",
+          // Must match the display layer's font metrics exactly — the two are
+          // overlaid, so the line-height is the same whole pixel value.
+          "absolute inset-0 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent pb-2 pr-2 pt-1.5 font-mono text-[11px] leading-[18px] text-transparent placeholder:text-muted-foreground focus:outline-none",
           readOnly ? "cursor-default caret-transparent" : "caret-foreground",
         )}
         style={{ paddingLeft: `calc(${gutterWidth} + 0.5rem)` }}

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -314,6 +314,8 @@ export function EditableValueBlock({
   enlargeable = false,
   autoDetectKind = false,
   minRows = 1,
+  growRows,
+  boxed = false,
 }: {
   label: string;
   text: string;
@@ -324,6 +326,14 @@ export function EditableValueBlock({
   enlargeable?: boolean;
   autoDetectKind?: boolean;
   minRows?: number;
+  /**
+   * When set, the field rests at `minRows` until the content grows past it, then
+   * springs to (at least) `growRows` — a small default that opens up once the
+   * value no longer fits.
+   */
+  growRows?: number;
+  /** Wrap the block in a bordered card with a muted header strip (like FormCard). */
+  boxed?: boolean;
 }) {
   const [kind, setKind] = React.useState<ValueKind>(defaultKind);
   const [menuOpen, setMenuOpen] = React.useState(false);
@@ -353,68 +363,90 @@ export function EditableValueBlock({
     }
   };
 
+  // Rest at minRows; once the content outgrows it, spring to growRows; enlarge
+  // opens it fully. LineNumberedTextarea still grows past this with more content.
+  const contentLines = text === "" ? 1 : text.split("\n").length;
+  const restingMin = growRows != null && contentLines > minRows ? growRows : minRows;
+  const effectiveMin = enlarged ? Math.max(restingMin, 24) : restingMin;
+
+  const controls = (
+    <div className="flex items-center gap-0.5">
+      {enlargeable && (
+        <button
+          type="button"
+          onClick={() => setEnlarged((v) => !v)}
+          title={enlarged ? "Shrink" : "Enlarge"}
+          aria-label={enlarged ? "Shrink field" : "Enlarge field"}
+          className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          {enlarged ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
+        </button>
+      )}
+      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            {KIND_LABEL[kind]}
+            <ChevronDown className="h-3 w-3" aria-hidden />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-28 p-1">
+          {KINDS.map((k) => (
+            <button
+              key={k}
+              type="button"
+              onClick={() => changeKind(k)}
+              className={cn(
+                "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
+                k === kind ? "bg-muted/70" : "hover:bg-muted/50",
+              )}
+            >
+              {KIND_LABEL[k]}
+            </button>
+          ))}
+        </PopoverContent>
+      </Popover>
+      {copyable && (
+        <CopyButton
+          value={text}
+          className="h-6 w-6 text-muted-foreground hover:text-foreground"
+          title="Copy"
+        />
+      )}
+    </div>
+  );
+
+  const field = (
+    <LineNumberedTextarea
+      value={text}
+      onChange={onChange}
+      minRows={effectiveMin}
+      highlightJson={kind === "json" || kind === "pretty"}
+      aria-label={ariaLabel ?? label}
+    />
+  );
+
+  if (boxed) {
+    return (
+      <div className="border border-border">
+        <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/50 px-3 py-1.5">
+          <span className="text-[12px] font-medium text-muted-foreground">{label}</span>
+          {controls}
+        </div>
+        <div className="p-3">{field}</div>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="mb-1 flex items-center justify-between gap-2">
         <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
-        <div className="flex items-center gap-0.5">
-          {enlargeable && (
-            <button
-              type="button"
-              onClick={() => setEnlarged((v) => !v)}
-              title={enlarged ? "Shrink" : "Enlarge"}
-              aria-label={enlarged ? "Shrink field" : "Enlarge field"}
-              className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            >
-              {enlarged ? (
-                <Minimize2 className="h-3.5 w-3.5" />
-              ) : (
-                <Maximize2 className="h-3.5 w-3.5" />
-              )}
-            </button>
-          )}
-          <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-            <PopoverTrigger asChild>
-              <button
-                type="button"
-                className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              >
-                {KIND_LABEL[kind]}
-                <ChevronDown className="h-3 w-3" aria-hidden />
-              </button>
-            </PopoverTrigger>
-            <PopoverContent align="end" className="w-28 p-1">
-              {KINDS.map((k) => (
-                <button
-                  key={k}
-                  type="button"
-                  onClick={() => changeKind(k)}
-                  className={cn(
-                    "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
-                    k === kind ? "bg-muted/70" : "hover:bg-muted/50",
-                  )}
-                >
-                  {KIND_LABEL[k]}
-                </button>
-              ))}
-            </PopoverContent>
-          </Popover>
-          {copyable && (
-            <CopyButton
-              value={text}
-              className="h-6 w-6 text-muted-foreground hover:text-foreground"
-              title="Copy"
-            />
-          )}
-        </div>
+        {controls}
       </div>
-      <LineNumberedTextarea
-        value={text}
-        onChange={onChange}
-        minRows={enlarged ? Math.max(minRows, 24) : minRows}
-        highlightJson={kind === "json" || kind === "pretty"}
-        aria-label={ariaLabel ?? label}
-      />
+      {field}
     </div>
   );
 }

--- a/frontend/ui/src/features/offline-eval/components/review-panel.tsx
+++ b/frontend/ui/src/features/offline-eval/components/review-panel.tsx
@@ -49,7 +49,7 @@ export function ReviewPanel({
   target: ReviewTarget | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSave: (review: HumanReview) => void;
+  onSave: (review: HumanReview) => void | Promise<void>;
   /** Toast description shown after saving; omit for none. */
   savedDescription?: string;
   /** Small note in the footer (e.g. "Saved in this page only."). */
@@ -73,14 +73,25 @@ export function ReviewPanel({
 
   if (!target) return null;
 
-  const handleSave = () => {
-    onSave({
-      verdict,
-      quality,
-      comment: comment.trim() || undefined,
-      reviewer: "You",
-      at: new Date().toISOString(),
-    });
+  const handleSave = async () => {
+    try {
+      // Await the persist so a failed request is never presented as saved. onSave may
+      // be sync (returns void) or return a promise that rejects on failure.
+      await onSave({
+        verdict,
+        quality,
+        comment: comment.trim() || undefined,
+        reviewer: "You",
+        at: new Date().toISOString(),
+      });
+    } catch {
+      toast({
+        title: "Could not save review",
+        description: "It wasn't persisted — please try again.",
+        tone: "warning",
+      });
+      return; // keep the drawer open with the reviewer's input intact
+    }
     toast({
       title: "Review saved",
       ...(savedDescription ? { description: savedDescription } : {}),

--- a/frontend/ui/src/features/offline-eval/components/seed-format.test.ts
+++ b/frontend/ui/src/features/offline-eval/components/seed-format.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Per-field seed formatting for captured values. The mode a freshly-captured
+ * value opens in should be a property of the FIELD (input/output expand,
+ * metadata stays inline), not of however the instrumented app happened to
+ * serialise it — and plain text must never be mangled.
+ */
+import { describe, it, expect } from "vitest";
+import { seedFormat } from "./code";
+
+describe("seedFormat — expanded (input, recorded output)", () => {
+  it("pretty-prints a compact JSON object", () => {
+    const out = seedFormat('{"message":"I was charged twice"}', "expanded");
+    expect(out.kind).toBe("pretty");
+    expect(out.text).toBe('{\n  "message": "I was charged twice"\n}');
+  });
+
+  it("normalises an already-indented value to the same canonical shape", () => {
+    const messy = '{\n    "a": 1\n}'; // 4-space indent from upstream
+    const out = seedFormat(messy, "expanded");
+    expect(out.kind).toBe("pretty");
+    expect(out.text).toBe('{\n  "a": 1\n}'); // canonical 2-space
+  });
+});
+
+describe("seedFormat — compact (metadata)", () => {
+  it("keeps a small flat object on one line", () => {
+    const out = seedFormat('{\n  "suite": "smoke"\n}', "compact");
+    expect(out.kind).toBe("json");
+    expect(out.text).toBe('{"suite":"smoke"}');
+  });
+
+  it("expands a NESTED value — one line stops being readable", () => {
+    const out = seedFormat('{"suite":"smoke","owner":{"team":"billing"}}', "compact");
+    expect(out.kind).toBe("pretty");
+    expect(out.text).toContain('\n  "suite": "smoke"');
+  });
+
+  it("expands a LONG value even when flat", () => {
+    const long = JSON.stringify({ note: "x".repeat(120) });
+    const out = seedFormat(long, "compact");
+    expect(out.kind).toBe("pretty");
+    expect(out.text).toContain("\n");
+  });
+
+  it("keeps a short flat array inline", () => {
+    const out = seedFormat('["smoke", "billing"]', "compact");
+    expect(out.kind).toBe("json");
+    expect(out.text).toBe('["smoke","billing"]');
+  });
+});
+
+describe("seedFormat — non-JSON is never mangled", () => {
+  it("leaves plain text exactly as-is", () => {
+    for (const prefer of ["expanded", "compact"] as const) {
+      const out = seedFormat("I forgot my password", prefer);
+      expect(out.kind).toBe("text");
+      expect(out.text).toBe("I forgot my password");
+    }
+  });
+
+  it("leaves JSON-looking-but-invalid text as-is", () => {
+    const broken = '{"a": 1,}';
+    const out = seedFormat(broken, "expanded");
+    expect(out.kind).toBe("text");
+    expect(out.text).toBe(broken);
+  });
+
+  it("leaves an empty value alone", () => {
+    expect(seedFormat("", "compact")).toEqual({ kind: "text", text: "" });
+  });
+
+  it("is idempotent — re-seeding an already-normalised value is a no-op", () => {
+    const once = seedFormat('{"suite":"smoke"}', "compact");
+    expect(seedFormat(once.text, "compact")).toEqual(once);
+    const pretty = seedFormat('{"a":1}', "expanded");
+    expect(seedFormat(pretty.text, "expanded")).toEqual(pretty);
+  });
+});

--- a/frontend/ui/src/features/offline-eval/components/test-case-review-drawer.tsx
+++ b/frontend/ui/src/features/offline-eval/components/test-case-review-drawer.tsx
@@ -48,7 +48,7 @@ export function TestCaseReviewDrawer({
   target: TestCaseReviewTarget | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSubmit: (result: { review: ReviewStatus; correctedExpected?: string }) => void;
+  onSubmit: (result: { review: ReviewStatus; correctedExpected?: string }) => void | Promise<void>;
 }) {
   const [checked, setChecked] = React.useState<boolean[]>(() => CHECKS.map(() => false));
   const [corrected, setCorrected] = React.useState("");

--- a/frontend/ui/src/features/traces/components/SpanKindIcon.tsx
+++ b/frontend/ui/src/features/traces/components/SpanKindIcon.tsx
@@ -1,15 +1,6 @@
 "use client";
 
-import {
-  Workflow,
-  Sparkle,
-  Bot,
-  Wrench,
-  ArrowRight,
-  FlaskConical,
-  Play,
-  Ruler,
-} from "lucide-react";
+import { FlaskConical, Play, Ruler } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { TREE_LAYOUT } from "../utils";
@@ -27,14 +18,13 @@ export function getSpanKindIcon(kind: string) {
     case "agent":
       return DOMAIN_ICONS.agent;
     case "tool":
-      return Wrench;
+      return DOMAIN_ICONS.tool;
     case "evaluation":
       return FlaskConical;
     case "task":
       return Play;
     case "scorer":
       return Ruler;
-      return DOMAIN_ICONS.tool;
     case "span":
     default:
       return DOMAIN_ICONS.span;

--- a/frontend/ui/src/features/traces/components/TraceIOValue.tsx
+++ b/frontend/ui/src/features/traces/components/TraceIOValue.tsx
@@ -4,24 +4,27 @@ import { useMemo, useState } from "react";
 import { ChevronDown, Loader2 } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ExpandableSection } from "@/components/ui/expandable-section";
+import { MarkdownView } from "@/components/ui/markdown-view";
 import { cn } from "@/lib/utils";
 import { ContentRenderer } from "./ContentRenderer";
 
 /**
  * A collapsible span I/O / metadata section with a format switcher in its header
  * (beside the copy button), matching the editable fields' chrome. Formats: Pretty
- * (the smart JSON tree / media renderer — the default), JSON (compact), Text (raw),
- * and YAML. The value is parsed as JSON when possible; a non-JSON string is shown as-is.
+ * (the smart JSON tree / media renderer — the default), JSON (flat, syntax-highlighted),
+ * Text (raw), and YAML. The value is parsed as JSON when possible; a non-JSON string is
+ * shown as-is.
  */
-type IOFormat = "pretty" | "json" | "text" | "yaml";
+type IOFormat = "pretty" | "json" | "text" | "yaml" | "markdown";
 
 const FORMAT_LABEL: Record<IOFormat, string> = {
   pretty: "Pretty",
   json: "JSON",
   text: "Text",
   yaml: "YAML",
+  markdown: "Markdown",
 };
-const FORMATS: IOFormat[] = ["pretty", "json", "text", "yaml"];
+const FORMATS: IOFormat[] = ["pretty", "json", "text", "yaml", "markdown"];
 
 function parseMaybe(content: string): unknown {
   try {
@@ -71,15 +74,68 @@ function toYaml(value: unknown, indent = 0): string {
     .join("\n");
 }
 
-function formatValue(value: unknown, format: Exclude<IOFormat, "pretty">): string {
-  switch (format) {
-    case "json":
-      return JSON.stringify(value ?? null);
-    case "text":
-      return toText(value);
-    case "yaml":
-      return toYaml(value);
+function formatValue(value: unknown, format: "text" | "yaml"): string {
+  return format === "yaml" ? toYaml(value) : toText(value);
+}
+
+/**
+ * JSON syntax highlighting for the flat "JSON" view, mirroring the palette the
+ * interactive tree (JsonRenderer) uses so switching formats keeps the coloring:
+ * keys sky, strings green, numbers blue, booleans purple, null orange, and the
+ * structural punctuation muted. A single regex tokenizes the serialized JSON; a
+ * quoted token is a key when a colon follows it, otherwise a string value.
+ */
+const JSON_TOKEN = /"(?:\\.|[^"\\])*"|\b(?:true|false|null)\b|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/g;
+const JSON_TOKEN_CLASS: Record<string, string> = {
+  key: "text-sky-600 dark:text-sky-400",
+  string: "text-green-700 dark:text-green-400",
+  number: "text-blue-600 dark:text-blue-400",
+  bool: "text-purple-600 dark:text-purple-400",
+  null: "text-orange-600 dark:text-orange-400",
+};
+
+function tokenizeJson(json: string): Array<{ text: string; kind?: string }> {
+  const out: Array<{ text: string; kind?: string }> = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  JSON_TOKEN.lastIndex = 0;
+  while ((m = JSON_TOKEN.exec(json)) !== null) {
+    if (m.index > last) out.push({ text: json.slice(last, m.index) });
+    const raw = m[0];
+    let kind: string;
+    if (raw[0] === '"') {
+      kind = /^\s*:/.test(json.slice(JSON_TOKEN.lastIndex)) ? "key" : "string";
+    } else if (raw === "true" || raw === "false") {
+      kind = "bool";
+    } else if (raw === "null") {
+      kind = "null";
+    } else {
+      kind = "number";
+    }
+    out.push({ text: raw, kind });
+    last = JSON_TOKEN.lastIndex;
   }
+  if (last < json.length) out.push({ text: json.slice(last) });
+  return out;
+}
+
+function HighlightedJson({ value }: { value: unknown }) {
+  const tokens = useMemo(() => tokenizeJson(JSON.stringify(value ?? null, null, 2)), [value]);
+  return (
+    <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed">
+      {tokens.map((t, i) =>
+        t.kind ? (
+          <span key={i} className={JSON_TOKEN_CLASS[t.kind]}>
+            {t.text}
+          </span>
+        ) : (
+          <span key={i} className="text-muted-foreground">
+            {t.text}
+          </span>
+        ),
+      )}
+    </pre>
+  );
 }
 
 /** Header format dropdown. A non-`<button>` trigger, since it lives inside the
@@ -162,6 +218,11 @@ export function TraceIOSection({
         <span className="text-[11px] text-muted-foreground">-</span>
       ) : format === "pretty" ? (
         <ContentRenderer content={content} />
+      ) : format === "markdown" ? (
+        // Model output is very often markdown; render it rather than showing the raw source.
+        <MarkdownView content={content} />
+      ) : format === "json" ? (
+        <HighlightedJson value={parsed} />
       ) : (
         <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed">
           {formatValue(parsed, format)}

--- a/frontend/ui/src/lib/api/traces.ts
+++ b/frontend/ui/src/lib/api/traces.ts
@@ -21,6 +21,7 @@ export async function getTraces(
   if (options.start_after) params.set("start_after", options.start_after);
   if (options.end_before) params.set("end_before", options.end_before);
   if (options.search_query) params.set("search_query", options.search_query);
+  if (options.include_evaluations) params.set("include_evaluations", "true");
   const filtersParam = serializeFiltersParam(options.filters);
   if (filtersParam) params.set("filters", filtersParam);
 

--- a/frontend/ui/src/lib/code-highlight.test.ts
+++ b/frontend/ui/src/lib/code-highlight.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { highlightCode, normalizeLang, type CodeToken } from "./code-highlight";
+
+/** Highlighting must be lossless: tokens always reconstruct the input exactly. */
+const roundTrip = (tokens: CodeToken[]) => tokens.map((t) => t.text).join("");
+const classOf = (tokens: CodeToken[], text: string) => tokens.find((t) => t.text === text)?.cls;
+
+describe("normalizeLang", () => {
+  it("maps the aliases we document", () => {
+    expect(normalizeLang("py")).toBe("python");
+    expect(normalizeLang("Python")).toBe("python");
+    expect(normalizeLang("js")).toBe("javascript");
+    expect(normalizeLang("ts")).toBe("typescript");
+    expect(normalizeLang("json")).toBe("json");
+  });
+
+  it("returns null for unknown/absent languages", () => {
+    expect(normalizeLang("rust")).toBeNull();
+    expect(normalizeLang("")).toBeNull();
+    expect(normalizeLang(null)).toBeNull();
+  });
+});
+
+describe("highlightCode", () => {
+  it("returns one plain token when the language is unknown", () => {
+    const t = highlightCode("fn main() {}", null);
+    expect(t).toEqual([{ text: "fn main() {}" }]);
+  });
+
+  it("classifies python comments, strings, keywords, numbers and calls", () => {
+    const src = ["# greet", "def greet(name):", '    return f"hi {name}" if True else 1'].join(
+      "\n",
+    );
+    const t = highlightCode(src, "python");
+    expect(roundTrip(t)).toBe(src);
+    expect(classOf(t, "# greet")).toContain("muted");
+    expect(classOf(t, "def")).toContain("purple");
+    expect(classOf(t, "True")).toContain("orange");
+    expect(classOf(t, "1")).toContain("blue");
+    expect(t.find((x) => x.text.includes('f"hi'))?.cls).toContain("green");
+  });
+
+  it("does not treat quotes inside a python triple-quoted string as a new string", () => {
+    const src = '"""say "hi" now"""\nx = 1';
+    const t = highlightCode(src, "python");
+    expect(roundTrip(t)).toBe(src);
+    expect(classOf(t, '"""say "hi" now"""')).toContain("green");
+  });
+
+  it("classifies javascript comments, template strings, keywords and constants", () => {
+    const src = ["// note", "const x = `a${b}c`;", "if (x === null) run(1.5);"].join("\n");
+    const t = highlightCode(src, "javascript");
+    expect(roundTrip(t)).toBe(src);
+    expect(classOf(t, "// note")).toContain("muted");
+    expect(classOf(t, "const")).toContain("purple");
+    expect(classOf(t, "`a${b}c`")).toContain("green");
+    expect(classOf(t, "null")).toContain("orange");
+    expect(classOf(t, "1.5")).toContain("blue");
+    expect(classOf(t, "run")).toContain("sky");
+  });
+
+  it("highlights typescript with the javascript rules", () => {
+    const t = highlightCode("interface A { b: string }", "typescript");
+    expect(classOf(t, "interface")).toContain("purple");
+  });
+
+  it("distinguishes json keys from string values", () => {
+    const src = '{"route": "billing"}';
+    const t = highlightCode(src, "json");
+    expect(roundTrip(t)).toBe(src);
+    expect(classOf(t, '"route"')).toContain("sky");
+    expect(classOf(t, '"billing"')).toContain("green");
+  });
+
+  it("is lossless on multi-line input and empty input", () => {
+    const src = "def f():\n\n    pass\n";
+    expect(roundTrip(highlightCode(src, "python"))).toBe(src);
+    expect(highlightCode("", "python")).toEqual([]);
+  });
+});

--- a/frontend/ui/src/lib/code-highlight.ts
+++ b/frontend/ui/src/lib/code-highlight.ts
@@ -1,0 +1,139 @@
+/**
+ * Dependency-free syntax highlighting for fenced code blocks in rendered markdown.
+ *
+ * Python and JavaScript are the languages we care about today (the SDK snippets the
+ * product emits); TypeScript reuses the JS rules and JSON gets a minimal pass. An
+ * unknown/absent language returns a single plain token, so the caller renders the
+ * code unstyled rather than mangling it.
+ *
+ * The palette matches the trace panel's JSON colouring (strings green, numbers blue,
+ * constants orange, keywords purple, callables sky) so code reads consistently
+ * wherever it appears.
+ */
+
+export interface CodeToken {
+  text: string;
+  cls?: string;
+}
+
+export type CodeLang = "python" | "javascript" | "typescript" | "json" | null;
+
+const CLS = {
+  comment: "text-muted-foreground italic",
+  string: "text-green-700 dark:text-green-400",
+  number: "text-blue-600 dark:text-blue-400",
+  keyword: "text-purple-600 dark:text-purple-400",
+  constant: "text-orange-600 dark:text-orange-400",
+  fn: "text-sky-600 dark:text-sky-400",
+  key: "text-sky-600 dark:text-sky-400",
+} as const;
+
+/**
+ * One lexer rule. `re` must use only NON-capturing groups internally — the
+ * tokenizer wraps each rule in exactly one capturing group to identify matches.
+ */
+interface Rule {
+  re: string;
+  cls: string;
+}
+
+const NUMBER = String.raw`\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b`;
+
+const PYTHON: Rule[] = [
+  { re: String.raw`#[^\n]*`, cls: CLS.comment },
+  // Triple-quoted strings first, so their inner quotes don't start a short string.
+  { re: String.raw`[rbfuRBFU]{0,2}(?:"""[\s\S]*?"""|'''[\s\S]*?''')`, cls: CLS.string },
+  { re: String.raw`[rbfuRBFU]{0,2}(?:"(?:\\.|[^"\\\n])*"|'(?:\\.|[^'\\\n])*')`, cls: CLS.string },
+  { re: String.raw`@[A-Za-z_]\w*`, cls: CLS.fn },
+  { re: String.raw`\b(?:True|False|None)\b`, cls: CLS.constant },
+  {
+    re: String.raw`\b(?:def|class|return|if|elif|else|for|while|import|from|as|with|try|except|finally|raise|yield|lambda|pass|break|continue|in|not|and|or|is|async|await|global|nonlocal|assert|del)\b`,
+    cls: CLS.keyword,
+  },
+  { re: NUMBER, cls: CLS.number },
+  { re: String.raw`\b[A-Za-z_]\w*(?=\s*\()`, cls: CLS.fn },
+];
+
+const JAVASCRIPT: Rule[] = [
+  { re: String.raw`//[^\n]*`, cls: CLS.comment },
+  { re: String.raw`/\*[\s\S]*?\*/`, cls: CLS.comment },
+  { re: "`(?:\\\\.|[^`\\\\])*`", cls: CLS.string },
+  { re: String.raw`"(?:\\.|[^"\\\n])*"|'(?:\\.|[^'\\\n])*'`, cls: CLS.string },
+  { re: String.raw`\b(?:true|false|null|undefined|NaN|Infinity)\b`, cls: CLS.constant },
+  {
+    re: String.raw`\b(?:const|let|var|function|return|if|else|for|while|of|in|new|class|extends|implements|import|from|export|default|async|await|try|catch|finally|throw|typeof|instanceof|this|super|switch|case|break|continue|do|delete|void|yield|interface|type|enum|public|private|protected|readonly|as|satisfies|static)\b`,
+    cls: CLS.keyword,
+  },
+  { re: NUMBER, cls: CLS.number },
+  { re: String.raw`\b[A-Za-z_$][\w$]*(?=\s*\()`, cls: CLS.fn },
+];
+
+const JSON_RULES: Rule[] = [
+  { re: String.raw`"(?:\\.|[^"\\])*"(?=\s*:)`, cls: CLS.key },
+  { re: String.raw`"(?:\\.|[^"\\])*"`, cls: CLS.string },
+  { re: String.raw`\b(?:true|false|null)\b`, cls: CLS.constant },
+  { re: String.raw`-?` + NUMBER, cls: CLS.number },
+];
+
+const RULES: Record<Exclude<CodeLang, null>, Rule[]> = {
+  python: PYTHON,
+  javascript: JAVASCRIPT,
+  typescript: JAVASCRIPT,
+  json: JSON_RULES,
+};
+
+const ALIASES: Record<string, Exclude<CodeLang, null>> = {
+  py: "python",
+  python: "python",
+  python3: "python",
+  js: "javascript",
+  jsx: "javascript",
+  javascript: "javascript",
+  node: "javascript",
+  mjs: "javascript",
+  ts: "typescript",
+  tsx: "typescript",
+  typescript: "typescript",
+  json: "json",
+};
+
+/** Map a fence's language hint (```py) to a supported lexer, or null if unknown. */
+export function normalizeLang(lang: string | null | undefined): CodeLang {
+  if (!lang) return null;
+  return ALIASES[lang.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * Tokenize `code` for `lang`. Returns plain (unclassed) tokens for anything the
+ * rules don't cover, so concatenating every token's text reproduces the input
+ * exactly — highlighting never drops or rewrites source.
+ */
+export function highlightCode(code: string, lang: CodeLang): CodeToken[] {
+  const rules = lang ? RULES[lang] : null;
+  if (!rules || !code) return code ? [{ text: code }] : [];
+
+  const re = new RegExp(rules.map((r) => `(${r.re})`).join("|"), "gm");
+  const out: CodeToken[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(code)) !== null) {
+    // Zero-length match would loop forever; bail defensively.
+    if (m[0] === "") {
+      re.lastIndex += 1;
+      continue;
+    }
+    if (m.index > last) out.push({ text: code.slice(last, m.index) });
+    // Exactly one capturing group matches — its position identifies the rule.
+    let groupIndex = -1;
+    for (let i = 1; i < m.length; i++) {
+      if (m[i] !== undefined) {
+        groupIndex = i;
+        break;
+      }
+    }
+    out.push({ text: m[0], cls: groupIndex > 0 ? rules[groupIndex - 1].cls : undefined });
+    last = m.index + m[0].length;
+  }
+  if (last < code.length) out.push({ text: code.slice(last) });
+  return out;
+}

--- a/frontend/ui/src/lib/eval/versions.ts
+++ b/frontend/ui/src/lib/eval/versions.ts
@@ -167,10 +167,19 @@ export async function publishDatasetVersion(opts: {
       });
     }
 
-    await tx.dataset.update({
-      where: { id: opts.datasetId },
+    // Conditional pointer move: repoint only if `currentVersionId` is still what we
+    // read at the top of this transaction. Under READ COMMITTED two concurrent
+    // publishes can both clear the `baseVersionId` check above and then both write
+    // here, silently dropping one update. Gating the write on the observed value makes
+    // the loser match zero rows, which we surface as a VersionConflict to retry —
+    // never a lost publish.
+    const moved = await tx.dataset.updateMany({
+      where: { id: opts.datasetId, currentVersionId: dataset.currentVersionId },
       data: { currentVersionId: version.id },
     });
+    if (moved.count === 0) {
+      throw new VersionConflict(dataset.currentVersionId ?? null);
+    }
 
     return {
       versionId: version.id,

--- a/frontend/ui/src/lib/remark-underline.ts
+++ b/frontend/ui/src/lib/remark-underline.ts
@@ -1,0 +1,66 @@
+/**
+ * Markdown has no underline syntax — `_x_` and `__x__` are emphasis/strong — and we
+ * don't render raw HTML (no rehype-raw), so `<u>…</u>` would otherwise be dropped.
+ *
+ * This tiny remark plugin pairs the inline `html` nodes remark emits for `<u>` and
+ * `</u>` and wraps what's between them in a node that renders as a real `<u>`
+ * element (via mdast's `data.hName`). Everything else is left untouched, so no
+ * other HTML becomes renderable.
+ */
+
+interface MdNode {
+  type: string;
+  value?: string;
+  children?: MdNode[];
+  data?: Record<string, unknown>;
+}
+
+const OPEN = /^<u\s*>$/i;
+const CLOSE = /^<\/u\s*>$/i;
+
+const isTag = (node: MdNode, re: RegExp) =>
+  node.type === "html" && typeof node.value === "string" && re.test(node.value.trim());
+
+function transform(node: MdNode): void {
+  const children = node.children;
+  if (!children) return;
+
+  const out: MdNode[] = [];
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+
+    if (isTag(child, OPEN)) {
+      // Scan forward for the matching close, tolerating nesting.
+      const inner: MdNode[] = [];
+      let depth = 1;
+      let j = i + 1;
+      for (; j < children.length; j++) {
+        const candidate = children[j];
+        if (isTag(candidate, OPEN)) depth++;
+        else if (isTag(candidate, CLOSE)) {
+          depth--;
+          if (depth === 0) break;
+        }
+        inner.push(candidate);
+      }
+      if (depth === 0 && j < children.length) {
+        inner.forEach(transform);
+        // `data.hName` makes mdast-util-to-hast emit <u> for this unknown node.
+        out.push({ type: "underline", data: { hName: "u" }, children: inner });
+        i = j; // skip the consumed closing tag
+        continue;
+      }
+      // Unbalanced — fall through and leave the node as-is.
+    }
+
+    transform(child);
+    out.push(child);
+  }
+  node.children = out;
+}
+
+export function remarkUnderline() {
+  return (tree: MdNode) => {
+    transform(tree);
+  };
+}

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -209,6 +209,9 @@ export interface TraceQueryOptions {
   search_query?: string;
   // Structured attribute filters, serialized as one URL-encoded JSON array.
   filters?: Predicate[];
+  // Include offline-evaluation traces (environment=evaluation), which the backend
+  // excludes from the default list.
+  include_evaluations?: boolean;
 }
 
 // Session types


### PR DESCRIPTION
## Summary

Fixes: #1660

Lets a user capture a span's inputs and outputs into a new or existing dataset straight from the trace viewer. The captured Output is a single editable field: left as recorded it stays the recorded output; edited, it becomes the expected output while the recorded value is still stored separately. One control does the work of three underlying values — input, recorded output, and expected output — without asking the user to reconcile them by hand. Long fields collapse behind an in-field expand control so a big value doesn't flood the drawer, and a saved span gets a "Dataset:" chip with a hover card naming where it was captured.

## How it works

A "Save as test case" button on the span header opens the drawer, seeded from the selected span's fetched I/O. While the drawer is open, clicking a different span in the tree retargets the drawer and its chip to that span; the drawer's own up/down chevrons walk spans too. The Output field's helper text flips as soon as it's edited — from "the recorded production output" to "your version becomes the expected outcome; the recorded output is still stored". Choosing "New dataset" reveals a name field. Saving posts input, expected, and recorded output together and publishes a new dataset version; if the span is already a case in that dataset the drawer offers to open the existing one instead of adding a duplicate.

## What's included

### Shared components
- `features/evaluations/components/trace-integration.tsx` — `SaveTestCaseDrawer` (dataset picker + new-dataset target, seeded Input / Output / Metadata blocks with the single-editable-Output semantics, span up/down navigation, source-attachment toggle, duplicate handling), `SpanDatasetChip` (the per-span "Dataset:" chip with a hover card carrying the dataset's version, last-updated, case count, and a copyable SDK snippet), and `TraceEvaluationChip` (the trace-level chip when a trace came from a run).
- `features/offline-eval/components/code.tsx` — `EditableValueBlock` with per-field JSON seed preference and in-field "…expand (N more characters)" collapse; `seedFormat` / `formatValue` for the per-field format detection (JSON / markdown / plain text) that decides how each seeded field renders.
- `components/ui/markdown-view.tsx` — provides `MarkdownView`.
- `features/traces/components/TraceIOValue.tsx` — provides `TraceIOSection`.
- `lib/api/traces.ts` — Trace API functions (Python backend - ClickHouse).
- `lib/code-highlight.ts` — Dependency-free syntax highlighting for fenced code blocks in rendered markdown.
- `lib/remark-underline.ts` — Markdown has no underline syntax — `_x_` and `__x__` are emphasis/strong — and we don't render raw HTML (no rehype-raw), so `<u>…</u>` would otherwise be dropped.
- `types/api.ts` — Shared API types for TraceRoot UI.

### Trace viewer integration
- `app/projects/[projectId]/traces/page.tsx` — wires the trace viewer to the drawer and chips: the "Save as test case" span-header button, the trace/span extra-tag chips, and retargeting the open drawer when the tree selection changes.

### Hooks / data

### Tests
- `app/projects/[projectId]/traces/page.user-filter.test.tsx` — covers `page.user-filter`.
- `features/offline-eval/components/seed-format.test.ts` — covers `seed-format`.
- `components/ui/markdown-view.test.tsx` — covers `markdown-view`.
- `features/evaluations/save-test-case-format.smoke.test.tsx` — covers `save-test-case-format.smoke`.
- `features/evaluations/save-test-case-span-sync.smoke.test.tsx` — covers `save-test-case-span-sync.smoke`.
- `features/offline-eval/components/code.review.test.tsx` — covers `code.review`.
- `lib/code-highlight.test.ts` — covers `code-highlight`.

### Backend
- `backend/rest/routers/public/traces_read.py` — Public, API-key-authenticated trace read endpoints (for the CLI). `GET /api/v1/public/traces` (list) and `GET /api/v1/public/traces/{trace_id}` (get).
- `backend/rest/routers/traces.py` — Trace query endpoints (user-authenticated, not public API).
- `backend/rest/services/trace_reader.py` — Service for reading traces from ClickHouse.

### UI
- `features/evaluations/views/evaluations-view.tsx` — provides `RunStatusBadge`, `EvaluationsView`, `formatElapsed`, `ScoreValue`.

## Test plan

- [ ] Output left unchanged is stored as the recorded output; edited, it is stored as the expected output with the recorded output retained.
- [ ] Long input / output / metadata collapse inline with a remaining-character count and expand in place.
- [ ] Each field is labelled by detected format (JSON / markdown / plain text) and renders accordingly.
- [ ] Selecting a different span in the tree retargets the drawer and its chip to that span.
- [ ] Saving into a new dataset creates it; saving into an existing one extends it and publishes a new version.
- [ ] A saved span shows a "Dataset:" chip whose hover card names the dataset, version, last-updated, and case count.
- [ ] Re-saving a span already captured in the chosen dataset offers to open the existing case instead of duplicating it.
