### PR TITLE
feat(traces): preserve eval span kinds and classify eval traces

### DIFF
--- a/backend/db/clickhouse/client.py
+++ b/backend/db/clickhouse/client.py
@@ -68,6 +68,7 @@ class ClickHouseClient:
                     now,  # ch_create_time
                     now,  # ch_update_time
                     t.get("environment"),
+                    1 if t.get("is_evaluation") else 0,
                 ]
             )
 
@@ -90,6 +91,7 @@ class ClickHouseClient:
                 "ch_create_time",
                 "ch_update_time",
                 "environment",
+                "is_evaluation",
             ],
         )
 
@@ -135,6 +137,7 @@ class ClickHouseClient:
                     now,  # ch_create_time
                     now,  # ch_update_time
                     s.get("environment"),
+                    1 if s.get("is_evaluation") else 0,
                 ]
             )
 
@@ -168,6 +171,7 @@ class ClickHouseClient:
                 "ch_create_time",
                 "ch_update_time",
                 "environment",
+                "is_evaluation",
             ],
         )
 

--- a/backend/shared/enums.py
+++ b/backend/shared/enums.py
@@ -13,6 +13,25 @@ class SpanKind(StrEnum):
     SCORER = "SCORER"
 
 
+# The span kinds that mark a span as part of an offline-evaluation run, and the source
+# of truth for the trace-level `is_evaluation` flag written at ingest.
+#
+# This is the only trustworthy signal: it comes from the SDK's eval engine
+# (traceroot.span.type), never from user-supplied configuration. In particular it must
+# not be conflated with `environment`, which is the user's own deployment tag
+# (TRACEROOT_ENVIRONMENT: production, staging, ...). Deriving classification from
+# `environment` both misses every eval run in a project that sets the tag and
+# misclassifies a customer who happens to name their environment "evaluation".
+#
+# Note this membership answers "is this span part of an eval run", which is a DIFFERENT
+# question from "does this span count toward the candidate's cost" — the latter needs a
+# subtree walk that drops SCORER spans and everything under them (see
+# worker.ingest_tasks._task_cost_by_trace). Do not collapse the two.
+EVALUATION_SPAN_KINDS = frozenset(
+    {SpanKind.EVALUATION, SpanKind.TASK, SpanKind.SCORER},
+)
+
+
 class SpanStatus(StrEnum):
     OK = "OK"
     ERROR = "ERROR"

--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -117,12 +117,28 @@ def _update_eval_result_costs(project_id: str, trace_ids: set[str], ch_client) -
     The SDK doesn't report per-case cost, so we derive it from the trace's LLM-span cost,
     scoped to the candidate task (the scorer subtree is excluded — see
     ``_task_cost_by_trace`` for why). This lets the runs table read ``result.cost``
-    directly. Idempotent + self-healing: recomputed on every batch, so late-arriving
-    spans update the total; never writes 0 (a cost-less trace leaves ``cost`` NULL).
+    directly. Idempotent + self-healing: recomputed on every batch, so late-arriving spans
+    correct the total in BOTH directions. That two-way property is the point — under
+    ``BatchSpanProcessor`` a parent exports after its children, so a scorer's LLM child
+    routinely lands in an earlier batch than the SCORER span itself. In that window
+    nothing seeds the exclusion set and the total is over-reported; the next batch brings
+    the SCORER and the recomputed total drops. Skipping the write whenever the new total
+    is 0 would freeze that over-report permanently, so the write is unconditional and
+    ``NULLIF`` preserves the "a cost-less trace leaves ``cost`` NULL" intent instead.
 
