### PR TITLE
feat(traces): exclude evaluation traces from lists and detectors

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -2,12 +2,12 @@
   "components": {
     "schemas": {
       "CompleteRunRequest": {
-        "additionalProperties": false,
         "description": "Complete/fail a run, reporting final completeness counts.",
         "properties": {
           "case_count": {
             "anyOf": [
               {
+                "maximum": 9007199254740991.0,
                 "minimum": 0.0,
                 "type": "integer"
               },
@@ -31,6 +31,7 @@
           "scored_count": {
             "anyOf": [
               {
+                "maximum": 9007199254740991.0,
                 "minimum": 0.0,
                 "type": "integer"
               },
@@ -43,6 +44,7 @@
           "scorer_error_count": {
             "anyOf": [
               {
+                "maximum": 9007199254740991.0,
                 "minimum": 0.0,
                 "type": "integer"
               },
@@ -67,6 +69,7 @@
           "task_error_count": {
             "anyOf": [
               {
+                "maximum": 9007199254740991.0,
                 "minimum": 0.0,
                 "type": "integer"
               },
@@ -880,7 +883,6 @@
         "type": "object"
       },
       "RegisterRunRequest": {
-        "additionalProperties": false,
         "description": "Register/start a run. Idempotent on ``client_run_id`` within an evaluation.",
         "properties": {
           "baseline_run_id": {
@@ -905,6 +907,7 @@
           "case_count": {
             "anyOf": [
               {
+                "maximum": 9007199254740991.0,
                 "minimum": 0.0,
                 "type": "integer"
               },
@@ -988,6 +991,7 @@
             "items": {
               "$ref": "#/components/schemas/ScorerRef"
             },
+            "maxItems": 200,
             "title": "Scorers",
             "type": "array"
           }
@@ -1039,7 +1043,6 @@
         "type": "object"
       },
       "ScoreInput": {
-        "additionalProperties": false,
         "description": "One scorer's outcome on one result. ``error`` set = the scorer failed to judge.",
         "properties": {
           "bool_value": {
@@ -1135,6 +1138,7 @@
         "description": "One prompt message of an LLM-judge scorer's definition.",
         "properties": {
           "content": {
+            "maxLength": 20000,
             "title": "Content",
             "type": "string"
           },
@@ -1153,7 +1157,7 @@
         "type": "object"
       },
       "ScorerRef": {
-        "description": "A scorer's descriptor. ``name`` + ``version`` are the comparison identity;\nthe richer metadata is optional and back-compatible (an old SDK sending only\n``{name, version}`` stays valid). Mirrors the non-strict ``ScorerRefSchema``,\nso unknown keys are ignored rather than rejected.\n\nThe DEFINITION fields (``scorer_type``, prompt/source, config) let the read-only\nScorer detail render an LLM judge's model + messages or a code scorer's snippet.",
+        "description": "A scorer's descriptor. ``name`` + ``version`` are the comparison identity;\nthe richer metadata is optional and back-compatible (an old SDK sending only\n``{name, version}`` stays valid). Mirrors the non-strict ``ScorerRefSchema``,\nso unknown keys are ignored rather than rejected.\n\nThe DEFINITION fields (``scorer_type``, prompt/source, config) let the read-only\nScorer detail render an LLM judge's model + messages or a code scorer's snippet.\n\n``scorer_type`` / ``output_type`` / ``language`` are display-only, so an\nunrecognised value from a newer SDK degrades to ``None`` rather than failing\nrun registration (which would lose the run's every result and score) \u2014\nmatching ``.catch(null)`` on the Zod side. The vocabularies that drive\npersistence and aggregation still reject.",
         "properties": {
           "description": {
             "anyOf": [
@@ -1204,6 +1208,7 @@
                 "items": {
                   "$ref": "#/components/schemas/ScorerMessage"
                 },
+                "maxItems": 50,
                 "type": "array"
               },
               {
@@ -1272,6 +1277,7 @@
           "source": {
             "anyOf": [
               {
+                "maxLength": 50000,
                 "type": "string"
               },
               {
@@ -1541,12 +1547,12 @@
         "type": "object"
       },
       "UpsertResultRequest": {
-        "additionalProperties": false,
-        "description": "Upsert one test-case result. Idempotent on (``run_id``, ``test_case_id``).\n``trace_id`` may be null now and set on a later call (out-of-order arrival).\nSending ``scores`` replaces the result's scores.",
+        "description": "Upsert one test-case result. Idempotent on (``run_id``, ``test_case_id``).\n``trace_id`` may be null now and set on a later call (out-of-order arrival).\n\n``scores`` is genuinely optional and carries three distinct meanings, so the\nout-of-order flow (POST the result with its scores, then re-POST later just to\nattach the OTel ``trace_id``) cannot destroy them: absent \u2192 leave the existing\nscores untouched, ``[]`` \u2192 clear them, non-empty \u2192 replace them. Do not give\nthis a ``default_factory=list``, which would collapse the first two cases.\n\nEvery optional field is a *partial* update: a key the caller omits keeps its\nstored value, while an explicit null clears it. Sending ``scores`` replaces\nthe result's scores (``[]`` clears them); omitting it leaves them alone.",
         "properties": {
           "baseline_output": {
             "anyOf": [
               {
+                "maxLength": 1000000,
                 "type": "string"
               },
               {
@@ -1558,6 +1564,7 @@
           "candidate_output": {
             "anyOf": [
               {
+                "maxLength": 1000000,
                 "type": "string"
               },
               {
@@ -1597,6 +1604,7 @@
           "duration_ms": {
             "anyOf": [
               {
+                "maximum": 9007199254740991.0,
                 "minimum": 0.0,
                 "type": "integer"
               },
@@ -1609,6 +1617,7 @@
           "expected_output": {
             "anyOf": [
               {
+                "maxLength": 1000000,
                 "type": "string"
               },
               {
@@ -1618,6 +1627,7 @@
             "title": "Expected Output"
           },
           "input": {
+            "maxLength": 1000000,
             "title": "Input",
             "type": "string"
           },
@@ -1636,6 +1646,7 @@
             "items": {
               "$ref": "#/components/schemas/ScoreInput"
             },
+            "maxItems": 200,
             "title": "Scores",
             "type": "array"
           },
@@ -2417,15 +2428,25 @@
             },
             "description": "Not found"
           },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request body too large"
+          },
           "422": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Validation error"
           },
           "503": {
             "content": {
@@ -2525,15 +2546,25 @@
             },
             "description": "Not found"
           },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request body too large"
+          },
           "422": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Validation error"
           },
           "503": {
             "content": {
@@ -2633,15 +2664,25 @@
             },
             "description": "Not found"
           },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request body too large"
+          },
           "422": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Validation error"
           },
           "503": {
             "content": {
@@ -2728,13 +2769,13 @@
             }
           },
           {
-            "description": "Include offline-evaluation traces (environment=evaluation). Excluded by default so evaluation runs do not appear in the production trace list.",
+            "description": "Include traces produced by offline-evaluation runs. Excluded by default so evaluation runs do not appear in the production trace list.",
             "in": "query",
             "name": "include_evaluations",
             "required": false,
             "schema": {
               "default": false,
-              "description": "Include offline-evaluation traces (environment=evaluation). Excluded by default so evaluation runs do not appear in the production trace list.",
+              "description": "Include traces produced by offline-evaluation runs. Excluded by default so evaluation runs do not appear in the production trace list.",
               "title": "Include Evaluations",
               "type": "boolean"
             }

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -64,8 +64,8 @@ async def list_traces(
     ),
     include_evaluations: bool = Query(
         False,
-        description="Include offline-evaluation traces (environment=evaluation). "
-        "Excluded by default so evaluation runs do not appear in the production trace list.",
+        description="Include traces produced by offline-evaluation runs. Excluded by "
+        "default so evaluation runs do not appear in the production trace list.",
     ),
 ):
     """List recent traces for the API key's project (newest first).

--- a/backend/rest/routers/sessions.py
+++ b/backend/rest/routers/sessions.py
@@ -36,6 +36,11 @@ async def list_sessions(
     search_query: str | None = Query(None, description="Search by session_id"),
     start_after: datetime | None = Query(None, description="Filter traces after this time"),
     end_before: datetime | None = Query(None, description="Filter traces before this time"),
+    include_evaluations: bool = Query(
+        False,
+        description="Include offline-evaluation traces in the session aggregates. "
+        "Excluded by default, matching the Traces list.",
+    ),
 ):
     """List unique sessions for a project with trace counts and token totals."""
     start_after, end_before = clamp_retention_window(_access.billing_plan, start_after, end_before)
@@ -48,6 +53,7 @@ async def list_sessions(
             search_query=search_query,
             start_after=start_after,
             end_before=end_before,
+            include_evaluations=include_evaluations,
         )
         return result
     except Exception as e:
@@ -70,6 +76,11 @@ async def get_session(
     _access: RateLimitedProjectAccess,
     start_after: datetime | None = Query(None, description="Filter traces after this time"),
     end_before: datetime | None = Query(None, description="Filter traces before this time"),
+    include_evaluations: bool = Query(
+        False,
+        description="Include offline-evaluation traces in this session's traces and "
+        "totals. Excluded by default, matching the session list.",
+    ),
 ):
     """Get session detail with all traces for conversation view."""
     start_after, end_before = clamp_retention_window(_access.billing_plan, start_after, end_before)
@@ -80,6 +91,7 @@ async def get_session(
             session_id=session_id,
             start_after=start_after,
             end_before=end_before,
+            include_evaluations=include_evaluations,
         )
         if result is None:
             raise HTTPException(

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -80,7 +80,7 @@ async def list_traces(
     ),
     include_evaluations: bool = Query(
         False,
-        description="Include offline-evaluation traces (environment=evaluation), "
+        description="Include traces produced by offline-evaluation runs, "
         "which are excluded by default.",
     ),
 ):

--- a/backend/rest/routers/users.py
+++ b/backend/rest/routers/users.py
@@ -36,6 +36,11 @@ async def list_users(
     search_query: str | None = Query(None, description="Search by user_id"),
     start_after: datetime | None = Query(None, description="Filter traces after this time"),
     end_before: datetime | None = Query(None, description="Filter traces before this time"),
+    include_evaluations: bool = Query(
+        False,
+        description="Include offline-evaluation traces in the per-user counts and "
+        "totals. Excluded by default, matching the Traces list.",
+    ),
 ):
     """List unique users for a project with trace counts."""
     start_after, end_before = clamp_retention_window(_access.billing_plan, start_after, end_before)
@@ -48,6 +53,7 @@ async def list_users(
             search_query=search_query,
             start_after=start_after,
             end_before=end_before,
+            include_evaluations=include_evaluations,
         )
         return result
     except Exception as e:

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -450,13 +450,21 @@ class TraceReaderService:
         # the span sub-queries reuse start_after (above) as a span-scan lower bound.
         conditions.extend(build_conditions(filters or [], params))
 
-        # Exclude offline-evaluation traces by default (trace-level, NULL-safe so
-        # untagged production traces are always kept). Shared by page + count.
-        if not include_evaluations:
-            conditions.append("(t.environment IS NULL OR t.environment != {excluded_env:String})")
-            params["excluded_env"] = "evaluation"
-
         where_clause = " AND ".join(conditions)
+
+        # Exclude offline-evaluation traces by default. This MUST be applied AFTER the
+        # ReplacingMergeTree dedup, never to the raw rows: an eval trace can have a shallow
+        # placeholder row (environment NULL, written when a child span arrives before the
+        # root) alongside the full root row (environment 'evaluation'). Filtering raw rows
+        # would drop the full row but keep the NULL shallow row, defeating the exclusion —
+        # so we filter the deduped latest row (NULL-safe, keeping untagged production
+        # traces). Shared by the page and count queries below.
+        env_clause = ""
+        if not include_evaluations:
+            env_clause = "environment IS NULL OR environment != {excluded_env:String}"
+            params["excluded_env"] = "evaluation"
+        page_env_where = f"WHERE ({env_clause})" if env_clause else ""
+        count_env_where = f"WHERE ({env_clause})" if env_clause else ""
 
         # Page the traces FIRST (cheap: trace metadata only, deduped via LIMIT 1 BY
         # instead of FINAL), then aggregate spans for ONLY that page's trace_ids.
@@ -472,12 +480,13 @@ class TraceReaderService:
                 FROM (
                     SELECT
                         t.trace_id, t.project_id, t.name, t.trace_start_time,
-                        t.user_id, t.session_id, t.input, t.output
+                        t.user_id, t.session_id, t.input, t.output, t.environment
                     FROM traces AS t
                     WHERE {where_clause}
                     ORDER BY t.ch_update_time DESC
                     LIMIT 1 BY t.project_id, t.trace_id
                 )
+                {page_env_where}
                 ORDER BY trace_start_time DESC
                 LIMIT {{limit:UInt32}} OFFSET {{offset:UInt32}}
             ),
@@ -528,11 +537,19 @@ class TraceReaderService:
         result = self._client.query(query, parameters=params)
         rows = result.result_rows
 
-        # Get total count (count(DISTINCT) dedupes ReplacingMergeTree rows; no FINAL)
+        # Total count: dedup per trace_id (argMax by ch_update_time collapses the
+        # ReplacingMergeTree rows to the latest one, like the page's LIMIT 1 BY), THEN
+        # apply the evaluation exclusion to that deduped row — so the count matches the
+        # page and can't be inflated by a shallow NULL-environment placeholder row.
         count_query = f"""
-            SELECT count(DISTINCT t.trace_id)
-            FROM traces AS t
-            WHERE {where_clause}
+            SELECT count()
+            FROM (
+                SELECT t.trace_id, argMax(t.environment, t.ch_update_time) AS environment
+                FROM traces AS t
+                WHERE {where_clause}
+                GROUP BY t.trace_id
+            )
+            {count_env_where}
         """
         count_result = self._client.query(count_query, parameters=params)
         total = count_result.result_rows[0][0] if count_result.result_rows else 0

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -68,6 +68,55 @@ def customer_traffic_only(alias: str = "") -> str:
     return f"{column} = '{USER_SOURCE}'"
 
 
+def _evaluation_exclusion(params: dict) -> str:
+    """SQL condition removing offline-evaluation traces from a ``traces AS t`` scan.
+
+    KEYED ON ``is_evaluation``, deliberately not on ``environment``. ``environment`` is the
+    customer's own deployment tag — free text passed straight through from
+    ``TRACEROOT_ENVIRONMENT``, and the filter dropdown offers back whatever strings they
+    actually sent. Overloading it as the evaluation marker would make a team that names a
+    pre-prod stack "evaluation" lose its entire trace list with no in-product way back.
+    ``is_evaluation`` is set by ingest from the SDK's eval span kinds and a customer cannot
+    collide with it. It is ``UInt8 DEFAULT 0``, never NULL, so there is no NULL branch:
+    "unknown" and "not an evaluation" are the same answer.
+
+    MONOTONIC ACROSS BATCHES — this is the read-side half of the guarantee. Ingest makes
+    the flag monotonic *within* a batch (any eval-kind span sets it for the trace, 0 -> 1
+    only). It cannot make it monotonic *between* batches: a later batch carrying only
+    non-eval-kind spans of an evaluation trace — say just the candidate task's LLM leaves —
+    rewrites the trace row with ``is_evaluation = 0`` and a newer ``ch_update_time``. So a
+    predicate read off the *deduped latest* row (``LIMIT 1 BY`` / ``argMax``) would un-hide
+    the trace the moment such a batch landed last, which is the common case rather than an
+    exotic race. This is a trace_id set-membership instead: any row anywhere flagged 1
+    hides the trace permanently, whatever order the writes arrived in. Because it never
+    reads the deduped row it is also safe in the SHARED where-clause, so the page and count
+    queries agree by construction rather than by both picking the same tie-break.
+
+    Scans ``traces`` (one row per trace per batch), not ``spans``, reading only the two
+    narrow columns in the predicate. Bound to the caller's window when there is one so it
+    prunes the same monthly partitions as the outer query.
+
+    Args:
+        params (dict): Query parameters for this statement. Must already contain
+            ``project_id``; ``start_after`` / ``end_before`` are reused as sub-select
+            bounds when the caller set them.
+
+    Returns:
+        str: A condition for the ``traces AS t`` where-clause.
+    """
+    bounds = [
+        "project_id = {project_id:String}",
+        "is_evaluation = 1",
+    ]
+    # Reuse the outer window. A trace outside it cannot reach the result anyway, and
+    # widening the excluded set here could only ever drop rows the outer query already does.
+    if "start_after" in params:
+        bounds.append("trace_start_time >= {start_after:DateTime64(3)}")
+    if "end_before" in params:
+        bounds.append("trace_start_time <= {end_before:DateTime64(3)}")
+    return "t.trace_id NOT IN (SELECT trace_id FROM traces WHERE " + " AND ".join(bounds) + ")"
+
+
 def _floor_minute(dt: datetime | None) -> datetime | None:
     """Truncate a datetime to the whole minute (for the distinct-values cache key)."""
     return dt.replace(second=0, microsecond=0) if dt is not None else None
@@ -395,10 +444,11 @@ class TraceReaderService:
     ) -> dict:
         """List traces with aggregated metrics from spans.
 
-        Offline-evaluation traces (``environment = 'evaluation'``) are excluded by
-        default so they do not pollute the production/staging Traces list; pass
-        ``include_evaluations=True`` to include them. The predicate is trace-level and
-        shared by the page and count queries (below), so counts and pagination match.
+        Offline-evaluation traces are excluded by default so they do not pollute the
+        production/staging Traces list; pass ``include_evaluations=True`` to include
+        them. The exclusion goes into the SHARED ``conditions`` list, so it reaches the
+        page query and the count query identically and ``meta.total`` always matches the
+        rows the caller can page through. See :func:`_evaluation_exclusion`.
         """
         offset = page * limit
 
@@ -450,21 +500,13 @@ class TraceReaderService:
         # the span sub-queries reuse start_after (above) as a span-scan lower bound.
         conditions.extend(build_conditions(filters or [], params))
 
-        where_clause = " AND ".join(conditions)
-
-        # Exclude offline-evaluation traces by default. This MUST be applied AFTER the
-        # ReplacingMergeTree dedup, never to the raw rows: an eval trace can have a shallow
-        # placeholder row (environment NULL, written when a child span arrives before the
-        # root) alongside the full root row (environment 'evaluation'). Filtering raw rows
-        # would drop the full row but keep the NULL shallow row, defeating the exclusion —
-        # so we filter the deduped latest row (NULL-safe, keeping untagged production
-        # traces). Shared by the page and count queries below.
-        env_clause = ""
+        # Hide offline-evaluation traces unless the caller opted in. Appended to the
+        # SHARED conditions (it is dedup-independent, see _evaluation_exclusion) so the
+        # page and the count exclude exactly the same traces.
         if not include_evaluations:
-            env_clause = "environment IS NULL OR environment != {excluded_env:String}"
-            params["excluded_env"] = "evaluation"
-        page_env_where = f"WHERE ({env_clause})" if env_clause else ""
-        count_env_where = f"WHERE ({env_clause})" if env_clause else ""
+            conditions.append(_evaluation_exclusion(params))
+
+        where_clause = " AND ".join(conditions)
 
         # Page the traces FIRST (cheap: trace metadata only, deduped via LIMIT 1 BY
         # instead of FINAL), then aggregate spans for ONLY that page's trace_ids.
@@ -480,13 +522,12 @@ class TraceReaderService:
                 FROM (
                     SELECT
                         t.trace_id, t.project_id, t.name, t.trace_start_time,
-                        t.user_id, t.session_id, t.input, t.output, t.environment
+                        t.user_id, t.session_id, t.input, t.output
                     FROM traces AS t
                     WHERE {where_clause}
                     ORDER BY t.ch_update_time DESC
                     LIMIT 1 BY t.project_id, t.trace_id
                 )
-                {page_env_where}
                 ORDER BY trace_start_time DESC
                 LIMIT {{limit:UInt32}} OFFSET {{offset:UInt32}}
             ),
@@ -537,19 +578,12 @@ class TraceReaderService:
         result = self._client.query(query, parameters=params)
         rows = result.result_rows
 
-        # Total count: dedup per trace_id (argMax by ch_update_time collapses the
-        # ReplacingMergeTree rows to the latest one, like the page's LIMIT 1 BY), THEN
-        # apply the evaluation exclusion to that deduped row — so the count matches the
-        # page and can't be inflated by a shallow NULL-environment placeholder row.
+        # Get total count (count(DISTINCT) dedupes ReplacingMergeTree rows; no FINAL).
+        # The evaluation exclusion rides in {where_clause} — shared with the page above.
         count_query = f"""
-            SELECT count()
-            FROM (
-                SELECT t.trace_id, argMax(t.environment, t.ch_update_time) AS environment
-                FROM traces AS t
-                WHERE {where_clause}
-                GROUP BY t.trace_id
-            )
-            {count_env_where}
+            SELECT count(DISTINCT t.trace_id)
+            FROM traces AS t
+            WHERE {where_clause}
         """
         count_result = self._client.query(count_query, parameters=params)
         total = count_result.result_rows[0][0] if count_result.result_rows else 0
@@ -880,8 +914,17 @@ class TraceReaderService:
         search_query: str | None = None,
         start_after: datetime | None = None,
         end_before: datetime | None = None,
+        include_evaluations: bool = False,
     ) -> dict:
-        """List unique sessions with aggregated trace statistics."""
+        """List unique sessions with aggregated trace statistics.
+
+        Offline-evaluation traces are excluded by default, matching ``list_traces``.
+        Without this a 200-item eval run sharing one ``session_id`` would be invisible in
+        Traces yet still show up here as a 200-trace session whose ``total_cost`` lands in
+        the project's per-session spend — the same trace hidden in one view and charged in
+        another. The exclusion also keeps ``trace_count``, the token totals and the
+        ``argMin``/``argMax`` displayed I/O consistent with what Traces shows.
+        """
         offset = page * limit
 
         # Build WHERE conditions on the traces table
@@ -905,6 +948,15 @@ class TraceReaderService:
         if end_before is not None:
             conditions.append("t.trace_start_time < {end_before:DateTime64(3)}")
             params["end_before"] = to_utc_naive(end_before)
+
+        # Shared by every CTE below (session_page, traces_dedup) AND the count query, so
+        # the paged sessions, their aggregates and meta.total all see the same traces.
+        # Kept in a local because the I/O-backfill query further down builds its own
+        # traces scan and must hide the same traces (an eval trace must not supply a
+        # session's displayed input/output).
+        eval_exclusion = "" if include_evaluations else _evaluation_exclusion(params)
+        if eval_exclusion:
+            conditions.append(eval_exclusion)
 
         where_clause = " AND ".join(conditions)
 
@@ -1030,6 +1082,7 @@ class TraceReaderService:
                     WHERE t.project_id = {{project_id:String}}
                       AND {customer_traffic_only("t")}
                       AND t.session_id IN ({{session_ids:Array(String)}})
+                      {f"AND {eval_exclusion}" if eval_exclusion else ""}
                     ORDER BY t.ch_update_time DESC
                     LIMIT 1 BY t.project_id, t.trace_id
                 ),
@@ -1086,8 +1139,15 @@ class TraceReaderService:
         session_id: str,
         start_after: datetime | None = None,
         end_before: datetime | None = None,
+        include_evaluations: bool = False,
     ) -> dict | None:
-        """Get session detail with all traces for conversation view."""
+        """Get session detail with all traces for conversation view.
+
+        Offline-evaluation traces are excluded by default, matching ``list_sessions`` —
+        the detail view must not list traces the list view already counted out, and its
+        ``trace_count`` / token / cost totals are computed from ``trace_ids`` gathered
+        here, so the exclusion propagates to them.
+        """
         params: dict = {"project_id": project_id, "session_id": session_id}
 
         # Build WHERE conditions
@@ -1106,6 +1166,9 @@ class TraceReaderService:
         if end_before is not None:
             conditions.append("t.trace_start_time < {end_before:DateTime64(3)}")
             params["end_before"] = to_utc_naive(end_before)
+
+        if not include_evaluations:
+            conditions.append(_evaluation_exclusion(params))
 
         where_clause = " AND ".join(conditions)
 
@@ -1268,8 +1331,15 @@ class TraceReaderService:
         search_query: str | None = None,
         start_after: datetime | None = None,
         end_before: datetime | None = None,
+        include_evaluations: bool = False,
     ) -> dict:
-        """List unique users with trace counts."""
+        """List unique users with trace counts.
+
+        Offline-evaluation traces are excluded by default, matching ``list_traces``, so a
+        user's ``trace_count`` and token/cost totals count the same traces the Traces view
+        shows. An eval run that carries a ``user_id`` would otherwise inflate that user's
+        spend — and could conjure a user who has no visible traces at all.
+        """
         offset = page * limit
 
         # Build WHERE conditions
@@ -1295,6 +1365,9 @@ class TraceReaderService:
         if end_before:
             conditions.append("t.trace_start_time <= {end_before:DateTime64(3)}")
             params["end_before"] = to_utc_naive(end_before)
+
+        if not include_evaluations:
+            conditions.append(_evaluation_exclusion(params))
 
         where_clause = " AND ".join(conditions)
 

--- a/backend/worker/detector_tasks.py
+++ b/backend/worker/detector_tasks.py
@@ -199,7 +199,21 @@ def _passes_trigger(trace_summary: dict, conditions: list[dict]) -> bool:
 def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dict]:
     """
     Query ClickHouse for the fields needed for trigger evaluation.
-    Returns {trace_id: {environment}}
+    Returns {trace_id: {environment, is_evaluation}}
+
+    ``is_evaluation`` is the ingest-set flag, NOT ``environment``. ``environment`` is
+    user-controlled free text (the SDK passes ``traceroot.environment`` straight through,
+    and the filter dropdown offers back whatever strings a customer actually sent), so a
+    team that legitimately names an environment "evaluation" must not have its detectors
+    silently switched off. The flag is derived by us from the SDK's eval span kinds and
+    cannot be collided with by naming a deployment.
+
+    ``max`` over ALL the trace's spans rather than reading the root span. OTel's
+    BatchSpanProcessor exports a span when it ENDS, so the ``EVALUATION`` root is normally
+    the LAST span of the trace to arrive: a root-keyed read answers "not an evaluation"
+    for the whole window before the root lands, and forever if the eval process is killed
+    first. ``max`` also makes the answer monotonic — any span flagged 1 settles it, and no
+    later row can clear it.
     """
     from db.clickhouse.client import get_clickhouse_client
 
@@ -212,7 +226,8 @@ def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dic
         """
         SELECT
             trace_id,
-            anyIf(environment, parent_span_id IS NULL) AS environment
+            anyIf(environment, parent_span_id IS NULL) AS environment,
+            max(is_evaluation) AS is_evaluation
         FROM spans
         WHERE project_id = {project_id:String}
           AND trace_id IN {trace_ids:Array(String)}
@@ -225,6 +240,7 @@ def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dic
     for row in result.result_rows:
         summaries[row[0]] = {
             "environment": row[1],  # Nullable — None if not set
+            "is_evaluation": bool(row[2]),
         }
     return summaries
 
@@ -280,13 +296,16 @@ def _get_active_detectors(project_id: str) -> list[dict]:
 def _detector_runs_on_trace(summary: dict, detector: dict) -> bool:
     """Whether a detector should run on this trace given its classification.
 
-    Offline-evaluation traces (``environment == "evaluation"``) are skipped by
-    default so production detectors do not run on evaluation runs — preventing
-    detector noise and any detector→evaluation→detector recursion. A detector can
-    opt in via ``run_on_evaluation`` (reserved for an explicit future config); until
-    that flag exists on the detector, the default is to skip.
+    Offline-evaluation traces are skipped by default so production detectors do not run
+    on evaluation runs — preventing detector noise and any detector→evaluation→detector
+    recursion. A detector can opt in via ``run_on_evaluation`` (reserved for an explicit
+    future config); until that flag exists on the detector, the default is to skip.
+
+    Keyed on ``is_evaluation`` (the ingest-set flag, see ``_get_trace_summaries``) and never
+    on ``environment``, which is user-controlled free text a customer may legitimately set
+    to "evaluation".
     """
-    if summary.get("environment") == "evaluation":
+    if summary.get("is_evaluation"):
         return bool(detector.get("run_on_evaluation", False))
     return True
 

--- a/backend/worker/detector_tasks.py
+++ b/backend/worker/detector_tasks.py
@@ -277,6 +277,20 @@ def _get_active_detectors(project_id: str) -> list[dict]:
     return detectors
 
 
+def _detector_runs_on_trace(summary: dict, detector: dict) -> bool:
+    """Whether a detector should run on this trace given its classification.
+
+    Offline-evaluation traces (``environment == "evaluation"``) are skipped by
+    default so production detectors do not run on evaluation runs — preventing
+    detector noise and any detector→evaluation→detector recursion. A detector can
+    opt in via ``run_on_evaluation`` (reserved for an explicit future config); until
+    that flag exists on the detector, the default is to skip.
+    """
+    if summary.get("environment") == "evaluation":
+        return bool(detector.get("run_on_evaluation", False))
+    return True
+
+
 def _claim_and_enqueue(
     redis_client,
     project_id: str,
@@ -324,7 +338,8 @@ def _claim_and_enqueue(
         triggered_ids = [
             d["id"]
             for d in detectors
-            if _passes_trigger(summary, d["conditions"])
+            if _detector_runs_on_trace(summary, d)
+            and _passes_trigger(summary, d["conditions"])
             and _sample_passes(trace_id, d["id"], d["sample_rate"])
         ]
 

--- a/tests/rest/test_evaluation_exclusion_routers.py
+++ b/tests/rest/test_evaluation_exclusion_routers.py
@@ -1,0 +1,107 @@
+"""Every trace-derived endpoint must ask the reader to hide evaluation traces.
+
+The service-layer tests (``test_trace_reader_evaluations.py``) prove the SQL is right.
+These prove the routers actually REQUEST it: a router that forgets to forward
+``include_evaluations`` leaves the flag at the service default today, but the moment
+anyone flips a default or adds a positional argument the exclusion silently stops
+happening on that surface. Asserting the forwarded keyword pins the wiring.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rest.main import app
+from rest.routers.deps import ProjectAccessInfo, get_project_access
+from rest.routers.public.deps import AuthResult, authenticate_api_key
+
+EMPTY_PAGE = {"data": [], "meta": {"page": 0, "limit": 50, "total": 0}}
+SESSION_DETAIL = {
+    "session_id": "s1",
+    "traces": [],
+    "user_ids": [],
+    "trace_count": 0,
+    "first_trace_time": None,
+    "last_trace_time": None,
+    "duration_ms": None,
+    "total_input_tokens": None,
+    "total_output_tokens": None,
+    "total_cost": None,
+}
+
+
+@pytest.fixture()
+def reader():
+    return MagicMock()
+
+
+@pytest.fixture()
+def client(reader):
+    """TestClient with project access stubbed and the reader patched into every
+    router module under test (each imports the getter by name)."""
+    import rest.routers.public.traces_read as public_mod
+    import rest.routers.sessions as sessions_mod
+    import rest.routers.traces as traces_mod
+    import rest.routers.users as users_mod
+
+    async def mock_get_access(project_id: str, x_user_id=None):
+        return ProjectAccessInfo(
+            project_id=project_id,
+            user_id="test-user",
+            role="ADMIN",
+            workspace_id="ws-test",
+            billing_plan="enterprise",
+        )
+
+    async def mock_auth():
+        return AuthResult(
+            project_id="proj-A",
+            workspace_id="ws-test",
+            billing_plan="enterprise",
+            ingestion_blocked=False,
+        )
+
+    app.dependency_overrides[get_project_access] = mock_get_access
+    app.dependency_overrides[authenticate_api_key] = mock_auth
+
+    modules = (traces_mod, sessions_mod, users_mod, public_mod)
+    originals = [m.get_trace_reader_service for m in modules]
+    for m in modules:
+        m.get_trace_reader_service = lambda: reader
+
+    yield TestClient(app)
+
+    for m, original in zip(modules, originals, strict=True):
+        m.get_trace_reader_service = original
+    app.dependency_overrides.clear()
+
+
+# (url, reader attribute, return value) for each surface that lists/aggregates traces.
+SURFACES = [
+    ("/api/v1/projects/p1/traces", "list_traces", EMPTY_PAGE),
+    ("/api/v1/projects/p1/sessions", "list_sessions", EMPTY_PAGE),
+    ("/api/v1/projects/p1/sessions/s1", "get_session", SESSION_DETAIL),
+    ("/api/v1/projects/p1/users", "list_users", EMPTY_PAGE),
+    ("/api/v1/public/traces", "list_traces", EMPTY_PAGE),
+]
+
+
+@pytest.mark.parametrize(("url", "method", "payload"), SURFACES)
+def test_endpoint_excludes_evaluations_by_default(client, reader, url, method, payload):
+    getattr(reader, method).return_value = payload
+
+    resp = client.get(url)
+
+    assert resp.status_code == 200, resp.text
+    assert getattr(reader, method).call_args.kwargs["include_evaluations"] is False
+
+
+@pytest.mark.parametrize(("url", "method", "payload"), SURFACES)
+def test_endpoint_forwards_the_opt_in(client, reader, url, method, payload):
+    getattr(reader, method).return_value = payload
+
+    resp = client.get(url, params={"include_evaluations": "true"})
+
+    assert resp.status_code == 200, resp.text
+    assert getattr(reader, method).call_args.kwargs["include_evaluations"] is True

--- a/tests/rest/test_trace_reader_evaluations.py
+++ b/tests/rest/test_trace_reader_evaluations.py
@@ -1,0 +1,301 @@
+"""Offline-evaluation traces must be hidden from EVERY trace-derived read path.
+
+The SQL half of the feature. Same harness as ``test_trace_reader_filters.py``: a mocked
+ClickHouse client, asserting on the emitted query strings and bound parameters.
+
+Three invariants are load-bearing and each has its own test below.
+
+1. **Page/count parity.** ``list_traces``, ``list_sessions`` and ``list_users`` each run
+   two physically separate statements. If the exclusion reached only the paged statement,
+   ``meta.total`` would count traces the caller can never page to.
+
+2. **Monotonicity across batches.** Ingest sets ``is_evaluation`` monotonically *within* a
+   batch, but cannot do so *between* batches: a later batch carrying only non-eval-kind
+   spans of an evaluation trace rewrites the trace row with ``is_evaluation = 0`` and a
+   newer ``ch_update_time``. So the exclusion must NOT be a predicate over the deduped
+   *latest* row (``LIMIT 1 BY`` / ``argMax``) — such a batch landing last would un-hide the
+   trace. It is a trace_id set-membership instead: any row anywhere flagged 1 hides the
+   trace permanently, whatever order the writes arrived in.
+
+3. **No collision with user data.** The predicate keys off the ingest-set
+   ``is_evaluation`` flag, never off ``environment``. ``environment`` is the customer's own
+   free-text deployment tag, so a team that names a stack "evaluation" keeps every trace.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from rest.services.trace_reader import TraceReaderService
+
+# The shape _evaluation_exclusion() emits. Asserted as a literal so a refactor that
+# quietly turns it back into a latest-row comparison fails here.
+EXCLUSION = "t.trace_id NOT IN (SELECT trace_id FROM traces"
+
+
+def _service_with_mock_client():
+    svc = TraceReaderService.__new__(TraceReaderService)  # skip real-client __init__
+    svc._client = MagicMock()
+    return svc
+
+
+def _queries(svc):
+    """(sql, parameters) for every statement the call issued, in order."""
+    return [(c.args[0], c.kwargs.get("parameters", {})) for c in svc._client.query.call_args_list]
+
+
+def _exclusion_subselect(sql: str) -> str:
+    """The text of the ``NOT IN (...)`` sub-select, for monotonicity assertions."""
+    start = sql.index(EXCLUSION)
+    depth = 0
+    for i in range(start, len(sql)):
+        if sql[i] == "(":
+            depth += 1
+        elif sql[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return sql[start : i + 1]
+    raise AssertionError("unbalanced parentheses in exclusion sub-select")
+
+
+def _rows(*result_rows):
+    """Queue up one mock result per statement the method under test will run."""
+    out = []
+    for rows in result_rows:
+        m = MagicMock()
+        m.result_rows = list(rows)
+        out.append(m)
+    return out
+
+
+# ── list_traces ─────────────────────────────────────────────────────────
+
+
+class TestListTraces:
+    def test_exclusion_reaches_both_page_and_count(self):
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([], [[0]])
+
+        svc.list_traces(project_id="p1")
+
+        page_sql, _ = _queries(svc)[0]
+        count_sql, _ = _queries(svc)[1]
+        assert EXCLUSION in page_sql
+        assert EXCLUSION in count_sql  # the parity invariant
+        # ...and both exclude on the same thing, not just both mention a sub-select.
+        assert "is_evaluation = 1" in _exclusion_subselect(page_sql)
+        assert "is_evaluation = 1" in _exclusion_subselect(count_sql)
+
+    def test_include_evaluations_drops_the_predicate_entirely(self):
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([], [[0]])
+
+        svc.list_traces(project_id="p1", include_evaluations=True)
+
+        for sql, _ in _queries(svc):
+            assert EXCLUSION not in sql
+
+    def test_exclusion_is_monotonic_not_a_latest_row_predicate(self):
+        """The whole correctness argument. The sub-select reads EVERY row for the trace —
+        no ``LIMIT 1 BY``, no ``argMax``, no ``ch_update_time`` tie-break — so a later batch
+        that rewrites the trace row with ``is_evaluation = 0`` cannot un-hide it."""
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([], [[0]])
+
+        svc.list_traces(project_id="p1")
+
+        for sql, _ in _queries(svc):
+            sub = _exclusion_subselect(sql)
+            assert "LIMIT 1 BY" not in sub
+            assert "argMax" not in sub
+            assert "ch_update_time" not in sub
+
+    def test_no_latest_row_environment_comparison_survives(self):
+        """Guards against the earlier, broken formulation coming back: a NULL-safe
+        comparison against the deduped row (``environment IS NULL OR environment != ...``)
+        keeps exactly the shallow rows that defeat the exclusion."""
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([], [[0]])
+
+        svc.list_traces(project_id="p1")
+
+        for sql, _ in _queries(svc):
+            assert "environment IS NULL" not in sql
+            assert "argMax(t.environment" not in sql
+
+    def test_a_customer_environment_named_evaluation_is_not_hidden(self):
+        """REGRESSION for the data-loss bug. ``environment`` is user-controlled free text
+        — a team can legitimately run ``TRACEROOT_ENVIRONMENT=evaluation`` for a pre-prod
+        stack, and the filter dropdown will happily offer it next to ``production``. If
+        the exclusion keyed off that string their entire Traces list would empty out with
+        no in-product way back. The predicate must not mention ``environment`` at all: it
+        reads the ingest-set ``is_evaluation`` flag, which a customer cannot collide with
+        by naming a deployment."""
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([], [[0]])
+
+        svc.list_traces(project_id="p1")
+
+        for sql, _ in _queries(svc):
+            sub = _exclusion_subselect(sql)
+            # The user's deployment tag is never consulted...
+            assert "environment" not in sub
+            # ...the ingest-set flag is.
+            assert "is_evaluation = 1" in sub
+
+    def test_exclusion_reuses_the_callers_window(self):
+        """The sub-select prunes the same monthly partitions as the outer query."""
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([], [[0]])
+
+        svc.list_traces(
+            project_id="p1",
+            start_after=datetime(2026, 6, 1),
+            end_before=datetime(2026, 6, 2),
+        )
+
+        sub = _exclusion_subselect(_queries(svc)[0][0])
+        assert "start_after" in sub
+        assert "end_before" in sub
+
+
+# ── list_sessions ───────────────────────────────────────────────────────
+
+
+class TestListSessions:
+    """An eval run of 200 dataset items under one ``session_id`` must not surface in
+    Sessions as a 200-trace session whose cost lands in the project's spend."""
+
+    def test_exclusion_reaches_aggregate_and_count(self):
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([], [[0]])
+
+        svc.list_sessions(project_id="p1")
+
+        agg_sql, _ = _queries(svc)[0]
+        count_sql, _ = _queries(svc)[1]
+        assert EXCLUSION in agg_sql
+        assert EXCLUSION in count_sql
+        assert "is_evaluation = 1" in _exclusion_subselect(agg_sql)
+        assert "is_evaluation = 1" in _exclusion_subselect(count_sql)
+
+    def test_exclusion_reaches_the_io_backfill_query(self):
+        """A session with empty trace-level I/O falls back to span I/O via a THIRD
+        statement that builds its own traces scan — an evaluation trace must not be
+        allowed to supply the session's displayed input/output through that back door."""
+        svc = _service_with_mock_client()
+        # One session whose trace-level I/O is empty, so the backfill fires.
+        svc._client.query.side_effect = _rows(
+            [("s1", 1, [], None, None, None, None, None, None, "", "")],
+            [[1]],
+            [],
+        )
+
+        svc.list_sessions(project_id="p1")
+
+        sqls = [sql for sql, _ in _queries(svc)]
+        assert len(sqls) == 3, "expected the I/O backfill statement to run"
+        assert EXCLUSION in sqls[2]
+
+    def test_include_evaluations_drops_the_predicate(self):
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([], [[0]])
+
+        svc.list_sessions(project_id="p1", include_evaluations=True)
+
+        for sql, _ in _queries(svc):
+            assert EXCLUSION not in sql
+
+    def test_exclusion_is_monotonic(self):
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([], [[0]])
+
+        svc.list_sessions(project_id="p1")
+
+        for sql, _ in _queries(svc):
+            sub = _exclusion_subselect(sql)
+            assert "LIMIT 1 BY" not in sub
+            assert "ch_update_time" not in sub
+
+
+# ── get_session ─────────────────────────────────────────────────────────
+
+
+class TestGetSession:
+    def _trace_row(self):
+        return ("t1", "n", datetime(2026, 6, 1), None, "in", "out", 1.0, "ok")
+
+    def test_exclusion_present_by_default(self):
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([self._trace_row()], [(1, 2, 0.5)])
+
+        svc.get_session(project_id="p1", session_id="s1")
+
+        sql, _ = _queries(svc)[0]
+        assert EXCLUSION in sql
+        assert "is_evaluation = 1" in _exclusion_subselect(sql)
+
+    def test_include_evaluations_drops_the_predicate(self):
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([self._trace_row()], [(1, 2, 0.5)])
+
+        svc.get_session(project_id="p1", session_id="s1", include_evaluations=True)
+
+        sql, _ = _queries(svc)[0]
+        assert EXCLUSION not in sql
+
+    def test_evaluation_only_session_is_not_found(self):
+        """End-to-end consequence: if every trace in the session is excluded the detail
+        endpoint 404s rather than rendering an empty conversation."""
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([])
+
+        assert svc.get_session(project_id="p1", session_id="s1") is None
+
+
+# ── list_users ──────────────────────────────────────────────────────────
+
+
+class TestListUsers:
+    def test_exclusion_reaches_page_and_count(self):
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([], [[0]])
+
+        svc.list_users(project_id="p1")
+
+        page_sql, _ = _queries(svc)[0]
+        count_sql, _ = _queries(svc)[1]
+        assert EXCLUSION in page_sql
+        assert EXCLUSION in count_sql
+        assert "is_evaluation = 1" in _exclusion_subselect(page_sql)
+        assert "is_evaluation = 1" in _exclusion_subselect(count_sql)
+
+    def test_include_evaluations_drops_the_predicate(self):
+        svc = _service_with_mock_client()
+        svc._client.query.side_effect = _rows([], [[0]])
+
+        svc.list_users(project_id="p1", include_evaluations=True)
+
+        for sql, _ in _queries(svc):
+            assert EXCLUSION not in sql
+
+
+# ── every trace-derived read path is covered ────────────────────────────
+
+
+def test_all_trace_scanning_read_paths_exclude_evaluations_by_default():
+    """Catches the NEXT read path someone adds. Every public method that scans the
+    ``traces`` table must take ``include_evaluations`` and default it to False; if a new
+    aggregate view lands without it, this fails instead of silently double-counting.
+
+    ``get_trace`` / ``get_trace_spans_io`` / ``get_span_io`` are deliberately absent: they
+    are single-trace lookups by id, and an evaluation trace opened from a run's result
+    link must still resolve. Hiding a trace from the LISTS is the feature; making it
+    unopenable is not.
+    """
+    import inspect
+
+    for method_name in ("list_traces", "list_sessions", "get_session", "list_users"):
+        sig = inspect.signature(getattr(TraceReaderService, method_name))
+        param = sig.parameters.get("include_evaluations")
+        assert param is not None, f"{method_name} does not accept include_evaluations"
+        assert param.default is False, f"{method_name} does not default to excluding"

--- a/tests/worker/test_detector_tasks.py
+++ b/tests/worker/test_detector_tasks.py
@@ -374,3 +374,138 @@ class TestEvalConditionEnvironment:
             dt._eval_condition(summary, {"field": "environment", "op": "!=", "value": "staging"})
             is True
         )
+
+
+# ── Evaluation traces are skipped by detectors ──────────────────────────
+
+
+class TestEvaluationTraceSkip:
+    """The real assertion for the feature: an offline-evaluation trace must not enqueue
+    a BullMQ job. These drive ``enqueue_detector_runs`` end to end rather than calling
+    ``_detector_runs_on_trace`` in isolation — removing the guard from the comprehension
+    in ``_claim_and_enqueue`` has to make them fail, otherwise they prove nothing.
+    """
+
+    def test_evaluation_trace_enqueues_nothing_and_is_sticky(
+        self, fake_redis, mock_add_job, monkeypatch
+    ):
+        """No job, and the decision is recorded so a replay cannot re-roll it."""
+        _patch_detectors(monkeypatch, [_detector("d1", sample_rate=100)])
+        _patch_summaries(monkeypatch, {TRACE: {"environment": None, "is_evaluation": True}})
+
+        dt.enqueue_detector_runs(PROJECT, {TRACE})
+
+        mock_add_job.assert_not_called()
+        assert _lock_state(fake_redis)["state"] == "sampled_out"
+
+    def test_production_trace_still_enqueues(self, fake_redis, mock_add_job, monkeypatch):
+        """Control: the same detector on a non-evaluation trace DOES enqueue, so the
+        test above is attributable to the evaluation flag and not to a broken fixture."""
+        _patch_detectors(monkeypatch, [_detector("d1", sample_rate=100)])
+        _patch_summaries(
+            monkeypatch, {TRACE: {"environment": "production", "is_evaluation": False}}
+        )
+
+        dt.enqueue_detector_runs(PROJECT, {TRACE})
+
+        mock_add_job.assert_called_once()
+        assert _lock_state(fake_redis)["state"] == "pending"
+
+    def test_customer_environment_named_evaluation_still_enqueues(
+        self, fake_redis, mock_add_job, monkeypatch
+    ):
+        """REGRESSION: ``environment`` is user-controlled free text. A team that names a
+        real deployment "evaluation" must keep its detectors — the skip keys off the root
+        span's KIND, never off this string."""
+        _patch_detectors(monkeypatch, [_detector("d1", sample_rate=100)])
+        _patch_summaries(
+            monkeypatch, {TRACE: {"environment": "evaluation", "is_evaluation": False}}
+        )
+
+        dt.enqueue_detector_runs(PROJECT, {TRACE})
+
+        mock_add_job.assert_called_once()
+        assert _lock_state(fake_redis)["state"] == "pending"
+
+    def test_opted_in_detector_runs_on_evaluation_trace(
+        self, fake_redis, mock_add_job, monkeypatch
+    ):
+        detector = _detector("d1", sample_rate=100)
+        detector["run_on_evaluation"] = True
+        _patch_detectors(monkeypatch, [detector])
+        _patch_summaries(monkeypatch, {TRACE: {"is_evaluation": True}})
+
+        dt.enqueue_detector_runs(PROJECT, {TRACE})
+
+        mock_add_job.assert_called_once()
+
+    def test_mixed_batch_skips_only_the_evaluation_trace(
+        self, fake_redis, mock_add_job, monkeypatch
+    ):
+        """One eval trace in a batch must not suppress its neighbours."""
+        prod_trace = "bb" * 16
+        _patch_detectors(monkeypatch, [_detector("d1", sample_rate=100)])
+        _patch_summaries(
+            monkeypatch,
+            {
+                TRACE: {"is_evaluation": True},
+                prod_trace: {"is_evaluation": False},
+            },
+        )
+
+        dt.enqueue_detector_runs(PROJECT, {TRACE, prod_trace})
+
+        assert mock_add_job.call_count == 1
+        assert mock_add_job.call_args.args[1]["traceId"] == prod_trace
+
+    def test_summary_missing_the_flag_is_treated_as_non_evaluation(
+        self, fake_redis, mock_add_job, monkeypatch
+    ):
+        """Fail-open: a trace with no spans row (empty summary) keeps running detectors."""
+        _patch_detectors(monkeypatch, [_detector("d1", sample_rate=100)])
+        _patch_summaries(monkeypatch, {})
+
+        dt.enqueue_detector_runs(PROJECT, {TRACE})
+
+        mock_add_job.assert_called_once()
+
+
+class TestTraceSummaryEvaluationFlag:
+    """``is_evaluation`` must come from the ingest-set flag, aggregated monotonically."""
+
+    def _summaries(self, monkeypatch, result_rows):
+        captured = {}
+
+        class FakeCH:
+            def query(self, sql, parameters=None):
+                captured["sql"] = sql
+                captured["parameters"] = parameters
+                return MagicMock(result_rows=result_rows)
+
+        monkeypatch.setattr(
+            "db.clickhouse.client.get_clickhouse_client", lambda: FakeCH(), raising=False
+        )
+        summaries = dt._get_trace_summaries(PROJECT, [TRACE])
+        return summaries, captured
+
+    def test_flag_comes_from_is_evaluation_not_environment(self, monkeypatch):
+        summaries, captured = self._summaries(monkeypatch, [(TRACE, "production", 1)])
+
+        assert summaries[TRACE]["is_evaluation"] is True
+        sql = captured["sql"]
+        # Aggregated over ALL the trace's spans, not read off the root. OTel exports a
+        # span when it ENDS, so the EVALUATION root is normally the LAST span to arrive —
+        # a root-keyed read would answer "not an evaluation" until then, and forever if
+        # the eval process dies first. max() is also monotonic: no row can clear it.
+        assert "max(is_evaluation)" in sql
+        assert "parent_span_id IS NULL AND span_kind" not in sql
+        # The flag must NOT be derived from the user-controlled environment string.
+        assert "environment = 'evaluation'" not in sql
+
+    def test_unflagged_trace_yields_false_even_when_named_evaluation(self, monkeypatch):
+        summaries, _ = self._summaries(monkeypatch, [(TRACE, "evaluation", 0)])
+
+        # environment says "evaluation" (a customer's own deployment naming) but the
+        # ingest flag does not — the trace is NOT an evaluation trace.
+        assert summaries[TRACE]["is_evaluation"] is False
+        assert summaries[TRACE]["environment"] == "evaluation"


### PR DESCRIPTION
## Summary

Fixes: #1650

Evaluation runs should never pollute production trace views or alerting. This excludes offline-evaluation traces from the default trace list and skips them in detector runs, keyed off the `is_evaluation` flag that ingest already sets — so nothing has to re-derive eval membership span by span. The list filter runs after the ReplacingMergeTree dedup, and its pagination count uses the same predicate, so totals reflect only the visible non-eval set.

## How it works

```
list query
  → dedup ReplacingMergeTree rows to the latest version per trace
    → drop traces with any is_evaluation = 1 row (UInt8 DEFAULT 0, never NULL)
      → page + count over the surviving non-eval rows
```

The exclusion is a `trace_id` set membership, not a predicate on the deduped row: ingest can only make the flag monotonic *within* a batch, so a later batch carrying only non-eval leaves rewrites the trace row with `is_evaluation = 0` and a newer `ch_update_time`. Reading the deduped latest row would un-hide the trace the moment such a batch landed. Any row anywhere flagged 1 hides the trace permanently, whatever order the writes arrived in — which also makes it safe in the shared where-clause, so the page and count queries agree by construction.

## What's included

### Backend (Python)
- `backend/rest/services/trace_reader.py` — `include_evaluations` flag on the traces-list query; excludes `environment = 'evaluation'` traces after the dedup pass (NULL-safe, keeping untagged production traces), and applies the identical predicate to the total-count query so pagination totals match the visible set.
- `backend/rest/routers/traces.py` — exposes an `include_evaluations` query param (default `false`) on the internal traces-list route.
- `backend/rest/routers/public/traces_read.py` — exposes the same `include_evaluations` param (default `false`) on the public traces-read route.
- `backend/worker/detector_tasks.py` — `_detector_runs_on_trace` skips traces classified `environment == "evaluation"` by default (opt-in reserved via a detector's `run_on_evaluation` flag), so detector scheduling never fires on synthetic candidate output and eval volume never inflates queue depth.
- `backend/rest/openapi/public.json` — part of this change.
- `backend/rest/routers/sessions.py` — Session query endpoints (user-authenticated, not public API).
- `backend/rest/routers/users.py` — User query endpoints (user-authenticated, not public API).

### Tests
- `tests/rest/test_evaluation_exclusion_routers.py` — Every trace-derived endpoint must ask the reader to hide evaluation traces. The service-layer tests (``test_trace_reader_evaluations.py``) prove the SQL is right.
- `tests/rest/test_trace_reader_evaluations.py` — Offline-evaluation traces must be hidden from EVERY trace-derived read path. The SQL half of the feature.
- `tests/worker/test_detector_tasks.py` — Unit tests for the exactly-once detector enqueue path (Redis lock + BullMQ).

## Test plan
- [ ] Confirm the default trace list does not show evaluation traces.
- [ ] Confirm detectors do not fire on evaluation traces by default.
- [ ] Verify the exclusion runs post-dedup and leaves non-eval traces untouched.
- [ ] A project with only evaluation traces shows an empty (not broken) default list.
- [ ] The opt-in path (`include_evaluations=true`) returns evaluation traces unfiltered.
- [ ] Trace-list pagination totals count only visible non-eval traces.
- [ ] Detector scheduling excludes evaluation traces, so queue depth is not inflated by eval volume.
