### PR TITLE
feat(rest): publish reporting OpenAPI with a parity guard

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -984,6 +984,16 @@
             ],
             "title": "Metadata"
           },
+          "provenance": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RunProvenance"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "scorers": {
             "items": {
               "$ref": "#/components/schemas/ScorerRef"
@@ -1036,6 +1046,132 @@
           "run_url"
         ],
         "title": "RegisterRunResponse",
+        "type": "object"
+      },
+      "RunProvenance": {
+        "description": "Typed execution provenance (git/CI/SDK identity + declared candidate\nmodel/prompt). Mirrors ``RunProvenanceSchema`` on the Zod side. Every field is\noptional and reported by the SDK from what it can actually observe; unknown\nvalues are absent/null and never inferred. Distinct from free-form ``metadata``\nand never a substitute for the user-facing ``candidate_version`` label.",
+        "properties": {
+          "ci_build_id": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ci Build Id"
+          },
+          "ci_provider": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ci Provider"
+          },
+          "declared_model": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Declared Model"
+          },
+          "declared_prompt_version": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Declared Prompt Version"
+          },
+          "git_commit": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Commit"
+          },
+          "git_dirty": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Dirty"
+          },
+          "git_ref": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Ref"
+          },
+          "git_repository": {
+            "anyOf": [
+              {
+                "maxLength": 500,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Repository"
+          },
+          "sdk_language": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sdk Language"
+          },
+          "sdk_version": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sdk Version"
+          }
+        },
+        "title": "RunProvenance",
         "type": "object"
       },
       "ScoreInput": {

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -28,6 +28,19 @@
             ],
             "title": "Main Score"
           },