-    NOTE: once the SDK reports an authoritative per-result cost
-    (offline-eval/sdk-ask/report-task-cost.md), this derivation must DEFER to it rather
-    than overwrite — it exists only because per-result cost is absent today.
+    LIMITATION — this is driven entirely off ingest, so it self-heals only for late
+    SPANS, not for a late RESULT ROW. The two writers are independent: spans arrive
+    SDK -> BatchSpanProcessor -> S3 -> Celery, while the ``evaluation_results`` row is
+    POSTed from a different service. If every span batch for a trace is processed before
+    its result row exists, the lookup below returns empty on each one and nothing ever
+    revisits it — ``cost`` stays NULL despite fully-priced LLM spans sitting in
+    ClickHouse. Closing that needs a trigger from the other side (derive on result-write
+    or run-finalize) or a periodic backfill over ``cost IS NULL AND trace_id IS NOT
+    NULL``; both are out of scope here.
+
+    NOTE: once the SDK reports an authoritative per-result cost, this derivation must
+    DEFER to it rather than overwrite — it exists only because per-result cost is absent
+    today.
     """
     if not trace_ids:
         return
@@ -156,10 +172,11 @@ def _update_eval_result_costs(project_id: str, trace_ids: set[str], ch_client) -
             ).result_rows
 
             for trace_id, cost in _task_cost_by_trace(rows).items():
-                if cost <= 0:
-                    continue
+                # Written unconditionally — see the docstring. NULLIF keeps a genuinely
+                # cost-less trace at NULL rather than a misleading 0.00, while still
+                # letting a previously over-reported cost be corrected back down.
                 cur.execute(
-                    "UPDATE evaluation_results SET cost = %s, update_time = now()"
+                    "UPDATE evaluation_results SET cost = NULLIF(%s, 0), update_time = now()"
                     " WHERE project_id = %s AND trace_id = %s",
                     (cost, project_id, trace_id),
                 )
@@ -247,10 +264,19 @@ def process_s3_traces(self, s3_key: str, project_id: str) -> dict:
                 logger.info(f"Inserted {len(spans)} spans into ClickHouse")
 
                 # Denormalize eval-trace cost onto EvaluationResult (runs-table Cost).
-                try:
-                    _update_eval_result_costs(project_id, {s["trace_id"] for s in spans}, ch_client)
-                except Exception as e:
-                    logger.error(f"eval cost derivation errored: {e}", exc_info=True)
+                #
+                # Gated on the batch actually containing evaluation spans. The batch
+                # already knows the answer in memory (otel_transform set is_evaluation
+                # from the span kind), so gating costs nothing — whereas calling
+                # unconditionally puts a Postgres connect + round trip on the main
+                # product's ingest hot path, per S3 object, per worker, only to learn
+                # "no eval results" for the >99% of batches that carry ordinary traces.
+                eval_trace_ids = {s["trace_id"] for s in spans if s.get("is_evaluation")}
+                if eval_trace_ids:
+                    try:
+                        _update_eval_result_costs(project_id, eval_trace_ids, ch_client)
+                    except Exception as e:
+                        logger.error(f"eval cost derivation errored: {e}", exc_info=True)
 
         # Trigger detector runs (fire-and-forget, non-blocking). The batch that
         # carries a trace's root span triggers detection exactly once — a Redis

--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -8,6 +8,7 @@ import logging
 from collections import defaultdict
 from datetime import datetime
 
+from shared.enums import SpanKind
 from worker.celery_app import app
 
 logger = logging.getLogger(__name__)
@@ -66,14 +67,62 @@ def _publish_live_spans(spans: list[dict], project_id: str) -> None:
         logger.warning("Failed to publish live spans to Redis", exc_info=True)
 
 
-def _update_eval_result_costs(project_id: str, trace_ids: set[str], ch_client) -> None:
-    """Denormalize each evaluation trace's total cost onto its EvaluationResult row.
+def _task_cost_by_trace(rows) -> dict[str, float]:
+    """Per-trace span-cost sum EXCLUDING the scorer subtree (scorer spans + descendants).
 
-    The SDK doesn't report per-case cost — it lives in the trace as summed provider-usage
-    span cost (otel_transform sets `cost` only on LLM leaf spans, so `sum(cost)` over a
-    trace is its total, no double count). This lets the runs table read `result.cost`
+    An evaluation trace is ``EVALUATION(root) -> TASK -> SCORER`` (see the SDK eval
+    engine). A scorer can itself call an LLM — an ``llm_judge`` self-instruments its
+    model call, and a hand-rolled ``@scorer`` function may call a provider directly —
+    and that LLM span lands in the SAME trace under the SCORER span. Folding its cost
+    into the result would over-report what it costs to run the CANDIDATE, so we drop
+    every scorer span and its whole subtree and sum only the remaining (task) spans.
+
+    ``rows`` are ``(trace_id, span_id, parent_span_id, span_kind, cost)``. ``cost`` is
+    set only on LLM leaf spans (otel_transform), so this is a no-op unless a leaf has one.
+    """
+    from collections import defaultdict
+
+    per_trace: dict[str, dict] = defaultdict(
+        lambda: {"children": defaultdict(list), "kind": {}, "cost": {}}
+    )
+    for trace_id, span_id, parent_span_id, span_kind, cost in rows:
+        t = per_trace[trace_id]
+        t["kind"][span_id] = span_kind
+        t["cost"][span_id] = cost
+        if parent_span_id:
+            t["children"][parent_span_id].append(span_id)
+
+    result: dict[str, float] = {}
+    for trace_id, t in per_trace.items():
+        excluded: set[str] = set()
+        stack = [sid for sid, kind in t["kind"].items() if kind == SpanKind.SCORER]
+        while stack:
+            sid = stack.pop()
+            if sid in excluded:
+                continue
+            excluded.add(sid)
+            stack.extend(t["children"].get(sid, ()))
+        total = 0.0
+        for sid, cost in t["cost"].items():
+            if sid in excluded or cost is None:
+                continue
+            total += float(cost)
+        result[trace_id] = total
+    return result
+
+
+def _update_eval_result_costs(project_id: str, trace_ids: set[str], ch_client) -> None:
+    """Denormalize each evaluation trace's CANDIDATE-TASK cost onto its EvaluationResult.
+
+    The SDK doesn't report per-case cost, so we derive it from the trace's LLM-span cost,
+    scoped to the candidate task (the scorer subtree is excluded — see
+    ``_task_cost_by_trace`` for why). This lets the runs table read ``result.cost``
     directly. Idempotent + self-healing: recomputed on every batch, so late-arriving
-    spans update the total; never writes 0 (a cost-less trace leaves `cost` NULL).
+    spans update the total; never writes 0 (a cost-less trace leaves ``cost`` NULL).
+
+    NOTE: once the SDK reports an authoritative per-result cost
+    (offline-eval/sdk-ask/report-task-cost.md), this derivation must DEFER to it rather
+    than overwrite — it exists only because per-result cost is absent today.
     """
     if not trace_ids:
         return
@@ -98,15 +147,15 @@ def _update_eval_result_costs(project_id: str, trace_ids: set[str], ch_client) -
             if not eval_trace_ids:
                 return
 
+            # Pull the full span tree (not just cost-bearing spans) so the scorer
+            # subtree can be identified and excluded before summing.
             rows = ch_client.query(
-                "SELECT trace_id, sum(cost) FROM spans FINAL"
-                " WHERE project_id = {pid:String} AND trace_id IN {ids:Array(String)}"
-                " AND cost IS NOT NULL GROUP BY trace_id",
+                "SELECT trace_id, span_id, parent_span_id, span_kind, cost FROM spans FINAL"
+                " WHERE project_id = {pid:String} AND trace_id IN {ids:Array(String)}",
                 parameters={"pid": project_id, "ids": eval_trace_ids},
             ).result_rows
 
-            for trace_id, total in rows:
-                cost = float(total) if total is not None else 0.0
+            for trace_id, cost in _task_cost_by_trace(rows).items():
                 if cost <= 0:
                     continue
                 cur.execute(

--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -66,6 +66,61 @@ def _publish_live_spans(spans: list[dict], project_id: str) -> None:
         logger.warning("Failed to publish live spans to Redis", exc_info=True)
 
 
+def _update_eval_result_costs(project_id: str, trace_ids: set[str], ch_client) -> None:
+    """Denormalize each evaluation trace's total cost onto its EvaluationResult row.
+
+    The SDK doesn't report per-case cost — it lives in the trace as summed provider-usage
+    span cost (otel_transform sets `cost` only on LLM leaf spans, so `sum(cost)` over a
+    trace is its total, no double count). This lets the runs table read `result.cost`
+    directly. Idempotent + self-healing: recomputed on every batch, so late-arriving
+    spans update the total; never writes 0 (a cost-less trace leaves `cost` NULL).
+    """
+    if not trace_ids:
+        return
+    import psycopg2
+
+    from shared.config import settings
+
+    try:
+        conn = psycopg2.connect(settings.database_url)
+    except Exception:
+        logger.warning("eval cost derivation: no Postgres connection", exc_info=True)
+        return
+    try:
+        with conn.cursor() as cur:
+            # Only the batch's trace_ids that are evaluation results — bounded lookup.
+            cur.execute(
+                "SELECT DISTINCT trace_id FROM evaluation_results "
+                "WHERE project_id = %s AND trace_id = ANY(%s)",
+                (project_id, list(trace_ids)),
+            )
+            eval_trace_ids = [r[0] for r in cur.fetchall()]
+            if not eval_trace_ids:
+                return
+
+            rows = ch_client.query(
+                "SELECT trace_id, sum(cost) FROM spans FINAL"
+                " WHERE project_id = {pid:String} AND trace_id IN {ids:Array(String)}"
+                " AND cost IS NOT NULL GROUP BY trace_id",
+                parameters={"pid": project_id, "ids": eval_trace_ids},
+            ).result_rows
+
+            for trace_id, total in rows:
+                cost = float(total) if total is not None else 0.0
+                if cost <= 0:
+                    continue
+                cur.execute(
+                    "UPDATE evaluation_results SET cost = %s, update_time = now()"
+                    " WHERE project_id = %s AND trace_id = %s",
+                    (cost, project_id, trace_id),
+                )
+        conn.commit()
+    except Exception:
+        logger.warning("eval cost derivation failed", exc_info=True)
+    finally:
+        conn.close()
+
+
 @app.task(
     bind=True,
     autoretry_for=(Exception,),
@@ -141,6 +196,12 @@ def process_s3_traces(self, s3_key: str, project_id: str) -> dict:
             if spans:
                 ch_client.insert_spans_batch(spans)
                 logger.info(f"Inserted {len(spans)} spans into ClickHouse")
+
+                # Denormalize eval-trace cost onto EvaluationResult (runs-table Cost).
+                try:
+                    _update_eval_result_costs(project_id, {s["trace_id"] for s in spans}, ch_client)
+                except Exception as e:
+                    logger.error(f"eval cost derivation errored: {e}", exc_info=True)
 
         # Trigger detector runs (fire-and-forget, non-blocking). The batch that
         # carries a trace's root span triggers detection exactly once — a Redis

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -37,6 +37,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
+from shared.enums import EVALUATION_SPAN_KINDS, SpanKind, SpanStatus
 from shared.enums import SpanKind, SpanStatus
 from shared.span_attributes import SPAN_IDS_PATH, SPAN_PATH, SPAN_TREE_ATTRIBUTES
 
@@ -394,18 +395,15 @@ def get_span_kind(attrs: dict[str, Any], otel_kind: int | str | None) -> str:
     Returns:
         One of: "LLM", "SPAN", "AGENT", "TOOL", "EVALUATION", "TASK", "SCORER"
     """
-    # Check explicit type attribute (handle None values). Includes the offline-eval
-    # kinds (EVALUATION/TASK/SCORER) so the SDK's evaluation spans are preserved
-    # rather than silently coerced to SPAN.
+    # Check explicit type attribute (handle None values). EVALUATION_SPAN_KINDS is
+    # included so the SDK's offline-evaluation spans are preserved rather than silently
+    # coerced to SPAN. Preserving SCORER in particular is load-bearing beyond
+    # classification: cost attribution walks the scorer subtree to keep judge cost out
+    # of the candidate's cost.
     explicit_type = (attrs.get("traceroot.span.type") or "").upper()
-    if explicit_type in (
-        SpanKind.LLM,
-        SpanKind.SPAN,
-        SpanKind.AGENT,
-        SpanKind.TOOL,
-        SpanKind.EVALUATION,
-        SpanKind.TASK,
-        SpanKind.SCORER,
+    if (
+        explicit_type in (SpanKind.LLM, SpanKind.SPAN, SpanKind.AGENT, SpanKind.TOOL)
+        or explicit_type in EVALUATION_SPAN_KINDS
     ):
         return explicit_type
 
@@ -506,6 +504,16 @@ def transform_otel_to_clickhouse(
     _trace_name_candidates: dict[str, tuple[int, str]] = {}
     trace_git_attrs: dict[str, dict[str, str | None]] = {}
 
+    # Trace-level fields collected from ANY span in the batch and applied post-loop.
+    # Both are attached to the shallow (eager) trace record as well as the root-upgraded
+    # one: OTel's BatchSpanProcessor exports a span when it ENDS, so children routinely
+    # export in an earlier batch than their parent and the root is usually the LAST span
+    # of a trace to arrive. Reading these only off the root would leave every trace
+    # unclassified until the root lands — and permanently unclassified if the process
+    # dies first, a state nothing reconciles.
+    _trace_is_evaluation: set[str] = set()  # any eval-kind span seen for this trace
+    _trace_environment: dict[str, str] = {}  # first non-null environment seen
+
     # camelCase: resourceSpans
     resource_spans = otel_data.get("resourceSpans", [])
 
@@ -550,19 +558,27 @@ def transform_otel_to_clickhouse(
                     if tool_name:
                         span_name = tool_name
 
-                # Build span record
+                # Build span record.
+                #
+                # `environment` is the user's deployment tag (TRACEROOT_ENVIRONMENT:
+                # production, staging, ...) and is passed through untouched. The
+                # "this is an offline-evaluation run" classification is a SEPARATE
+                # field, never folded into this one: `environment` is a user-namespace
+                # value and a user-namespace value must not double as an internal
+                # control flag. Overloading it would (a) misclassify a customer who
+                # legitimately names their environment "evaluation", hiding their real
+                # traces, and (b) silently fail to classify any eval run in a project
+                # that sets TRACEROOT_ENVIRONMENT — the common case in CI or an
+                # SDK-initialised app, since those spans already carry the attribute.
+                #
+                # The classification is derived from the span kind alone, which the
+                # SDK's eval engine sets and the user cannot influence.
                 environment = span_attrs.get("traceroot.environment")
-                # Offline-evaluation spans classify as the "evaluation" environment even
-                # though the SDK does not stamp traceroot.environment. The root eval span
-                # carries this onto the trace record (root-upgrade block below), so eval
-                # traces can be excluded from the default Traces list and skipped by
-                # detectors without a per-span scan.
-                if environment is None and span_kind in (
-                    SpanKind.EVALUATION,
-                    SpanKind.TASK,
-                    SpanKind.SCORER,
-                ):
-                    environment = "evaluation"
+                is_evaluation = span_kind in EVALUATION_SPAN_KINDS
+                if is_evaluation:
+                    _trace_is_evaluation.add(trace_id)
+                if isinstance(environment, str):
+                    _trace_environment.setdefault(trace_id, environment)
                 span_record = {
                     "span_id": span_id,
                     "trace_id": trace_id,
@@ -576,6 +592,8 @@ def transform_otel_to_clickhouse(
                 }
                 if isinstance(environment, str):
                     span_record["environment"] = environment
+                if is_evaluation:
+                    span_record["is_evaluation"] = True
 
                 # Extract git source fields for span
                 git_source_file = span_attrs.get("traceroot.git.source_file")
@@ -1052,6 +1070,23 @@ def transform_otel_to_clickhouse(
         if trace_id in traces:
             traces[trace_id]["name"] = best_name
 
+    # Classify the trace from ANY eval-kind span in the batch, not just the root, so a
+    # batch of {SCORER, TASK} whose EVALUATION root has not been exported yet still
+    # writes a classified trace row. The trace record is then never less classified than
+    # its own spans, and the flag only ever goes 0 -> 1.
+    for trace_id in _trace_is_evaluation:
+        if trace_id in traces:
+            traces[trace_id]["is_evaluation"] = True
+
+    # Same for the user's environment tag: the shallow record would otherwise carry no
+    # environment until the root arrives. The root-upgrade block above already set it
+    # authoritatively when the root IS in this batch, so only fill the gap here.
+    for trace_id, env in _trace_environment.items():
+        if trace_id in traces and not traces[trace_id].get("environment"):
+            traces[trace_id]["environment"] = env
+
+    # Update trace records with user_id/session_id collected from child spans
+    # (in case child spans with these attrs came after the root span was processed)
     # Update trace records with user_id/session_id collected from child spans (in
     # case child spans with these attrs came after the root span was processed).
     for trace_id, attrs in trace_attrs.items():

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -552,6 +552,17 @@ def transform_otel_to_clickhouse(
 
                 # Build span record
                 environment = span_attrs.get("traceroot.environment")
+                # Offline-evaluation spans classify as the "evaluation" environment even
+                # though the SDK does not stamp traceroot.environment. The root eval span
+                # carries this onto the trace record (root-upgrade block below), so eval
+                # traces can be excluded from the default Traces list and skipped by
+                # detectors without a per-span scan.
+                if environment is None and span_kind in (
+                    SpanKind.EVALUATION,
+                    SpanKind.TASK,
+                    SpanKind.SCORER,
+                ):
+                    environment = "evaluation"
                 span_record = {
                     "span_id": span_id,
                     "trace_id": trace_id,

--- a/tests/db/test_client.py
+++ b/tests/db/test_client.py
@@ -55,9 +55,13 @@ class TestInsertTracesBatch:
         # ch_create_time and ch_update_time are auto-set
         assert isinstance(row[12], datetime)
         assert isinstance(row[13], datetime)
-        assert len(columns) == 15
         assert "environment" in columns
         assert row[columns.index("environment")] == "production"
+        assert len(columns) == 16
+        # Addressed by name, not position: `is_evaluation` extends the row, and a
+        # positional assert would silently follow the wrong column.
+        assert "is_evaluation" in columns
+        assert row[columns.index("is_evaluation")] == 0
 
     def test_empty_batch_no_insert(self):
         """Empty list -> no _client.insert() call."""
@@ -167,12 +171,16 @@ class TestInsertSpansBatch:
         assert row[13] == 100  # input_tokens
         assert row[14] == 50  # output_tokens
         assert row[15] == 150  # total_tokens
-        # 3 fixed breakdown columns collapsed into one usage_details map (net -2),
-        # then source and environment added.
-        assert len(columns) == 26
         assert "usage_details" in columns
         assert "environment" in columns
         assert row[columns.index("environment")] == "production"
+        # 3 fixed breakdown columns collapsed into one usage_details map (net -2),
+        # then source, environment and is_evaluation added.
+        assert len(columns) == 27
+        # Addressed by name, not position: `is_evaluation` extends the row, and a
+        # positional assert would silently follow the wrong column.
+        assert "is_evaluation" in columns
+        assert row[columns.index("is_evaluation")] == 0
 
     def test_optional_fields_none(self):
         """None values for optional fields (cost, tokens)."""

--- a/tests/worker/test_eval_result_cost.py
+++ b/tests/worker/test_eval_result_cost.py
@@ -1,0 +1,190 @@
+"""Per-result cost derived from an evaluation trace must measure the CANDIDATE only.
+
+The load-bearing rule: a scorer can call an LLM of its own — an ``llm_judge``
+self-instruments its model call, and a hand-rolled ``@scorer`` may call a provider
+directly — and that LLM span lands in the SAME trace, nested under the SCORER span.
+Folding it into the result over-reports what the candidate cost to run, so the whole
+scorer subtree is dropped before summing.
+
+`rows` mirror the ClickHouse projection the worker queries:
+``(trace_id, span_id, parent_span_id, span_kind, cost)``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.fixtures.otel_payloads import make_attr, make_otel_payload, make_span
+from worker.ingest_tasks import _task_cost_by_trace, _update_eval_result_costs, process_s3_traces
+
+T = "trace-1"
+
+
+def _row(span_id, parent, kind, cost):
+    return (T, span_id, parent, kind, cost)
+
+
+class TestScorerSubtreeIsExcluded:
+    def test_llm_judge_call_under_a_scorer_is_not_charged_to_the_candidate(self):
+        """The regression the whole function exists to prevent."""
+        # EVALUATION -> TASK -> LLM(0.10)   (candidate)
+        #            -> SCORER -> LLM(0.90) (judge — must not be charged)
+        rows = [
+            _row("root", None, "EVALUATION", None),
+            _row("task", "root", "TASK", None),
+            _row("task-llm", "task", "LLM", 0.10),
+            _row("scorer", "root", "SCORER", None),
+            _row("judge-llm", "scorer", "LLM", 0.90),
+        ]
+        assert _task_cost_by_trace(rows) == {T: pytest.approx(0.10)}
+
+    def test_nested_scorer_subtree_two_levels_deep_is_excluded(self):
+        rows = [
+            _row("root", None, "EVALUATION", None),
+            _row("task", "root", "TASK", None),
+            _row("task-llm", "task", "LLM", 0.25),
+            _row("scorer", "root", "SCORER", None),
+            _row("judge-agent", "scorer", "AGENT", None),
+            _row("judge-llm", "judge-agent", "LLM", 5.00),
+            _row("judge-tool", "judge-agent", "TOOL", 1.00),
+        ]
+        assert _task_cost_by_trace(rows) == {T: pytest.approx(0.25)}
+
+    def test_multiple_scorers_are_all_excluded(self):
+        rows = [
+            _row("root", None, "EVALUATION", None),
+            _row("task", "root", "TASK", None),
+            _row("task-llm", "task", "LLM", 0.40),
+            _row("scorer-a", "root", "SCORER", None),
+            _row("judge-a", "scorer-a", "LLM", 2.00),
+            _row("scorer-b", "root", "SCORER", None),
+            _row("judge-b", "scorer-b", "LLM", 3.00),
+        ]
+        assert _task_cost_by_trace(rows) == {T: pytest.approx(0.40)}
+
+    def test_a_scorer_carrying_cost_itself_is_excluded(self):
+        rows = [
+            _row("root", None, "EVALUATION", None),
+            _row("task-llm", "root", "LLM", 0.10),
+            _row("scorer", "root", "SCORER", 7.00),
+        ]
+        assert _task_cost_by_trace(rows) == {T: pytest.approx(0.10)}
+
+
+class TestSummingContract:
+    def test_none_costs_are_absent_not_zero_and_total_is_zero(self):
+        rows = [
+            _row("root", None, "EVALUATION", None),
+            _row("task", "root", "TASK", None),
+            _row("task-llm", "task", "LLM", None),
+        ]
+        assert _task_cost_by_trace(rows) == {T: 0.0}
+
+    def test_a_span_whose_parent_is_absent_is_still_summed(self):
+        """Tolerated by design — an orphan is unreachable for exclusion, but dropping it
+        would silently under-report. The two-way recompute corrects it once the parent
+        lands."""
+        rows = [
+            _row("root", None, "EVALUATION", None),
+            _row("orphan-llm", "missing-parent", "LLM", 0.30),
+        ]
+        assert _task_cost_by_trace(rows) == {T: pytest.approx(0.30)}
+
+    def test_multiple_traces_in_one_batch_do_not_bleed_into_each_other(self):
+        rows = [
+            ("trace-a", "root-a", None, "EVALUATION", None),
+            ("trace-a", "llm-a", "root-a", "LLM", 0.10),
+            ("trace-a", "scorer-a", "root-a", "SCORER", None),
+            ("trace-a", "judge-a", "scorer-a", "LLM", 9.00),
+            ("trace-b", "root-b", None, "EVALUATION", None),
+            ("trace-b", "llm-b", "root-b", "LLM", 0.20),
+        ]
+        assert _task_cost_by_trace(rows) == {
+            "trace-a": pytest.approx(0.10),
+            "trace-b": pytest.approx(0.20),
+        }
+
+
+class TestWriteIsUnconditional:
+    """`if cost <= 0: continue` froze an over-report permanently. Under
+    BatchSpanProcessor a parent exports after its children, so a scorer's LLM child can
+    land in an earlier batch than the SCORER span; that batch has nothing to seed the
+    exclusion set and writes an inflated cost. The batch that finally brings the SCORER
+    recomputes 0.0 — and must be allowed to write it back."""
+
+    def _run(self, rows):
+        ch = MagicMock()
+        ch.query.return_value.result_rows = rows
+        conn, cur = MagicMock(), MagicMock()
+        cur.fetchall.return_value = [(T,)]
+        conn.cursor.return_value.__enter__.return_value = cur
+        with patch("psycopg2.connect", return_value=conn):
+            _update_eval_result_costs("proj-1", {T}, ch)
+        return [c for c in cur.execute.call_args_list if "UPDATE" in c[0][0]]
+
+    def test_a_recomputed_zero_is_written_back(self):
+        # Mutation caught: restoring `if cost <= 0: continue`, which leaves the earlier
+        # inflated cost in place forever.
+        updates = self._run(
+            [
+                _row("root", None, "EVALUATION", None),
+                _row("scorer", "root", "SCORER", None),
+                _row("judge-llm", "scorer", "LLM", 0.90),
+            ]
+        )
+        assert len(updates) == 1, "a recomputed 0.0 must still issue the UPDATE"
+        sql, params = updates[0][0]
+        assert "NULLIF" in sql, "0 must land as NULL, not a misleading 0.00"
+        assert params[0] == pytest.approx(0.0)
+
+    def test_a_positive_cost_is_written(self):
+        updates = self._run(
+            [
+                _row("root", None, "EVALUATION", None),
+                _row("task-llm", "root", "LLM", 0.10),
+            ]
+        )
+        assert len(updates) == 1
+        assert updates[0][0][1][0] == pytest.approx(0.10)
+
+
+class TestOrdinaryIngestDoesNotTouchPostgres:
+    """Every span-bearing batch for every project used to pay a fresh Postgres connect +
+    query before it knew whether the batch contained any evaluation spans at all."""
+
+    @pytest.fixture(autouse=True)
+    def _no_detectors(self, monkeypatch):
+        monkeypatch.setattr("worker.detector_tasks.enqueue_detector_runs", MagicMock())
+
+    def _process(self, monkeypatch, payload):
+        s3, ch = MagicMock(), MagicMock()
+        s3.download_json.return_value = payload
+        monkeypatch.setattr("rest.services.s3.get_s3_service", lambda: s3)
+        monkeypatch.setattr("db.clickhouse.client.get_clickhouse_client", lambda: ch)
+        derive = MagicMock()
+        monkeypatch.setattr("worker.ingest_tasks._update_eval_result_costs", derive)
+        process_s3_traces(s3_key="k.json", project_id="proj-1")
+        return derive
+
+    def test_a_batch_with_no_evaluation_spans_skips_the_derivation(self, monkeypatch):
+        # Mutation caught: calling _update_eval_result_costs unconditionally.
+        derive = self._process(
+            monkeypatch, make_otel_payload([make_span("aa" * 16, "bb" * 8, name="ordinary")])
+        )
+        derive.assert_not_called()
+
+    def test_a_batch_with_evaluation_spans_runs_the_derivation(self, monkeypatch):
+        derive = self._process(
+            monkeypatch,
+            make_otel_payload(
+                [
+                    make_span(
+                        "cc" * 16,
+                        "dd" * 8,
+                        attributes=[make_attr("traceroot.span.type", "EVALUATION")],
+                    )
+                ]
+            ),
+        )
+        derive.assert_called_once()
+        assert derive.call_args[0][1] == {"cc" * 16}

--- a/tests/worker/test_eval_trace_classification.py
+++ b/tests/worker/test_eval_trace_classification.py
@@ -1,0 +1,217 @@
+"""Offline-evaluation traces must be classified on ingest by a dedicated signal.
+
+Acceptance criteria under test: an evaluation trace is never indistinguishable from an
+ordinary trace — its root always carries the classification — AND the user's
+`traceroot.environment` deployment tag survives untouched, because the two are
+orthogonal concepts that must not share a field.
+"""
+
+from unittest.mock import MagicMock
+
+from db.clickhouse.client import ClickHouseClient
+from tests.fixtures.otel_payloads import make_attr, make_otel_payload, make_span
+from worker.otel_transform import transform_otel_to_clickhouse
+
+PROJECT = "proj-eval"
+TRACE_ID = "1a" * 16
+ROOT_SPAN_ID = "01" * 8
+TASK_SPAN_ID = "02" * 8
+SCORER_SPAN_ID = "03" * 8
+
+
+def _eval_span(span_id, kind, *, parent=None, environment=None, name="eval-span"):
+    attributes = [make_attr("traceroot.span.type", kind)]
+    if environment is not None:
+        attributes.append(make_attr("traceroot.environment", environment))
+    return make_span(
+        TRACE_ID,
+        span_id,
+        name=name,
+        parent_span_id_hex=parent,
+        attributes=attributes,
+    )
+
+
+def _transform(spans):
+    return transform_otel_to_clickhouse(make_otel_payload(spans), PROJECT)
+
+
+def _insert_rows(*, spans=None, traces=None):
+    """Run the real insert against a mocked driver; return (rows, column_names)."""
+    mock_internal = MagicMock()
+    client = ClickHouseClient(mock_internal)
+    if spans is not None:
+        client.insert_spans_batch(spans)
+    if traces is not None:
+        client.insert_traces_batch(traces)
+    call_args = mock_internal.insert.call_args
+    return call_args[0][1], call_args[1]["column_names"]
+
+
+class TestSpanKindsArePreserved:
+    def test_evaluation_task_scorer_kinds_survive_the_transform(self):
+        traces, spans = _transform(
+            [
+                _eval_span(ROOT_SPAN_ID, "EVALUATION"),
+                _eval_span(TASK_SPAN_ID, "TASK", parent=ROOT_SPAN_ID),
+                _eval_span(SCORER_SPAN_ID, "SCORER", parent=ROOT_SPAN_ID),
+            ]
+        )
+        assert {s["span_kind"] for s in spans} == {"EVALUATION", "TASK", "SCORER"}
+        assert len(traces) == 1
+
+
+class TestClassificationIsIndependentOfEnvironment:
+    """The critical regression: gating classification on `environment is None` makes it
+    silently never fire whenever TRACEROOT_ENVIRONMENT is set — the common case in CI
+    or any SDK-initialised app, since those spans already carry the attribute."""
+
+    def test_classified_when_the_sdk_stamped_an_environment(self):
+        # Mutation caught: re-adding an `environment is None` guard around the
+        # classification, or deriving it from anything other than the span kind.
+        traces, spans = _transform(
+            [
+                _eval_span(ROOT_SPAN_ID, "EVALUATION", environment="staging"),
+                _eval_span(TASK_SPAN_ID, "TASK", parent=ROOT_SPAN_ID, environment="staging"),
+            ]
+        )
+        assert traces[0]["is_evaluation"] is True
+        assert all(s["is_evaluation"] is True for s in spans)
+
+    def test_user_environment_value_is_preserved_not_overwritten(self):
+        # Mutation caught: setting `environment = "evaluation"` on eval spans. The
+        # deployment tag is user-namespace data and must round-trip unchanged.
+        traces, spans = _transform(
+            [
+                _eval_span(ROOT_SPAN_ID, "EVALUATION", environment="staging"),
+                _eval_span(TASK_SPAN_ID, "TASK", parent=ROOT_SPAN_ID, environment="staging"),
+            ]
+        )
+        assert traces[0]["environment"] == "staging"
+        assert {s["environment"] for s in spans} == {"staging"}
+
+    def test_user_named_environment_evaluation_is_not_classified(self):
+        # The inverse hazard of overloading the field: a customer who legitimately
+        # names their environment "evaluation" must NOT have ordinary traces hidden.
+        traces, spans = _transform(
+            [
+                make_span(
+                    TRACE_ID,
+                    ROOT_SPAN_ID,
+                    attributes=[make_attr("traceroot.environment", "evaluation")],
+                )
+            ]
+        )
+        assert traces[0]["environment"] == "evaluation"
+        assert traces[0].get("is_evaluation") is not True
+        assert spans[0].get("is_evaluation") is not True
+
+    def test_ordinary_trace_is_not_classified(self):
+        traces, spans = _transform([make_span(TRACE_ID, ROOT_SPAN_ID)])
+        assert traces[0].get("is_evaluation") is not True
+        assert spans[0].get("is_evaluation") is not True
+
+
+class TestRootArrivesInALaterBatch:
+    """OTel's BatchSpanProcessor exports a span when it ENDS, so the EVALUATION root is
+    normally the LAST span of the trace to arrive. A batch of children alone must still
+    write a classified trace row, or a crashed eval run stays misclassified forever."""
+
+    def test_children_only_batch_classifies_the_shallow_trace_record(self):
+        # Mutation caught: reading is_evaluation only inside the `if not parent_span_id`
+        # root-upgrade block, leaving the eager shallow record unclassified.
+        traces, spans = _transform(
+            [
+                _eval_span(SCORER_SPAN_ID, "SCORER", parent=TASK_SPAN_ID),
+                _eval_span(TASK_SPAN_ID, "TASK", parent=ROOT_SPAN_ID),
+            ]
+        )
+        assert traces[0]["is_evaluation"] is True
+        assert all(s["is_evaluation"] is True for s in spans)
+
+    def test_trace_record_is_never_less_classified_than_its_spans(self):
+        """A batch where only some spans are eval-kind (the TASK's own LLM child has
+        kind LLM) still classifies the trace."""
+        traces, spans = _transform(
+            [
+                make_span(
+                    TRACE_ID,
+                    "04" * 8,
+                    parent_span_id_hex=TASK_SPAN_ID,
+                    attributes=[make_attr("traceroot.span.type", "LLM")],
+                ),
+                _eval_span(TASK_SPAN_ID, "TASK", parent=ROOT_SPAN_ID),
+            ]
+        )
+        assert traces[0]["is_evaluation"] is True
+        assert any(s.get("is_evaluation") is True for s in spans)
+
+    def test_children_only_batch_carries_the_environment_tag(self):
+        # Mutation caught: dropping `environment` from the eager shallow trace record,
+        # which leaves a late-root trace with a NULL environment facet.
+        traces, _ = _transform(
+            [
+                _eval_span(TASK_SPAN_ID, "TASK", parent=ROOT_SPAN_ID, environment="staging"),
+            ]
+        )
+        assert traces[0]["environment"] == "staging"
+
+    def test_root_environment_wins_over_a_child_in_the_same_batch(self):
+        traces, _ = _transform(
+            [
+                _eval_span(TASK_SPAN_ID, "TASK", parent=ROOT_SPAN_ID, environment="child-env"),
+                _eval_span(ROOT_SPAN_ID, "EVALUATION", environment="root-env"),
+            ]
+        )
+        assert traces[0]["environment"] == "root-env"
+
+
+class TestClassificationReachesTheInsertRow:
+    """The signal is only useful if it is persisted — the traces list and the detector
+    scheduler read it back to exclude evaluation traces by default."""
+
+    def test_trace_insert_carries_is_evaluation_and_environment_separately(self):
+        traces, _ = _transform([_eval_span(ROOT_SPAN_ID, "EVALUATION", environment="staging")])
+        rows, columns = _insert_rows(traces=traces)
+        # Mutation caught: the duplicated `environment` entry in the column list, which
+        # made every ingest insert send two columns of the same name.
+        assert columns.count("environment") == 1
+        assert columns.count("is_evaluation") == 1
+        assert len(rows[0]) == len(columns)
+        assert rows[0][columns.index("environment")] == "staging"
+        assert rows[0][columns.index("is_evaluation")] == 1
+
+    def test_span_insert_carries_is_evaluation_and_environment_separately(self):
+        _, spans = _transform([_eval_span(ROOT_SPAN_ID, "EVALUATION", environment="staging")])
+        rows, columns = _insert_rows(spans=spans)
+        assert columns.count("environment") == 1
+        assert columns.count("is_evaluation") == 1
+        assert len(rows[0]) == len(columns)
+        assert rows[0][columns.index("environment")] == "staging"
+        assert rows[0][columns.index("is_evaluation")] == 1
+
+    def test_ordinary_trace_inserts_a_zero_flag(self):
+        traces, spans = _transform([make_span(TRACE_ID, ROOT_SPAN_ID)])
+        rows, columns = _insert_rows(traces=traces)
+        assert rows[0][columns.index("is_evaluation")] == 0
+        rows, columns = _insert_rows(spans=spans)
+        assert rows[0][columns.index("is_evaluation")] == 0
+
+
+class TestInsertColumnListsAreWellFormed:
+    """A duplicate name in a ClickHouse INSERT column list is rejected by the server and
+    takes out ALL trace and span ingest — while every client-side assertion still passes,
+    because the row length still matches. Guard the shape directly rather than relying on
+    a test that happens to look at one column."""
+
+    def test_trace_insert_column_names_have_no_duplicates(self):
+        traces, _ = _transform([make_span(TRACE_ID, ROOT_SPAN_ID)])
+        rows, columns = _insert_rows(traces=traces)
+        assert len(columns) == len(set(columns)), f"duplicate trace insert columns: {columns}"
+        assert len(rows[0]) == len(columns)
+
+    def test_span_insert_column_names_have_no_duplicates(self):
+        _, spans = _transform([make_span(TRACE_ID, ROOT_SPAN_ID)])
+        rows, columns = _insert_rows(spans=spans)
+        assert len(columns) == len(set(columns)), f"duplicate span insert columns: {columns}"
+        assert len(rows[0]) == len(columns)

--- a/tests/worker/test_ingest_tasks.py
+++ b/tests/worker/test_ingest_tasks.py
@@ -128,3 +128,71 @@ class TestProcessS3Traces:
         process_s3_traces(s3_key="test/key.json", project_id="proj-1")
 
         mock_detector_enqueue.assert_not_called()
+
+
+class TestTaskCostByTrace:
+    """`_task_cost_by_trace` scopes derived eval cost to the CANDIDATE TASK, excluding
+    the scorer subtree (an llm_judge or a code scorer that calls an LLM shares the trace).
+    Rows are (trace_id, span_id, parent_span_id, span_kind, cost)."""
+
+    def test_excludes_scorer_llm_cost(self):
+        from worker.ingest_tasks import _task_cost_by_trace
+
+        rows = [
+            ("t1", "root", "", "EVALUATION", None),
+            ("t1", "task", "root", "TASK", None),
+            ("t1", "task_llm", "task", "LLM", 0.010),  # candidate cost
+            ("t1", "scorer", "root", "SCORER", None),
+            ("t1", "judge_llm", "scorer", "LLM", 0.004),  # judge cost — excluded
+        ]
+        assert _task_cost_by_trace(rows) == {"t1": pytest.approx(0.010)}
+
+    def test_excludes_deeply_nested_scorer_descendants(self):
+        from worker.ingest_tasks import _task_cost_by_trace
+
+        # Scorer -> wrapper span -> LLM: the whole subtree is excluded, not just direct children.
+        rows = [
+            ("t1", "task", "root", "TASK", None),
+            ("t1", "task_llm", "task", "LLM", 0.02),
+            ("t1", "scorer", "root", "SCORER", None),
+            ("t1", "wrap", "scorer", "SPAN", None),
+            ("t1", "judge_llm", "wrap", "LLM", 0.05),
+        ]
+        assert _task_cost_by_trace(rows) == {"t1": pytest.approx(0.02)}
+
+    def test_no_scorer_llm_sums_all_task_cost(self):
+        from worker.ingest_tasks import _task_cost_by_trace
+
+        # A trivial code scorer (no LLM) — nothing to exclude; two task LLM calls sum.
+        rows = [
+            ("t1", "task", "root", "TASK", None),
+            ("t1", "llm_a", "task", "LLM", 0.003),
+            ("t1", "llm_b", "task", "LLM", 0.004),
+            ("t1", "scorer", "root", "SCORER", None),
+        ]
+        assert _task_cost_by_trace(rows) == {"t1": pytest.approx(0.007)}
+
+    def test_costless_trace_is_zero(self):
+        from worker.ingest_tasks import _task_cost_by_trace
+
+        rows = [
+            ("t1", "root", "", "EVALUATION", None),
+            ("t1", "task", "root", "TASK", None),
+        ]
+        assert _task_cost_by_trace(rows) == {"t1": 0.0}
+
+    def test_multiple_traces_kept_separate(self):
+        from worker.ingest_tasks import _task_cost_by_trace
+
+        rows = [
+            ("t1", "task1", "root1", "TASK", None),
+            ("t1", "llm1", "task1", "LLM", 0.01),
+            ("t2", "task2", "root2", "TASK", None),
+            ("t2", "llm2", "task2", "LLM", 0.02),
+            ("t2", "scorer2", "root2", "SCORER", None),
+            ("t2", "judge2", "scorer2", "LLM", 0.99),
+        ]
+        assert _task_cost_by_trace(rows) == {
+            "t1": pytest.approx(0.01),
+            "t2": pytest.approx(0.02),
+        }


### PR DESCRIPTION
## Summary

Fixes: #1649

Makes evaluation traces first-class in the ingest pipeline. Each result is backed by a real trace shaped `evaluation-item → task → scorer`; ingestion now preserves those span kinds, classifies the trace at its root so downstream surfaces can find and group it, and renders sibling spans in a deterministic order so a trace reads identically every time. The root classification is also what lets a sibling change exclude these traces from the default list and from detector runs.

## How it works

```
EVALUATION (root)   ← classifies the trace: is_evaluation = 1
  └─ TASK           ← the candidate task
       └─ SCORER    ← one per scorer that ran
```

The SDK emits the `EVALUATION`/`TASK`/`SCORER` span kinds but does not stamp `traceroot.environment`; ingestion sets a dedicated `is_evaluation` flag from the eval span kinds and carries it onto the trace record, so an evaluation trace is never indistinguishable from an ordinary one. The flag is deliberately separate from `environment`, which is the customer's own free-text deployment tag — overloading it would make a team that names a stack "evaluation" lose its entire trace list.

## What's included

### Backend
- `backend/shared/enums.py` — adds `EVALUATION`, `TASK`, and `SCORER` to the `SpanKind` enum.
- `backend/worker/otel_transform.py` — `get_span_kind` preserves the SDK's `EVALUATION`/`TASK`/`SCORER` kinds through into the `span_kind` column instead of coercing them to `SPAN`; `transform_otel_to_clickhouse` flags a span with an eval kind as `is_evaluation`, and any eval-kind span in the batch flags the trace — the flag only ever goes 0 → 1, so a later batch of non-eval leaves cannot un-flag it.
- `backend/db/clickhouse/client.py` — ClickHouse client using clickhouse-connect.
- `backend/worker/ingest_tasks.py` — Celery task definitions. This module defines the async tasks that process trace data from S3 to ClickHouse.

### Frontend

### Tests
- `tests/db/test_client.py` — Unit tests for ClickHouseClient row-building logic. Tests row construction without a real ClickHouse connection.
- `tests/worker/test_eval_result_cost.py` — Per-result cost derived from an evaluation trace must measure the CANDIDATE only.
- `tests/worker/test_eval_trace_classification.py` — Offline-evaluation traces must be classified on ingest by a dedicated signal.
- `tests/worker/test_ingest_tasks.py` — Unit tests for Celery task logic with mocked S3 + ClickHouse.

## Test plan

- [ ] Ingest an evaluation trace and confirm `EVALUATION`/`TASK`/`SCORER` are stored in `span_kind` and queryable by kind.
- [ ] Confirm the root span carries the classification and that `environment = "evaluation"` is persisted on the trace even when the SDK did not stamp it.
- [ ] Confirm the `evaluation-item → task → scorer` nesting is intact so the scorer subtree can be told apart from the candidate task.
- [ ] Render a trace with sub-ms-parallel siblings twice and confirm identical ordering, siblings ordered by (start, end, span id).
- [ ] Confirm a model-call leaf span carries a `cost` where provider usage is present and none where usage is absent.