+          "main_score_name": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Score Name"
+          },
           "scored_count": {
             "anyOf": [
               {

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -2,12 +2,12 @@
   "components": {
     "schemas": {
       "CompleteRunRequest": {
-        "additionalProperties": false,
         "description": "Complete/fail a run, reporting final completeness counts.",
         "properties": {
           "case_count": {
             "anyOf": [
               {
+                "maximum": 9007199254740991.0,
                 "minimum": 0.0,
                 "type": "integer"
               },
@@ -44,6 +44,7 @@
           "scored_count": {
             "anyOf": [
               {
+                "maximum": 9007199254740991.0,
                 "minimum": 0.0,
                 "type": "integer"
               },
@@ -56,6 +57,7 @@
           "scorer_error_count": {
             "anyOf": [
               {
+                "maximum": 9007199254740991.0,
                 "minimum": 0.0,
                 "type": "integer"
               },
@@ -80,6 +82,7 @@
           "task_error_count": {
             "anyOf": [
               {
+                "maximum": 9007199254740991.0,
                 "minimum": 0.0,
                 "type": "integer"
               },
@@ -893,7 +896,6 @@
         "type": "object"
       },
       "RegisterRunRequest": {
-        "additionalProperties": false,
         "description": "Register/start a run. Idempotent on ``client_run_id`` within an evaluation.",
         "properties": {
           "baseline_run_id": {
@@ -918,6 +920,7 @@
           "case_count": {
             "anyOf": [
               {
+                "maximum": 9007199254740991.0,
                 "minimum": 0.0,
                 "type": "integer"
               },
@@ -1011,6 +1014,7 @@
             "items": {
               "$ref": "#/components/schemas/ScorerRef"
             },
+            "maxItems": 200,
             "title": "Scorers",
             "type": "array"
           }
@@ -1188,7 +1192,6 @@
         "type": "object"
       },
       "ScoreInput": {
-        "additionalProperties": false,
         "description": "One scorer's outcome on one result. ``error`` set = the scorer failed to judge.",
         "properties": {
           "bool_value": {
@@ -1284,6 +1287,7 @@
         "description": "One prompt message of an LLM-judge scorer's definition.",
         "properties": {
           "content": {
+            "maxLength": 20000,
             "title": "Content",
             "type": "string"
           },
@@ -1302,7 +1306,7 @@
         "type": "object"
       },
       "ScorerRef": {
-        "description": "A scorer's descriptor. ``name`` + ``version`` are the comparison identity;\nthe richer metadata is optional and back-compatible (an old SDK sending only\n``{name, version}`` stays valid). Mirrors the non-strict ``ScorerRefSchema``,\nso unknown keys are ignored rather than rejected.\n\nThe DEFINITION fields (``scorer_type``, prompt/source, config) let the read-only\nScorer detail render an LLM judge's model + messages or a code scorer's snippet.",
+        "description": "A scorer's descriptor. ``name`` + ``version`` are the comparison identity;\nthe richer metadata is optional and back-compatible (an old SDK sending only\n``{name, version}`` stays valid). Mirrors the non-strict ``ScorerRefSchema``,\nso unknown keys are ignored rather than rejected.\n\nThe DEFINITION fields (``scorer_type``, prompt/source, config) let the read-only\nScorer detail render an LLM judge's model + messages or a code scorer's snippet.\n\n``scorer_type`` / ``output_type`` / ``language`` are display-only, so an\nunrecognised value from a newer SDK degrades to ``None`` rather than failing\nrun registration (which would lose the run's every result and score) \u2014\nmatching ``.catch(null)`` on the Zod side. The vocabularies that drive\npersistence and aggregation still reject.",
         "properties": {
           "description": {
             "anyOf": [
@@ -1353,6 +1357,7 @@
                 "items": {
                   "$ref": "#/components/schemas/ScorerMessage"
                 },
+                "maxItems": 50,
                 "type": "array"
               },
               {
@@ -1421,6 +1426,7 @@
           "source": {
             "anyOf": [
               {
+                "maxLength": 50000,
                 "type": "string"
               },
               {
@@ -1690,12 +1696,12 @@
         "type": "object"
       },
       "UpsertResultRequest": {
-        "additionalProperties": false,
-        "description": "Upsert one test-case result. Idempotent on (``run_id``, ``test_case_id``).\n``trace_id`` may be null now and set on a later call (out-of-order arrival).\nSending ``scores`` replaces the result's scores.",
+        "description": "Upsert one test-case result. Idempotent on (``run_id``, ``test_case_id``).\n``trace_id`` may be null now and set on a later call (out-of-order arrival).\n\n``scores`` is genuinely optional and carries three distinct meanings, so the\nout-of-order flow (POST the result with its scores, then re-POST later just to\nattach the OTel ``trace_id``) cannot destroy them: absent \u2192 leave the existing\nscores untouched, ``[]`` \u2192 clear them, non-empty \u2192 replace them. Do not give\nthis a ``default_factory=list``, which would collapse the first two cases.\n\nEvery optional field is a *partial* update: a key the caller omits keeps its\nstored value, while an explicit null clears it. Sending ``scores`` replaces\nthe result's scores (``[]`` clears them); omitting it leaves them alone.",
         "properties": {
           "baseline_output": {
             "anyOf": [
               {
+                "maxLength": 1000000,
                 "type": "string"
               },
               {
@@ -1707,6 +1713,7 @@
           "candidate_output": {
             "anyOf": [
               {
+                "maxLength": 1000000,
                 "type": "string"
               },
               {
@@ -1746,6 +1753,7 @@
           "duration_ms": {
             "anyOf": [
               {
+                "maximum": 9007199254740991.0,
                 "minimum": 0.0,
                 "type": "integer"
               },
@@ -1758,6 +1766,7 @@
           "expected_output": {
             "anyOf": [
               {
+                "maxLength": 1000000,
                 "type": "string"
               },
               {
@@ -1767,6 +1776,7 @@
             "title": "Expected Output"
           },
           "input": {
+            "maxLength": 1000000,
             "title": "Input",
             "type": "string"
           },
@@ -1785,6 +1795,7 @@
             "items": {
               "$ref": "#/components/schemas/ScoreInput"
             },
+            "maxItems": 200,
             "title": "Scores",
             "type": "array"
           },
@@ -2566,15 +2577,25 @@
             },
             "description": "Not found"
           },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request body too large"
+          },
           "422": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Validation error"
           },
           "503": {
             "content": {
@@ -2674,15 +2695,25 @@
             },
             "description": "Not found"
           },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request body too large"
+          },
           "422": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Validation error"
           },
           "503": {
             "content": {
@@ -2782,15 +2813,25 @@
             },
             "description": "Not found"
           },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request body too large"
+          },
           "422": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Validation error"
           },
           "503": {
             "content": {

--- a/backend/rest/schemas/eval.py
+++ b/backend/rest/schemas/eval.py
@@ -334,6 +334,10 @@ class CompleteRunRequest(BaseModel):
 
     status: EvalRunStatus
     main_score: JsonFloat | None = None
+    # The run-level main-score metric name, RESOLVED at completion — lets an SDK
+    # register before any scorer's emitted name is known and name it here. Additive:
+    # an older SDK omits it. Mirrors ``main_score_name`` on the Zod CompleteRunRequest.
+    main_score_name: str | None = Field(default=None, min_length=1, max_length=200)
     case_count: JsonNonNegativeInt | None = None
     scored_count: JsonNonNegativeInt | None = None
     task_error_count: JsonNonNegativeInt | None = None

--- a/backend/rest/schemas/eval.py
+++ b/backend/rest/schemas/eval.py
@@ -8,7 +8,9 @@ handlers — the gateway forwards the (validated) body on and never duplicates i
 
 Parity rules with the Zod source:
 - ``z.string().min(1).max(n)`` → ``Field(min_length=1, max_length=n)``.
-- ``z.number().int().nonnegative()`` → ``int`` with ``ge=0``; ``z.number()`` → ``float``.
+- ``z.number().int().nonnegative()`` → ``JsonNonNegativeInt``; ``z.number()`` →
+  ``JsonFloat``; ``z.boolean()`` → ``JsonBool`` (see the JSON-strict scalars below —
+  plain ``int``/``float``/``bool`` would coerce where Zod does not).
 - ``.nullable().optional()`` → ``T | None = None``; ``.default(x)`` → default ``x``.
 - ``z.array(X).max(n)`` → ``list[X]`` with ``max_length=n``.
 - A display-only enum with ``.catch(null)`` → ``Literal[...] | None`` plus a
@@ -27,13 +29,69 @@ still enforced here so a malformed payload never reaches the control plane.
 
 A cross-language drift test (``tests/rest/test_eval_contract_parity.py`` +
 ``eval-contract-parity.drift.test.ts``) feeds the same representative payloads to
-both layers and asserts identical accept/reject verdicts.
+both layers and asserts identical accept/reject verdicts, and compares every model
+here against the shared structural roster (``eval-contract-shape.json``) so that a
+field added or re-bounded on one layer only fails without needing a fixture for it.
 """
 
 import json
-from typing import Any, Literal, get_args
+from typing import Annotated, Any, Literal, get_args
 
-from pydantic import BaseModel, Field, ValidationInfo, field_validator
+from pydantic import BaseModel, BeforeValidator, Field, ValidationInfo, field_validator
+
+# --- JSON-strict scalars ----------------------------------------------------
+#
+# Pydantic's default (lax) mode coerces across JSON types — ``"0.5"`` validates as
+# a float, ``"3"`` and ``true`` as an int, ``"yes"`` and ``1`` as a bool. Zod's
+# ``z.number()`` / ``z.boolean()`` do none of that. Left alone, the gateway would
+# ACCEPT a body the control plane then 400s on, which is the exact two-hop failure
+# this contract pairing exists to prevent (the gateway forwards the raw, un-normalized
+# bytes upstream, so its coercion never even reaches the writer).
+#
+# Blanket ``ConfigDict(strict=True)`` is the wrong tool: it also rejects ``24.0`` on
+# an int field, which Zod's ``z.number().int()`` accepts — JSON has no int/float
+# distinction, so ``24.0`` and ``24`` are the same wire value. These per-field types
+# reject only the cross-type coercions, keeping the integral-float case valid.
+
+
+def _json_number(v: Any) -> Any:
+    """Reject the values ``z.number()`` rejects: JSON strings and booleans."""
+    if isinstance(v, (bool, str)):
+        raise ValueError("must be a JSON number (a string or boolean is not coerced)")
+    return v
+
+
+def _json_int(v: Any) -> Any:
+    """As ``_json_number``, but also accept an integral float (``24.0`` == ``24`` on the wire)."""
+    if isinstance(v, (bool, str)):
+        raise ValueError("must be a JSON number (a string or boolean is not coerced)")
+    if isinstance(v, float) and v.is_integer():
+        return int(v)
+    return v
+
+
+def _json_bool(v: Any) -> Any:
+    """Reject the values ``z.boolean()`` rejects: everything that is not a JSON boolean."""
+    if not isinstance(v, bool):
+        raise ValueError("must be a JSON boolean (a string or number is not coerced)")
+    return v
+
+
+#: ``z.number()`` — a JSON number, never a coerced string/boolean.
+JsonFloat = Annotated[float, BeforeValidator(_json_number)]
+#: ``z.boolean()`` — a JSON boolean, never a coerced string/number.
+JsonBool = Annotated[bool, BeforeValidator(_json_bool)]
+#: ``Number.MAX_SAFE_INTEGER``. Zod's ``z.number().int()`` is ``Number.isSafeInteger``,
+#: so the control plane rejects anything past this — an unbounded ``int`` here would
+#: accept a count the control plane then 400s on. Python has no such ceiling of its own.
+JSON_SAFE_INT_MAX = 9_007_199_254_740_991
+# The bounds must precede the validator in the Annotated chain: applied after it,
+# pydantic cannot fold `ge`/`le` into the integer/number core schema and publishes raw
+# `"ge": 0` keywords instead of JSON Schema's `"minimum": 0`.
+#: ``z.number().int().nonnegative()``.
+JsonNonNegativeInt = Annotated[int, Field(ge=0, le=JSON_SAFE_INT_MAX), BeforeValidator(_json_int)]
+#: ``z.number().nonnegative()``.
+JsonNonNegativeFloat = Annotated[float, Field(ge=0), BeforeValidator(_json_number)]
 
 # --- Payload caps (mirror the shared caps at the top of the Zod contract) ----
 
@@ -121,7 +179,7 @@ class ScorerRef(BaseModel):
     version: str = Field(min_length=1, max_length=50)
     value_type: ScorerValueType | None = None
     direction: ScorerDirection | None = None
-    threshold: float | None = None
+    threshold: JsonFloat | None = None
     # SDK-reported definition (all optional; absent or unrecognised → "—" in the detail).
     scorer_type: ScorerType | None = None
     output_type: ScorerOutputType | None = None
@@ -151,10 +209,10 @@ class ScoreInput(BaseModel):
 
     scorer_name: str = Field(min_length=1, max_length=200)
     scorer_version: str = Field(min_length=1, max_length=50)
-    numeric_value: float | None = None
-    bool_value: bool | None = None
+    numeric_value: JsonFloat | None = None
+    bool_value: JsonBool | None = None
     string_value: str | None = Field(default=None, max_length=2000)
-    passed: bool | None = None
+    passed: JsonBool | None = None
     explanation: str | None = Field(default=None, max_length=5000)
     error: str | None = Field(default=None, max_length=5000)
 
@@ -176,7 +234,7 @@ class RegisterRunRequest(BaseModel):
     # SDK-supplied idempotency key.
     client_run_id: str | None = Field(default=None, min_length=1, max_length=128)
     baseline_run_id: str | None = Field(default=None, min_length=1, max_length=64)
-    case_count: int | None = Field(default=None, ge=0)
+    case_count: JsonNonNegativeInt | None = None
     # Free-form run provenance (model, prompt, config, git repo/ref/commit, …).
     metadata: dict[str, Any] | None = None
 
@@ -226,14 +284,18 @@ class UpsertResultRequest(BaseModel):
     candidate_output: str | None = Field(default=None, max_length=EVAL_PAYLOAD_TEXT_MAX)
     baseline_output: str | None = Field(default=None, max_length=EVAL_PAYLOAD_TEXT_MAX)
     status: EvalResultStatus
-    main_score: float | None = None
+    main_score: JsonFloat | None = None
     change: ResultChange | None = None
     task_error: str | None = Field(default=None, max_length=10000)
-    duration_ms: int | None = Field(default=None, ge=0)
-    cost: float | None = Field(default=None, ge=0)
+    duration_ms: JsonNonNegativeInt | None = None
+    cost: JsonNonNegativeFloat | None = None
     # None (absent) and [] (explicit clear) mean different things to the writer, so
-    # this deliberately has no default_factory.
-    scores: list[ScoreInput] | None = Field(default=None, max_length=EVAL_SCORER_LIST_MAX)
+    # this deliberately has no default_factory. The annotation is NOT ``| None``: the
+    # Zod field is ``.optional()`` and not ``.nullable()``, so an explicit
+    # ``"scores": null`` is a 400 upstream and must not be accepted (and forwarded)
+    # here. Absence is carried by the default, which pydantic never validates, so the
+    # attribute is still ``None`` when the key was omitted.
+    scores: list[ScoreInput] = Field(default=None, max_length=EVAL_SCORER_LIST_MAX)
 
 
 class UpsertResultResponse(BaseModel):
@@ -247,11 +309,11 @@ class CompleteRunRequest(BaseModel):
     """Complete/fail a run, reporting final completeness counts."""
 
     status: EvalRunStatus
-    main_score: float | None = None
-    case_count: int | None = Field(default=None, ge=0)
-    scored_count: int | None = Field(default=None, ge=0)
-    task_error_count: int | None = Field(default=None, ge=0)
-    scorer_error_count: int | None = Field(default=None, ge=0)
+    main_score: JsonFloat | None = None
+    case_count: JsonNonNegativeInt | None = None
+    scored_count: JsonNonNegativeInt | None = None
+    task_error_count: JsonNonNegativeInt | None = None
+    scorer_error_count: JsonNonNegativeInt | None = None
 
 
 class CompleteRunResponse(BaseModel):

--- a/backend/rest/schemas/eval.py
+++ b/backend/rest/schemas/eval.py
@@ -220,6 +220,28 @@ class ScoreInput(BaseModel):
 # --- (a) Register / start a run ---------------------------------------------
 
 
+class RunProvenance(BaseModel):
+    """Typed execution provenance (git/CI/SDK identity + declared candidate
+    model/prompt). Mirrors ``RunProvenanceSchema`` on the Zod side. Every field is
+    optional and reported by the SDK from what it can actually observe; unknown
+    values are absent/null and never inferred. Distinct from free-form ``metadata``
+    and never a substitute for the user-facing ``candidate_version`` label.
+    """
+
+    git_repository: str | None = Field(default=None, max_length=500)
+    git_ref: str | None = Field(default=None, max_length=500)
+    git_commit: str | None = Field(default=None, max_length=200)
+    git_dirty: bool | None = None
+    ci_provider: str | None = Field(default=None, max_length=100)
+    ci_build_id: str | None = Field(default=None, max_length=200)
+    sdk_language: str | None = Field(default=None, max_length=50)
+    sdk_version: str | None = Field(default=None, max_length=50)
+    # Declared candidate identity — surfaced only if the SDK reports it, never
+    # inferred from candidate_version or any label.
+    declared_model: str | None = Field(default=None, max_length=200)
+    declared_prompt_version: str | None = Field(default=None, max_length=200)
+
+
 class RegisterRunRequest(BaseModel):
     """Register/start a run. Idempotent on ``client_run_id`` within an evaluation."""
 
@@ -235,7 +257,9 @@ class RegisterRunRequest(BaseModel):
     client_run_id: str | None = Field(default=None, min_length=1, max_length=128)
     baseline_run_id: str | None = Field(default=None, min_length=1, max_length=64)
     case_count: JsonNonNegativeInt | None = None
-    # Free-form run provenance (model, prompt, config, git repo/ref/commit, …).
+    # Typed execution provenance (git/CI/SDK identity, declared candidate model/prompt).
+    provenance: RunProvenance | None = None
+    # Free-form run metadata — arbitrary user key/values, kept verbatim.
     metadata: dict[str, Any] | None = None
 
     @field_validator("metadata", mode="before")

--- a/frontend/packages/core/prisma/migrations/20260801000000_add_run_provenance/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260801000000_add_run_provenance/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable: typed execution provenance (git/CI/SDK identity + declared candidate
+-- model/prompt). Additive and nullable — existing runs are unaffected; the SDK
+-- reports what it can observe and unknown fields stay absent.
+ALTER TABLE "evaluation_runs" ADD COLUMN "provenance" JSONB;
+
+-- Drop the orphan `model` column: it had no contract field and no writer, so it was
+-- always NULL. Declared candidate model now lives in `provenance.declared_model`,
+-- kept distinct from the (unverified) user-facing `candidate_version` label.
+ALTER TABLE "evaluation_runs" DROP COLUMN "model";

--- a/frontend/packages/core/prisma/migrations/20260801020000_add_test_case_result_provenance/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260801020000_add_test_case_result_provenance/migration.sql
@@ -1,0 +1,4 @@
+-- Eval-result provenance on a saved test case: the run and result it was captured
+-- from. Additive and nullable — non-result cases (trace/span, SDK) keep both null.
+ALTER TABLE "test_cases" ADD COLUMN "source_run_id" VARCHAR;
+ALTER TABLE "test_cases" ADD COLUMN "source_result_id" VARCHAR;

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -577,8 +577,8 @@ model EvaluationRun {
   taskErrorCount   Int       @default(0) @map("task_error_count")
   scorerErrorCount Int       @default(0) @map("scorer_error_count")
   scorers          Json?     @map("scorers") @db.JsonB // [{name, version, value_type?, direction?, threshold?}]
-  model            String?   @db.VarChar
-  metadata         Json?     @map("metadata") @db.JsonB // structured run provenance (model, prompt, config, git)
+  provenance       Json?     @map("provenance") @db.JsonB // typed execution provenance: git/ci/sdk identity + declared candidate model/prompt
+  metadata         Json?     @map("metadata") @db.JsonB // free-form user run metadata (arbitrary key/values, kept verbatim)
   clientRunId      String?   @map("client_run_id") @db.VarChar // SDK idempotency key
   startedAt        DateTime  @default(now()) @map("started_at") @db.Timestamp(6)
   completedAt      DateTime? @map("completed_at") @db.Timestamp(6)

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -523,6 +523,11 @@ model TestCase {
   sourceSpanId     String?  @map("source_span_id") @db.VarChar
   sourceSpanName   String?  @map("source_span_name") @db.VarChar
   sourceSpanKind   String?  @map("source_span_kind") @db.VarChar // "AGENT"|"LLM"|"TOOL"|"SPAN"|"trace"
+  // Provenance when a case is saved from an evaluation result: the run and result
+  // it was captured from. Distinct from trace/span provenance (a result also carries
+  // a trace id, but the run/result ids are the authoritative eval-side origin).
+  sourceRunId      String?  @map("source_run_id") @db.VarChar
+  sourceResultId   String?  @map("source_result_id") @db.VarChar
   addedBy          String?  @map("added_by") @db.VarChar
   createTime       DateTime @default(now()) @map("create_time") @db.Timestamp(6)
 

--- a/frontend/packages/core/src/__tests__/contract-shape.ts
+++ b/frontend/packages/core/src/__tests__/contract-shape.ts
@@ -1,0 +1,205 @@
+/**
+ * Structural shape extraction for the cross-layer contract guard (Zod side).
+ *
+ * Fixture replay can only guard the constraints a fixture happens to exercise: add
+ * an OPTIONAL field to one layer and every existing verdict is unchanged, so both
+ * suites stay green while the two layers have silently diverged. This module reduces
+ * each Zod schema to a language-neutral descriptor — property names, required set,
+ * nullability, enum members, bounds, array item types, unknown-key policy — that is
+ * compared against the checked-in roster in `eval-contract-shape.json`. The Pydantic
+ * side derives the identical descriptor from `model_json_schema()` in
+ * `tests/rest/test_eval_contract_parity.py`, so a field added, removed or retyped on
+ * ONE layer fails that layer's roster comparison by construction.
+ *
+ * Both sides normalize away representational differences that carry no contract
+ * meaning: `anyOf: [T, null]` collapses to `nullable`, a null/absent default is
+ * dropped (Zod's absent-key `undefined` and pydantic's `None` default mean the same
+ * "the caller omitted it"), and titles/descriptions are ignored.
+ */
+import { z } from "zod";
+
+/** A type and its constraints, independent of where it appears. */
+export type TypeShape = {
+  type: string;
+  enum?: readonly unknown[];
+  const?: unknown;
+  min_length?: number;
+  max_length?: number;
+  minimum?: number;
+  maximum?: number;
+  items?: TypeShape;
+  min_items?: number;
+  max_items?: number;
+};
+
+export type FieldShape = TypeShape & {
+  required: boolean;
+  nullable: boolean;
+  default?: unknown;
+};
+
+export type ObjectShape = {
+  kind: "object";
+  /** `.strict()` / `extra="forbid"` → "forbid"; a plain object that strips → "strip". */
+  unknown_keys: "forbid" | "strip";
+  fields: Record<string, FieldShape>;
+};
+
+export type UnionShape = {
+  kind: "discriminated_union";
+  discriminator: string;
+  variants: Record<string, ObjectShape>;
+};
+
+export type Shape = ObjectShape | UnionShape;
+
+/** A JSON Schema node. Only the keywords both generators emit are read below. */
+type JsonSchema = Record<string, unknown> & {
+  type?: string;
+  properties?: Record<string, JsonSchema>;
+  items?: JsonSchema;
+  required?: string[];
+  enum?: unknown[];
+  anyOf?: JsonSchema[];
+  oneOf?: JsonSchema[];
+};
+
+const isNullNode = (node: JsonSchema) => node?.type === "null";
+
+/** `anyOf: [T, null]` (either order) → `[T, true]`; anything else → `[node, false]`. */
+function unwrapNullable(node: JsonSchema): [JsonSchema, boolean] {
+  const variants = node.anyOf ?? node.oneOf;
+  if (Array.isArray(variants) && variants.length === 2) {
+    if (isNullNode(variants[1])) return [variants[0], true];
+    if (isNullNode(variants[0])) return [variants[1], true];
+  }
+  return [node, false];
+}
+
+function refName(ref: string): string {
+  return ref.slice(ref.lastIndexOf("/") + 1);
+}
+
+function put<T extends object>(target: T, key: string, value: unknown): void {
+  if (value !== undefined) (target as Record<string, unknown>)[key] = value;
+}
+
+/**
+ * `z.number().int()` is `Number.isSafeInteger`, so it publishes ±(2^53-1) bounds that
+ * describe the JS number type rather than the wire contract; the gateway spells the
+ * same ceiling as `JSON_SAFE_INT_MAX`. Both sides drop the sentinel so an integer
+ * field compares on the bounds the contract actually chose (`minimum: 0`, `max: 5`).
+ */
+function sansSafeIntegerBound(value: unknown): unknown {
+  return value === Number.MAX_SAFE_INTEGER || value === -Number.MAX_SAFE_INTEGER
+    ? undefined
+    : value;
+}
+
+/** Reduce one JSON Schema node to its language-neutral type descriptor. */
+export function typeShape(node: JsonSchema): TypeShape {
+  if (typeof node.$ref === "string") return { type: refName(node.$ref) };
+  if (node.const !== undefined) return { type: "literal", const: node.const };
+  if (Array.isArray(node.enum)) return { type: "enum", enum: [...node.enum] };
+
+  switch (node.type) {
+    case "string": {
+      const shape: TypeShape = { type: "string" };
+      put(shape, "min_length", node.minLength);
+      put(shape, "max_length", node.maxLength);
+      return shape;
+    }
+    case "integer":
+    case "number": {
+      const shape: TypeShape = { type: node.type };
+      put(shape, "minimum", sansSafeIntegerBound(node.minimum));
+      put(shape, "maximum", sansSafeIntegerBound(node.maximum));
+      return shape;
+    }
+    case "boolean":
+      return { type: "boolean" };
+    case "array": {
+      const shape: TypeShape = { type: "array", items: typeShape(node.items ?? {}) };
+      put(shape, "min_items", node.minItems);
+      put(shape, "max_items", node.maxItems);
+      return shape;
+    }
+    case "object":
+      // A free-form JSON object (a Zod record / a pydantic `dict[str, Any]`). Named
+      // object models are always emitted as `$ref` and handled above.
+      if (node.properties === undefined) return { type: "json_object" };
+      throw new Error(`unnamed inline object: ${JSON.stringify(node).slice(0, 120)}`);
+    case undefined:
+      // `z.unknown()` / pydantic `Any` — an unconstrained JSON value.
+      return { type: "any" };
+  }
+  throw new Error(`unsupported schema node: ${JSON.stringify(node).slice(0, 120)}`);
+}
+
+function objectShape(node: JsonSchema): ObjectShape {
+  const required = new Set<string>(node.required ?? []);
+  const fields: Record<string, FieldShape> = {};
+  for (const [name, raw] of Object.entries<JsonSchema>(node.properties ?? {})) {
+    const [inner, nullable] = unwrapNullable(raw);
+    const field: FieldShape = {
+      ...typeShape(inner),
+      required: required.has(name),
+      nullable,
+    };
+    // A null default is the absent-key default on both layers; only a real value
+    // (`"evaluation"`, `[]`) is part of the contract.
+    if (raw.default !== undefined && raw.default !== null) field.default = raw.default;
+    fields[name] = field;
+  }
+  return {
+    kind: "object",
+    unknown_keys: node.additionalProperties === false ? "forbid" : "strip",
+    fields,
+  };
+}
+
+function unionShape(node: JsonSchema): UnionShape {
+  const variants: Record<string, ObjectShape> = {};
+  let discriminator: string | undefined;
+  for (const variant of node.oneOf ?? node.anyOf ?? []) {
+    const shape = objectShape(variant);
+    const key = Object.entries(variant.properties ?? {}).find(
+      ([, prop]) => (prop as JsonSchema).const !== undefined,
+    );
+    if (!key) throw new Error("discriminated union variant without a literal discriminator");
+    discriminator = key[0];
+    variants[String((key[1] as JsonSchema).const)] = shape;
+  }
+  return { kind: "discriminated_union", discriminator: discriminator!, variants };
+}
+
+/** True for the schemas the roster covers: object models and discriminated unions. */
+function isModelSchema(value: unknown): value is z.ZodType {
+  const type = (value as { _zod?: { def?: { type?: string } } })?._zod?.def?.type;
+  return type === "object" || type === "union";
+}
+
+/**
+ * Every exported `*Schema` object model in the contract module, keyed by model name
+ * (the export name minus its `Schema` suffix, which is how the pydantic classes are
+ * named). Enumerated from the module's exports rather than hand-listed, so a newly
+ * added schema is covered — or fails the roster's coverage assertion — automatically.
+ */
+export function contractShapes(module: Record<string, unknown>): Record<string, Shape> {
+  const models = Object.entries(module)
+    .filter(([name, value]) => name.endsWith("Schema") && isModelSchema(value))
+    .map(([name, value]) => [name.replace(/Schema$/, ""), value as z.ZodType] as const);
+
+  // Registering ids makes `toJSONSchema` emit `$ref: "#/$defs/<ModelName>"` for a
+  // nested model instead of inlining it, matching how pydantic names its `$defs`.
+  for (const [name, schema] of models) {
+    if (z.globalRegistry.get(schema)?.id !== name) z.globalRegistry.add(schema, { id: name });
+  }
+
+  const shapes: Record<string, Shape> = {};
+  for (const [name, schema] of models) {
+    const json = z.toJSONSchema(schema, { io: "input", unrepresentable: "any" }) as JsonSchema;
+    shapes[name] = json.oneOf || json.anyOf ? unionShape(json) : objectShape(json);
+  }
+  return shapes;
+}

--- a/frontend/packages/core/src/__tests__/eval-contract-parity-fixtures.json
+++ b/frontend/packages/core/src/__tests__/eval-contract-parity-fixtures.json
@@ -1,0 +1,283 @@
+{
+  "_comment": "Shared representative payloads for the eval reporting write contract. BOTH the Zod schemas (eval-contract-parity.drift.test.ts) and the gateway Pydantic models (tests/rest/test_eval_contract_parity.py) are asserted to agree on every accept/reject verdict here, guarding against drift across the two-hop layers. Keep this the single source of truth; add a case here and both layers must agree. Boundary max-length cases are omitted (symmetric by construction); the meaningful parity checks are required/optional, nullability, enums, strict-unknown-key rejection, non-strict scorer key stripping, and non-negative numeric bounds.",
+  "register": {
+    "schema": "RegisterRunRequestSchema",
+    "valid": [
+      {
+        "name": "full",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "dataset_version_id": "dv1",
+          "candidate_version": "git:abc123",
+          "main_score_name": "Routing accuracy",
+          "environment": "staging",
+          "scorers": [
+            {
+              "name": "routing-accuracy",
+              "version": "v3",
+              "value_type": "numeric",
+              "direction": "higher_is_better",
+              "threshold": 0.8
+            },
+            { "name": "helpfulness", "version": "v2" }
+          ],
+          "client_run_id": "client-1",
+          "baseline_run_id": "run-prev",
+          "case_count": 24,
+          "metadata": { "model": "claude", "git": { "ref": "abc123" } }
+        }
+      },
+      {
+        "name": "minimal",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123"
+        }
+      },
+      {
+        "name": "explicit_nulls",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "dataset_version_id": null,
+          "main_score_name": null,
+          "client_run_id": null,
+          "baseline_run_id": null,
+          "case_count": null,
+          "metadata": null
+        }
+      },
+      {
+        "name": "scorer_with_ignored_extra_key",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "scorers": [{ "name": "routing-accuracy", "version": "v3", "unknown_scorer_field": "x" }]
+        }
+      }
+    ],
+    "invalid": [
+      {
+        "name": "missing_candidate_version",
+        "payload": { "evaluation_name": "Billing routing", "dataset_id": "ds1" }
+      },
+      {
+        "name": "unknown_top_level_key",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "not_a_field": true
+        }
+      },
+      {
+        "name": "empty_evaluation_name",
+        "payload": {
+          "evaluation_name": "",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123"
+        }
+      },
+      {
+        "name": "negative_case_count",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "case_count": -1
+        }
+      },
+      {
+        "name": "scorer_missing_version",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "scorers": [{ "name": "routing-accuracy" }]
+        }
+      }
+    ]
+  },
+  "upsert_result": {
+    "schema": "UpsertResultRequestSchema",
+    "valid": [
+      {
+        "name": "passing_with_scores",
+        "payload": {
+          "test_case_id": "case-1",
+          "trace_id": "trace-aaa",
+          "input": "double charge refund?",
+          "candidate_output": "billing",
+          "expected_output": "billing",
+          "status": "passed",
+          "main_score": 1,
+          "change": "improved",
+          "scores": [
+            { "scorer_name": "routing-accuracy", "scorer_version": "v3", "numeric_value": 1 },
+            { "scorer_name": "helpfulness", "scorer_version": "v2", "numeric_value": 0.9 }
+          ]
+        }
+      },
+      {
+        "name": "task_error",
+        "payload": {
+          "test_case_id": "case-2",
+          "input": "invoice never arrived",
+          "candidate_output": null,
+          "status": "errored",
+          "task_error": "ToolTimeout: lookup_invoice timed out",
+          "scores": []
+        }
+      },
+      {
+        "name": "scorer_error",
+        "payload": {
+          "test_case_id": "case-3",
+          "input": "explain the tax line",
+          "candidate_output": "billing",
+          "status": "passed",
+          "main_score": 1,
+          "scores": [
+            {
+              "scorer_name": "helpfulness",
+              "scorer_version": "v2",
+              "numeric_value": null,
+              "error": "Judge returned malformed JSON"
+            }
+          ]
+        }
+      },
+      {
+        "name": "not_scored",
+        "payload": {
+          "test_case_id": "case-4",
+          "input": "cancel and refund",
+          "candidate_output": "billing",
+          "status": "not_scored",
+          "main_score": null,
+          "scores": [
+            {
+              "scorer_name": "routing-accuracy",
+              "scorer_version": "v3",
+              "numeric_value": null,
+              "error": "KeyError"
+            }
+          ]
+        }
+      },
+      {
+        "name": "minimal",
+        "payload": { "test_case_id": "case-5", "input": "where is my order", "status": "passed" }
+      },
+      {
+        "name": "with_duration_cost_and_typed_scores",
+        "payload": {
+          "test_case_id": "case-6",
+          "input": "q",
+          "baseline_output": "old",
+          "status": "passed",
+          "duration_ms": 1200,
+          "cost": 0.0034,
+          "scores": [
+            {
+              "scorer_name": "categorical",
+              "scorer_version": "v1",
+              "string_value": "good",
+              "bool_value": true,
+              "passed": true,
+              "explanation": "looks right"
+            }
+          ]
+        }
+      }
+    ],
+    "invalid": [
+      {
+        "name": "missing_status",
+        "payload": { "test_case_id": "case-1", "input": "x" }
+      },
+      {
+        "name": "missing_input",
+        "payload": { "test_case_id": "case-1", "status": "passed" }
+      },
+      {
+        "name": "bad_status_enum",
+        "payload": { "test_case_id": "case-1", "input": "x", "status": "kinda_passed" }
+      },
+      {
+        "name": "bad_change_enum",
+        "payload": {
+          "test_case_id": "case-1",
+          "input": "x",
+          "status": "passed",
+          "change": "better"
+        }
+      },
+      {
+        "name": "unknown_top_level_key",
+        "payload": { "test_case_id": "case-1", "input": "x", "status": "passed", "nope": 1 }
+      },
+      {
+        "name": "unknown_score_key",
+        "payload": {
+          "test_case_id": "case-1",
+          "input": "x",
+          "status": "passed",
+          "scores": [{ "scorer_name": "s", "scorer_version": "v1", "bogus": 1 }]
+        }
+      },
+      {
+        "name": "negative_duration",
+        "payload": {
+          "test_case_id": "case-1",
+          "input": "x",
+          "status": "passed",
+          "duration_ms": -5
+        }
+      },
+      {
+        "name": "empty_test_case_id",
+        "payload": { "test_case_id": "", "input": "x", "status": "passed" }
+      }
+    ]
+  },
+  "complete": {
+    "schema": "CompleteRunRequestSchema",
+    "valid": [
+      {
+        "name": "full",
+        "payload": {
+          "status": "completed_with_errors",
+          "main_score": 93.8,
+          "case_count": 24,
+          "scored_count": 22,
+          "task_error_count": 1,
+          "scorer_error_count": 1
+        }
+      },
+      { "name": "minimal", "payload": { "status": "completed" } },
+      {
+        "name": "explicit_nulls",
+        "payload": {
+          "status": "failed",
+          "main_score": null,
+          "case_count": null,
+          "scored_count": null,
+          "task_error_count": null,
+          "scorer_error_count": null
+        }
+      }
+    ],
+    "invalid": [
+      { "name": "missing_status", "payload": { "main_score": 90 } },
+      { "name": "bad_status_enum", "payload": { "status": "done" } },
+      { "name": "unknown_key", "payload": { "status": "completed", "extra": 1 } },
+      { "name": "negative_count", "payload": { "status": "completed", "case_count": -2 } },
+      { "name": "fractional_count", "payload": { "status": "completed", "scored_count": 1.5 } }
+    ]
+  }
+}

--- a/frontend/packages/core/src/__tests__/eval-contract-parity-fixtures.json
+++ b/frontend/packages/core/src/__tests__/eval-contract-parity-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Shared representative payloads for the eval reporting write contract. BOTH the Zod schemas (eval-contract-parity.drift.test.ts) and the gateway Pydantic models (tests/rest/test_eval_contract_parity.py) are asserted to agree on every accept/reject verdict here, guarding against drift across the two-hop layers. Keep this the single source of truth; add a case here and both layers must agree. Boundary max-length cases are omitted (symmetric by construction); the meaningful parity checks are required/optional, nullability, enums, strict-unknown-key rejection, non-strict scorer key stripping, and non-negative numeric bounds.",
+  "_comment": "Shared representative payloads for the eval reporting write contract. BOTH the Zod schemas (eval-contract-parity.drift.test.ts) and the gateway Pydantic models (tests/rest/test_eval_contract_parity.py) are asserted to agree on every verdict here, guarding against drift across the two-hop layers. Keep this the single source of truth; add a case here and both layers must agree. Three buckets: `valid` (both accept), `invalid` (both reject), and `degraded` (both accept AND normalize to the same value, for the display-only vocabularies that catch-to-null instead of rejecting and the non-strict scorer that strips unknown keys - an `expect` path reads `a.0.b` out of the parsed payload, and a missing key reads as null on both sides). What is worth a fixture: required/optional, nullability, enums, strict-unknown-key rejection, non-strict key stripping, numeric bounds, and above all JSON TYPE coercion, where the layers genuinely disagreed - pydantic's lax mode coerced `\"0.5\"`, `\"3\"`, `true` and `1` into numbers and booleans that Zod's non-coercive primitives reject, so the gateway accepted bodies the control plane 400s on. Note `24.0` and `24` are the same JSON value, so an integral float stays VALID on an integer field. Symmetric-by-construction max-length cases are still omitted; the structural roster in eval-contract-shape.json covers bounds, and catches the one-sided OPTIONAL field no fixture can.",
   "register": {
     "schema": "RegisterRunRequestSchema",
     "valid": [
@@ -58,6 +58,69 @@
           "candidate_version": "git:abc123",
           "scorers": [{ "name": "routing-accuracy", "version": "v3", "unknown_scorer_field": "x" }]
         }
+      },
+      {
+        "name": "llm_judge_scorer_definition",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "scorers": [
+            {
+              "name": "faithfulness",
+              "version": "v1",
+              "scorer_type": "llm_judge",
+              "output_type": "score",
+              "value_type": "numeric",
+              "direction": "higher_is_better",
+              "threshold": 0.7,
+              "model": "claude-sonnet",
+              "description": "Judges whether the answer is grounded in the retrieved context.",
+              "metadata": { "temperature": 0 },
+              "messages": [
+                { "role": "system", "content": "grade this" },
+                { "role": "user", "content": "{{input}}" }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "name": "code_scorer_definition",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "scorers": [
+            {
+              "name": "exact-match",
+              "version": "v1",
+              "scorer_type": "code",
+              "output_type": "classification",
+              "value_type": "boolean",
+              "language": "python",
+              "source": "def score(a, b):\n    return a == b"
+            }
+          ]
+        }
+      },
+      {
+        "name": "case_count_at_js_safe_integer_ceiling",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "case_count": 9007199254740991
+        }
+      },
+      {
+        "name": "integral_float_case_count",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "case_count": 24.0
+        }
       }
     ],
     "invalid": [
@@ -99,6 +162,111 @@
           "candidate_version": "git:abc123",
           "scorers": [{ "name": "routing-accuracy" }]
         }
+      },
+      {
+        "name": "case_count_as_string",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "case_count": "24"
+        }
+      },
+      {
+        "name": "case_count_as_boolean",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "case_count": true
+        }
+      },
+      {
+        "name": "case_count_beyond_js_safe_integer",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "case_count": 9007199254740992
+        }
+      },
+      {
+        "name": "evaluation_name_as_number",
+        "payload": {
+          "evaluation_name": 123,
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123"
+        }
+      },
+      {
+        "name": "scorer_threshold_as_string",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "scorers": [{ "name": "routing-accuracy", "version": "v3", "threshold": "0.5" }]
+        }
+      },
+      {
+        "name": "scorer_message_with_empty_role",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "scorers": [
+            {
+              "name": "faithfulness",
+              "version": "v1",
+              "messages": [{ "role": "", "content": "grade this" }]
+            }
+          ]
+        }
+      },
+      {
+        "name": "scorer_message_missing_content",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "scorers": [
+            { "name": "faithfulness", "version": "v1", "messages": [{ "role": "system" }] }
+          ]
+        }
+      }
+    ],
+    "degraded": [
+      {
+        "name": "unrecognised_display_only_vocabularies_become_null",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "scorers": [
+            {
+              "name": "faithfulness",
+              "version": "v1",
+              "scorer_type": "regex",
+              "output_type": "histogram",
+              "language": "go"
+            }
+          ]
+        },
+        "expect": {
+          "scorers.0.scorer_type": null,
+          "scorers.0.output_type": null,
+          "scorers.0.language": null,
+          "scorers.0.name": "faithfulness"
+        }
+      },
+      {
+        "name": "unknown_scorer_key_is_stripped",
+        "payload": {
+          "evaluation_name": "Billing routing",
+          "dataset_id": "ds1",
+          "candidate_version": "git:abc123",
+          "scorers": [{ "name": "routing-accuracy", "version": "v3", "unknown_scorer_field": "x" }]
+        },
+        "expect": { "scorers.0.unknown_scorer_field": null }
       }
     ]
   },
@@ -193,6 +361,16 @@
             }
           ]
         }
+      },
+      {
+        "name": "integral_float_duration",
+        "payload": {
+          "test_case_id": "case-7",
+          "input": "q",
+          "status": "passed",
+          "duration_ms": 1200.0,
+          "cost": 0
+        }
       }
     ],
     "invalid": [
@@ -242,6 +420,68 @@
       {
         "name": "empty_test_case_id",
         "payload": { "test_case_id": "", "input": "x", "status": "passed" }
+      },
+      {
+        "name": "input_as_number",
+        "payload": { "test_case_id": "case-1", "input": 123, "status": "passed" }
+      },
+      {
+        "name": "main_score_as_string",
+        "payload": {
+          "test_case_id": "case-1",
+          "input": "x",
+          "status": "passed",
+          "main_score": "0.5"
+        }
+      },
+      {
+        "name": "cost_as_string",
+        "payload": { "test_case_id": "case-1", "input": "x", "status": "passed", "cost": "1.5" }
+      },
+      {
+        "name": "duration_ms_as_boolean",
+        "payload": {
+          "test_case_id": "case-1",
+          "input": "x",
+          "status": "passed",
+          "duration_ms": true
+        }
+      },
+      {
+        "name": "score_bool_value_as_string",
+        "payload": {
+          "test_case_id": "case-1",
+          "input": "x",
+          "status": "passed",
+          "scores": [{ "scorer_name": "s", "scorer_version": "v1", "bool_value": "yes" }]
+        }
+      },
+      {
+        "name": "score_passed_as_number",
+        "payload": {
+          "test_case_id": "case-1",
+          "input": "x",
+          "status": "passed",
+          "scores": [{ "scorer_name": "s", "scorer_version": "v1", "passed": 1 }]
+        }
+      },
+      {
+        "name": "score_numeric_value_as_string",
+        "payload": {
+          "test_case_id": "case-1",
+          "input": "x",
+          "status": "passed",
+          "scores": [{ "scorer_name": "s", "scorer_version": "v1", "numeric_value": "0.9" }]
+        }
+      },
+      {
+        "name": "explicit_null_scores",
+        "payload": {
+          "test_case_id": "case-1",
+          "input": "x",
+          "status": "passed",
+          "scores": null
+        }
       }
     ]
   },
@@ -261,6 +501,10 @@
       },
       { "name": "minimal", "payload": { "status": "completed" } },
       {
+        "name": "integral_float_counts",
+        "payload": { "status": "completed", "case_count": 24.0, "scored_count": 22.0 }
+      },
+      {
         "name": "explicit_nulls",
         "payload": {
           "status": "failed",
@@ -277,7 +521,14 @@
       { "name": "bad_status_enum", "payload": { "status": "done" } },
       { "name": "unknown_key", "payload": { "status": "completed", "extra": 1 } },
       { "name": "negative_count", "payload": { "status": "completed", "case_count": -2 } },
-      { "name": "fractional_count", "payload": { "status": "completed", "scored_count": 1.5 } }
+      { "name": "fractional_count", "payload": { "status": "completed", "scored_count": 1.5 } },
+      { "name": "main_score_as_string", "payload": { "status": "completed", "main_score": "0.5" } },
+      { "name": "case_count_as_string", "payload": { "status": "completed", "case_count": "3" } },
+      {
+        "name": "scored_count_as_boolean",
+        "payload": { "status": "completed", "scored_count": true }
+      },
+      { "name": "status_as_number", "payload": { "status": 1 } }
     ]
   }
 }

--- a/frontend/packages/core/src/__tests__/eval-contract-parity.drift.test.ts
+++ b/frontend/packages/core/src/__tests__/eval-contract-parity.drift.test.ts
@@ -31,9 +31,7 @@ type Case = { name: string; payload: unknown };
 describe("eval reporting contract parity (Zod)", () => {
   for (const group of Object.keys(SCHEMAS) as Group[]) {
     const schema = SCHEMAS[group];
-    const bucket = (fixtures as unknown as Record<string, { valid: Case[]; invalid: Case[] }>)[
-      group
-    ];
+    const bucket = (fixtures as Record<string, { valid: Case[]; invalid: Case[] }>)[group];
 
     it(`accepts every representative valid ${group} payload`, () => {
       for (const c of bucket.valid) {

--- a/frontend/packages/core/src/__tests__/eval-contract-parity.drift.test.ts
+++ b/frontend/packages/core/src/__tests__/eval-contract-parity.drift.test.ts
@@ -5,19 +5,32 @@
  * (the Prisma-owned Next.js control plane validates with them) and the Pydantic
  * models in the FastAPI gateway (`backend/rest/schemas/eval.py`). Both must agree
  * on exactly which SDK payloads are valid, or the gateway would accept requests
- * the control plane rejects (or vice-versa).
+ * the control plane rejects (or vice-versa) — and the gateway forwards the raw
+ * request bytes upstream, so its validation is the only place that can catch it.
  *
- * This test and `tests/rest/test_eval_contract_parity.py` load the SAME fixture
- * file and assert the SAME accept/reject verdicts. If someone edits one schema
- * without the other, one side goes red.
+ * This file and `tests/rest/test_eval_contract_parity.py` run the same two halves
+ * against their own layer:
+ *
+ * 1. BEHAVIOURAL — replay the shared payloads in `eval-contract-parity-fixtures.json`
+ *    and assert identical accept/reject verdicts, plus identical normalization of the
+ *    values that degrade rather than reject.
+ * 2. STRUCTURAL — reduce every schema to a language-neutral descriptor and compare it
+ *    against the shared roster in `eval-contract-shape.json`. Fixtures alone cannot
+ *    catch a one-sided OPTIONAL field or bound (no fixture sends it, so every verdict
+ *    is unchanged and both suites stay green); the roster makes any field added,
+ *    removed or retyped on one layer only red by construction, and its coverage
+ *    assertion makes a NEW schema fail until it is listed.
  */
 import { describe, it, expect } from "vitest";
+import * as contract from "../eval-contract.ts";
 import {
   RegisterRunRequestSchema,
   UpsertResultRequestSchema,
   CompleteRunRequestSchema,
 } from "../eval-contract.ts";
+import { contractShapes, type Shape } from "./contract-shape.ts";
 import fixtures from "./eval-contract-parity-fixtures.json" with { type: "json" };
+import roster from "./eval-contract-shape.json" with { type: "json" };
 
 const SCHEMAS = {
   register: RegisterRunRequestSchema,
@@ -26,12 +39,31 @@ const SCHEMAS = {
 } as const;
 
 type Group = keyof typeof SCHEMAS;
-type Case = { name: string; payload: unknown };
+type Case = { name: string; payload: unknown; expect?: Record<string, unknown> };
+type Bucket = { valid: Case[]; invalid: Case[]; degraded?: Case[] };
+
+const buckets = fixtures as unknown as Record<string, Bucket>;
+
+/**
+ * Read `a.0.b` out of a parsed payload (list indices are numeric segments). A key Zod
+ * stripped reads as null, matching how the pydantic side reads a field that is not set
+ * — the two layers spell "not there" differently and a fixture cannot say `undefined`.
+ */
+function at(value: unknown, path: string): unknown {
+  return (
+    path
+      .split(".")
+      .reduce<unknown>(
+        (acc, segment) => (acc as Record<string, unknown> | undefined)?.[segment],
+        value,
+      ) ?? null
+  );
+}
 
 describe("eval reporting contract parity (Zod)", () => {
   for (const group of Object.keys(SCHEMAS) as Group[]) {
     const schema = SCHEMAS[group];
-    const bucket = (fixtures as Record<string, { valid: Case[]; invalid: Case[] }>)[group];
+    const bucket = buckets[group];
 
     it(`accepts every representative valid ${group} payload`, () => {
       for (const c of bucket.valid) {
@@ -46,5 +78,51 @@ describe("eval reporting contract parity (Zod)", () => {
         expect(result.success, `${group}/${c.name} should be REJECTED`).toBe(false);
       }
     });
+
+    // Accept/reject parity is not enough where a layer NORMALIZES instead: a
+    // display-only vocabulary degrades an unrecognised member to null rather than
+    // failing the whole run, and a non-strict scorer strips unknown keys. Both layers
+    // must land on the same value, or the control plane stores something the gateway
+    // never saw.
+    it(`degrades every ${group} payload the same way`, () => {
+      for (const c of bucket.degraded ?? []) {
+        const result = schema.safeParse(c.payload);
+        expect(result.success, `${group}/${c.name} should be ACCEPTED`).toBe(true);
+        if (!result.success) continue;
+        for (const [path, expected] of Object.entries(c.expect ?? {})) {
+          expect(at(result.data, path), `${group}/${c.name} at ${path}`).toEqual(expected);
+        }
+      }
+    });
   }
+});
+
+describe("eval reporting contract shape (Zod)", () => {
+  const shapes = contractShapes(contract as Record<string, unknown>);
+  const paired = roster.paired as unknown as Record<string, Shape>;
+  const zodOnly = roster.zod_only as unknown as Record<string, Shape>;
+  const pydanticOnly = roster.pydantic_only as unknown as Record<string, Shape>;
+
+  // An unlisted schema must FAIL, not silently pass: a schema with no roster entry is
+  // a schema with zero cross-layer coverage. Listing it (in `paired`, or in `zod_only`
+  // with the reason it has no gateway counterpart) is the deliberate act asserted on.
+  it("the roster covers every exported contract schema", () => {
+    expect(Object.keys(shapes).sort()).toEqual(
+      [...Object.keys(paired), ...Object.keys(zodOnly)].sort(),
+    );
+  });
+
+  for (const [name, expected] of [...Object.entries(paired), ...Object.entries(zodOnly)]) {
+    it(`${name} matches the roster`, () => {
+      expect(shapes[name]).toEqual(expected);
+    });
+  }
+
+  // The recorded asymmetry must stay real: writing a Zod schema for one of these is
+  // the moment its entry has to be promoted to `paired` and compared field-for-field.
+  it("the gateway-only models have no Zod counterpart", () => {
+    for (const name of Object.keys(pydanticOnly)) {
+      expect(shapes[name], `${name} now exists on both layers`).toBeUndefined();
+    }
+  });
 });

--- a/frontend/packages/core/src/__tests__/eval-contract-shape.json
+++ b/frontend/packages/core/src/__tests__/eval-contract-shape.json
@@ -41,13 +41,21 @@
         },
         "value_type": {
           "type": "enum",
-          "enum": ["numeric", "boolean", "categorical"],
+          "enum": [
+            "numeric",
+            "boolean",
+            "categorical"
+          ],
           "required": false,
           "nullable": true
         },
         "direction": {
           "type": "enum",
-          "enum": ["higher_is_better", "lower_is_better", "none"],
+          "enum": [
+            "higher_is_better",
+            "lower_is_better",
+            "none"
+          ],
           "required": false,
           "nullable": true
         },
@@ -58,13 +66,19 @@
         },
         "scorer_type": {
           "type": "enum",
-          "enum": ["llm_judge", "code"],
+          "enum": [
+            "llm_judge",
+            "code"
+          ],
           "required": false,
           "nullable": true
         },
         "output_type": {
           "type": "enum",
-          "enum": ["score", "classification"],
+          "enum": [
+            "score",
+            "classification"
+          ],
           "required": false,
           "nullable": true
         },
@@ -96,7 +110,10 @@
         },
         "language": {
           "type": "enum",
-          "enum": ["python", "typescript"],
+          "enum": [
+            "python",
+            "typescript"
+          ],
           "required": false,
           "nullable": true
         },
@@ -156,6 +173,71 @@
         "error": {
           "type": "string",
           "max_length": 5000,
+          "required": false,
+          "nullable": true
+        }
+      }
+    },
+    "RunProvenance": {
+      "kind": "object",
+      "unknown_keys": "strip",
+      "fields": {
+        "git_repository": {
+          "type": "string",
+          "max_length": 500,
+          "required": false,
+          "nullable": true
+        },
+        "git_ref": {
+          "type": "string",
+          "max_length": 500,
+          "required": false,
+          "nullable": true
+        },
+        "git_commit": {
+          "type": "string",
+          "max_length": 200,
+          "required": false,
+          "nullable": true
+        },
+        "git_dirty": {
+          "type": "boolean",
+          "required": false,
+          "nullable": true
+        },
+        "ci_provider": {
+          "type": "string",
+          "max_length": 100,
+          "required": false,
+          "nullable": true
+        },
+        "ci_build_id": {
+          "type": "string",
+          "max_length": 200,
+          "required": false,
+          "nullable": true
+        },
+        "sdk_language": {
+          "type": "string",
+          "max_length": 50,
+          "required": false,
+          "nullable": true
+        },
+        "sdk_version": {
+          "type": "string",
+          "max_length": 50,
+          "required": false,
+          "nullable": true
+        },
+        "declared_model": {
+          "type": "string",
+          "max_length": 200,
+          "required": false,
+          "nullable": true
+        },
+        "declared_prompt_version": {
+          "type": "string",
+          "max_length": 200,
           "required": false,
           "nullable": true
         }
@@ -235,6 +317,11 @@
         "case_count": {
           "type": "integer",
           "minimum": 0,
+          "required": false,
+          "nullable": true
+        },
+        "provenance": {
+          "type": "RunProvenance",
           "required": false,
           "nullable": true
         },
@@ -325,7 +412,12 @@
         },
         "status": {
           "type": "enum",
-          "enum": ["passed", "failed", "errored", "not_scored"],
+          "enum": [
+            "passed",
+            "failed",
+            "errored",
+            "not_scored"
+          ],
           "required": true,
           "nullable": false
         },
@@ -336,7 +428,11 @@
         },
         "change": {
           "type": "enum",
-          "enum": ["improved", "regressed", "unchanged"],
+          "enum": [
+            "improved",
+            "regressed",
+            "unchanged"
+          ],
           "required": false,
           "nullable": true
         },
@@ -522,14 +618,22 @@
         },
         "review": {
           "type": "enum",
-          "enum": ["needs_review", "ready"],
+          "enum": [
+            "needs_review",
+            "ready"
+          ],
           "required": false,
           "nullable": false,
           "default": "needs_review"
         },
         "capture_reason": {
           "type": "enum",
-          "enum": ["manual", "error", "failed_tool", "negative_feedback"],
+          "enum": [
+            "manual",
+            "error",
+            "failed_tool",
+            "negative_feedback"
+          ],
           "required": false,
           "nullable": false,
           "default": "manual"
@@ -583,7 +687,10 @@
         },
         "review": {
           "type": "enum",
-          "enum": ["needs_review", "ready"],
+          "enum": [
+            "needs_review",
+            "ready"
+          ],
           "required": false,
           "nullable": false
         }
@@ -595,7 +702,11 @@
       "fields": {
         "verdict": {
           "type": "enum",
-          "enum": ["pass", "fail", "unsure"],
+          "enum": [
+            "pass",
+            "fail",
+            "unsure"
+          ],
           "required": true,
           "nullable": false
         },

--- a/frontend/packages/core/src/__tests__/eval-contract-shape.json
+++ b/frontend/packages/core/src/__tests__/eval-contract-shape.json
@@ -1,0 +1,820 @@
+{
+  "_comment": "Structural roster for the eval reporting contract: the language-neutral shape of every model, checked in once and asserted from BOTH layers. tests/rest/test_eval_contract_parity.py derives it from pydantic's model_json_schema() and eval-contract-parity.drift.test.ts from zod's toJSONSchema(); a field added, removed, retyped, re-bounded or made required on ONE layer only fails that layer's comparison, which the accept/reject fixtures in eval-contract-parity-fixtures.json cannot catch for an OPTIONAL field (no fixture sends it, so every verdict is unchanged). Regenerate deliberately, never to make a test pass: a diff here IS the contract change. Both sides normalize away representation-only differences - anyOf [T, null] collapses to `nullable`, a null default is dropped (zod's absent-key undefined and pydantic's None default both mean `the caller omitted it`), and z.number().int()'s Number.MAX_SAFE_INTEGER bounds are dropped (the gateway mirrors that ceiling as JSON_SAFE_INT_MAX).",
+  "_paired_comment": "Defined on both layers and asserted identical on both. `unknown_keys` is zod .strict() / pydantic extra=forbid vs a plain object that strips.",
+  "paired": {
+    "ScorerMessage": {
+      "kind": "object",
+      "unknown_keys": "strip",
+      "fields": {
+        "role": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 50,
+          "required": true,
+          "nullable": false
+        },
+        "content": {
+          "type": "string",
+          "max_length": 20000,
+          "required": true,
+          "nullable": false
+        }
+      }
+    },
+    "ScorerRef": {
+      "kind": "object",
+      "unknown_keys": "strip",
+      "fields": {
+        "name": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 200,
+          "required": true,
+          "nullable": false
+        },
+        "version": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 50,
+          "required": true,
+          "nullable": false
+        },
+        "value_type": {
+          "type": "enum",
+          "enum": ["numeric", "boolean", "categorical"],
+          "required": false,
+          "nullable": true
+        },
+        "direction": {
+          "type": "enum",
+          "enum": ["higher_is_better", "lower_is_better", "none"],
+          "required": false,
+          "nullable": true
+        },
+        "threshold": {
+          "type": "number",
+          "required": false,
+          "nullable": true
+        },
+        "scorer_type": {
+          "type": "enum",
+          "enum": ["llm_judge", "code"],
+          "required": false,
+          "nullable": true
+        },
+        "output_type": {
+          "type": "enum",
+          "enum": ["score", "classification"],
+          "required": false,
+          "nullable": true
+        },
+        "description": {
+          "type": "string",
+          "max_length": 2000,
+          "required": false,
+          "nullable": true
+        },
+        "metadata": {
+          "type": "any",
+          "required": false,
+          "nullable": true
+        },
+        "model": {
+          "type": "string",
+          "max_length": 200,
+          "required": false,
+          "nullable": true
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "ScorerMessage"
+          },
+          "max_items": 50,
+          "required": false,
+          "nullable": true
+        },
+        "language": {
+          "type": "enum",
+          "enum": ["python", "typescript"],
+          "required": false,
+          "nullable": true
+        },
+        "source": {
+          "type": "string",
+          "max_length": 50000,
+          "required": false,
+          "nullable": true
+        }
+      }
+    },
+    "ScoreInput": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "scorer_name": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 200,
+          "required": true,
+          "nullable": false
+        },
+        "scorer_version": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 50,
+          "required": true,
+          "nullable": false
+        },
+        "numeric_value": {
+          "type": "number",
+          "required": false,
+          "nullable": true
+        },
+        "bool_value": {
+          "type": "boolean",
+          "required": false,
+          "nullable": true
+        },
+        "string_value": {
+          "type": "string",
+          "max_length": 2000,
+          "required": false,
+          "nullable": true
+        },
+        "passed": {
+          "type": "boolean",
+          "required": false,
+          "nullable": true
+        },
+        "explanation": {
+          "type": "string",
+          "max_length": 5000,
+          "required": false,
+          "nullable": true
+        },
+        "error": {
+          "type": "string",
+          "max_length": 5000,
+          "required": false,
+          "nullable": true
+        }
+      }
+    },
+    "RegisterRunRequest": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "evaluation_name": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 200,
+          "required": true,
+          "nullable": false
+        },
+        "dataset_id": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 64,
+          "required": true,
+          "nullable": false
+        },
+        "dataset_version_id": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 64,
+          "required": false,
+          "nullable": true
+        },
+        "candidate_version": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 200,
+          "required": true,
+          "nullable": false
+        },
+        "main_score_name": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 200,
+          "required": false,
+          "nullable": true
+        },
+        "environment": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 64,
+          "required": false,
+          "nullable": false,
+          "default": "evaluation"
+        },
+        "scorers": {
+          "type": "array",
+          "items": {
+            "type": "ScorerRef"
+          },
+          "max_items": 200,
+          "required": false,
+          "nullable": false,
+          "default": []
+        },
+        "client_run_id": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 128,
+          "required": false,
+          "nullable": true
+        },
+        "baseline_run_id": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 64,
+          "required": false,
+          "nullable": true
+        },
+        "case_count": {
+          "type": "integer",
+          "minimum": 0,
+          "required": false,
+          "nullable": true
+        },
+        "metadata": {
+          "type": "json_object",
+          "required": false,
+          "nullable": true
+        }
+      }
+    },
+    "RegisterRunResponse": {
+      "kind": "object",
+      "unknown_keys": "strip",
+      "fields": {
+        "evaluation_id": {
+          "type": "string",
+          "required": true,
+          "nullable": false
+        },
+        "evaluation_run_id": {
+          "type": "string",
+          "required": true,
+          "nullable": false
+        },
+        "run_number": {
+          "type": "integer",
+          "required": true,
+          "nullable": false
+        },
+        "dataset_version_id": {
+          "type": "string",
+          "required": true,
+          "nullable": false
+        },
+        "run_path": {
+          "type": "string",
+          "required": true,
+          "nullable": false
+        },
+        "run_url": {
+          "type": "string",
+          "required": true,
+          "nullable": false
+        }
+      }
+    },
+    "UpsertResultRequest": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "test_case_id": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 64,
+          "required": true,
+          "nullable": false
+        },
+        "trace_id": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 64,
+          "required": false,
+          "nullable": true
+        },
+        "input": {
+          "type": "string",
+          "max_length": 1000000,
+          "required": true,
+          "nullable": false
+        },
+        "expected_output": {
+          "type": "string",
+          "max_length": 1000000,
+          "required": false,
+          "nullable": true
+        },
+        "candidate_output": {
+          "type": "string",
+          "max_length": 1000000,
+          "required": false,
+          "nullable": true
+        },
+        "baseline_output": {
+          "type": "string",
+          "max_length": 1000000,
+          "required": false,
+          "nullable": true
+        },
+        "status": {
+          "type": "enum",
+          "enum": ["passed", "failed", "errored", "not_scored"],
+          "required": true,
+          "nullable": false
+        },
+        "main_score": {
+          "type": "number",
+          "required": false,
+          "nullable": true
+        },
+        "change": {
+          "type": "enum",
+          "enum": ["improved", "regressed", "unchanged"],
+          "required": false,
+          "nullable": true
+        },
+        "task_error": {
+          "type": "string",
+          "max_length": 10000,
+          "required": false,
+          "nullable": true
+        },
+        "duration_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "required": false,
+          "nullable": true
+        },
+        "cost": {
+          "type": "number",
+          "minimum": 0,
+          "required": false,
+          "nullable": true
+        },
+        "scores": {
+          "type": "array",
+          "items": {
+            "type": "ScoreInput"
+          },
+          "max_items": 200,
+          "required": false,
+          "nullable": false
+        }
+      }
+    },
+    "UpsertResultResponse": {
+      "kind": "object",
+      "unknown_keys": "strip",
+      "fields": {
+        "evaluation_result_id": {
+          "type": "string",
+          "required": true,
+          "nullable": false
+        }
+      }
+    },
+    "CompleteRunRequest": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "status": {
+          "type": "enum",
+          "enum": [
+            "running",
+            "completed",
+            "completed_with_errors",
+            "failed",
+            "incomplete",
+            "cancelled"
+          ],
+          "required": true,
+          "nullable": false
+        },
+        "main_score": {
+          "type": "number",
+          "required": false,
+          "nullable": true
+        },
+        "case_count": {
+          "type": "integer",
+          "minimum": 0,
+          "required": false,
+          "nullable": true
+        },
+        "scored_count": {
+          "type": "integer",
+          "minimum": 0,
+          "required": false,
+          "nullable": true
+        },
+        "task_error_count": {
+          "type": "integer",
+          "minimum": 0,
+          "required": false,
+          "nullable": true
+        },
+        "scorer_error_count": {
+          "type": "integer",
+          "minimum": 0,
+          "required": false,
+          "nullable": true
+        }
+      }
+    },
+    "CompleteRunResponse": {
+      "kind": "object",
+      "unknown_keys": "strip",
+      "fields": {
+        "evaluation_run_id": {
+          "type": "string",
+          "required": true,
+          "nullable": false
+        },
+        "status": {
+          "type": "enum",
+          "enum": [
+            "running",
+            "completed",
+            "completed_with_errors",
+            "failed",
+            "incomplete",
+            "cancelled"
+          ],
+          "required": true,
+          "nullable": false
+        }
+      }
+    }
+  },
+  "_zod_only_comment": "Zod schemas with no gateway model: the dataset + dataset-version routes are untyped catch-alls the gateway forwards without parsing, so there is nothing to compare them to. Their shape is still pinned here so a one-sided edit is red, and the pydantic suite asserts no model by these names exists - adding one is the moment the entry moves to `paired`.",
+  "zod_only": {
+    "CreateDatasetRequest": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "name": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 200,
+          "required": true,
+          "nullable": false
+        },
+        "description": {
+          "type": "string",
+          "max_length": 2000,
+          "required": false,
+          "nullable": true
+        }
+      }
+    },
+    "UpdateDatasetRequest": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "name": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 200,
+          "required": false,
+          "nullable": false
+        },
+        "description": {
+          "type": "string",
+          "max_length": 2000,
+          "required": false,
+          "nullable": true
+        }
+      }
+    },
+    "CreateTestCaseRequest": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "input": {
+          "type": "string",
+          "max_length": 1000000,
+          "required": true,
+          "nullable": false
+        },
+        "expected": {
+          "type": "string",
+          "max_length": 1000000,
+          "required": false,
+          "nullable": true
+        },
+        "recorded_output": {
+          "type": "string",
+          "max_length": 1000000,
+          "required": false,
+          "nullable": true
+        },
+        "metadata": {
+          "type": "json_object",
+          "required": false,
+          "nullable": true
+        },
+        "review": {
+          "type": "enum",
+          "enum": ["needs_review", "ready"],
+          "required": false,
+          "nullable": false,
+          "default": "needs_review"
+        },
+        "capture_reason": {
+          "type": "enum",
+          "enum": ["manual", "error", "failed_tool", "negative_feedback"],
+          "required": false,
+          "nullable": false,
+          "default": "manual"
+        },
+        "source_trace_id": {
+          "type": "string",
+          "max_length": 64,
+          "required": false,
+          "nullable": true
+        },
+        "source_span_id": {
+          "type": "string",
+          "max_length": 64,
+          "required": false,
+          "nullable": true
+        },
+        "source_span_name": {
+          "type": "string",
+          "max_length": 400,
+          "required": false,
+          "nullable": true
+        },
+        "source_span_kind": {
+          "type": "string",
+          "max_length": 32,
+          "required": false,
+          "nullable": true
+        }
+      }
+    },
+    "UpdateTestCaseRequest": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "input": {
+          "type": "string",
+          "max_length": 1000000,
+          "required": false,
+          "nullable": false
+        },
+        "expected": {
+          "type": "string",
+          "max_length": 1000000,
+          "required": false,
+          "nullable": true
+        },
+        "metadata": {
+          "type": "json_object",
+          "required": false,
+          "nullable": true
+        },
+        "review": {
+          "type": "enum",
+          "enum": ["needs_review", "ready"],
+          "required": false,
+          "nullable": false
+        }
+      }
+    },
+    "CreateHumanScoreRequest": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "verdict": {
+          "type": "enum",
+          "enum": ["pass", "fail", "unsure"],
+          "required": true,
+          "nullable": false
+        },
+        "quality": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5,
+          "required": false,
+          "nullable": true
+        },
+        "comment": {
+          "type": "string",
+          "max_length": 5000,
+          "required": false,
+          "nullable": true
+        },
+        "reviewer": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 200,
+          "required": true,
+          "nullable": false
+        }
+      }
+    },
+    "PublicUpsertDatasetRequest": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "dataset_id": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 64,
+          "required": true,
+          "nullable": false
+        },
+        "name": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 200,
+          "required": true,
+          "nullable": false
+        },
+        "description": {
+          "type": "string",
+          "max_length": 2000,
+          "required": false,
+          "nullable": true
+        },
+        "metadata": {
+          "type": "json_object",
+          "required": false,
+          "nullable": true
+        }
+      }
+    },
+    "PublicUpdateDatasetRequest": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "name": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 200,
+          "required": false,
+          "nullable": false
+        },
+        "description": {
+          "type": "string",
+          "max_length": 2000,
+          "required": false,
+          "nullable": true
+        },
+        "metadata": {
+          "type": "json_object",
+          "required": false,
+          "nullable": true
+        }
+      }
+    },
+    "DatasetChange": {
+      "kind": "discriminated_union",
+      "discriminator": "op",
+      "variants": {
+        "upsert": {
+          "kind": "object",
+          "unknown_keys": "strip",
+          "fields": {
+            "op": {
+              "type": "literal",
+              "const": "upsert",
+              "required": true,
+              "nullable": false
+            },
+            "test_case_id": {
+              "type": "string",
+              "min_length": 1,
+              "max_length": 64,
+              "required": true,
+              "nullable": false
+            },
+            "input": {
+              "type": "any",
+              "required": true,
+              "nullable": false
+            },
+            "expected": {
+              "type": "any",
+              "required": false,
+              "nullable": false
+            },
+            "metadata": {
+              "type": "json_object",
+              "required": false,
+              "nullable": true
+            },
+            "source_trace_id": {
+              "type": "string",
+              "max_length": 64,
+              "required": false,
+              "nullable": true
+            },
+            "source_span_id": {
+              "type": "string",
+              "max_length": 64,
+              "required": false,
+              "nullable": true
+            }
+          }
+        },
+        "archive": {
+          "kind": "object",
+          "unknown_keys": "strip",
+          "fields": {
+            "op": {
+              "type": "literal",
+              "const": "archive",
+              "required": true,
+              "nullable": false
+            },
+            "test_case_id": {
+              "type": "string",
+              "min_length": 1,
+              "max_length": 64,
+              "required": true,
+              "nullable": false
+            }
+          }
+        },
+        "delete": {
+          "kind": "object",
+          "unknown_keys": "strip",
+          "fields": {
+            "op": {
+              "type": "literal",
+              "const": "delete",
+              "required": true,
+              "nullable": false
+            },
+            "test_case_id": {
+              "type": "string",
+              "min_length": 1,
+              "max_length": 64,
+              "required": true,
+              "nullable": false
+            }
+          }
+        }
+      }
+    },
+    "PublishDatasetVersionRequest": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "base_version_id": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 64,
+          "required": true,
+          "nullable": true
+        },
+        "label": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 64,
+          "required": false,
+          "nullable": false
+        },
+        "changes": {
+          "type": "array",
+          "items": {
+            "type": "DatasetChange"
+          },
+          "min_items": 1,
+          "required": true,
+          "nullable": false
+        },
+        "idempotency_key": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 128,
+          "required": false,
+          "nullable": true
+        }
+      }
+    }
+  },
+  "_pydantic_only_comment": "Gateway models with no Zod counterpart. ErrorResponse is the gateway's OWN normalized {detail} envelope: the control plane returns {error: ...} and the gateway rewrites it, so a Zod schema for it would assert something the control plane does not emit.",
+  "pydantic_only": {
+    "ErrorResponse": {
+      "kind": "object",
+      "unknown_keys": "strip",
+      "fields": {
+        "detail": {
+          "type": "string",
+          "required": true,
+          "nullable": false
+        }
+      }
+    }
+  }
+}

--- a/frontend/packages/core/src/__tests__/eval-contract-shape.json
+++ b/frontend/packages/core/src/__tests__/eval-contract-shape.json
@@ -912,6 +912,58 @@
           "nullable": true
         }
       }
+    },
+    "SaveResultToDatasetRequest": {
+      "kind": "object",
+      "unknown_keys": "forbid",
+      "fields": {
+        "action": {
+          "type": "enum",
+          "enum": [
+            "update_existing_case",
+            "save_new_case",
+            "duplicate_as_variant"
+          ],
+          "required": true,
+          "nullable": false
+        },
+        "dataset_id": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 64,
+          "required": false,
+          "nullable": true
+        },
+        "input": {
+          "type": "string",
+          "max_length": 1000000,
+          "required": false,
+          "nullable": true
+        },
+        "expected": {
+          "type": "string",
+          "max_length": 1000000,
+          "required": false,
+          "nullable": true
+        },
+        "use_candidate_as_expected": {
+          "type": "boolean",
+          "required": false,
+          "nullable": false
+        },
+        "metadata": {
+          "type": "json_object",
+          "required": false,
+          "nullable": true
+        },
+        "idempotency_key": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 128,
+          "required": false,
+          "nullable": true
+        }
+      }
     }
   },
   "_pydantic_only_comment": "Gateway models with no Zod counterpart. ErrorResponse is the gateway's OWN normalized {detail} envelope: the control plane returns {error: ...} and the gateway rewrites it, so a Zod schema for it would assert something the control plane does not emit.",

--- a/frontend/packages/core/src/__tests__/eval-contract-shape.json
+++ b/frontend/packages/core/src/__tests__/eval-contract-shape.json
@@ -498,6 +498,13 @@
           "required": false,
           "nullable": true
         },
+        "main_score_name": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 200,
+          "required": false,
+          "nullable": true
+        },
         "case_count": {
           "type": "integer",
           "minimum": 0,

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -176,6 +176,36 @@ export type ScoreInput = z.infer<typeof ScoreInputSchema>;
 // ---------------------------------------------------------------------------
 
 /**
+ * Structured, machine-collected run provenance — the verifiable execution
+ * context around the run. Distinct from free-form `metadata`: every field is
+ * typed, optional, and reported by the SDK from what it can actually observe
+ * (git/CI/SDK identity). Unknown values are omitted or null and are never
+ * inferred; a missing block never rejects a run. `candidate_version` stays the
+ * user-facing label — provenance is not a substitute for it and is never
+ * treated as a verified identity beyond what the SDK reported.
+ */
+export const RunProvenanceSchema = z
+  .object({
+    git_repository: z.string().max(500).nullable().optional(),
+    git_ref: z.string().max(500).nullable().optional(),
+    git_commit: z.string().max(200).nullable().optional(),
+    git_dirty: z.boolean().nullable().optional(),
+    ci_provider: z.string().max(100).nullable().optional(),
+    ci_build_id: z.string().max(200).nullable().optional(),
+    sdk_language: z.string().max(50).nullable().optional(),
+    sdk_version: z.string().max(50).nullable().optional(),
+    /**
+     * Declared candidate identity — surfaced only if the SDK reports it, never
+     * inferred from `candidate_version` or any label.
+     */
+    declared_model: z.string().max(200).nullable().optional(),
+    declared_prompt_version: z.string().max(200).nullable().optional(),
+  });
+// Non-strict (strips unknown keys), mirroring ScorerRef and the permissive
+// gateway: a newer SDK adding a provenance field must not 422 the whole run.
+export type RunProvenance = z.infer<typeof RunProvenanceSchema>;
+
+/**
  * Register/start a run. Idempotent on `client_run_id` within an evaluation:
  * re-sending the same key returns the existing run. The evaluation lineage is
  * resolved (create-if-absent) from `evaluation_name` + `dataset_id`.
@@ -195,10 +225,15 @@ export const RegisterRunRequestSchema = z
     baseline_run_id: z.string().min(1).max(64).nullable().optional(),
     case_count: z.number().int().nonnegative().nullable().optional(),
     /**
-     * Structured run provenance (model, prompt, config, git repo/ref/commit, …).
-     * Free-form and optional — the current SDK does not send it, and its absence
-     * never rejects a run. Presented as informational secondary detail, never as
-     * an evaluation error, and never a source of secrets.
+     * Typed execution provenance (git/CI/SDK identity, declared candidate
+     * model/prompt). Optional; absence never rejects a run. See
+     * {@link RunProvenanceSchema}.
+     */
+    provenance: RunProvenanceSchema.nullable().optional(),
+    /**
+     * Free-form run metadata — arbitrary user key/values, kept verbatim. Distinct
+     * from `provenance` (typed) — presented as informational secondary detail,
+     * never an evaluation error, and never a source of secrets.
      */
     metadata: MetadataSchema.nullable().optional(),
   })

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -205,26 +205,34 @@ export const RegisterRunRequestSchema = z
   .strict();
 export type RegisterRunRequest = z.infer<typeof RegisterRunRequestSchema>;
 
-export interface RegisterRunResponse {
-  evaluation_id: string;
-  evaluation_run_id: string;
-  run_number: number;
-  dataset_version_id: string;
+/**
+ * The response bodies are schemas, not bare interfaces, so the structural parity
+ * guard can introspect them the same way it introspects the requests — a response
+ * field added on one layer only is otherwise invisible to every test. The gateway
+ * proxies the upstream body verbatim, so these are the published contract and the
+ * inferred types below stay the single definition the handlers write against.
+ */
+export const RegisterRunResponseSchema = z.object({
+  evaluation_id: z.string(),
+  evaluation_run_id: z.string(),
+  run_number: z.number().int(),
+  dataset_version_id: z.string(),
   /**
    * UI-relative path to the run, `/projects/<projectId>/evaluations/<runId>`. The
    * backend owns the route shape. Kept for back-compat; prefer `run_url` for the
    * printed link — joining `run_path` to the SDK's `host_url` only resolves when the
    * API and UI share an origin (breaks in split-origin dev, where host_url is the API).
    */
-  run_path: string;
+  run_path: z.string(),
   /**
    * Absolute, clickable run URL — `run_path` resolved against the control plane's
    * configured public app origin (`NEXT_PUBLIC_APP_URL`). Correct regardless of how
    * the API and UI origins are split, so the SDK should print this verbatim rather
    * than reconstructing the link from `host_url`.
    */
-  run_url: string;
-}
+  run_url: z.string(),
+});
+export type RegisterRunResponse = z.infer<typeof RegisterRunResponseSchema>;
 
 /**
  * Upsert one test-case result. Idempotent on (`run_id`, `test_case_id`).
@@ -280,9 +288,10 @@ export const UpsertResultRequestSchema = z
   .strict();
 export type UpsertResultRequest = z.infer<typeof UpsertResultRequestSchema>;
 
-export interface UpsertResultResponse {
-  evaluation_result_id: string;
-}
+export const UpsertResultResponseSchema = z.object({
+  evaluation_result_id: z.string(),
+});
+export type UpsertResultResponse = z.infer<typeof UpsertResultResponseSchema>;
 
 /** Complete/fail a run, reporting final completeness counts. */
 export const CompleteRunRequestSchema = z
@@ -296,6 +305,13 @@ export const CompleteRunRequestSchema = z
   })
   .strict();
 export type CompleteRunRequest = z.infer<typeof CompleteRunRequestSchema>;
+
+export const CompleteRunResponseSchema = z.object({
+  evaluation_run_id: z.string(),
+  /** Echoes the persisted run status. */
+  status: EvalRunStatusSchema,
+});
+export type CompleteRunResponse = z.infer<typeof CompleteRunResponseSchema>;
 
 // ---------------------------------------------------------------------------
 // User-session CRUD requests (Datasets pages)

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -395,6 +395,40 @@ export const UpdateTestCaseRequestSchema = z
   .strict();
 export type UpdateTestCaseRequest = z.infer<typeof UpdateTestCaseRequestSchema>;
 
+/** The three explicit evaluation-result → dataset actions the UI can request. */
+export const ResultDatasetActionSchema = z.enum([
+  "update_existing_case",
+  "save_new_case",
+  "duplicate_as_variant",
+]);
+export type ResultDatasetAction = z.infer<typeof ResultDatasetActionSchema>;
+
+/**
+ * Save an evaluation result into a dataset. Candidate output is NEVER used as the
+ * expected output unless `use_candidate_as_expected` is set (or an explicit
+ * `expected` is supplied). Re-saving a result into its ORIGINATING dataset as a new
+ * case is refused with a conflict that directs the client to update instead — only
+ * `duplicate_as_variant` intentionally creates a second logical case.
+ */
+export const SaveResultToDatasetRequestSchema = z
+  .object({
+    action: ResultDatasetActionSchema,
+    /** Target dataset for save_new_case / duplicate_as_variant. For
+     *  update_existing_case it is ignored (the originating dataset is used). */
+    dataset_id: z.string().min(1).max(64).nullable().optional(),
+    /** Case input; defaults to the result's recorded input when omitted. */
+    input: z.string().max(EVAL_PAYLOAD_TEXT_MAX).nullable().optional(),
+    /** Explicit expected output. */
+    expected: z.string().max(EVAL_PAYLOAD_TEXT_MAX).nullable().optional(),
+    /** Explicit opt-in to set expected = the result's candidate output. */
+    use_candidate_as_expected: z.boolean().optional(),
+    metadata: MetadataSchema.nullable().optional(),
+    /** Idempotency for retried requests (a replay returns the version already published). */
+    idempotency_key: z.string().min(1).max(128).nullable().optional(),
+  })
+  .strict();
+export type SaveResultToDatasetRequest = z.infer<typeof SaveResultToDatasetRequestSchema>;
+
 export const CreateHumanScoreRequestSchema = z
   .object({
     verdict: HumanVerdictSchema,

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -333,6 +333,15 @@ export const CompleteRunRequestSchema = z
   .object({
     status: EvalRunStatusSchema,
     main_score: z.number().nullable().optional(),
+    /**
+     * The run-level main-score metric name, RESOLVED at completion. Lets an SDK
+     * register a run before any scorer's emitted metric name is known and name it
+     * here once it is. Optional and additive — an older SDK omits it and keeps the
+     * name it chose at registration (or none). When registration already fixed a
+     * name, this must match it (a mismatch is a conflict); for a successfully scored
+     * run the resolved name must exist among the run's emitted scores.
+     */
+    main_score_name: z.string().min(1).max(200).nullable().optional(),
     case_count: z.number().int().nonnegative().nullable().optional(),
     scored_count: z.number().int().nonnegative().nullable().optional(),
     task_error_count: z.number().int().nonnegative().nullable().optional(),

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/dataset-case/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/dataset-case/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest } from "next/server";
+import { Role, SaveResultToDatasetRequestSchema } from "@traceroot/core";
+import {
+  requireAuth,
+  requireProjectAccess,
+  errorResponse,
+  successResponse,
+} from "@/lib/auth-helpers";
+import {
+  saveResultToDataset,
+  ResultNotFound,
+  NoOriginatingCase,
+  CircularSaveConflict,
+} from "@/lib/eval/result-to-dataset";
+import { DatasetNotFound, VersionConflict } from "@/lib/eval/versions";
+
+type RouteParams = { params: Promise<{ projectId: string; resultId: string }> };
+
+// POST — save this evaluation result into a dataset: update the originating case,
+// save a new case, or duplicate as a variant. This is a dataset write (it publishes
+// a new immutable version), never a scoring action, and it never copies the
+// candidate output into `expected` implicitly.
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, resultId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId, Role.MEMBER);
+  if (accessResult.error) return accessResult.error;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse("Invalid JSON", 400);
+  }
+  const parsed = SaveResultToDatasetRequestSchema.safeParse(body);
+  if (!parsed.success) return errorResponse(parsed.error.issues[0].message, 400);
+  const d = parsed.data;
+
+  // save/duplicate target an explicit dataset; update derives it from the result.
+  if ((d.action === "save_new_case" || d.action === "duplicate_as_variant") && !d.dataset_id) {
+    return errorResponse(`${d.action} requires a dataset_id`, 400);
+  }
+
+  try {
+    const published = await saveResultToDataset({
+      projectId,
+      resultId,
+      action: d.action,
+      datasetId: d.dataset_id ?? undefined,
+      input: d.input,
+      expected: d.expected,
+      useCandidateAsExpected: d.use_candidate_as_expected ?? false,
+      metadata: d.metadata,
+      idempotencyKey: d.idempotency_key ?? null,
+      addedBy: authResult.user.email ?? authResult.user.id,
+    });
+    return successResponse(
+      {
+        dataset_id: published.datasetId,
+        version_id: published.versionId,
+        version_number: published.versionNumber,
+        test_case_id: published.focusTestCaseId,
+        case_count: published.caseCount,
+        replayed: published.replayed,
+      },
+      201,
+    );
+  } catch (e) {
+    if (e instanceof ResultNotFound) return errorResponse(e.message, 404);
+    if (e instanceof DatasetNotFound) return errorResponse(e.message, 404);
+    if (e instanceof NoOriginatingCase) return errorResponse(e.message, 409);
+    // Actionable conflict: the message directs the client to update_existing_case.
+    if (e instanceof CircularSaveConflict) return errorResponse(e.message, 409);
+    if (e instanceof VersionConflict) return errorResponse("Dataset version conflict", 409);
+    throw e;
+  }
+}

--- a/frontend/ui/src/app/api/public/evaluation-runs/[runId]/complete/route.test.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/[runId]/complete/route.test.ts
@@ -50,6 +50,9 @@ beforeEach(() => {
     completedAt: null,
     caseCount: 10,
     scoredCount: 0,
+    // Registered without a resolved main-score name (the B1 flow); tests that need a
+    // name fixed at registration override this.
+    mainScoreName: null,
   });
   requireApiKeyProjectMock.mockReset();
   requireApiKeyProjectMock.mockResolvedValue({ projectId: "proj-1" });
@@ -129,5 +132,96 @@ describe("POST /api/public/evaluation-runs/[runId]/complete", () => {
 
     expect(res.status).toBe(404);
     expect(storedRun()).toMatchObject({ status: "running", completedAt: null });
+  });
+});
+
+// B1 — resolving the run-level main-score name at completion. `EvaluationRun.mainScoreName`
+// is the authoritative run-specific selection; these cover registration-first vs
+// completion-first resolution, conflicts, the successful-run existence check, and the
+// honest-terminal-state escape hatch. Score rows carry a flat `runId` because the fake
+// store flattens the `{ result: { runId } }` relation filter one level.
+function addScore(scorerName: string) {
+  store.score.rows.push({ scorerName, runId: "run-1", projectId: "proj-1" });
+}
+
+describe("POST complete — main score name resolution (B1)", () => {
+  it("resolves an unnamed run's main score at completion and persists it", async () => {
+    addScore("quality");
+    const res = await POST(makeRequest({ ...FINISHED, main_score_name: "quality" }), params);
+
+    expect(res.status).toBe(200);
+    // The run now carries the resolved name — the authoritative run-level selection the
+    // read model reads back and the headline/comparison label from.
+    expect(storedRun()).toMatchObject({ status: "completed", mainScoreName: "quality" });
+  });
+
+  it("accepts a completion name that matches the one fixed at registration (idempotent)", async () => {
+    storedRun().mainScoreName = "accuracy";
+    addScore("accuracy");
+
+    const first = await POST(makeRequest({ ...FINISHED, main_score_name: "accuracy" }), params);
+    const second = await POST(makeRequest({ ...FINISHED, main_score_name: "accuracy" }), params);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(storedRun()).toMatchObject({ status: "completed", mainScoreName: "accuracy" });
+  });
+
+  it("rejects a completion name that conflicts with registration, without mutating the run", async () => {
+    storedRun().mainScoreName = "accuracy";
+
+    const res = await POST(makeRequest({ ...FINISHED, main_score_name: "quality" }), params);
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatch(/already "accuracy".*cannot be changed/i);
+    // Original selection unchanged and the run is untouched (still running).
+    expect(storedRun()).toMatchObject({
+      status: "running",
+      mainScoreName: "accuracy",
+      completedAt: null,
+    });
+  });
+
+  it("rejects a successful completion whose name is absent from every emitted score", async () => {
+    addScore("quality"); // the only emitted metric
+
+    const res = await POST(makeRequest({ ...FINISHED, main_score_name: "not_emitted" }), params);
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/not found among this run's emitted scores/i);
+    // Not mutated — the run stays open so it can be completed honestly.
+    expect(storedRun()).toMatchObject({ status: "running", mainScoreName: null });
+  });
+
+  it("lets an all-scorer-error run reach a failed terminal state with no resolved name", async () => {
+    const res = await POST(
+      makeRequest({
+        status: "failed",
+        case_count: 3,
+        scored_count: 0,
+        scorer_error_count: 3,
+      }),
+      params,
+    );
+
+    expect(res.status).toBe(200);
+    // Terminal failure persists (not stranded), and no name was invented.
+    expect(storedRun()).toMatchObject({
+      status: "failed",
+      mainScoreName: null,
+      completedAt: new Date("2026-07-31T12:00:00.000Z"),
+    });
+  });
+
+  it("preserves existing behavior for an old payload that omits main_score_name", async () => {
+    // Registered with a name, but no matching score row exists — an older SDK's
+    // completion (no main_score_name) must still succeed and must not run the new
+    // existence check.
+    storedRun().mainScoreName = "accuracy";
+
+    const res = await POST(makeRequest(FINISHED), params);
+
+    expect(res.status).toBe(200);
+    expect(storedRun()).toMatchObject({ status: "completed", mainScoreName: "accuracy" });
   });
 });

--- a/frontend/ui/src/app/api/public/evaluation-runs/[runId]/complete/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/[runId]/complete/route.ts
@@ -16,7 +16,7 @@ export async function POST(request: Request, { params }: RouteParams) {
 
   const run = await prisma.evaluationRun.findFirst({
     where: { id: runId, projectId },
-    select: { id: true, status: true, completedAt: true },
+    select: { id: true, status: true, completedAt: true, mainScoreName: true },
   });
   if (!run) return NextResponse.json({ error: "Evaluation run not found" }, { status: 404 });
 
@@ -43,10 +43,62 @@ export async function POST(request: Request, { params }: RouteParams) {
     );
   }
 
+  // Resolve the run-level main-score name. Omitting `main_score_name` (every older
+  // SDK) preserves the existing behavior: the name chosen at registration stands and
+  // nothing here is validated. Only a non-null provided name engages resolution —
+  // an explicit null is treated as "unspecified", never as clearing a chosen name.
+  const providedName = c.main_score_name ?? undefined;
+  let resolvedName: string | null | undefined; // undefined = don't write the column
+  if (providedName !== undefined) {
+    if (run.mainScoreName !== null && run.mainScoreName !== undefined) {
+      // Registration already fixed the name — completion may only confirm it.
+      if (providedName !== run.mainScoreName) {
+        // Actionable conflict; the run is NOT mutated.
+        return NextResponse.json(
+          {
+            error:
+              `Run's main score name is already "${run.mainScoreName}" and cannot be ` +
+              `changed to "${providedName}". Re-run with the registered name, or register ` +
+              `a new run to use a different one.`,
+          },
+          { status: 409 },
+        );
+      }
+      // Matches — idempotent, no column change needed.
+    } else {
+      // Registration omitted the name; completion resolves it now.
+      resolvedName = providedName;
+    }
+
+    // For a successfully scored run, the resolved name must correspond to a real
+    // emitted score (a scorer that errored still leaves a row under its name). A
+    // failed/incomplete/cancelled run is exempt, so a run can always reach an honest
+    // terminal state even when name resolution never happened.
+    const SUCCESS_TERMINAL = new Set(["completed", "completed_with_errors"]);
+    const effectiveName = resolvedName ?? run.mainScoreName ?? null;
+    if (SUCCESS_TERMINAL.has(c.status) && effectiveName !== null) {
+      const scoreRow = await prisma.score.findFirst({
+        where: { scorerName: effectiveName, result: { runId } },
+        select: { id: true },
+      });
+      if (!scoreRow) {
+        return NextResponse.json(
+          {
+            error:
+              `Main score name "${effectiveName}" was not found among this run's emitted ` +
+              `scores. Complete as failed/incomplete, or report a score under that name.`,
+          },
+          { status: 400 },
+        );
+      }
+    }
+  }
+
   const updated = await prisma.evaluationRun.update({
     where: { id: runId },
     data: {
       status: c.status,
+      ...(resolvedName !== undefined ? { mainScoreName: resolvedName } : {}),
       ...(c.main_score !== undefined ? { mainScore: c.main_score } : {}),
       ...(c.case_count !== undefined && c.case_count !== null ? { caseCount: c.case_count } : {}),
       ...(c.scored_count !== undefined && c.scored_count !== null

--- a/frontend/ui/src/app/api/public/evaluation-runs/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/route.ts
@@ -175,6 +175,9 @@ async function registerRun(
       // SDK sends it; a legacy {name, version} scorer stays valid. Cast because
       // the scorer metadata field is typed `unknown` (arbitrary JSON).
       scorers: req.scorers as unknown as Prisma.InputJsonValue,
+      // Typed execution provenance (git/CI/SDK + declared candidate model/prompt),
+      // kept distinct from free-form `metadata`. Absent when the SDK reports none.
+      provenance: (req.provenance ?? undefined) as Prisma.InputJsonValue | undefined,
       metadata: (req.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
       clientRunId: req.client_run_id ?? null,
     },

--- a/frontend/ui/src/features/evaluations/types.ts
+++ b/frontend/ui/src/features/evaluations/types.ts
@@ -6,6 +6,24 @@ import type { RunComparison, ResultComparison } from "@/lib/eval/comparison";
 
 export type { RunComparison, ResultComparison, Classification } from "@/lib/eval/comparison";
 
+/**
+ * Typed execution provenance surfaced on a run — mirrors the SDK's
+ * `RunProvenance` contract. Every field is optional/nullable; unknowns are null
+ * and never inferred. Distinct from free-form `metadata`.
+ */
+export interface RunProvenance {
+  git_repository: string | null;
+  git_ref: string | null;
+  git_commit: string | null;
+  git_dirty: boolean | null;
+  ci_provider: string | null;
+  ci_build_id: string | null;
+  sdk_language: string | null;
+  sdk_version: string | null;
+  declared_model: string | null;
+  declared_prompt_version: string | null;
+}
+
 /** The per-result comparison block the run-detail route embeds on each result. */
 export type ResultRowComparison = Pick<
   ResultComparison,
@@ -164,8 +182,9 @@ export interface RunRow {
   erroredCount: number;
   notScoredCount: number;
   scorers: Array<{ name: string; version: string }> | null;
-  model: string | null;
-  /** Structured run provenance (model, prompt, config, git). Free-form; may be null. */
+  /** Typed execution provenance (git/CI/SDK identity, declared candidate model/prompt); null when the SDK reported none. */
+  provenance: RunProvenance | null;
+  /** Free-form user run metadata (arbitrary key/values); may be null. */
   metadata: Record<string, unknown> | null;
   startedAt: string;
   completedAt: string | null;

--- a/frontend/ui/src/lib/eval/result-to-dataset.ts
+++ b/frontend/ui/src/lib/eval/result-to-dataset.ts
@@ -1,0 +1,177 @@
+import { prisma } from "@traceroot/core";
+import { publishDatasetVersion, newTestCaseId, type TestCaseSeed } from "./versions";
+
+/**
+ * Save an evaluation result into a dataset — the three explicit result-driven
+ * actions, built on the immutable versioning engine (`publishDatasetVersion`).
+ *
+ * Invariants enforced here:
+ *  - Candidate output is NEVER used as expected implicitly. `expected` is set only
+ *    from an explicit value or an explicit "use candidate as expected" opt-in; the
+ *    candidate always rides along separately as `recordedOutput`.
+ *  - Updating an existing case publishes a new immutable version and preserves the
+ *    stable logical `testCaseId`.
+ *  - Re-saving a result into its ORIGINATING dataset as a *new* case is refused with
+ *    a conflict (→ update instead); only `duplicate_as_variant` opts into a second
+ *    logical case.
+ *  - Idempotency: a retried request with the same key returns the already-published
+ *    version rather than duplicating (delegated to the engine).
+ */
+export type ResultDatasetAction =
+  | "update_existing_case"
+  | "save_new_case"
+  | "duplicate_as_variant";
+
+export class ResultNotFound extends Error {
+  constructor() {
+    super("Evaluation result not found");
+    this.name = "ResultNotFound";
+  }
+}
+
+/** The result is not backed by a live dataset case, so there is nothing to update. */
+export class NoOriginatingCase extends Error {
+  constructor() {
+    super("This result is not linked to a live dataset test case to update.");
+    this.name = "NoOriginatingCase";
+  }
+}
+
+/** Re-saving a result into its originating dataset would silently duplicate a case. */
+export class CircularSaveConflict extends Error {
+  constructor(public readonly existingTestCaseId: string) {
+    super(
+      "This result already maps to a test case in its originating dataset. Use " +
+        "update_existing_case, or duplicate_as_variant to intentionally add a second case.",
+    );
+    this.name = "CircularSaveConflict";
+  }
+}
+
+export async function saveResultToDataset(opts: {
+  projectId: string;
+  resultId: string;
+  action: ResultDatasetAction;
+  /** Target dataset for save/duplicate; ignored for update (uses the originating one). */
+  datasetId?: string | null;
+  /** `undefined` = omitted (keep current on update / default to the result on new). */
+  input?: string | null;
+  /** `undefined` = omitted; an explicit `null` clears expected. Never the candidate. */
+  expected?: string | null;
+  /** Explicit opt-in: set expected = the result's candidate output. */
+  useCandidateAsExpected?: boolean;
+  /** `undefined` = omitted. */
+  metadata?: unknown;
+  idempotencyKey?: string | null;
+  addedBy?: string | null;
+}) {
+  const result = await prisma.evaluationResult.findFirst({
+    where: { id: opts.resultId, projectId: opts.projectId },
+    select: {
+      id: true,
+      runId: true,
+      testCaseId: true,
+      traceId: true,
+      input: true,
+      candidateOutput: true,
+    },
+  });
+  if (!result) throw new ResultNotFound();
+  const run = await prisma.evaluationRun.findFirst({
+    where: { id: result.runId, projectId: opts.projectId },
+    select: { datasetId: true },
+  });
+  if (!run) throw new ResultNotFound();
+
+  const originatingDatasetId = run.datasetId;
+  const inputProvided = opts.input !== undefined;
+  const expectedProvided = opts.expected !== undefined;
+  const metadataProvided = opts.metadata !== undefined;
+
+  // Never default expected to candidate: only an explicit value or explicit opt-in.
+  const resolveExpected = (currentExpected: string | null): string | null => {
+    if (opts.useCandidateAsExpected) return result.candidateOutput ?? null;
+    if (expectedProvided) return opts.expected ?? null;
+    return currentExpected;
+  };
+
+  // Is the result still backed by a live case in its originating dataset?
+  const dataset = await prisma.dataset.findFirst({
+    where: { id: originatingDatasetId, projectId: opts.projectId },
+    select: { currentVersionId: true },
+  });
+  const originatingCaseLive =
+    dataset?.currentVersionId != null &&
+    (await prisma.testCase.findFirst({
+      where: { testCaseId: result.testCaseId, datasetVersionId: dataset.currentVersionId },
+      select: { testCaseId: true },
+    })) !== null;
+
+  if (opts.action === "update_existing_case") {
+    if (!originatingCaseLive) throw new NoOriginatingCase();
+    return publishDatasetVersion({
+      datasetId: originatingDatasetId,
+      projectId: opts.projectId,
+      createdBy: opts.addedBy ?? null,
+      idempotencyKey: opts.idempotencyKey ?? null,
+      transform: (current) => {
+        // Update expected/input/metadata only as explicitly supplied; the stable
+        // logical testCaseId is preserved, so lineage is unbroken.
+        const cases = current.map((c) =>
+          c.testCaseId === result.testCaseId
+            ? {
+                ...c,
+                input: inputProvided ? (opts.input ?? "") : c.input,
+                expected: resolveExpected(c.expected),
+                metadata: metadataProvided ? opts.metadata : c.metadata,
+              }
+            : c,
+        );
+        return { cases, focusTestCaseId: result.testCaseId };
+      },
+    });
+  }
+
+  // save_new_case / duplicate_as_variant → append a NEW logical case.
+  const targetDatasetId = opts.datasetId ?? originatingDatasetId;
+
+  // Circular guard: a plain save back into the originating dataset, where the case
+  // still exists, is a duplicate — refuse and direct the client to update instead.
+  if (
+    opts.action === "save_new_case" &&
+    targetDatasetId === originatingDatasetId &&
+    originatingCaseLive
+  ) {
+    throw new CircularSaveConflict(result.testCaseId);
+  }
+
+  const newSeed: TestCaseSeed = {
+    testCaseId: newTestCaseId(),
+    input: inputProvided ? (opts.input ?? "") : result.input,
+    // A brand-new case: expected defaults to null (never the candidate) unless set.
+    expected: resolveExpected(null),
+    // The candidate output is recorded separately, never as expected.
+    recordedOutput: result.candidateOutput ?? null,
+    metadata: metadataProvided ? opts.metadata : null,
+    review: "needs_review",
+    captureReason: "manual",
+    sourceTraceId: result.traceId ?? null,
+    sourceSpanId: null,
+    sourceSpanName: null,
+    sourceSpanKind: null,
+    sourceRunId: result.runId,
+    sourceResultId: result.id,
+    addedBy: opts.addedBy ?? null,
+  };
+
+  return publishDatasetVersion({
+    datasetId: targetDatasetId,
+    projectId: opts.projectId,
+    createdBy: opts.addedBy ?? null,
+    idempotencyKey: opts.idempotencyKey ?? null,
+    transform: (current) => ({
+      cases: [...current, newSeed],
+      focusTestCaseId: newSeed.testCaseId,
+    }),
+  });
+}

--- a/frontend/ui/src/lib/eval/versions.ts
+++ b/frontend/ui/src/lib/eval/versions.ts
@@ -24,6 +24,10 @@ export type TestCaseSeed = {
   sourceSpanId: string | null;
   sourceSpanName: string | null;
   sourceSpanKind: string | null;
+  /** Eval-result provenance (set when a case is saved from a result). Optional so
+   *  non-result cases omit it; `toSeed` carries it across version copies. */
+  sourceRunId?: string | null;
+  sourceResultId?: string | null;
   addedBy: string | null;
   /**
    * When this case was first created. Carried across version copies so an
@@ -47,6 +51,8 @@ function toSeed(c: TestCase): TestCaseSeed {
     sourceSpanId: c.sourceSpanId,
     sourceSpanName: c.sourceSpanName,
     sourceSpanKind: c.sourceSpanKind,
+    sourceRunId: c.sourceRunId,
+    sourceResultId: c.sourceResultId,
     addedBy: c.addedBy,
     createTime: c.createTime,
   };

--- a/tests/rest/test_eval_contract_parity.py
+++ b/tests/rest/test_eval_contract_parity.py
@@ -95,7 +95,7 @@ def test_pydantic_rejects_invalid(label: str, model: type[BaseModel], case: dict
             "rest/schemas/eval.py. The gateway forwards bodies verbatim and FastAPI validates "
             "before the handler runs, so forbidding here would 422 a field the gateway does not "
             "yet model and it would never reach persistence. Asserted instead by "
-            "tests/rest/test_public_eval_gateway.py::test_unmodelled_field_still_reaches_the_handler."
+            "tests/rest/test_public_eval_gateway_security.py::test_unmodelled_field_still_reaches_the_handler."
         )
     with pytest.raises(ValidationError):
         model.model_validate(case["payload"])

--- a/tests/rest/test_eval_contract_parity.py
+++ b/tests/rest/test_eval_contract_parity.py
@@ -1,0 +1,88 @@
+"""Cross-layer drift guard (Pydantic side).
+
+The public eval reporting contract is defined twice: the Zod schemas in
+``frontend/packages/core/src/eval-contract.ts`` (the Next.js control plane) and
+the Pydantic models in ``rest.schemas.eval`` (the FastAPI gateway). If they
+disagree on which payloads are valid, the gateway could accept a request the
+control plane rejects (or vice-versa).
+
+This test and ``eval-contract-parity.drift.test.ts`` load the SAME fixture file
+and assert the SAME accept/reject verdicts on every representative payload — so a
+one-sided schema edit turns one language's suite red.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from rest.schemas.eval import CompleteRunRequest, RegisterRunRequest, UpsertResultRequest
+
+FIXTURES = (
+    Path(__file__).resolve().parents[2]
+    / "frontend"
+    / "packages"
+    / "core"
+    / "src"
+    / "__tests__"
+    / "eval-contract-parity-fixtures.json"
+)
+
+MODELS: dict[str, type[BaseModel]] = {
+    "register": RegisterRunRequest,
+    "upsert_result": UpsertResultRequest,
+    "complete": CompleteRunRequest,
+}
+
+
+def _fixtures() -> dict:
+    return json.loads(FIXTURES.read_text(encoding="utf-8"))
+
+
+def _cases(kind: str) -> list[tuple[str, type[BaseModel], dict]]:
+    data = _fixtures()
+    out: list[tuple[str, type[BaseModel], dict]] = []
+    for group, model in MODELS.items():
+        for case in data[group][kind]:
+            out.append((f"{group}/{case['name']}", model, case["payload"]))
+    return out
+
+
+_VALID = _cases("valid")
+_INVALID = _cases("invalid")
+
+
+def test_fixture_file_is_the_shared_source():
+    # The Zod drift test loads this exact file; guard against a rename/move.
+    assert FIXTURES.exists(), FIXTURES
+    data = _fixtures()
+    assert set(data) >= set(MODELS)
+
+
+@pytest.mark.parametrize("label,model,payload", _VALID, ids=[c[0] for c in _VALID])
+def test_pydantic_accepts_valid(label: str, model: type[BaseModel], payload: dict):
+    # Must not raise; mirrors Zod safeParse().success === true for the same payload.
+    model.model_validate(payload)
+
+
+@pytest.mark.parametrize("label,model,payload", _INVALID, ids=[c[0] for c in _INVALID])
+def test_pydantic_rejects_invalid(label: str, model: type[BaseModel], payload: dict):
+    # Must raise; mirrors Zod safeParse().success === false for the same payload.
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)
+
+
+def test_non_strict_scorer_ignores_unknown_keys():
+    # Parity detail: ScorerRefSchema is a plain (non-strict) z.object that STRIPS
+    # unknown keys, so the gateway must ignore them too (not forbid) — otherwise a
+    # future SDK sending richer scorer metadata would 422 at the gateway only.
+    run = RegisterRunRequest.model_validate(
+        {
+            "evaluation_name": "x",
+            "dataset_id": "ds1",
+            "candidate_version": "v1",
+            "scorers": [{"name": "s", "version": "v1", "unknown_scorer_field": "x"}],
+        }
+    )
+    assert not hasattr(run.scorers[0], "unknown_scorer_field")

--- a/tests/rest/test_eval_contract_parity.py
+++ b/tests/rest/test_eval_contract_parity.py
@@ -4,30 +4,45 @@ The public eval reporting contract is defined twice: the Zod schemas in
 ``frontend/packages/core/src/eval-contract.ts`` (the Next.js control plane) and
 the Pydantic models in ``rest.schemas.eval`` (the FastAPI gateway). If they
 disagree on which payloads are valid, the gateway could accept a request the
-control plane rejects (or vice-versa).
+control plane rejects (or vice-versa) — and because the gateway forwards the raw
+request bytes upstream, its own validation is the only place that divergence can
+be caught before the SDK sees a confusing 400.
 
-This test and ``eval-contract-parity.drift.test.ts`` load the SAME fixture file
-and assert the SAME accept/reject verdicts on every representative payload — so a
-one-sided schema edit turns one language's suite red.
+The guard has two halves, and this file and ``eval-contract-parity.drift.test.ts``
+run the same two against their own layer:
+
+1. BEHAVIOURAL — replay the shared payload fixtures in
+   ``eval-contract-parity-fixtures.json`` and assert identical accept/reject
+   verdicts (plus identical normalization of the values that degrade rather than
+   reject). Catches semantics no schema shape can express.
+2. STRUCTURAL — reduce every model to a language-neutral descriptor and compare it
+   against the shared roster in ``eval-contract-shape.json``. Fixtures alone cannot
+   catch a one-sided OPTIONAL field or a one-sided bound: no fixture exercises them,
+   so every verdict is unchanged and both suites stay green. The roster makes any
+   field added, removed or retyped on one layer only fail that layer's comparison,
+   and its coverage assertion makes a NEW model fail until it is listed.
 """
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from rest.schemas.eval import CompleteRunRequest, RegisterRunRequest, UpsertResultRequest
-
-FIXTURES = (
-    Path(__file__).resolve().parents[2]
-    / "frontend"
-    / "packages"
-    / "core"
-    / "src"
-    / "__tests__"
-    / "eval-contract-parity-fixtures.json"
+from rest.schemas import eval as eval_schemas
+from rest.schemas.eval import (
+    JSON_SAFE_INT_MAX,
+    CompleteRunRequest,
+    RegisterRunRequest,
+    UpsertResultRequest,
 )
+
+_SHARED = (
+    Path(__file__).resolve().parents[2] / "frontend" / "packages" / "core" / "src" / "__tests__"
+)
+FIXTURES = _SHARED / "eval-contract-parity-fixtures.json"
+SHAPES = _SHARED / "eval-contract-shape.json"
 
 MODELS: dict[str, type[BaseModel]] = {
     "register": RegisterRunRequest,
@@ -40,37 +55,76 @@ def _fixtures() -> dict:
     return json.loads(FIXTURES.read_text(encoding="utf-8"))
 
 
+def _roster() -> dict:
+    return json.loads(SHAPES.read_text(encoding="utf-8"))
+
+
 def _cases(kind: str) -> list[tuple[str, type[BaseModel], dict]]:
     data = _fixtures()
     out: list[tuple[str, type[BaseModel], dict]] = []
     for group, model in MODELS.items():
-        for case in data[group][kind]:
-            out.append((f"{group}/{case['name']}", model, case["payload"]))
+        for case in data[group].get(kind, []):
+            out.append((f"{group}/{case['name']}", model, case))
     return out
 
 
 _VALID = _cases("valid")
 _INVALID = _cases("invalid")
+_DEGRADED = _cases("degraded")
 
 
-def test_fixture_file_is_the_shared_source():
-    # The Zod drift test loads this exact file; guard against a rename/move.
+def test_fixture_files_are_the_shared_source():
+    # The Zod drift test loads these exact files; guard against a rename/move.
     assert FIXTURES.exists(), FIXTURES
-    data = _fixtures()
-    assert set(data) >= set(MODELS)
+    assert SHAPES.exists(), SHAPES
+    assert set(_fixtures()) >= set(MODELS)
 
 
-@pytest.mark.parametrize("label,model,payload", _VALID, ids=[c[0] for c in _VALID])
-def test_pydantic_accepts_valid(label: str, model: type[BaseModel], payload: dict):
+@pytest.mark.parametrize("label,model,case", _VALID, ids=[c[0] for c in _VALID])
+def test_pydantic_accepts_valid(label: str, model: type[BaseModel], case: dict):
     # Must not raise; mirrors Zod safeParse().success === true for the same payload.
-    model.model_validate(payload)
+    model.model_validate(case["payload"])
 
 
-@pytest.mark.parametrize("label,model,payload", _INVALID, ids=[c[0] for c in _INVALID])
-def test_pydantic_rejects_invalid(label: str, model: type[BaseModel], payload: dict):
+@pytest.mark.parametrize("label,model,case", _INVALID, ids=[c[0] for c in _INVALID])
+def test_pydantic_rejects_invalid(label: str, model: type[BaseModel], case: dict):
     # Must raise; mirrors Zod safeParse().success === false for the same payload.
+    if case["name"].startswith(_UNKNOWN_KEY_PREFIX):
+        pytest.skip(
+            "Unknown-key rejection is deliberately Zod-only — see the module docstring in "
+            "rest/schemas/eval.py. The gateway forwards bodies verbatim and FastAPI validates "
+            "before the handler runs, so forbidding here would 422 a field the gateway does not "
+            "yet model and it would never reach persistence. Asserted instead by "
+            "tests/rest/test_public_eval_gateway.py::test_unmodelled_field_still_reaches_the_handler."
+        )
     with pytest.raises(ValidationError):
-        model.model_validate(payload)
+        model.model_validate(case["payload"])
+
+
+def _at_path(value: Any, path: str) -> Any:
+    """Read ``a.0.b`` out of a validated model (list indices are numeric segments)."""
+    for segment in path.split("."):
+        if isinstance(value, BaseModel):
+            value = getattr(value, segment, None)
+        elif segment.isdigit():
+            value = value[int(segment)]
+        else:
+            value = value.get(segment) if isinstance(value, dict) else getattr(value, segment, None)
+    return value
+
+
+@pytest.mark.parametrize("label,model,case", _DEGRADED, ids=[c[0] for c in _DEGRADED])
+def test_pydantic_degrades_instead_of_rejecting(label: str, model: type[BaseModel], case: dict):
+    """Accept/reject parity is not enough where a layer NORMALIZES the value instead.
+
+    A display-only vocabulary degrades an unrecognised member to null rather than
+    failing the whole run (``.catch(null)`` / the ``mode="before"`` validator), and a
+    non-strict scorer strips unknown keys. Both layers must land on the same value,
+    or the gateway publishes something the control plane never stored.
+    """
+    parsed = model.model_validate(case["payload"])
+    for path, expected in case["expect"].items():
+        assert _at_path(parsed, path) == expected, path
 
 
 def test_non_strict_scorer_ignores_unknown_keys():
@@ -86,3 +140,168 @@ def test_non_strict_scorer_ignores_unknown_keys():
         }
     )
     assert not hasattr(run.scorers[0], "unknown_scorer_field")
+
+
+# --- Structural shapes -------------------------------------------------------
+#
+# Mirrors `contract-shape.ts`: both sides reduce a model to the same descriptor, so
+# the roster is directly comparable. Representational differences that carry no
+# contract meaning are normalized away — `anyOf: [T, null]` collapses to `nullable`,
+# and a None/absent default is dropped (pydantic's `None` default and Zod's absent-key
+# `undefined` both just mean "the caller omitted it").
+
+
+def _unwrap_nullable(node: dict) -> tuple[dict, bool]:
+    variants = node.get("anyOf") or node.get("oneOf")
+    if isinstance(variants, list) and len(variants) == 2:
+        if variants[1] == {"type": "null"}:
+            return variants[0], True
+        if variants[0] == {"type": "null"}:
+            return variants[1], True
+    return node, False
+
+
+def _put(target: dict, key: str, value: Any) -> None:
+    if value is not None:
+        target[key] = value
+
+
+def _sans_safe_integer_bound(value: Any) -> Any:
+    """Drop the ``Number.isSafeInteger`` sentinel that ``z.number().int()`` publishes.
+
+    It describes the JS number type rather than a choice the contract made; the gateway
+    mirrors the same ceiling as ``JSON_SAFE_INT_MAX``, so dropping it on both sides
+    leaves an integer field comparing on its real bounds (``minimum: 0``, ``max: 5``).
+    """
+    return None if value in (JSON_SAFE_INT_MAX, -JSON_SAFE_INT_MAX) else value
+
+
+def _type_shape(node: dict) -> dict:
+    """Reduce one JSON Schema node to its language-neutral type descriptor."""
+    if "$ref" in node:
+        return {"type": node["$ref"].rsplit("/", 1)[-1]}
+    if "const" in node:
+        return {"type": "literal", "const": node["const"]}
+    if "enum" in node:
+        return {"type": "enum", "enum": list(node["enum"])}
+
+    kind = node.get("type")
+    if kind == "string":
+        shape = {"type": "string"}
+        _put(shape, "min_length", node.get("minLength"))
+        _put(shape, "max_length", node.get("maxLength"))
+        return shape
+    if kind in ("integer", "number"):
+        shape = {"type": kind}
+        _put(shape, "minimum", _sans_safe_integer_bound(node.get("minimum")))
+        _put(shape, "maximum", _sans_safe_integer_bound(node.get("maximum")))
+        return shape
+    if kind == "boolean":
+        return {"type": "boolean"}
+    if kind == "array":
+        shape = {"type": "array", "items": _type_shape(node.get("items", {}))}
+        _put(shape, "min_items", node.get("minItems"))
+        _put(shape, "max_items", node.get("maxItems"))
+        return shape
+    if kind == "object":
+        # A free-form JSON object (`dict[str, Any]` / a Zod record). Named object
+        # models are always emitted as a `$ref` and handled above.
+        if "properties" not in node:
+            return {"type": "json_object"}
+        raise AssertionError(f"unnamed inline object: {json.dumps(node)[:120]}")
+    if kind is None:
+        # `Any` / `z.unknown()` — an unconstrained JSON value.
+        return {"type": "any"}
+    raise AssertionError(f"unsupported schema node: {json.dumps(node)[:120]}")
+
+
+def _model_shape(model: type[BaseModel]) -> dict:
+    schema = model.model_json_schema()
+    fields: dict[str, dict] = {}
+    for name, prop in schema.get("properties", {}).items():
+        inner, nullable = _unwrap_nullable(prop)
+        info = model.model_fields[name]
+        shape = _type_shape(inner)
+        shape["required"] = info.is_required()
+        shape["nullable"] = nullable
+        # Read the default off the field rather than the JSON Schema: pydantic omits a
+        # `default_factory` value from the schema, and the Zod side publishes it.
+        default = None if info.is_required() else info.get_default(call_default_factory=True)
+        if default is not None:
+            shape["default"] = default
+        fields[name] = shape
+    return {
+        "kind": "object",
+        "unknown_keys": "forbid" if schema.get("additionalProperties") is False else "strip",
+        "fields": fields,
+    }
+
+
+def _contract_models() -> dict[str, type[BaseModel]]:
+    """Every model DEFINED in ``rest.schemas.eval``, enumerated from the module.
+
+    Enumerated rather than hand-listed so a newly added model is covered by the
+    roster — or fails ``test_shape_roster_covers_every_model`` — automatically.
+    """
+    return {
+        name: obj
+        for name, obj in vars(eval_schemas).items()
+        if isinstance(obj, type)
+        and issubclass(obj, BaseModel)
+        and obj.__module__ == eval_schemas.__name__
+    }
+
+
+#: Gateway request bodies. Zod owns unknown-key strictness for these; the Pydantic
+#: models stay permissive so the gateway forwards a field it does not model rather
+#: than 422-ing it before the authoritative writer ever sees it.
+_GATEWAY_PERMISSIVE_MODELS = frozenset(
+    {"ScoreInput", "RegisterRunRequest", "UpsertResultRequest", "CompleteRunRequest"}
+)
+#: Fixture cases that assert unknown-key rejection — Zod-side only, same reason.
+#: Matched by prefix so a newly added `unknown_*` case is covered automatically.
+_UNKNOWN_KEY_PREFIX = "unknown"
+
+_ROSTER = _roster()
+_PYDANTIC_NAMES = sorted(set(_ROSTER["paired"]) | set(_ROSTER["pydantic_only"]))
+
+
+def test_shape_roster_covers_every_model():
+    """An unlisted model must FAIL, not silently pass — that is the whole point.
+
+    A model added to the gateway without a roster entry is a model with zero
+    cross-layer coverage; listing it (in ``paired``, or in ``pydantic_only`` with the
+    reason it has no Zod counterpart) is the deliberate act this asserts on.
+    """
+    assert sorted(_contract_models()) == _PYDANTIC_NAMES
+
+
+@pytest.mark.parametrize("name", _PYDANTIC_NAMES)
+def test_model_shape_matches_roster(name: str):
+    """A field added/removed/retyped on ONE layer fails here by construction.
+
+    ``unknown_keys`` is compared everywhere EXCEPT the gateway request bodies, where
+    the two layers differ on purpose: the Zod schemas are ``.strict()`` while the
+    Pydantic models are deliberately not ``extra="forbid"`` (see the module docstring
+    in ``rest/schemas/eval.py``). Forbidding at the gateway would 422 a field it does
+    not yet model — breaking a rolling deploy where a newer SDK talks to an older
+    gateway fronting a handler that would have accepted it. Every other part of the
+    shape is still compared field-for-field, so real drift still fails here.
+    """
+    expected = _ROSTER["paired"].get(name) or _ROSTER["pydantic_only"][name]
+    actual = _model_shape(_contract_models()[name])
+    if name in _GATEWAY_PERMISSIVE_MODELS:
+        expected = {k: v for k, v in expected.items() if k != "unknown_keys"}
+        actual = {k: v for k, v in actual.items() if k != "unknown_keys"}
+    assert actual == expected
+
+
+@pytest.mark.parametrize("name", sorted(_ROSTER["zod_only"]))
+def test_zod_only_models_have_no_gateway_counterpart(name: str):
+    """The asymmetry the roster records must stay real.
+
+    These are contract schemas the gateway forwards without typing (the dataset
+    catch-alls). Adding a Pydantic model for one is exactly the moment it must be
+    promoted to ``paired`` and start being compared field-for-field.
+    """
+    assert name not in _contract_models()

--- a/tests/rest/test_public_eval_gateway.py
+++ b/tests/rest/test_public_eval_gateway.py
@@ -257,18 +257,3 @@ def test_typed_route_rejects_invalid_body_before_forwarding(client):
     )
     assert resp.status_code == 422
     assert not route.called
-
-
-@respx.mock
-def test_typed_route_rejects_unknown_field_before_forwarding(client):
-    # The Zod contract is .strict(); the Pydantic mirror forbids extras → 422, no forward.
-    route = respx.post(f"{UI}/api/public/evaluation-runs/run1/complete").mock(
-        return_value=Response(200)
-    )
-    resp = client.post(
-        "/api/v1/public/evaluation-runs/run1/complete",
-        headers=AUTH_HEADER,
-        json={"status": "completed", "not_a_field": 1},
-    )
-    assert resp.status_code == 422
-    assert not route.called

--- a/tests/rest/test_public_eval_gateway.py
+++ b/tests/rest/test_public_eval_gateway.py
@@ -178,3 +178,97 @@ def test_requires_authentication():
     with TestClient(app) as bare:
         resp = bare.post("/api/v1/public/datasets", json={"dataset_id": "ds1", "name": "x"})
     assert resp.status_code == 401
+
+
+# --- Typed Phase-4 reporting routes -----------------------------------------
+
+VALID_REGISTER = {
+    "evaluation_name": "Billing routing",
+    "dataset_id": "ds1",
+    "candidate_version": "git:abc123",
+    "scorers": [{"name": "routing-accuracy", "version": "v3"}],
+}
+VALID_RESULT = {"test_case_id": "case-1", "input": "q", "status": "passed", "scores": []}
+VALID_COMPLETE = {"status": "completed", "case_count": 3, "scored_count": 3}
+
+
+@respx.mock
+def test_register_run_typed_route_forwards_body(client):
+    route = respx.post(f"{UI}/api/public/evaluation-runs").mock(
+        return_value=Response(201, json={"evaluation_run_id": "run1", "run_number": 1})
+    )
+    resp = client.post("/api/v1/public/evaluation-runs", headers=AUTH_HEADER, json=VALID_REGISTER)
+    assert resp.status_code == 201
+    assert route.called
+    sent = json.loads(route.calls.last.request.content)
+    assert sent["evaluation_name"] == "Billing routing"
+    assert route.calls.last.request.headers["authorization"] == "Bearer tr_key"
+
+
+@respx.mock
+def test_upsert_result_typed_route_forwards_to_run_scoped_path(client):
+    route = respx.post(f"{UI}/api/public/evaluation-runs/run1/results").mock(
+        return_value=Response(200, json={"evaluation_result_id": "res1"})
+    )
+    resp = client.post(
+        "/api/v1/public/evaluation-runs/run1/results", headers=AUTH_HEADER, json=VALID_RESULT
+    )
+    assert resp.status_code == 200
+    assert route.called
+    assert json.loads(route.calls.last.request.content)["test_case_id"] == "case-1"
+
+
+@respx.mock
+def test_complete_run_typed_route_forwards_to_run_scoped_path(client):
+    route = respx.post(f"{UI}/api/public/evaluation-runs/run1/complete").mock(
+        return_value=Response(200, json={"evaluation_run_id": "run1", "status": "completed"})
+    )
+    resp = client.post(
+        "/api/v1/public/evaluation-runs/run1/complete", headers=AUTH_HEADER, json=VALID_COMPLETE
+    )
+    assert resp.status_code == 200
+    assert route.called
+
+
+@respx.mock
+def test_scores_subpath_still_forwards_via_hidden_catchall(client):
+    # The additive per-scorer scores endpoint is not typed; it still proxies through
+    # the catch-all, unshadowed by the explicit `/results` route above it.
+    route = respx.post(f"{UI}/api/public/evaluation-runs/run1/results/case-1/scores").mock(
+        return_value=Response(200, json={"score_id": "s1"})
+    )
+    resp = client.post(
+        "/api/v1/public/evaluation-runs/run1/results/case-1/scores",
+        headers=AUTH_HEADER,
+        json={"scorer_name": "helpfulness", "scorer_version": "v2", "numeric_value": 0.9},
+    )
+    assert resp.status_code == 200
+    assert route.called
+
+
+@respx.mock
+def test_typed_route_rejects_invalid_body_before_forwarding(client):
+    # Missing required `candidate_version` → 422 at the gateway; nothing is forwarded.
+    route = respx.post(f"{UI}/api/public/evaluation-runs").mock(return_value=Response(201))
+    resp = client.post(
+        "/api/v1/public/evaluation-runs",
+        headers=AUTH_HEADER,
+        json={"evaluation_name": "x", "dataset_id": "ds1"},
+    )
+    assert resp.status_code == 422
+    assert not route.called
+
+
+@respx.mock
+def test_typed_route_rejects_unknown_field_before_forwarding(client):
+    # The Zod contract is .strict(); the Pydantic mirror forbids extras → 422, no forward.
+    route = respx.post(f"{UI}/api/public/evaluation-runs/run1/complete").mock(
+        return_value=Response(200)
+    )
+    resp = client.post(
+        "/api/v1/public/evaluation-runs/run1/complete",
+        headers=AUTH_HEADER,
+        json={"status": "completed", "not_a_field": 1},
+    )
+    assert resp.status_code == 422
+    assert not route.called

--- a/tests/rest/test_public_eval_gateway_security.py
+++ b/tests/rest/test_public_eval_gateway_security.py
@@ -1,0 +1,296 @@
+"""Security tests for the public offline-eval gateway (a reverse proxy).
+
+The gateway concatenates a caller-influenced subpath onto the control-plane
+origin and relays headers across the trust boundary, so the properties under
+test here are the ones that keep it from becoming an open proxy:
+
+* only the nine real upstream routes are reachable, and nothing containing a
+  dot-segment (raw or percent-encoded) is ever forwarded;
+* forwarded headers are an allowlist — the caller's session `Cookie` and its
+  `X-Forwarded-For` never reach the control plane;
+* every route is rate limited and stamps the limiter identity;
+* the gateway's own validation errors use the documented `{"detail": "<str>"}`
+  envelope, and a field the gateway does not model still reaches the handler.
+
+Every test asserts on the *forwarded upstream request* (or on its absence), not
+just on the status code, so a regression that forwards the wrong thing fails.
+"""
+
+import json
+
+import pytest
+import respx
+from fastapi import Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.testclient import TestClient
+from httpx import Response
+
+import rest.routers.public.eval as eval_gateway
+from rest.main import app, validation_exception_handler
+from rest.rate_limit import limiter
+from rest.routers.public.deps import (
+    AuthResult,
+    authenticate_and_stamp_identity,
+    authenticate_api_key,
+)
+
+UI = "http://localhost:3000"
+AUTH_HEADER = {"Authorization": "Bearer tr_sometoken"}
+
+VALID_RUN = {
+    "evaluation_name": "e",
+    "dataset_id": "d",
+    "candidate_version": "v1",
+}
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[authenticate_api_key] = lambda: AuthResult(
+        project_id="proj-A",
+        workspace_id="ws-1",
+        billing_plan="enterprise",
+        ingestion_blocked=False,
+    )
+    yield TestClient(app)
+
+
+@pytest.fixture()
+def upstream():
+    """Catch-all mock for the control plane; `.calls` proves what was forwarded."""
+    with respx.mock(assert_all_called=False) as mock:
+        mock.route().mock(return_value=Response(200, json={"ok": True}))
+        yield mock
+
+
+# --- Path traversal / route allowlist ---------------------------------------
+
+
+class TestUpstreamPathAllowlist:
+    @pytest.mark.parametrize(
+        ("method", "path", "body"),
+        [
+            # Percent-encoded traversal: uvicorn (and TestClient) unquote the path
+            # before routing, so `..%2F` reaches the handler as `../`, and httpx
+            # would then collapse it against the control-plane origin.
+            ("POST", "/api/v1/public/datasets/..%2F..%2Finternal%2Fvalidate-api-key", {}),
+            ("GET", "/api/v1/public/dataset-versions/..%2F..%2Fauth%2Fsign-up%2Femail", None),
+            # Single-level traversal through a typed route's `{run_id}`: a valid
+            # body, so the request reaches the handler and only the path is at issue.
+            ("POST", "/api/v1/public/evaluation-runs/%2e%2e/complete", {"status": "completed"}),
+            # Double-encoded traversal arrives with a literal `%`.
+            ("POST", "/api/v1/public/datasets/%252e%252e%252finternal", {}),
+            # Backslash and absolute-URL smuggling.
+            ("POST", "/api/v1/public/datasets/..%5C..%5Cinternal", {}),
+            ("POST", "/api/v1/public/datasets/http:%2F%2Fevil.example%2Fx", {}),
+        ],
+    )
+    def test_traversal_attempts_are_404_and_never_forwarded(
+        self, client, upstream, method, path, body
+    ):
+        resp = client.request(method, path, headers=AUTH_HEADER, json=body)
+        assert resp.status_code == 404, resp.text
+        assert resp.json() == {"detail": "Not found"}
+        # The security property: nothing left the process.
+        assert upstream.calls.call_count == 0
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            # Shapes that are not real upstream routes.
+            "/api/v1/public/datasets/ds1/versions/v1/extra",
+            "/api/v1/public/evaluation-runs/run1/results/tc1/unknown",
+            "/api/v1/public/evaluation-runs/run1/anything",
+        ],
+    )
+    def test_unknown_route_shapes_are_404_and_never_forwarded(self, client, upstream, path):
+        resp = client.post(path, headers=AUTH_HEADER, json={})
+        assert resp.status_code == 404
+        assert upstream.calls.call_count == 0
+
+    def test_method_not_implemented_upstream_is_not_forwarded(self, client, upstream):
+        # `datasets/{id}/versions` is GET+POST upstream; PATCH is not a real route.
+        resp = client.patch("/api/v1/public/datasets/ds1/versions", headers=AUTH_HEADER, json={})
+        assert resp.status_code == 404
+        assert upstream.calls.call_count == 0
+
+    @pytest.mark.parametrize(
+        ("method", "path", "expected_upstream"),
+        [
+            ("GET", "/api/v1/public/datasets", f"{UI}/api/public/datasets"),
+            ("GET", "/api/v1/public/datasets/ds1", f"{UI}/api/public/datasets/ds1"),
+            (
+                "GET",
+                "/api/v1/public/datasets/ds1/versions",
+                f"{UI}/api/public/datasets/ds1/versions",
+            ),
+            (
+                "GET",
+                "/api/v1/public/dataset-versions/dv1",
+                f"{UI}/api/public/dataset-versions/dv1",
+            ),
+            (
+                "POST",
+                "/api/v1/public/evaluation-runs/run1/results/tc1/scores",
+                f"{UI}/api/public/evaluation-runs/run1/results/tc1/scores",
+            ),
+            (
+                "POST",
+                "/api/v1/public/evaluation-runs/run1/results/tc1/human-score",
+                f"{UI}/api/public/evaluation-runs/run1/results/tc1/human-score",
+            ),
+        ],
+    )
+    def test_real_routes_still_forward_unchanged(
+        self, client, upstream, method, path, expected_upstream
+    ):
+        resp = client.request(method, path, headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        assert upstream.calls.call_count == 1
+        assert str(upstream.calls.last.request.url) == expected_upstream
+
+    def test_typed_route_forwards_its_run_id(self, client, upstream):
+        resp = client.post(
+            "/api/v1/public/evaluation-runs/run1/complete",
+            headers=AUTH_HEADER,
+            json={"status": "completed"},
+        )
+        assert resp.status_code == 200
+        assert (
+            str(upstream.calls.last.request.url) == f"{UI}/api/public/evaluation-runs/run1/complete"
+        )
+
+
+# --- Header allowlist --------------------------------------------------------
+
+
+class TestForwardedHeaderAllowlist:
+    def test_cookie_and_spoofable_headers_are_stripped(self, client, upstream):
+        resp = client.get(
+            "/api/v1/public/datasets",
+            headers={
+                **AUTH_HEADER,
+                "Cookie": "better-auth.session_token=stolen",
+                "X-Forwarded-For": "1.2.3.4",
+                "X-Real-Ip": "1.2.3.4",
+                "X-Internal-Secret": "guessed",
+                "Te": "trailers",
+                "User-Agent": "traceroot-sdk/1.0",
+            },
+        )
+        assert resp.status_code == 200
+        forwarded = upstream.calls.last.request.headers
+        # The confused-deputy credential must not cross the trust boundary.
+        assert "cookie" not in forwarded
+        for name in ("x-forwarded-for", "x-real-ip", "x-internal-secret", "te"):
+            assert name not in forwarded, name
+        # What the SDK legitimately needs still arrives.
+        assert forwarded["authorization"] == "Bearer tr_sometoken"
+        assert forwarded["user-agent"] == "traceroot-sdk/1.0"
+
+    def test_allowlisted_tracing_headers_are_forwarded(self, client, upstream):
+        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        client.get(
+            "/api/v1/public/datasets",
+            headers={**AUTH_HEADER, "traceparent": traceparent, "Idempotency-Key": "k1"},
+        )
+        forwarded = upstream.calls.last.request.headers
+        assert forwarded["traceparent"] == traceparent
+        assert forwarded["idempotency-key"] == "k1"
+
+
+# --- Rate limiting -----------------------------------------------------------
+
+
+def _eval_routes():
+    return [
+        r
+        for r in app.routes
+        if getattr(r, "endpoint", None) is not None
+        and getattr(r.endpoint, "__module__", "") == eval_gateway.__name__
+    ]
+
+
+class TestRateLimiting:
+    def test_every_eval_route_is_registered_with_the_limiter(self):
+        routes = _eval_routes()
+        assert routes, "no eval gateway routes found"
+        registered = set(limiter._dynamic_route_limits)
+        for route in routes:
+            name = f"{eval_gateway.__name__}.{route.endpoint.__name__}"
+            assert name in registered, f"{name} has no rate limit"
+
+    def test_every_eval_route_stamps_the_rate_limit_identity(self):
+        """Without the stamped dependency the limiter keys off an unstamped
+        request.state, so the decorator above would be inert."""
+        for route in _eval_routes():
+            calls = [d.call for d in route.dependant.dependencies]
+            assert authenticate_and_stamp_identity in calls, route.path
+
+
+# --- Body cap ----------------------------------------------------------------
+
+
+def test_oversized_body_is_rejected_before_forwarding(client, upstream, monkeypatch):
+    monkeypatch.setattr(eval_gateway, "_MAX_FORWARD_BODY_BYTES", 16)
+    resp = client.post(
+        "/api/v1/public/evaluation-runs/run1/results/tc1/scores",
+        headers=AUTH_HEADER,
+        content=b"x" * 64,
+    )
+    assert resp.status_code == 413
+    assert resp.json() == {"detail": "Request body too large"}
+    assert upstream.calls.call_count == 0
+
+
+# --- Error envelope ----------------------------------------------------------
+
+
+class TestErrorEnvelope:
+    def test_gateway_validation_error_uses_the_detail_string_envelope(self, client, upstream):
+        resp = client.post(
+            "/api/v1/public/evaluation-runs",
+            headers=AUTH_HEADER,
+            json={**VALID_RUN, "case_count": -1},
+        )
+        assert resp.status_code == 422
+        body = resp.json()
+        # Not FastAPI's default list-of-objects: an SDK formats this as a message.
+        assert isinstance(body["detail"], str)
+        assert "case_count" in body["detail"]
+        assert upstream.calls.call_count == 0
+
+    def test_upstream_error_reads_the_same_shape(self, client):
+        with respx.mock(assert_all_called=False) as mock:
+            mock.route().mock(return_value=Response(400, json={"error": "bad dataset"}))
+            resp = client.post(
+                "/api/v1/public/evaluation-runs", headers=AUTH_HEADER, json=VALID_RUN
+            )
+        assert resp.status_code == 400
+        assert resp.json() == {"detail": "bad dataset"}
+
+    async def test_non_public_routes_keep_fastapis_default_envelope(self):
+        """The string envelope is the *public* contract; the dashboard/internal
+        routes keep FastAPI's default body, which the Next.js app already parses."""
+        errors = [{"loc": ("query", "limit"), "msg": "Input should be <= 200", "type": "le"}]
+        request = Request(
+            {"type": "http", "method": "GET", "path": "/api/v1/traces", "headers": []}
+        )
+        resp = await validation_exception_handler(request, RequestValidationError(errors))
+        assert isinstance(json.loads(resp.body)["detail"], list)
+
+
+# --- Verbatim body forwarding ------------------------------------------------
+
+
+def test_unmodelled_field_still_reaches_the_handler(client, upstream):
+    """The gateway must not be the strictness gate — a
+    field a newer SDK adds has to reach the Prisma-owned handler that owns it."""
+    resp = client.post(
+        "/api/v1/public/evaluation-runs",
+        headers=AUTH_HEADER,
+        json={**VALID_RUN, "field_from_a_newer_sdk": "keep-me"},
+    )
+    assert resp.status_code == 200
+    assert upstream.calls.call_count == 1
+    assert b"field_from_a_newer_sdk" in upstream.calls.last.request.content

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -159,3 +159,91 @@ def test_detectors_list_route_documents_error_responses():
     assert "get" in paths["/api/v1/public/detectors"]
     responses = paths["/api/v1/public/detectors"]["get"]["responses"]
     assert set(responses) >= {"200", "401", "500"}
+
+
+# --- Phase-4 evaluation reporting routes ------------------------------------
+
+
+def test_eval_reporting_routes_are_published():
+    """The three typed reporting endpoints appear as explicit POST operations."""
+    paths = _schema()["paths"]
+    assert "post" in paths["/api/v1/public/evaluation-runs"]
+    assert "post" in paths["/api/v1/public/evaluation-runs/{run_id}/results"]
+    assert "post" in paths["/api/v1/public/evaluation-runs/{run_id}/complete"]
+
+
+def test_eval_reporting_routes_document_request_and_response_schemas():
+    schema = _schema()
+    paths = schema["paths"]
+    components = schema["components"]["schemas"]
+    cases = {
+        "/api/v1/public/evaluation-runs": ("RegisterRunRequest", "RegisterRunResponse", "201"),
+        "/api/v1/public/evaluation-runs/{run_id}/results": (
+            "UpsertResultRequest",
+            "UpsertResultResponse",
+            "200",
+        ),
+        "/api/v1/public/evaluation-runs/{run_id}/complete": (
+            "CompleteRunRequest",
+            "CompleteRunResponse",
+            "200",
+        ),
+    }
+    for path, (req_model, resp_model, ok) in cases.items():
+        op = paths[path]["post"]
+        req_ref = op["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+        assert req_ref.endswith(f"/{req_model}"), (path, req_ref)
+        resp_ref = op["responses"][ok]["content"]["application/json"]["schema"]["$ref"]
+        assert resp_ref.endswith(f"/{resp_model}"), (path, resp_ref)
+        assert req_model in components
+        assert resp_model in components
+    # Nested request models are pulled in transitively.
+    for nested in ("ScorerRef", "ScoreInput"):
+        assert nested in components
+
+
+def test_eval_reporting_routes_document_path_params():
+    paths = _schema()["paths"]
+    for path in (
+        "/api/v1/public/evaluation-runs/{run_id}/results",
+        "/api/v1/public/evaluation-runs/{run_id}/complete",
+    ):
+        params = paths[path]["post"].get("parameters", [])
+        run_id = next((p for p in params if p.get("name") == "run_id"), None)
+        assert run_id is not None, path
+        assert run_id["in"] == "path"
+        assert run_id["required"] is True
+    # The collection endpoint has no path parameter.
+    assert paths["/api/v1/public/evaluation-runs"]["post"].get("parameters", []) == []
+
+
+def test_eval_reporting_routes_document_error_and_auth_contract():
+    paths = _schema()["paths"]
+    for path in (
+        "/api/v1/public/evaluation-runs",
+        "/api/v1/public/evaluation-runs/{run_id}/results",
+        "/api/v1/public/evaluation-runs/{run_id}/complete",
+    ):
+        op = paths[path]["post"]
+        # Validation (422), domain 400/404, plus the shared auth 401/503.
+        assert set(op["responses"]) >= {"400", "404", "422", "401", "503"}
+        assert op["security"] == [{"BearerAuth": []}]
+        # Error bodies use the canonical {detail} envelope.
+        for code in ("400", "404"):
+            ref = op["responses"][code]["content"]["application/json"]["schema"]["$ref"]
+            assert ref.endswith("/ErrorResponse")
+
+
+def test_untyped_dataset_catch_alls_stay_hidden():
+    """Dataset + dataset-version catch-alls remain unpublished until a later phase."""
+    paths = _schema()["paths"]
+    assert not any(p.startswith("/api/v1/public/datasets") for p in paths), paths
+    assert not any(p.startswith("/api/v1/public/dataset-versions") for p in paths), paths
+    # The additive per-scorer scores / human-score run subpaths also stay hidden:
+    # only the three explicit reporting paths are published under evaluation-runs.
+    eval_paths = {p for p in paths if p.startswith("/api/v1/public/evaluation-runs")}
+    assert eval_paths == {
+        "/api/v1/public/evaluation-runs",
+        "/api/v1/public/evaluation-runs/{run_id}/results",
+        "/api/v1/public/evaluation-runs/{run_id}/complete",
+    }


### PR DESCRIPTION
## Summary

Fixes: #1648

Publishes the public eval reporting API as a machine-readable OpenAPI artifact so a client can be generated from it, and keeps the two contract layers — Zod in the control plane and Pydantic in the gateway — provably in lockstep. Without the parity and drift guards, the gateway could accept a request the control plane rejects (or vice-versa) and no test would catch it; with them, editing one layer without the other turns a test red.

## What's included

### Contract
- `backend/rest/schemas/eval.py` — the Pydantic mirror of the Zod contract, field-for-field: `RegisterRunRequest`, `UpsertResultRequest`, `CompleteRunRequest` and their responses, `ScorerRef` (including the definition fields and `ScorerMessage`), `ScoreInput`, and the shared `ErrorResponse` envelope. Field constraints mirror the Zod validators, but the request models are deliberately **not** `extra="forbid"` even though the Zod schemas are `.strict()`: these run in the *gateway*, which forwards bodies verbatim to the Next.js handler that persists them. A `forbid` here would 422 a field the gateway does not yet model so it never reaches persistence, and would break rolling deploys by rejecting a newer SDK's optional field on every older gateway instance — and the field constraints (`min_length`/`max_length`, `ge=0`, nullability, defaults) mirror the Zod validators, so accept/reject verdicts line up across layers.

### Schema

### Tests
- `tests/rest/test_eval_contract_parity.py` — the Pydantic side of the cross-layer check: feeds the representative payloads to the Pydantic models and asserts the expected accept/reject verdicts.
- `frontend/packages/core/src/__tests__/eval-contract-parity.drift.test.ts` — the Zod side: feeds the same payloads to the Zod schemas and asserts identical verdicts.
- `frontend/packages/core/src/__tests__/eval-contract-parity-fixtures.json` — the shared fixture set both layers consume, including a bare `{ name, version }` scorer and a full LLM-judge / code definition, plus strict-vs-ignore unknown-key cases.
- `tests/rest/test_public_openapi.py` — the drift guard: regenerates the schema from the models and fails if `public.json` is stale or hand-edited.
- `tests/rest/test_public_eval_gateway.py` — Tests for the public offline-eval API gateway.
- `tests/rest/test_public_eval_gateway_security.py` — Security tests for the public offline-eval gateway (a reverse proxy).

### Frontend
- `frontend/packages/core/src/__tests__/contract-shape.ts` — Structural shape extraction for the cross-layer contract guard (Zod side).
- `frontend/packages/core/src/__tests__/eval-contract-shape.json` — part of this change.
- `frontend/packages/core/src/eval-contract.ts` — Offline-evaluation contract — the shared, typed shapes for both the user-session CRUD routes and the API-key SDK reporting routes.

## Test plan

- [ ] Regenerate `public.json` from the models and confirm it matches the committed file; hand-edit it and confirm the drift check fails.
- [ ] Run both parity suites and confirm the Zod and Pydantic layers agree on every representative valid/invalid payload, including unknown-key strict-vs-ignore behavior.
- [ ] Confirm the fixtures include a bare `{ name, version }` scorer and a full LLM-judge / code definition, and that both layers accept each identically.
- [ ] Change one contract layer without the other and confirm a parity test turns red.
- [ ] Feed `public.json` to a client generator and confirm it produces a client that matches the served routes.
