### PR TITLE
feat(evaluations): runs-list read model

### DIFF
--- a/frontend/packages/core/prisma/migrations/20260731000000_add_eval_read_model_indexes/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260731000000_add_eval_read_model_indexes/migration.sql
@@ -1,0 +1,13 @@
+-- CreateIndex: the runs list is `where project_id = ? [and evaluation_id = ?]
+-- [and dataset_id = ?] order by started_at desc` with offset pagination. With only
+-- the single-column project_id index, every page fetches the whole matching history
+-- and top-N-sorts it, so a page costs O(project run count) instead of O(page size).
+-- Descending to match the ordering exactly, turning pagination into an index scan.
+CREATE INDEX "ix_evaluation_run_project_started_at" ON "evaluation_runs"("project_id", "started_at" DESC);
+CREATE INDEX "ix_evaluation_run_evaluation_started_at" ON "evaluation_runs"("evaluation_id", "started_at" DESC);
+
+-- CreateIndex: the dataset filter on the same list had no index on this table at all.
+CREATE INDEX "ix_evaluation_run_dataset_started_at" ON "evaluation_runs"("dataset_id", "started_at" DESC);
+
+-- CreateIndex: the lineage aggregate sums cost and duration grouped by evaluation_id.
+CREATE INDEX "ix_evaluation_result_evaluation_id" ON "evaluation_results"("evaluation_id");

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -609,6 +609,15 @@ model EvaluationRun {
   // also serves the per-evaluation run list.
   @@unique([evaluationId, runNumber], map: "uq_run_evaluation_run_number")
   @@index([projectId], map: "ix_evaluation_run_project_id")
+  // The runs list is `where project_id = ? [and evaluation_id = ?] order by
+  // started_at desc` with skip/take. On the single-column indexes alone every page
+  // fetches the whole matching history and top-N-sorts it, so cost grows with the
+  // project's run count rather than the page size. Descending to match the ordering
+  // exactly, so pagination becomes a plain index scan.
+  @@index([projectId, startedAt(sort: Desc)], map: "ix_evaluation_run_project_started_at")
+  @@index([evaluationId, startedAt(sort: Desc)], map: "ix_evaluation_run_evaluation_started_at")
+  // The dataset filter on the same list had no index on this table at all.
+  @@index([datasetId, startedAt(sort: Desc)], map: "ix_evaluation_run_dataset_started_at")
   @@map("evaluation_runs")
 }
 
@@ -641,6 +650,9 @@ model EvaluationResult {
   @@unique([runId, testCaseId], map: "uq_result_run_test_case")
   @@index([projectId], map: "ix_evaluation_result_project_id")
   @@index([traceId], map: "ix_evaluation_result_trace_id")
+  // The lineage aggregate sums cost and duration grouped by evaluation_id; without
+  // this it is a project-wide scan of the results table.
+  @@index([evaluationId], map: "ix_evaluation_result_evaluation_id")
   @@map("evaluation_results")
 }
 

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/route.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Evaluation-lineage list: each stable evaluation with its run count and latest run,
+ * plus the dataset NAME resolved in one batched query (never one lookup per lineage)
+ * and scoped to the project so a stale datasetId reads as null. Auth + Prisma mocked.
+ */
+import { it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  evaluation: { findMany: vi.fn() },
+  dataset: { findMany: vi.fn() },
+  // Each lineage carries an aggregate row derived at read time (average score over
+  // the runs that were actually scored, plus summed cost/duration over its results).
+  evaluationRun: { groupBy: vi.fn() },
+  evaluationResult: { groupBy: vi.fn() },
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return { ...actual, prisma: prismaMock };
+});
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET } from "./route";
+
+const params = { params: Promise.resolve({ projectId: "p1" }) };
+
+function evaluation(over: Record<string, unknown> = {}) {
+  return {
+    id: "eval_1",
+    projectId: "p1",
+    name: "ticket-routing",
+    datasetId: "ds1",
+    _count: { runs: 4 },
+    runs: [
+      {
+        id: "run_4",
+        runNumber: 4,
+        candidateVersion: "sonnet",
+        status: "completed",
+        mainScore: 0.75,
+        startedAt: new Date("2026-07-21T00:00:00Z"),
+        datasetVersionId: "dv2",
+      },
+    ],
+    ...over,
+  };
+}
+
+async function rows(res: { json: () => Promise<unknown> }) {
+  return ((await res.json()) as { data: Record<string, unknown>[] }).data;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+  prismaMock.dataset.findMany.mockResolvedValue([{ id: "ds1", name: "support" }]);
+  // No aggregate rows unless a case sets them: a lineage with no scored run reports
+  // nulls rather than a fabricated zero.
+  prismaMock.evaluationRun.groupBy.mockResolvedValue([]);
+  prismaMock.evaluationResult.groupBy.mockResolvedValue([]);
+});
+
+it("returns each lineage with its dataset name, run count, and latest run", async () => {
+  prismaMock.evaluation.findMany.mockResolvedValue([evaluation()]);
+
+  const res = await GET({} as never, params);
+  expect(res.status).toBe(200);
+  const row = (await rows(res))[0];
+  expect(row).toMatchObject({ id: "eval_1", datasetName: "support", runCount: 4 });
+  expect(row.latestRun).toMatchObject({ id: "run_4", runNumber: 4 });
+});
+
+it("reports a null latest run for a lineage that has never run", async () => {
+  prismaMock.evaluation.findMany.mockResolvedValue([evaluation({ runs: [], _count: { runs: 0 } })]);
+  const row = (await rows(await GET({} as never, params)))[0];
+  expect(row.latestRun).toBeNull();
+  expect(row.runCount).toBe(0);
+});
+
+it("resolves every distinct dataset in a single batched query", async () => {
+  prismaMock.evaluation.findMany.mockResolvedValue([
+    evaluation(),
+    evaluation({ id: "eval_2" }), // same dataset — must not add a query or a duplicate id
+    evaluation({ id: "eval_3", datasetId: "ds2" }),
+  ]);
+  prismaMock.dataset.findMany.mockResolvedValue([
+    { id: "ds1", name: "support" },
+    { id: "ds2", name: "billing" },
+  ]);
+
+  const data = await rows(await GET({} as never, params));
+  expect(data.map((r) => r.datasetName)).toEqual(["support", "support", "billing"]);
+  expect(prismaMock.dataset.findMany).toHaveBeenCalledTimes(1);
+  expect(prismaMock.dataset.findMany.mock.calls[0][0].where).toEqual({
+    id: { in: ["ds1", "ds2"] },
+    projectId: "p1",
+  });
+});
+
+it("reports a null dataset name when the dataset is missing from this project", async () => {
+  prismaMock.evaluation.findMany.mockResolvedValue([evaluation({ datasetId: "ds_gone" })]);
+  prismaMock.dataset.findMany.mockResolvedValue([]);
+  expect((await rows(await GET({} as never, params)))[0].datasetName).toBeNull();
+});
+
+it("returns an empty list and skips the dataset query when there are no lineages", async () => {
+  prismaMock.evaluation.findMany.mockResolvedValue([]);
+  expect(await rows(await GET({} as never, params))).toEqual([]);
+  expect(prismaMock.dataset.findMany).not.toHaveBeenCalled();
+});
+
+it("401s an unauthenticated caller before touching the database", async () => {
+  auth.requireAuth.mockResolvedValue({
+    error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+  });
+  expect((await GET({} as never, params)).status).toBe(401);
+  expect(prismaMock.evaluation.findMany).not.toHaveBeenCalled();
+});
+
+it("403s a caller without project access", async () => {
+  auth.requireProjectAccess.mockResolvedValue({
+    error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+  });
+  expect((await GET({} as never, params)).status).toBe(403);
+  expect(prismaMock.evaluation.findMany).not.toHaveBeenCalled();
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/route.ts
@@ -43,12 +43,58 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
       : [];
   const datasetName = new Map(datasets.map((d) => [d.id, d.name]));
 
-  const data = evaluations.map((e) => ({
-    ...e,
-    datasetName: datasetName.get(e.datasetId) ?? null,
-    runCount: e._count.runs,
-    latestRun: e.runs[0] ?? null,
-  }));
+  // Lineage aggregate, derived at read time like every other eval number. Two grouped
+  // queries for the whole list, never a per-lineage round trip.
+  //
+  // `_avg.mainScore` and `_count.mainScore` both ignore null, so the average covers
+  // only runs that were actually scored and `scoredRunCount` reports that denominator.
+  // Averaging over every run instead would drag a lineage toward 0 for runs that were
+  // never judged — a quality collapse that never happened.
+  const evaluationIds = evaluations.map((e) => e.id);
+  const [runAggregates, resultAggregates] =
+    evaluationIds.length > 0
+      ? await Promise.all([
+          prisma.evaluationRun.groupBy({
+            by: ["evaluationId"],
+            where: { projectId, evaluationId: { in: evaluationIds } },
+            _avg: { mainScore: true },
+            _count: { mainScore: true },
+          }),
+          // Cost and duration live per case, so the lineage totals sum the results.
+          // `durationMs` is summed case time, matching how the runs list derives an
+          // in-flight run's elapsed — not wall clock, which would count idle gaps.
+          prisma.evaluationResult.groupBy({
+            by: ["evaluationId"],
+            where: { projectId, evaluationId: { in: evaluationIds } },
+            _sum: { cost: true, durationMs: true },
+          }),
+        ])
+      : [[], []];
+  const runAggByEvaluation = new Map(runAggregates.map((a) => [a.evaluationId, a]));
+  const resultAggByEvaluation = new Map(resultAggregates.map((a) => [a.evaluationId, a]));
+
+  const data = evaluations.map((e) => {
+    const latestRun = e.runs[0] ?? null;
+    const runAgg = runAggByEvaluation.get(e.id);
+    const resultAgg = resultAggByEvaluation.get(e.id);
+    return {
+      ...e,
+      datasetName: datasetName.get(e.datasetId) ?? null,
+      runCount: e._count.runs,
+      latestRun,
+      aggregate: {
+        runCount: e._count.runs,
+        scoredRunCount: runAgg?._count.mainScore ?? 0,
+        // Null rather than 0 when no run in the lineage was ever scored.
+        averageMainScore: runAgg?._avg.mainScore ?? null,
+        totalCost: resultAgg?._sum.cost ?? null,
+        totalDurationMs: resultAgg?._sum.durationMs ?? null,
+        // Latest by the same run ordering the list already uses (startedAt desc).
+        latestStatus: latestRun?.status ?? null,
+        latestStartedAt: latestRun?.startedAt ?? null,
+      },
+    };
+  });
 
   return successResponse({ data });
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Run/result read-back validation (Phase H).
+ *
+ * A reported run, read back through the run-detail route, must expose: the exact
+ * dataset version, candidate version, run identity, each result's trace id, scores
+ * with INDEPENDENT scorer errors, the task error, the run status/finality, human
+ * scores, and the baseline relationship. prisma is mocked with a fully-formed run
+ * (the route uses nested `include`), so this asserts the route's exposure + derived
+ * fields, not the storage engine.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+const db = vi.hoisted(() => ({
+  run: null as unknown,
+  baseline: null as unknown,
+  dataset: null as unknown,
+}));
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return {
+    ...actual,
+    prisma: {
+      // The route fetches the candidate (id run1) and then the baseline (id run0).
+      evaluationRun: {
+        findFirst: vi.fn(async (args: { where: { id: string } }) =>
+          args.where.id === "run0" ? db.baseline : args.where.id === "run1" ? db.run : null,
+        ),
+      },
+      dataset: { findFirst: vi.fn(async () => db.dataset) },
+    },
+  };
+});
+
+import { GET } from "./route";
+
+const PROJECT_ID = "p1";
+const params = (runId: string) => ({
+  params: Promise.resolve({ projectId: PROJECT_ID, runId }),
+});
+
+beforeEach(() => {
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1", email: "e@x.com" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: PROJECT_ID } });
+  db.dataset = { id: "ds1", name: "Billing routing" };
+  db.run = {
+    id: "run1",
+    projectId: PROJECT_ID,
+    evaluationId: "eval1",
+    datasetId: "ds1",
+    datasetVersionId: "dv12",
+    runNumber: 27,
+    candidateVersion: "git:4a91c02",
+    status: "completed_with_errors",
+    mainScore: 0.9,
+    mainScoreName: "routing-accuracy",
+    caseCount: 3,
+    scoredCount: 2,
+    taskErrorCount: 1,
+    scorerErrorCount: 1,
+    baselineRunId: "run0",
+    scorers: [{ name: "routing-accuracy", version: "v3" }],
+    evaluation: { name: "Billing routing" },
+    datasetVersion: { label: "v12" },
+    baselineRun: {
+      id: "run0",
+      runNumber: 26,
+      candidateVersion: "git:0000000",
+      mainScore: 0.75,
+      evaluationId: "eval1",
+      datasetVersionId: "dv12", // same version → comparable
+      datasetVersion: { label: "v12" },
+    },
+    results: [
+      {
+        id: "res1",
+        runId: "run1",
+        testCaseId: "case-1",
+        traceId: "tr_abc",
+        status: "passed",
+        mainScore: 1,
+        taskError: null,
+        candidateOutput: "billing",
+        scores: [
+          {
+            id: "s1",
+            scorerName: "routing-accuracy",
+            scorerVersion: "v3",
+            numericValue: 1,
+            error: null,
+          },
+          // Independent scorer error: value null, error set — never a zero.
+          {
+            id: "s2",
+            scorerName: "helpfulness",
+            scorerVersion: "v2",
+            numericValue: null,
+            error: "Judge returned malformed JSON",
+          },
+        ],
+        humanScores: [
+          { id: "h1", verdict: "pass", quality: 4, comment: "looks right", reviewer: "e@x.com" },
+        ],
+      },
+      {
+        id: "res2",
+        runId: "run1",
+        testCaseId: "case-2",
+        traceId: null,
+        status: "errored",
+        mainScore: null,
+        // Task error: the application failed, distinct from a scorer error.
+        taskError: "ToolTimeout: lookup_invoice timed out",
+        candidateOutput: null,
+        scores: [],
+        humanScores: [],
+      },
+    ],
+  };
+  // The baseline run (fetched separately by the route) with raw results/scores that
+  // pair on the main scorer so the derived comparison is trustworthy.
+  db.baseline = {
+    id: "run0",
+    projectId: PROJECT_ID,
+    evaluationId: "eval1",
+    datasetId: "ds1",
+    datasetVersionId: "dv12",
+    runNumber: 26,
+    candidateVersion: "git:0000000",
+    status: "completed",
+    baselineRunId: null,
+    mainScore: 0.75,
+    mainScoreName: "routing-accuracy",
+    scorers: [{ name: "routing-accuracy", version: "v3" }],
+    results: [
+      {
+        testCaseId: "case-1",
+        status: "passed",
+        mainScore: 0.5,
+        candidateOutput: "billing",
+        durationMs: 700,
+        scores: [
+          { scorerName: "routing-accuracy", scorerVersion: "v3", numericValue: 0.5, error: null },
+        ],
+      },
+      {
+        testCaseId: "case-2",
+        status: "passed",
+        mainScore: 1,
+        candidateOutput: "technical",
+        durationMs: 720,
+        scores: [
+          { scorerName: "routing-accuracy", scorerVersion: "v3", numericValue: 1, error: null },
+        ],
+      },
+    ],
+  };
+});
+
+async function read(runId = "run1") {
+  const res = await GET({} as never, params(runId));
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe("run/result read-back", () => {
+  it("exposes run identity, exact dataset version, candidate, and status/finality", async () => {
+    const { status, body } = await read();
+    expect(status).toBe(200);
+    const run = body.run as Record<string, unknown>;
+    expect(run.id).toBe("run1");
+    expect(run.runNumber).toBe(27);
+    expect(run.datasetVersionId).toBe("dv12");
+    expect(run.datasetVersionLabel).toBe("v12");
+    expect(run.candidateVersion).toBe("git:4a91c02");
+    expect(run.status).toBe("completed_with_errors");
+    expect(run.errorCount).toBe(2); // taskErrorCount + scorerErrorCount
+  });
+
+  it("exposes the baseline relationship and comparable delta", async () => {
+    const run = (await read()).body.run as Record<string, unknown>;
+    expect(run.baselineRunId).toBe("run0");
+    expect(run.baselineComparable).toBe(true);
+    expect(run.changeFromBaseline).toBeCloseTo(0.15); // 0.9 - 0.75
+  });
+
+  it("exposes result trace id, task error, scores with independent scorer errors, and human scores", async () => {
+    const results = (await read()).body.results as Array<Record<string, unknown>>;
+    expect(results).toHaveLength(2);
+
+    const passed = results.find((r) => r.testCaseId === "case-1")!;
+    expect(passed.traceId).toBe("tr_abc");
+    const scores = passed.scores as Array<Record<string, unknown>>;
+    const helpfulness = scores.find((s) => s.scorerName === "helpfulness")!;
+    expect(helpfulness.error).toContain("malformed JSON");
+    expect(helpfulness.numericValue).toBeNull(); // scorer error is not a zero
+    expect((passed.humanScores as unknown[]).length).toBe(1);
+
+    const errored = results.find((r) => r.testCaseId === "case-2")!;
+    expect(errored.status).toBe("errored");
+    expect(errored.taskError).toContain("ToolTimeout");
+    expect(errored.candidateOutput).toBeNull();
+    expect((errored.scores as unknown[]).length).toBe(0);
+  });
+
+  it("marks an incompatible baseline (different dataset version) as not comparable", async () => {
+    (db.baseline as { datasetVersionId: string }).datasetVersionId = "dv11";
+    const run = (await read()).body.run as Record<string, unknown>;
+    expect(run.baselineComparable).toBe(false);
+    expect(run.changeFromBaseline).toBeNull();
+    expect((run.comparison as { reasons: string[] }).reasons).toContain(
+      "different_dataset_version",
+    );
+  });
+
+  it("404s an unknown run", async () => {
+    db.run = null;
+    expect((await read("missing")).status).toBe(404);
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.test.ts
@@ -1,8 +1,9 @@
 /**
- * Run-detail shaping: a baseline delta is only computed when the baseline run
- * measured the identical population (same evaluation + same dataset snapshot);
- * otherwise the UI must get `changeFromBaseline: null` and `baselineComparable:
- * false` so it warns instead of subtracting incompatible numbers.
+ * Run-detail derivation: the read path derives candidate-vs-baseline comparison from
+ * the two runs' raw results/scores (never the stored change/baselineOutput columns),
+ * exposing a `comparison` block and per-result comparison. A back-compat scalar delta
+ * is null unless the comparison is trustworthy, so the UI never subtracts incompatible
+ * numbers. Auth + Prisma are mocked.
  */
 import { it, expect, vi, beforeEach } from "vitest";
 
@@ -27,66 +28,181 @@ import { GET } from "./route";
 
 const params = { params: Promise.resolve({ projectId: "p1", runId: "run-1" }) };
 
-function baseRun(baselineRun: unknown) {
+function score(name: string, numericValue: number | null, error: string | null = null) {
+  return {
+    scorerName: name,
+    scorerVersion: "unversioned",
+    numericValue,
+    boolValue: null,
+    stringValue: null,
+    error,
+  };
+}
+
+/** A candidate run with two cases, main scorer `acc`; one case regresses vs baseline. */
+function candidate(over: Record<string, unknown> = {}) {
   return {
     id: "run-1",
     projectId: "p1",
     evaluationId: "eval-1",
     datasetId: "ds1",
     datasetVersionId: "dv2",
-    mainScore: 90,
+    runNumber: 2,
+    candidateVersion: "sonnet",
+    status: "completed",
+    baselineRunId: "run-0",
+    mainScore: 0.5,
+    mainScoreName: "acc",
     taskErrorCount: 0,
     scorerErrorCount: 0,
+    scorers: [{ name: "acc", version: "unversioned" }],
+    startedAt: new Date("2026-07-21T00:00:00Z"),
+    completedAt: new Date("2026-07-21T00:00:04Z"),
     evaluation: { name: "Billing routing" },
     datasetVersion: { label: "v2" },
-    baselineRun,
-    results: [],
+    baselineRun: {
+      id: "run-0",
+      runNumber: 1,
+      candidateVersion: "opus",
+      mainScore: 1,
+      evaluationId: "eval-1",
+      datasetVersionId: "dv2",
+      datasetVersion: { label: "v2" },
+    },
+    results: [
+      {
+        id: "r_a",
+        testCaseId: "t0",
+        traceId: "tr_a",
+        input: "a",
+        expectedOutput: "billing",
+        candidateOutput: "billing",
+        status: "passed",
+        mainScore: 1,
+        change: "improved",
+        baselineOutput: "STORED-IGNORED",
+        taskError: null,
+        durationMs: 900,
+        cost: null,
+        scores: [score("acc", 1)],
+        humanScores: [],
+      },
+      {
+        id: "r_b",
+        testCaseId: "t5",
+        traceId: "tr_b",
+        input: "b",
+        expectedOutput: "technical",
+        candidateOutput: "general",
+        status: "passed",
+        mainScore: 0,
+        change: "unchanged",
+        baselineOutput: null,
+        taskError: null,
+        durationMs: 1000,
+        cost: null,
+        scores: [score("acc", 0)],
+        humanScores: [],
+      },
+    ],
+    ...over,
+  };
+}
+
+function baseline(over: Record<string, unknown> = {}) {
+  return {
+    id: "run-0",
+    projectId: "p1",
+    evaluationId: "eval-1",
+    datasetId: "ds1",
+    datasetVersionId: "dv2",
+    runNumber: 1,
+    candidateVersion: "opus",
+    status: "completed",
+    baselineRunId: null,
+    mainScore: 1,
+    mainScoreName: "acc",
+    scorers: [{ name: "acc", version: "unversioned" }],
+    results: [
+      {
+        testCaseId: "t0",
+        status: "passed",
+        mainScore: 1,
+        candidateOutput: "billing",
+        durationMs: 800,
+        scores: [score("acc", 1)],
+      },
+      {
+        testCaseId: "t5",
+        status: "passed",
+        mainScore: 1,
+        candidateOutput: "technical",
+        durationMs: 850,
+        scores: [score("acc", 1)],
+      },
+    ],
+    ...over,
   };
 }
 
 beforeEach(() => {
+  prismaMock.evaluationRun.findFirst.mockReset();
+  prismaMock.dataset.findFirst.mockReset();
   auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
   auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
   prismaMock.dataset.findFirst.mockResolvedValue({ id: "ds1", name: "Billing routing" });
 });
 
-it("computes a delta when the baseline shares the same evaluation and snapshot", async () => {
-  prismaMock.evaluationRun.findFirst.mockResolvedValue(
-    baseRun({
-      id: "run-0",
-      mainScore: 70,
-      evaluationId: "eval-1",
-      datasetVersionId: "dv2",
-      datasetVersion: { label: "v2" },
-    }),
-  );
-  const body = (await (await GET({} as never, params)).json()) as Record<string, never>;
-  const run = body.run as unknown as { changeFromBaseline: number; baselineComparable: boolean };
-  expect(run.baselineComparable).toBe(true);
-  expect(run.changeFromBaseline).toBe(20);
+it("derives change/baselineOutput + a comparison block from raw scores; ignores stored columns", async () => {
+  prismaMock.evaluationRun.findFirst
+    .mockResolvedValueOnce(candidate())
+    .mockResolvedValueOnce(baseline());
+  const body = (await (await GET({} as never, params)).json()) as {
+    run: Record<string, unknown>;
+    results: Record<string, unknown>[];
+  };
+
+  const cmp = body.run.comparison as Record<string, unknown>;
+  expect(cmp.available).toBe(true);
+  expect(cmp.trustworthy).toBe(true);
+  expect((cmp.mainScore as { delta: number }).delta).toBeCloseTo(-0.5);
+  expect(cmp.caseCounts).toMatchObject({ regressed: 1, unchanged: 1 });
+  expect(body.run.changeFromBaseline).toBeCloseTo(-0.5);
+  expect(body.run.baselineComparable).toBe(true);
+  expect(body.run.elapsedMs).toBe(4000);
+
+  const t0 = body.results.find((r) => r.testCaseId === "t0")!;
+  expect(t0.change).toBe("unchanged");
+  expect(t0.baselineOutput).toBe("billing"); // derived, NOT the stored "STORED-IGNORED"
+  const t5 = body.results.find((r) => r.testCaseId === "t5")!;
+  expect(t5.change).toBe("regressed"); // stored said "unchanged"
+  expect((t5.comparison as { regressedCellCount: number }).regressedCellCount).toBe(1);
 });
 
-it("refuses a delta when the baseline used a different dataset snapshot", async () => {
-  prismaMock.evaluationRun.findFirst.mockResolvedValue(
-    baseRun({
-      id: "run-0",
-      mainScore: 70,
-      evaluationId: "eval-1",
-      datasetVersionId: "dv1", // different snapshot
-      datasetVersion: { label: "v1" },
-    }),
+it("refuses a scalar delta when the baseline used a different dataset snapshot", async () => {
+  prismaMock.evaluationRun.findFirst
+    .mockResolvedValueOnce(candidate())
+    .mockResolvedValueOnce(baseline({ datasetVersionId: "dv1" }));
+  const body = (await (await GET({} as never, params)).json()) as { run: Record<string, unknown> };
+  expect(body.run.baselineComparable).toBe(false);
+  expect(body.run.changeFromBaseline).toBeNull();
+  expect((body.run.comparison as { reasons: string[] }).reasons).toContain(
+    "different_dataset_version",
   );
-  const body = (await (await GET({} as never, params)).json()) as Record<string, never>;
-  const run = body.run as unknown as {
-    changeFromBaseline: number | null;
-    baselineComparable: boolean;
-  };
-  expect(run.baselineComparable).toBe(false);
-  expect(run.changeFromBaseline).toBeNull();
+});
+
+it("reports no baseline when none is linked", async () => {
+  prismaMock.evaluationRun.findFirst.mockResolvedValueOnce(
+    candidate({ baselineRunId: null, baselineRun: null }),
+  );
+  const body = (await (await GET({} as never, params)).json()) as { run: Record<string, unknown> };
+  expect(body.run.baselineComparable).toBe(false);
+  expect(body.run.changeFromBaseline).toBeNull();
+  expect((body.run.comparison as { reasons: string[] }).reasons).toEqual(["no_baseline"]);
 });
 
 it("404s an unknown run", async () => {
-  prismaMock.evaluationRun.findFirst.mockResolvedValue(null);
+  prismaMock.evaluationRun.findFirst.mockResolvedValueOnce(null);
   const res = await GET({} as never, params);
   expect(res.status).toBe(404);
 });

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
@@ -6,10 +6,19 @@ import {
   errorResponse,
   successResponse,
 } from "@/lib/auth-helpers";
+import { compareRuns } from "@/lib/eval/comparison";
+import { toComparisonRun, toComparisonResults, caseChangeToLegacy } from "@/lib/eval/comparison-db";
 
 type RouteParams = { params: Promise<{ projectId: string; runId: string }> };
 
-// GET — a single evaluation run with its results, scores, and human scores.
+function elapsedMs(startedAt: Date, completedAt: Date | null): number | null {
+  if (!completedAt) return null;
+  const ms = completedAt.getTime() - startedAt.getTime();
+  return ms >= 0 ? ms : null;
+}
+
+// GET — a single evaluation run with its results, scores, human scores, and the
+// backend-derived candidate-vs-baseline comparison (the single source of truth).
 export async function GET(_req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
@@ -44,32 +53,64 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
   });
   if (!run) return errorResponse("Evaluation run not found", 404);
 
+  // The baseline's raw results + scores, in one bounded query (no per-row N+1).
+  const baselineRun = run.baselineRunId
+    ? await prisma.evaluationRun.findFirst({
+        where: { id: run.baselineRunId, projectId },
+        include: { results: { include: { scores: true } } },
+      })
+    : null;
+
   const dataset = await prisma.dataset.findFirst({
     where: { id: run.datasetId, projectId },
     select: { id: true, name: true },
   });
 
-  // Baseline delta only when the two runs measured the identical population.
-  const baseline = run.baselineRun;
-  const comparable =
-    !!baseline &&
-    baseline.evaluationId === run.evaluationId &&
-    baseline.datasetVersionId === run.datasetVersionId;
-  const changeFromBaseline =
-    comparable && run.mainScore !== null && baseline!.mainScore !== null
-      ? run.mainScore - baseline!.mainScore
-      : null;
+  // Derive the comparison from the two runs' raw results/scores — never the stored
+  // change/baselineOutput columns.
+  const { comparison, results: resultComparisons } = compareRuns({
+    candidate: toComparisonRun(run),
+    candidateResults: toComparisonResults(run.results),
+    baseline: baselineRun ? toComparisonRun(baselineRun) : null,
+    baselineResults: baselineRun ? toComparisonResults(baselineRun.results) : [],
+  });
+  const cmpByCase = new Map(resultComparisons.map((c) => [c.testCaseId, c]));
 
-  const { results, ...runFields } = run;
+  const results = run.results.map((r) => {
+    const cmp = cmpByCase.get(r.testCaseId);
+    return {
+      ...r,
+      // Derived values win over the stored columns.
+      change: cmp ? caseChangeToLegacy(cmp.caseChange) : null,
+      baselineOutput: cmp ? cmp.baselineOutput : null,
+      comparison: cmp
+        ? {
+            caseChange: cmp.caseChange,
+            pairing: cmp.pairing,
+            mainScore: cmp.mainScore,
+            scorerCells: cmp.scorerCells,
+            regressedCellCount: cmp.regressedCellCount,
+            comparableCellCount: cmp.comparableCellCount,
+          }
+        : null,
+    };
+  });
+
+  const { results: _omit, ...runFields } = run;
   return successResponse({
     run: {
       ...runFields,
       evaluationName: run.evaluation.name,
       datasetName: dataset?.name ?? null,
       datasetVersionLabel: run.datasetVersion.label,
-      changeFromBaseline,
-      baselineComparable: comparable,
+      // Back-compat run-level fields, now sourced from the derived comparison. The scalar
+      // delta stays null unless the comparison is trustworthy, so the UI never subtracts
+      // incompatible numbers; the richer `comparison` block carries the raw delta + trust.
+      changeFromBaseline: comparison.trustworthy ? comparison.mainScore.delta : null,
+      baselineComparable: comparison.trustworthy,
       errorCount: run.taskErrorCount + run.scorerErrorCount,
+      elapsedMs: elapsedMs(run.startedAt, run.completedAt),
+      comparison,
     },
     results,
   });

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Run-list derivation: the list exposes a restrained comparison summary
+ * (regressedCaseCount + trustworthy scalar delta + elapsedMs) from the SAME engine as
+ * run detail, batched (baseline runs + all results) so a page is a bounded number of
+ * queries, never a per-row N+1.
+ */
+import { it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  evaluationRun: { findMany: vi.fn(), count: vi.fn() },
+  dataset: { findMany: vi.fn() },
+  evaluationResult: { findMany: vi.fn() },
+  $transaction: vi.fn(async (arr: Promise<unknown>[]) => Promise.all(arr)),
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET } from "./route";
+
+const nextUrl = (qs = "") => ({ nextUrl: { searchParams: new URLSearchParams(qs) } });
+const params = { params: Promise.resolve({ projectId: "p1" }) };
+
+function score(name: string, numericValue: number) {
+  return {
+    scorerName: name,
+    scorerVersion: "unversioned",
+    numericValue,
+    boolValue: null,
+    stringValue: null,
+    error: null,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+  prismaMock.$transaction.mockImplementation(async (arr: Promise<unknown>[]) => Promise.all(arr));
+  prismaMock.dataset.findMany.mockResolvedValue([{ id: "ds1", name: "support" }]);
+});
+
+it("derives regressedCaseCount + trustworthy delta + elapsedMs for a listed run", async () => {
+  const candidate = {
+    id: "run_c",
+    projectId: "p1",
+    evaluationId: "e1",
+    datasetId: "ds1",
+    datasetVersionId: "dv1",
+    runNumber: 2,
+    candidateVersion: "sonnet",
+    status: "completed",
+    baselineRunId: "run_b",
+    mainScore: 0.5,
+    mainScoreName: "acc",
+    taskErrorCount: 0,
+    scorerErrorCount: 0,
+    scorers: [{ name: "acc", version: "unversioned" }],
+    startedAt: new Date("2026-07-21T00:00:00Z"),
+    completedAt: new Date("2026-07-21T00:00:05Z"),
+    evaluation: { name: "ticket-routing" },
+    datasetVersion: { label: "v1" },
+  };
+  const baselineRun = {
+    id: "run_b",
+    projectId: "p1",
+    evaluationId: "e1",
+    datasetId: "ds1",
+    datasetVersionId: "dv1",
+    runNumber: 1,
+    candidateVersion: "opus",
+    status: "completed",
+    baselineRunId: null,
+    mainScore: 1,
+    mainScoreName: "acc",
+    scorers: [{ name: "acc", version: "unversioned" }],
+  };
+
+  prismaMock.evaluationRun.findMany
+    .mockResolvedValueOnce([candidate]) // page runs
+    .mockResolvedValueOnce([baselineRun]); // baselines
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.findMany.mockResolvedValue([
+    {
+      runId: "run_c",
+      testCaseId: "t0",
+      status: "passed",
+      mainScore: 1,
+      candidateOutput: "billing",
+      durationMs: 900,
+      scores: [score("acc", 1)],
+    },
+    {
+      runId: "run_c",
+      testCaseId: "t5",
+      status: "passed",
+      mainScore: 0,
+      candidateOutput: "general",
+      durationMs: 950,
+      scores: [score("acc", 0)],
+    },
+    {
+      runId: "run_b",
+      testCaseId: "t0",
+      status: "passed",
+      mainScore: 1,
+      candidateOutput: "billing",
+      durationMs: 800,
+      scores: [score("acc", 1)],
+    },
+    {
+      runId: "run_b",
+      testCaseId: "t5",
+      status: "passed",
+      mainScore: 1,
+      candidateOutput: "technical",
+      durationMs: 850,
+      scores: [score("acc", 1)],
+    },
+  ]);
+
+  const body = (await (await GET(nextUrl() as never, params)).json()) as {
+    data: Record<string, unknown>[];
+  };
+  const row = body.data[0];
+  expect(row.regressedCaseCount).toBe(1);
+  expect(row.changeFromBaseline).toBeCloseTo(-0.5);
+  expect(row.baselineComparable).toBe(true);
+  expect(row.elapsedMs).toBe(5000);
+  // Bounded: one page-runs query + one baselines query + one results query (+ datasets).
+  expect(prismaMock.evaluationRun.findMany).toHaveBeenCalledTimes(2);
+  expect(prismaMock.evaluationResult.findMany).toHaveBeenCalledTimes(1);
+});
+
+it("shows null comparison fields for a run with no baseline", async () => {
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([
+    {
+      id: "run_solo",
+      projectId: "p1",
+      evaluationId: "e1",
+      datasetId: "ds1",
+      datasetVersionId: "dv1",
+      runNumber: 1,
+      candidateVersion: "opus",
+      status: "completed",
+      baselineRunId: null,
+      mainScore: 1,
+      mainScoreName: "acc",
+      taskErrorCount: 0,
+      scorerErrorCount: 0,
+      scorers: [],
+      startedAt: new Date("2026-07-21T00:00:00Z"),
+      completedAt: null,
+      evaluation: { name: "e" },
+      datasetVersion: { label: "v1" },
+    },
+  ]);
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+
+  const body = (await (await GET(nextUrl() as never, params)).json()) as {
+    data: Record<string, unknown>[];
+  };
+  const row = body.data[0];
+  expect(row.changeFromBaseline).toBeNull();
+  expect(row.regressedCaseCount).toBeNull();
+  expect(row.baselineComparable).toBe(false);
+  expect(row.elapsedMs).toBeNull();
+  // No baseline ids → the baselines findMany is skipped (only the page-runs query ran).
+  expect(prismaMock.evaluationRun.findMany).toHaveBeenCalledTimes(1);
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts
@@ -1,15 +1,16 @@
 /**
- * Run-list derivation: the list exposes a restrained comparison summary
- * (regressedCaseCount + trustworthy scalar delta + elapsedMs) from the SAME engine as
- * run detail, batched (baseline runs + all results) so a page is a bounded number of
- * queries, never a per-row N+1.
+ * Run-list derivation. Status counts, pass rate, cost and duration come from one
+ * grouped aggregate — no result rows cross the wire for them. The restrained
+ * comparison summary (regressedCaseCount + trustworthy scalar delta) still comes from
+ * the SAME engine as run detail, but only for runs that declare a baseline, batched so
+ * a page is a bounded number of queries and never a per-row N+1.
  */
 import { it, expect, vi, beforeEach } from "vitest";
 
 const prismaMock = vi.hoisted(() => ({
   evaluationRun: { findMany: vi.fn(), count: vi.fn() },
   dataset: { findMany: vi.fn() },
-  evaluationResult: { findMany: vi.fn() },
+  evaluationResult: { findMany: vi.fn(), groupBy: vi.fn() },
   $transaction: vi.fn(async (arr: Promise<unknown>[]) => Promise.all(arr)),
 }));
 const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
@@ -41,12 +42,32 @@ function score(name: string, numericValue: number) {
   };
 }
 
+/**
+ * One row as `groupBy(["runId", "status"])` returns it. Counts, cost and case
+ * duration are aggregated in the database, so the route never sees result rows for
+ * them — only these groups.
+ */
+function group(
+  runId: string,
+  status: string,
+  count: number,
+  sums: { cost?: number; durationMs?: number } = {},
+) {
+  return {
+    runId,
+    status,
+    _count: { _all: count },
+    _sum: { cost: sums.cost ?? null, durationMs: sums.durationMs ?? null },
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
   auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
   prismaMock.$transaction.mockImplementation(async (arr: Promise<unknown>[]) => Promise.all(arr));
   prismaMock.dataset.findMany.mockResolvedValue([{ id: "ds1", name: "support" }]);
+  prismaMock.evaluationResult.groupBy.mockResolvedValue([]);
 });
 
 it("derives regressedCaseCount + trustworthy delta + elapsedMs for a listed run", async () => {
@@ -136,9 +157,25 @@ it("derives regressedCaseCount + trustworthy delta + elapsedMs for a listed run"
   expect(row.changeFromBaseline).toBeCloseTo(-0.5);
   expect(row.baselineComparable).toBe(true);
   expect(row.elapsedMs).toBe(5000);
-  // Bounded: one page-runs query + one baselines query + one results query (+ datasets).
+  // Bounded: one page-runs query + one baselines query + one grouped aggregate + one
+  // comparison-results query (+ datasets).
   expect(prismaMock.evaluationRun.findMany).toHaveBeenCalledTimes(2);
+  expect(prismaMock.evaluationResult.groupBy).toHaveBeenCalledTimes(1);
   expect(prismaMock.evaluationResult.findMany).toHaveBeenCalledTimes(1);
+  // The comparison rows are projected, not slurped: the unbounded TEXT columns the
+  // engine never reads (input, expectedOutput, baselineOutput, taskError) stay in the
+  // database. `include: { scores: true }` would have pulled all of them.
+  const resultArgs = prismaMock.evaluationResult.findMany.mock.calls[0][0];
+  expect(resultArgs.include).toBeUndefined();
+  expect(Object.keys(resultArgs.select).sort()).toEqual([
+    "candidateOutput",
+    "durationMs",
+    "mainScore",
+    "runId",
+    "scores",
+    "status",
+    "testCaseId",
+  ]);
 });
 
 it("shows null comparison fields for a run with no baseline", async () => {
@@ -174,9 +211,13 @@ it("shows null comparison fields for a run with no baseline", async () => {
   expect(row.changeFromBaseline).toBeNull();
   expect(row.regressedCaseCount).toBeNull();
   expect(row.baselineComparable).toBe(false);
+  // Mid-flight with no cases yet: nothing to derive a duration from either way.
   expect(row.elapsedMs).toBeNull();
-  // No baseline ids → the baselines findMany is skipped (only the page-runs query ran).
+  // No baseline ids → the baselines findMany is skipped (only the page-runs query ran),
+  // and with no run on the page declaring a baseline the per-case comparison query is
+  // skipped entirely. The status counts still come back — from the grouped aggregate.
   expect(prismaMock.evaluationRun.findMany).toHaveBeenCalledTimes(1);
+  expect(prismaMock.evaluationResult.findMany).not.toHaveBeenCalled();
 });
 
 it("derives per-status counts for a listed run", async () => {
@@ -202,12 +243,11 @@ it("derives per-status counts for a listed run", async () => {
   };
   prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run]);
   prismaMock.evaluationRun.count.mockResolvedValue(1);
-  prismaMock.evaluationResult.findMany.mockResolvedValue([
-    { runId: "run_c", testCaseId: "t0", status: "passed", mainScore: 1, scores: [] },
-    { runId: "run_c", testCaseId: "t1", status: "passed", mainScore: 1, scores: [] },
-    { runId: "run_c", testCaseId: "t2", status: "failed", mainScore: 0, scores: [] },
-    { runId: "run_c", testCaseId: "t3", status: "errored", mainScore: null, scores: [] },
-    { runId: "run_c", testCaseId: "t4", status: "not_scored", mainScore: null, scores: [] },
+  prismaMock.evaluationResult.groupBy.mockResolvedValue([
+    group("run_c", "passed", 2),
+    group("run_c", "failed", 1),
+    group("run_c", "errored", 1),
+    group("run_c", "not_scored", 1),
   ]);
 
   const body = (await (await GET(nextUrl() as never, params)).json()) as {
@@ -217,6 +257,125 @@ it("derives per-status counts for a listed run", async () => {
   expect(body.data[0].failedCount).toBe(1);
   expect(body.data[0].erroredCount).toBe(1);
   expect(body.data[0].notScoredCount).toBe(1);
+});
+
+it("returns the pass rate, derived from the same counts", async () => {
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([
+    {
+      id: "run_c",
+      projectId: "p1",
+      evaluationId: "e1",
+      datasetId: "ds1",
+      datasetVersionId: "dv1",
+      runNumber: 2,
+      candidateVersion: "sonnet",
+      status: "completed",
+      baselineRunId: null,
+      mainScore: 0.66,
+      mainScoreName: "acc",
+      taskErrorCount: 0,
+      scorerErrorCount: 0,
+      scorers: [],
+      startedAt: new Date("2026-07-21T00:00:00Z"),
+      completedAt: new Date("2026-07-21T00:00:05Z"),
+      evaluation: { name: "ticket-routing" },
+      datasetVersion: { label: "v1" },
+    },
+  ]);
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.groupBy.mockResolvedValue([
+    group("run_c", "passed", 18),
+    group("run_c", "failed", 4),
+    group("run_c", "errored", 2),
+    group("run_c", "not_scored", 1),
+  ]);
+
+  const body = (await (await GET(nextUrl() as never, params)).json()) as {
+    data: Record<string, unknown>[];
+  };
+  // Exact, not toBeCloseTo: a loose tolerance would also accept a denominator that
+  // wrongly folded in the errored and not-scored cases.
+  expect(body.data[0].passRate).toBe(18 / 22);
+  expect(body.data[0].excludedSummary).toBe("2 errored, 1 not scored");
+});
+
+// The load-bearing rule, on the wire rather than left to each client: a run whose
+// harness broke must render "—", not a catastrophic-looking 0%.
+it("returns a null pass rate for an all-errored run, never 0", async () => {
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([
+    {
+      id: "run_c",
+      projectId: "p1",
+      evaluationId: "e1",
+      datasetId: "ds1",
+      datasetVersionId: "dv1",
+      runNumber: 3,
+      candidateVersion: "sonnet",
+      status: "completed_with_errors",
+      baselineRunId: null,
+      mainScore: null,
+      mainScoreName: "acc",
+      taskErrorCount: 3,
+      scorerErrorCount: 0,
+      scorers: [],
+      startedAt: new Date("2026-07-21T00:00:00Z"),
+      completedAt: new Date("2026-07-21T00:00:05Z"),
+      evaluation: { name: "ticket-routing" },
+      datasetVersion: { label: "v1" },
+    },
+  ]);
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.groupBy.mockResolvedValue([group("run_c", "errored", 3)]);
+
+  const body = (await (await GET(nextUrl() as never, params)).json()) as {
+    data: Record<string, unknown>[];
+  };
+  expect(body.data[0].passRate).toBeNull();
+  expect(body.data[0].passRate).not.toBe(0);
+  expect(body.data[0].excludedSummary).toBe("3 errored");
+});
+
+// A non-terminal run still reports a running duration. Returning null
+// would blank the duration column on exactly the row someone is watching.
+it("reports a running duration for a mid-flight run with no completedAt", async () => {
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([
+    {
+      id: "run_live",
+      projectId: "p1",
+      evaluationId: "e1",
+      datasetId: "ds1",
+      datasetVersionId: "dv1",
+      runNumber: 4,
+      candidateVersion: "sonnet",
+      status: "running",
+      baselineRunId: null,
+      mainScore: null,
+      mainScoreName: "acc",
+      taskErrorCount: 0,
+      scorerErrorCount: 0,
+      scorers: [],
+      startedAt: new Date("2026-07-21T00:00:00Z"),
+      completedAt: null,
+      evaluation: { name: "ticket-routing" },
+      datasetVersion: { label: "v1" },
+    },
+  ]);
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.groupBy.mockResolvedValue([
+    group("run_live", "passed", 80, { cost: 0.4, durationMs: 72000 }),
+    group("run_live", "failed", 40, { cost: 0.2, durationMs: 36000 }),
+  ]);
+
+  const body = (await (await GET(nextUrl() as never, params)).json()) as {
+    data: Record<string, unknown>[];
+  };
+  const row = body.data[0];
+  expect(row.elapsedMs).toBe(108000);
+  // Partial counts and cost stay coherent beside it.
+  expect(row.passedCount).toBe(80);
+  expect(row.failedCount).toBe(40);
+  expect(row.passRate).toBe(80 / 120);
+  expect(row.cost).toBeCloseTo(0.6);
 });
 
 it("reports zero counts for a run with no results, without extra queries", async () => {
@@ -242,15 +401,15 @@ it("reports zero counts for a run with no results, without extra queries", async
   };
   prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run]);
   prismaMock.evaluationRun.count.mockResolvedValue(1);
-  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
 
   const body = (await (await GET(nextUrl() as never, params)).json()) as {
     data: Record<string, unknown>[];
   };
   expect(body.data[0].passedCount).toBe(0);
   expect(body.data[0].failedCount).toBe(0);
-  // Still exactly one results query — the counts add no round trips.
-  expect(prismaMock.evaluationResult.findMany).toHaveBeenCalledTimes(1);
+  expect(body.data[0].passRate).toBeNull();
+  // Still exactly one grouped query — the counts add no round trips.
+  expect(prismaMock.evaluationResult.groupBy).toHaveBeenCalledTimes(1);
 });
 
 it("prefers the derived counts over a stored scoredCount that disagrees", async () => {
@@ -280,9 +439,9 @@ it("prefers the derived counts over a stored scoredCount that disagrees", async 
   };
   prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run]);
   prismaMock.evaluationRun.count.mockResolvedValue(1);
-  prismaMock.evaluationResult.findMany.mockResolvedValue([
-    { runId: "run_c", testCaseId: "t0", status: "passed", mainScore: 1, scores: [] },
-    { runId: "run_c", testCaseId: "t1", status: "failed", mainScore: 0, scores: [] },
+  prismaMock.evaluationResult.groupBy.mockResolvedValue([
+    group("run_c", "passed", 1),
+    group("run_c", "failed", 1),
   ]);
 
   const body = (await (await GET(nextUrl() as never, params)).json()) as {
@@ -290,6 +449,8 @@ it("prefers the derived counts over a stored scoredCount that disagrees", async 
   };
   expect(body.data[0].passedCount).toBe(1);
   expect(body.data[0].failedCount).toBe(1);
+  // The served rate uses the derived denominator, not scoredCount — 1/2, not 1/9.
+  expect(body.data[0].passRate).toBe(0.5);
   // The stored counter is passed through untouched — it is not reconciled in v1.
   expect(body.data[0].scoredCount).toBe(9);
 });

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts
@@ -178,3 +178,118 @@ it("shows null comparison fields for a run with no baseline", async () => {
   // No baseline ids → the baselines findMany is skipped (only the page-runs query ran).
   expect(prismaMock.evaluationRun.findMany).toHaveBeenCalledTimes(1);
 });
+
+it("derives per-status counts for a listed run", async () => {
+  const run = {
+    id: "run_c",
+    projectId: "p1",
+    evaluationId: "e1",
+    datasetId: "ds1",
+    datasetVersionId: "dv1",
+    runNumber: 2,
+    candidateVersion: "sonnet",
+    status: "completed",
+    baselineRunId: null,
+    mainScore: 0.5,
+    mainScoreName: "acc",
+    taskErrorCount: 1,
+    scorerErrorCount: 0,
+    scorers: [{ name: "acc", version: "unversioned" }],
+    startedAt: new Date("2026-07-21T00:00:00Z"),
+    completedAt: new Date("2026-07-21T00:00:05Z"),
+    evaluation: { name: "ticket-routing" },
+    datasetVersion: { label: "v1" },
+  };
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run]);
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.findMany.mockResolvedValue([
+    { runId: "run_c", testCaseId: "t0", status: "passed", mainScore: 1, scores: [] },
+    { runId: "run_c", testCaseId: "t1", status: "passed", mainScore: 1, scores: [] },
+    { runId: "run_c", testCaseId: "t2", status: "failed", mainScore: 0, scores: [] },
+    { runId: "run_c", testCaseId: "t3", status: "errored", mainScore: null, scores: [] },
+    { runId: "run_c", testCaseId: "t4", status: "not_scored", mainScore: null, scores: [] },
+  ]);
+
+  const body = (await (await GET(nextUrl() as never, params)).json()) as {
+    data: Record<string, unknown>[];
+  };
+  expect(body.data[0].passedCount).toBe(2);
+  expect(body.data[0].failedCount).toBe(1);
+  expect(body.data[0].erroredCount).toBe(1);
+  expect(body.data[0].notScoredCount).toBe(1);
+});
+
+it("reports zero counts for a run with no results, without extra queries", async () => {
+  const run = {
+    id: "run_empty",
+    projectId: "p1",
+    evaluationId: "e1",
+    datasetId: "ds1",
+    datasetVersionId: "dv1",
+    runNumber: 1,
+    candidateVersion: "sonnet",
+    status: "running",
+    baselineRunId: null,
+    mainScore: null,
+    mainScoreName: "acc",
+    taskErrorCount: 0,
+    scorerErrorCount: 0,
+    scorers: [],
+    startedAt: new Date("2026-07-21T00:00:00Z"),
+    completedAt: null,
+    evaluation: { name: "ticket-routing" },
+    datasetVersion: { label: "v1" },
+  };
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run]);
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+
+  const body = (await (await GET(nextUrl() as never, params)).json()) as {
+    data: Record<string, unknown>[];
+  };
+  expect(body.data[0].passedCount).toBe(0);
+  expect(body.data[0].failedCount).toBe(0);
+  // Still exactly one results query — the counts add no round trips.
+  expect(prismaMock.evaluationResult.findMany).toHaveBeenCalledTimes(1);
+});
+
+it("prefers the derived counts over a stored scoredCount that disagrees", async () => {
+  // scoredCount says 9, the result rows say 2 judged. The rows win: numerator and
+  // denominator must come from the same source or the fraction can exceed 1.
+  const run = {
+    id: "run_c",
+    projectId: "p1",
+    evaluationId: "e1",
+    datasetId: "ds1",
+    datasetVersionId: "dv1",
+    runNumber: 3,
+    candidateVersion: "sonnet",
+    status: "completed",
+    baselineRunId: null,
+    mainScore: 0.5,
+    mainScoreName: "acc",
+    caseCount: 9,
+    scoredCount: 9,
+    taskErrorCount: 0,
+    scorerErrorCount: 0,
+    scorers: [{ name: "acc", version: "unversioned" }],
+    startedAt: new Date("2026-07-21T00:00:00Z"),
+    completedAt: new Date("2026-07-21T00:00:05Z"),
+    evaluation: { name: "ticket-routing" },
+    datasetVersion: { label: "v1" },
+  };
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run]);
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.findMany.mockResolvedValue([
+    { runId: "run_c", testCaseId: "t0", status: "passed", mainScore: 1, scores: [] },
+    { runId: "run_c", testCaseId: "t1", status: "failed", mainScore: 0, scores: [] },
+  ]);
+
+  const body = (await (await GET(nextUrl() as never, params)).json()) as {
+    data: Record<string, unknown>[];
+  };
+  expect(body.data[0].passedCount).toBe(1);
+  expect(body.data[0].failedCount).toBe(1);
+  // The stored counter is passed through untouched — it is not reconciled in v1.
+  expect(body.data[0].scoredCount).toBe(9);
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
@@ -1,22 +1,15 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@traceroot/core";
 import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+import { compareRuns } from "@/lib/eval/comparison";
+import { toComparisonRun, toComparisonResults } from "@/lib/eval/comparison-db";
 
 type RouteParams = { params: Promise<{ projectId: string }> };
 
-/** Delta vs baseline only when the two runs measured the identical population. */
-function changeFromBaseline(
-  run: { mainScore: number | null; evaluationId: string; datasetVersionId: string },
-  baseline: { mainScore: number | null; evaluationId: string; datasetVersionId: string } | null,
-): number | null {
-  if (!baseline || run.mainScore === null || baseline.mainScore === null) return null;
-  if (
-    baseline.evaluationId !== run.evaluationId ||
-    baseline.datasetVersionId !== run.datasetVersionId
-  ) {
-    return null; // incompatible snapshot — no delta
-  }
-  return run.mainScore - baseline.mainScore;
+function elapsedMs(startedAt: Date, completedAt: Date | null): number | null {
+  if (!completedAt) return null;
+  const ms = completedAt.getTime() - startedAt.getTime();
+  return ms >= 0 ? ms : null;
 }
 
 // GET — evaluation runs (executions) for the project. Filters: evaluation_id,
@@ -62,9 +55,6 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       include: {
         evaluation: { select: { name: true } },
         datasetVersion: { select: { label: true } },
-        baselineRun: {
-          select: { mainScore: true, evaluationId: true, datasetVersionId: true },
-        },
       },
     }),
     prisma.evaluationRun.count({ where }),
@@ -80,14 +70,55 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       : [];
   const datasetName = new Map(datasets.map((d) => [d.id, d.name]));
 
-  const data = runs.map((r) => ({
-    ...r,
-    evaluationName: r.evaluation.name,
-    datasetName: datasetName.get(r.datasetId) ?? null,
-    datasetVersionLabel: r.datasetVersion.label,
-    changeFromBaseline: changeFromBaseline(r, r.baselineRun),
-    errorCount: r.taskErrorCount + r.scorerErrorCount,
-  }));
+  // Restrained per-run comparison summary from the SAME engine as run detail — batched
+  // so the whole page costs a bounded number of queries (baseline runs + all results),
+  // never a per-row N+1. For very large runs this is the natural summary/cache boundary.
+  const baselineIds = [
+    ...new Set(runs.map((r) => r.baselineRunId).filter((x): x is string => !!x)),
+  ];
+  const baselineRuns =
+    baselineIds.length > 0
+      ? await prisma.evaluationRun.findMany({ where: { id: { in: baselineIds }, projectId } })
+      : [];
+  const baselineById = new Map(baselineRuns.map((b) => [b.id, b]));
+
+  const resultRunIds = [...new Set([...runs.map((r) => r.id), ...baselineIds])];
+  const allResults =
+    resultRunIds.length > 0
+      ? await prisma.evaluationResult.findMany({
+          where: { runId: { in: resultRunIds }, projectId },
+          include: { scores: true },
+        })
+      : [];
+  const resultsByRun = new Map<string, typeof allResults>();
+  for (const r of allResults) {
+    const list = resultsByRun.get(r.runId);
+    if (list) list.push(r);
+    else resultsByRun.set(r.runId, [r]);
+  }
+
+  const data = runs.map((r) => {
+    const baseline = r.baselineRunId ? (baselineById.get(r.baselineRunId) ?? null) : null;
+    const { comparison } = compareRuns({
+      candidate: toComparisonRun(r),
+      candidateResults: toComparisonResults(resultsByRun.get(r.id) ?? []),
+      baseline: baseline ? toComparisonRun(baseline) : null,
+      baselineResults: baseline ? toComparisonResults(resultsByRun.get(baseline.id) ?? []) : [],
+    });
+    return {
+      ...r,
+      evaluationName: r.evaluation.name,
+      datasetName: datasetName.get(r.datasetId) ?? null,
+      datasetVersionLabel: r.datasetVersion.label,
+      // Delta + regressed-case count only when trustworthy; otherwise null (UI shows —),
+      // never a misleading number beside an incompatible baseline.
+      changeFromBaseline: comparison.trustworthy ? comparison.mainScore.delta : null,
+      regressedCaseCount: comparison.trustworthy ? comparison.caseCounts.regressed : null,
+      baselineComparable: comparison.trustworthy,
+      errorCount: r.taskErrorCount + r.scorerErrorCount,
+      elapsedMs: elapsedMs(r.startedAt, r.completedAt),
+    };
+  });
 
   return successResponse({ data, meta: { page, limit, total } });
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@traceroot/core";
 import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
 import { compareRuns } from "@/lib/eval/comparison";
 import { toComparisonRun, toComparisonResults } from "@/lib/eval/comparison-db";
+import { countResultStatuses } from "@/lib/eval/pass-rate";
 
 type RouteParams = { params: Promise<{ projectId: string }> };
 
@@ -105,6 +106,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       baseline: baseline ? toComparisonRun(baseline) : null,
       baselineResults: baseline ? toComparisonResults(resultsByRun.get(baseline.id) ?? []) : [],
     });
+    const statusCounts = countResultStatuses(resultsByRun.get(r.id) ?? []);
     return {
       ...r,
       evaluationName: r.evaluation.name,
@@ -117,6 +119,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       baselineComparable: comparison.trustworthy,
       errorCount: r.taskErrorCount + r.scorerErrorCount,
       elapsedMs: elapsedMs(r.startedAt, r.completedAt),
+      ...statusCounts,
     };
   });
 

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
@@ -3,14 +3,32 @@ import { prisma } from "@traceroot/core";
 import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
 import { compareRuns } from "@/lib/eval/comparison";
 import { toComparisonRun, toComparisonResults } from "@/lib/eval/comparison-db";
-import { countResultStatuses } from "@/lib/eval/pass-rate";
+import { countResultStatuses, passRate, excludedSummary } from "@/lib/eval/pass-rate";
 
 type RouteParams = { params: Promise<{ projectId: string }> };
 
-function elapsedMs(startedAt: Date, completedAt: Date | null): number | null {
-  if (!completedAt) return null;
-  const ms = completedAt.getTime() - startedAt.getTime();
-  return ms >= 0 ? ms : null;
+/**
+ * Run duration, derived rather than stored. A finished run is wall-clock
+ * started → completed. A run still in flight has no completion time, so it falls
+ * back to the span of its cases' durations — returning null there would blank the
+ * duration column on exactly the rows someone is watching tick upward.
+ */
+function elapsedMs(
+  startedAt: Date,
+  completedAt: Date | null,
+  caseDurationMs: number | null,
+): number | null {
+  if (completedAt) {
+    const ms = completedAt.getTime() - startedAt.getTime();
+    if (ms >= 0) return ms;
+  }
+  return caseDurationMs;
+}
+
+/** Sum the non-null members, or null when there are none — never a misleading 0. */
+function sumOrNull(values: Array<number | null>): number | null {
+  const present = values.filter((v): v is number => v != null);
+  return present.length > 0 ? present.reduce((a, b) => a + b, 0) : null;
 }
 
 // GET — evaluation runs (executions) for the project. Filters: evaluation_id,
@@ -71,24 +89,80 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       : [];
   const datasetName = new Map(datasets.map((d) => [d.id, d.name]));
 
-  // Restrained per-run comparison summary from the SAME engine as run detail — batched
-  // so the whole page costs a bounded number of queries (baseline runs + all results),
-  // never a per-row N+1. For very large runs this is the natural summary/cache boundary.
+  // Status counts, cost and case-duration totals are aggregated IN the database: one
+  // grouped query returns a handful of rows for the whole page. Folding them in Node
+  // instead would pull every result row for every listed run — including four
+  // unbounded TEXT columns (input/expected/candidate/baseline output) none of these
+  // derivations read — to produce four integers and two sums per row.
+  const pageRunIds = runs.map((r) => r.id);
+  const resultGroups =
+    pageRunIds.length > 0
+      ? await prisma.evaluationResult.groupBy({
+          by: ["runId", "status"],
+          where: { runId: { in: pageRunIds }, projectId },
+          _count: { _all: true },
+          _sum: { cost: true, durationMs: true },
+        })
+      : [];
+  const groupsByRun = new Map<string, typeof resultGroups>();
+  for (const g of resultGroups) {
+    const list = groupsByRun.get(g.runId);
+    if (list) list.push(g);
+    else groupsByRun.set(g.runId, [g]);
+  }
+
+  // Restrained per-run comparison summary from the SAME engine as run detail. This is
+  // the one derivation that genuinely needs per-case rows, so it is narrowed twice:
+  // to the runs that actually declare a baseline (plus those baselines), and to the
+  // columns the engine reads. Still batched — a bounded number of queries per page,
+  // never a per-row N+1.
   const baselineIds = [
     ...new Set(runs.map((r) => r.baselineRunId).filter((x): x is string => !!x)),
   ];
   const baselineRuns =
     baselineIds.length > 0
-      ? await prisma.evaluationRun.findMany({ where: { id: { in: baselineIds }, projectId } })
+      ? await prisma.evaluationRun.findMany({
+          where: { id: { in: baselineIds }, projectId },
+          select: {
+            id: true,
+            runNumber: true,
+            evaluationId: true,
+            datasetVersionId: true,
+            candidateVersion: true,
+            status: true,
+            mainScore: true,
+            mainScoreName: true,
+            baselineRunId: true,
+            scorers: true,
+          },
+        })
       : [];
   const baselineById = new Map(baselineRuns.map((b) => [b.id, b]));
 
-  const resultRunIds = [...new Set([...runs.map((r) => r.id), ...baselineIds])];
+  const comparedRunIds = runs.filter((r) => r.baselineRunId).map((r) => r.id);
+  const resultRunIds = [...new Set([...comparedRunIds, ...baselineIds])];
   const allResults =
     resultRunIds.length > 0
       ? await prisma.evaluationResult.findMany({
           where: { runId: { in: resultRunIds }, projectId },
-          include: { scores: true },
+          select: {
+            runId: true,
+            testCaseId: true,
+            status: true,
+            mainScore: true,
+            candidateOutput: true,
+            durationMs: true,
+            scores: {
+              select: {
+                scorerName: true,
+                scorerVersion: true,
+                numericValue: true,
+                boolValue: true,
+                stringValue: true,
+                error: true,
+              },
+            },
+          },
         })
       : [];
   const resultsByRun = new Map<string, typeof allResults>();
@@ -106,11 +180,14 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       baseline: baseline ? toComparisonRun(baseline) : null,
       baselineResults: baseline ? toComparisonResults(resultsByRun.get(baseline.id) ?? []) : [],
     });
-    const statusCounts = countResultStatuses(resultsByRun.get(r.id) ?? []);
+    const groups = groupsByRun.get(r.id) ?? [];
+    const statusCounts = countResultStatuses(
+      groups.map((g) => ({ status: g.status, count: g._count._all })),
+    );
     // Total cost across the run's cases (SDK-reported per result). Null when no case
     // reported a cost — never a misleading 0.
-    const costRows = (resultsByRun.get(r.id) ?? []).filter((x) => x.cost != null);
-    const cost = costRows.length > 0 ? costRows.reduce((sum, x) => sum + (x.cost ?? 0), 0) : null;
+    const cost = sumOrNull(groups.map((g) => g._sum.cost));
+    const caseDurationMs = sumOrNull(groups.map((g) => g._sum.durationMs));
     return {
       ...r,
       evaluationName: r.evaluation.name,
@@ -123,8 +200,13 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       regressedCaseCount: comparison.trustworthy ? comparison.caseCounts.regressed : null,
       baselineComparable: comparison.trustworthy,
       errorCount: r.taskErrorCount + r.scorerErrorCount,
-      elapsedMs: elapsedMs(r.startedAt, r.completedAt),
+      elapsedMs: elapsedMs(r.startedAt, r.completedAt, caseDurationMs),
       ...statusCounts,
+      // Served, not left to each consumer: passed / (passed + failed), null when
+      // nothing was judged. A client recomputing it would divide by zero and render
+      // an all-errored run as a catastrophic-looking 0%.
+      passRate: passRate(statusCounts.passedCount, statusCounts.failedCount),
+      excludedSummary: excludedSummary(statusCounts.erroredCount, statusCounts.notScoredCount),
     };
   });
 

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
@@ -107,11 +107,16 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       baselineResults: baseline ? toComparisonResults(resultsByRun.get(baseline.id) ?? []) : [],
     });
     const statusCounts = countResultStatuses(resultsByRun.get(r.id) ?? []);
+    // Total cost across the run's cases (SDK-reported per result). Null when no case
+    // reported a cost — never a misleading 0.
+    const costRows = (resultsByRun.get(r.id) ?? []).filter((x) => x.cost != null);
+    const cost = costRows.length > 0 ? costRows.reduce((sum, x) => sum + (x.cost ?? 0), 0) : null;
     return {
       ...r,
       evaluationName: r.evaluation.name,
       datasetName: datasetName.get(r.datasetId) ?? null,
       datasetVersionLabel: r.datasetVersion.label,
+      cost,
       // Delta + regressed-case count only when trustworthy; otherwise null (UI shows —),
       // never a misleading number beside an incompatible baseline.
       changeFromBaseline: comparison.trustworthy ? comparison.mainScore.delta : null,

--- a/frontend/ui/src/app/api/public/datasets/[datasetId]/route.test.ts
+++ b/frontend/ui/src/app/api/public/datasets/[datasetId]/route.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Public dataset read + metadata update (A3), the surface the SDK pins against.
+ * Everything is snake_case on the wire, the project comes from the API key (never the
+ * body), and a metadata PATCH distinguishes "absent" (leave alone) from an explicit
+ * null (clear the JsonB column). Published versions are never touched here.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  // The path param may be the SDK-chosen `client_dataset_id` or the internal id, so
+  // the route tries the compound-unique lookup first and falls back to findFirst.
+  dataset: { findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
+}));
+const apiAuth = vi.hoisted(() => ({ requireApiKeyProject: vi.fn() }));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+  NextRequest: class {},
+}));
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return { ...actual, prisma: prismaMock };
+});
+vi.mock("@/lib/eval/auth", () => ({ requireApiKeyProject: apiAuth.requireApiKeyProject }));
+
+import { Prisma } from "@traceroot/core";
+import { GET, PATCH } from "./route";
+
+const params = { params: Promise.resolve({ datasetId: "ds1" }) };
+
+const getReq = () => ({}) as unknown as Request;
+const jsonReq = (body: unknown) => ({ json: async () => body }) as unknown as Request;
+const badJsonReq = () =>
+  ({
+    json: async () => {
+      throw new Error("bad json");
+    },
+  }) as unknown as Request;
+
+const stored = {
+  id: "ds1",
+  name: "support",
+  description: "tickets",
+  currentVersionId: "dv2",
+};
+
+async function body(res: { json: () => Promise<unknown> }) {
+  return (await res.json()) as Record<string, unknown>;
+}
+const patchData = () => prismaMock.dataset.update.mock.calls[0][0].data;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiAuth.requireApiKeyProject.mockResolvedValue({ projectId: "p1" });
+  prismaMock.dataset.update.mockResolvedValue(stored);
+  // Default: the path param is not a client_dataset_id, so the lookup falls through
+  // to the internal-id findFirst that these cases stub.
+  prismaMock.dataset.findUnique.mockResolvedValue(null);
+});
+
+describe("GET", () => {
+  it("returns the dataset in snake_case with the version to pin", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue(stored);
+
+    const res = await GET(getReq(), params);
+    expect(res.status).toBe(200);
+    expect(await body(res)).toEqual({
+      dataset_id: "ds1",
+      name: "support",
+      description: "tickets",
+      current_dataset_version_id: "dv2",
+    });
+    // The project comes from the key, so another project's id reads as not found.
+    expect(prismaMock.dataset.findFirst.mock.calls[0][0].where).toEqual({
+      id: "ds1",
+      projectId: "p1",
+    });
+  });
+
+  it("resolves the path param as the SDK's client_dataset_id before the internal id", async () => {
+    // The SDK pins by the id it chose, so that lookup wins and the internal-id
+    // fallback is never reached — otherwise a client id equal to some other
+    // dataset's internal id would read the wrong row.
+    prismaMock.dataset.findUnique.mockResolvedValue(stored);
+
+    expect((await body(await GET(getReq(), params))).dataset_id).toBe("ds1");
+    expect(prismaMock.dataset.findUnique.mock.calls[0][0].where).toEqual({
+      projectId_clientDatasetId: { projectId: "p1", clientDatasetId: "ds1" },
+    });
+    expect(prismaMock.dataset.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("reports a null version for a dataset with nothing published yet", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue({ ...stored, currentVersionId: null });
+    expect((await body(await GET(getReq(), params))).current_dataset_version_id).toBeNull();
+  });
+
+  it("404s a dataset the key's project cannot see", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue(null);
+    const res = await GET(getReq(), params);
+    expect(res.status).toBe(404);
+    expect(await body(res)).toEqual({ error: "Dataset not found" });
+  });
+
+  it("401s a request with a bad API key before touching the database", async () => {
+    apiAuth.requireApiKeyProject.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Invalid API key" }) },
+    });
+    const res = await GET(getReq(), params);
+    expect(res.status).toBe(401);
+    expect(prismaMock.dataset.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe("PATCH", () => {
+  it("updates only the fields present and echoes the dataset back", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue({ id: "ds1" });
+    prismaMock.dataset.update.mockResolvedValue({ ...stored, name: "renamed" });
+
+    const res = await PATCH(jsonReq({ name: "renamed" }), params);
+    expect(res.status).toBe(200);
+    expect(await body(res)).toMatchObject({ dataset_id: "ds1", name: "renamed" });
+    expect(patchData()).toEqual({ name: "renamed" }); // description/metadata untouched
+  });
+
+  it("replaces metadata with an object and clears it with an explicit null", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue({ id: "ds1" });
+
+    await PATCH(jsonReq({ metadata: { owner: "hao" } }), params);
+    expect(patchData().metadata).toEqual({ owner: "hao" });
+
+    prismaMock.dataset.update.mockClear();
+    await PATCH(jsonReq({ metadata: null, description: null }), params);
+    expect(patchData().metadata).toBe(Prisma.DbNull);
+    expect(patchData().description).toBeNull();
+  });
+
+  it("400s an unparseable body", async () => {
+    const res = await PATCH(badJsonReq(), params);
+    expect(res.status).toBe(400);
+    expect(await body(res)).toEqual({ error: "Invalid JSON" });
+  });
+
+  it("400s a body that fails the public schema", async () => {
+    const res = await PATCH(jsonReq({ name: "" }), params);
+    expect(res.status).toBe(400);
+    expect(prismaMock.dataset.update).not.toHaveBeenCalled();
+  });
+
+  it("400s an unknown field rather than silently ignoring it", async () => {
+    const res = await PATCH(jsonReq({ current_dataset_version_id: "dv1" }), params);
+    expect(res.status).toBe(400);
+    expect(prismaMock.dataset.update).not.toHaveBeenCalled();
+  });
+
+  it("404s a dataset the key's project cannot see, without updating", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue(null);
+    const res = await PATCH(jsonReq({ name: "renamed" }), params);
+    expect(res.status).toBe(404);
+    expect(prismaMock.dataset.update).not.toHaveBeenCalled();
+  });
+
+  it("401s a request with a bad API key before touching the database", async () => {
+    apiAuth.requireApiKeyProject.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Invalid API key" }) },
+    });
+    const res = await PATCH(jsonReq({ name: "renamed" }), params);
+    expect(res.status).toBe(401);
+    expect(prismaMock.dataset.update).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.prefetch.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.prefetch.test.tsx
@@ -18,6 +18,9 @@ vi.mock("@/features/traces/hooks", () => ({
   }),
   usePrefetchTraces: () => prefetch,
   useTracesExist: () => ({ data: { exists: true }, isPending: false }),
+  // The page also mounts the offline-eval save drawer, which reads per-span I/O.
+  // Nothing here exercises it, so it stays unresolved.
+  useSpanIO: () => ({ data: undefined }),
 }));
 vi.mock("@/lib/hooks/use-list-page-state", () => ({
   useListPageState: () => ({

--- a/frontend/ui/src/features/evaluations/types.ts
+++ b/frontend/ui/src/features/evaluations/types.ts
@@ -4,7 +4,12 @@
  */
 import type { RunComparison, ResultComparison } from "@/lib/eval/comparison";
 
-export type { RunComparison, ResultComparison, Classification } from "@/lib/eval/comparison";
+export type {
+  RunComparison,
+  ResultComparison,
+  ScorerCellComparison,
+  Classification,
+} from "@/lib/eval/comparison";
 
 /** The per-result comparison block the run-detail route embeds on each result. */
 export type ResultRowComparison = Pick<
@@ -180,6 +185,8 @@ export interface RunRow {
   baselineComparable?: boolean;
   /** Run wall-clock (completedAt − startedAt), null while running. */
   elapsedMs?: number | null;
+  /** Derived (list route): total SDK-reported case cost; null when none reported. */
+  cost?: number | null;
 }
 
 export interface RunDetail extends RunRow {

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.interactions.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.interactions.test.tsx
@@ -1,0 +1,383 @@
+// @vitest-environment jsdom
+/**
+ * Interaction coverage for the trace viewer shell: header actions (fullscreen,
+ * new tab, AI, RCA alert), the offline-eval extension points (header identity /
+ * status, diff toggle, selection callbacks) and the tree/timeline scroll sync.
+ *
+ * Complements TraceViewerPanel.test.tsx, which covers layout and content states.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen, fireEvent, act } from "@testing-library/react";
+import type { Span, TraceDetail } from "@/types/api";
+
+const mocks = vi.hoisted(() => ({
+  aiPanelOpen: false,
+  setAiPanelOpen: vi.fn(),
+  setAiContext: vi.fn(),
+  setAiInitialSessionId: vi.fn(),
+  findings: undefined as unknown,
+  rca: undefined as unknown,
+}));
+
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({
+    aiPanelOpen: mocks.aiPanelOpen,
+    setAiPanelOpen: mocks.setAiPanelOpen,
+    setAiContext: mocks.setAiContext,
+    setAiInitialSessionId: mocks.setAiInitialSessionId,
+    registerAiHost: () => () => {},
+    sidebarCollapsed: false,
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined, isLoading: false, error: null }),
+}));
+vi.mock("@/lib/api", () => ({ getTrace: vi.fn() }));
+vi.mock("../hooks/use-trace-stream", () => ({ useTraceStream: vi.fn() }));
+vi.mock("@/features/detectors/hooks/use-findings", () => ({
+  useTraceFindings: () => ({ data: mocks.findings }),
+  useRca: () => ({ data: mocks.rca }),
+  useTraceDetectorRuns: () => ({ data: undefined, isLoading: false, error: null }),
+}));
+
+// The tree and timeline are replaced by probes that surface their callbacks as
+// buttons, so selection/collapse/scroll-sync paths are reachable from a test.
+const scrollToSpan = vi.hoisted(() => vi.fn());
+vi.mock("./SpanTreeView", async () => {
+  const React = await import("react");
+  return {
+    SpanTreeView: React.forwardRef(function TreeProbe(
+      props: {
+        onSelect: (sel: unknown) => void;
+        onToggleCollapse: (id: string) => void;
+        collapsedIds: Set<string>;
+      },
+      ref: React.Ref<unknown>,
+    ) {
+      React.useImperativeHandle(ref, () => ({ scrollToSpan }));
+      return (
+        <div>
+          <button type="button" onClick={() => props.onSelect({ type: "trace" })}>
+            tree-select-trace
+          </button>
+          <button type="button" onClick={() => props.onToggleCollapse("span-1")}>
+            tree-toggle
+          </button>
+          <span data-testid="collapsed-count">{props.collapsedIds.size}</span>
+        </div>
+      );
+    }),
+  };
+});
+vi.mock("./SpanTimelineView", () => ({
+  SpanTimelineView: (props: {
+    onSelect: (sel: unknown) => void;
+    scrollRef: React.RefObject<HTMLDivElement | null>;
+    onScroll: () => void;
+  }) => (
+    <div data-testid="timeline">
+      <div data-testid="timeline-scroll" ref={props.scrollRef} onScroll={props.onScroll} />
+      <button
+        type="button"
+        onClick={() => props.onSelect({ type: "span", span: { span_id: "span-9" } })}
+      >
+        timeline-select-span
+      </button>
+    </div>
+  ),
+}));
+vi.mock("./TraceDetectorsTab", () => ({
+  TraceDetectorsTab: () => <div data-testid="detectors-tab" />,
+}));
+vi.mock("@/features/ai-assistant/components/ai-assistant-panel", () => ({
+  AiAssistantPanel: () => <div data-testid="ai-panel" />,
+}));
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => null,
+}));
+// The detail panel is exercised by SpanInfoPanel.test.tsx; here it only needs to
+// report the props the viewer computes for it.
+vi.mock("./SpanInfoPanel", () => ({
+  SpanInfoPanel: (props: { diffMode?: boolean; spanActions?: React.ReactNode }) => (
+    <div data-testid="span-info" data-diff={String(!!props.diffMode)}>
+      {props.spanActions}
+    </div>
+  ),
+}));
+
+import { TraceViewerPanel } from "./TraceViewerPanel";
+
+const SPAN: Span = {
+  span_id: "span-1",
+  trace_id: "trace-1",
+  parent_span_id: null,
+  name: "root",
+  span_kind: "SPAN",
+  span_start_time: "2026-07-17T10:24:00.000Z",
+  span_end_time: "2026-07-17T10:24:01.000Z",
+  status: "OK",
+  status_message: null,
+  model_name: null,
+  cost: null,
+  input_tokens: null,
+  output_tokens: null,
+  total_tokens: null,
+  git_source_file: null,
+  git_source_line: null,
+  git_source_function: null,
+};
+
+const TRACE: TraceDetail = {
+  trace_id: "trace-1",
+  project_id: "proj-1",
+  name: "t",
+  trace_start_time: "2026-07-17T10:24:00.000Z",
+  user_id: null,
+  session_id: null,
+  git_ref: null,
+  git_repo: null,
+  environment: "production",
+  release: null,
+  input: null,
+  output: null,
+  metadata: null,
+  spans: [SPAN],
+};
+
+function renderPanel(props: Partial<React.ComponentProps<typeof TraceViewerPanel>> = {}) {
+  return render(
+    <TraceViewerPanel
+      projectId="proj-1"
+      traceId="trace-1"
+      onClose={vi.fn()}
+      onNavigate={vi.fn()}
+      canNavigateUp
+      canNavigateDown
+      traceOverride={TRACE}
+      {...props}
+    />,
+  );
+}
+
+beforeEach(() => {
+  mocks.aiPanelOpen = false;
+  mocks.findings = undefined;
+  mocks.rca = undefined;
+  vi.clearAllMocks();
+});
+afterEach(() => cleanup());
+
+describe("TraceViewerPanel header actions", () => {
+  it("navigates with the up/down buttons", () => {
+    const onNavigate = vi.fn();
+    renderPanel({ onNavigate });
+    fireEvent.click(screen.getByTitle("Previous trace"));
+    fireEvent.click(screen.getByTitle("Next trace"));
+    expect(onNavigate).toHaveBeenNthCalledWith(1, "up");
+    expect(onNavigate).toHaveBeenNthCalledWith(2, "down");
+  });
+
+  it("toggles fullscreen from the expand button", () => {
+    const { container } = renderPanel();
+    const panel = container.firstElementChild as HTMLElement;
+    expect(panel.className).toContain("w-[70%]");
+    fireEvent.click(screen.getByTitle("Expand to full screen"));
+    expect(panel.className).toContain("w-[calc(100%-12rem)]");
+    fireEvent.click(screen.getByTitle("Restore default size"));
+    expect(panel.className).toContain("w-[70%]");
+  });
+
+  it("opens the trace in a new tab with the current filters", () => {
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    // No override: under one, traceId is the synthetic eval-<resultId> and this
+    // control is deliberately hidden (covered separately below).
+    renderPanel({
+      traceOverride: undefined,
+      dateFilter: { id: "1h" },
+      newTabPath: "/projects/proj-1/detectors",
+    });
+    fireEvent.click(screen.getByTitle("Open in new tab"));
+    expect(open).toHaveBeenCalledTimes(1);
+    const url = open.mock.calls[0][0] as string;
+    expect(url).toContain("/projects/proj-1/detectors");
+    expect(url).toContain("traceId=trace-1");
+    expect(url).toContain("fullscreen=1");
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults the new-tab target to the project traces page", () => {
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    renderPanel({ traceOverride: undefined });
+    fireEvent.click(screen.getByTitle("Open in new tab"));
+    expect(open.mock.calls[0][0]).toContain("/projects/proj-1/traces");
+    vi.unstubAllGlobals();
+  });
+
+  it("hides the new-tab control and sends no assistant context under an override", () => {
+    // Under an override the panel renders a reconstructed eval trace whose id is a
+    // synthetic eval-<resultId>: no URL and no assistant lookup can resolve it, so
+    // the control is hidden and the assistant gets null rather than a dead id.
+    renderPanel();
+    expect(screen.queryByTitle("Open in new tab")).toBeNull();
+    fireEvent.click(screen.getByTitle("AI Assistant"));
+    expect(mocks.setAiContext).toHaveBeenCalledWith(null);
+  });
+
+  it("opens a fresh AI chat from the bot button", () => {
+    renderPanel({ traceOverride: undefined });
+    fireEvent.click(screen.getByTitle("AI Assistant"));
+    expect(mocks.setAiContext).toHaveBeenCalledWith({ traceId: "trace-1" });
+    expect(mocks.setAiInitialSessionId).toHaveBeenCalledWith(undefined);
+    expect(mocks.setAiPanelOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("closes the panel from the X button", () => {
+    const onClose = vi.fn();
+    renderPanel({ onClose });
+    // The close button is the only header button without a title.
+    const buttons = Array.from(document.querySelectorAll("button"));
+    const close = buttons.find((b) => !b.getAttribute("title") && b.className.includes("h-7 w-7"));
+    fireEvent.click(close!);
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("TraceViewerPanel RCA alert", () => {
+  it("hides the Alert button when there is no RCA record", () => {
+    renderPanel();
+    expect(screen.queryByText("Alert")).toBeNull();
+  });
+
+  it("opens the RCA session from the Alert button", () => {
+    mocks.findings = { findings: [{ finding_id: "f1" }] };
+    mocks.rca = { rca: { sessionId: "sess-rca" } };
+    renderPanel({ traceOverride: undefined });
+    fireEvent.click(screen.getByText("Alert"));
+    expect(mocks.setAiInitialSessionId).toHaveBeenCalledWith("sess-rca");
+    expect(mocks.setAiPanelOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("auto-opens the RCA chat when arriving from the findings page", () => {
+    mocks.findings = { findings: [{ finding_id: "f1" }] };
+    mocks.rca = { rca: { sessionId: "sess-rca" } };
+    renderPanel({ traceOverride: undefined, autoOpenRca: true });
+    expect(mocks.setAiInitialSessionId).toHaveBeenCalledWith("sess-rca");
+    expect(mocks.setAiPanelOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("does not auto-open while the RCA session is still unresolved", () => {
+    mocks.findings = { findings: [{ finding_id: "f1" }] };
+    mocks.rca = { rca: null };
+    renderPanel({ traceOverride: undefined, autoOpenRca: true });
+    expect(mocks.setAiPanelOpen).not.toHaveBeenCalled();
+  });
+});
+
+describe("TraceViewerPanel offline-eval extensions", () => {
+  it("renders the supplied header identity with a copy affordance", () => {
+    renderPanel({ headerIdentity: { label: "Test case", value: "case-1" } });
+    expect(screen.getByText("Test case")).toBeTruthy();
+    expect(screen.getByText("case-1")).toBeTruthy();
+    expect(screen.getByTitle("Copy test case id")).toBeTruthy();
+  });
+
+  it("renders a header status badge", () => {
+    renderPanel({ headerStatus: <span>Passed</span> });
+    expect(screen.getByText("Passed")).toBeTruthy();
+  });
+
+  it("hides the diff toggle without a baseline", () => {
+    renderPanel();
+    expect(screen.queryByText("Diff")).toBeNull();
+  });
+
+  it("toggles diff mode and forwards it to the detail panel", () => {
+    const matchSpan = vi.fn(() => SPAN);
+    renderPanel({ diffBaseline: { trace: TRACE, matchSpan } });
+    expect(screen.getByTestId("span-info").dataset.diff).toBe("false");
+    fireEvent.click(screen.getByText("Diff"));
+    expect(screen.getByTestId("span-info").dataset.diff).toBe("true");
+    fireEvent.click(screen.getByText("Diff"));
+    expect(screen.getByTestId("span-info").dataset.diff).toBe("false");
+  });
+
+  it("starts in diff mode when defaultDiffOn is set", () => {
+    renderPanel({
+      diffBaseline: { trace: TRACE, matchSpan: () => SPAN },
+      defaultDiffOn: true,
+    });
+    expect(screen.getByTestId("span-info").dataset.diff).toBe("true");
+  });
+
+  it("renders per-selection span actions", () => {
+    renderPanel({
+      spanActions: () => <button type="button">Save as test case</button>,
+      spanHeaderAction: () => <span>hdr</span>,
+      spanExtraTags: () => <span>tag</span>,
+    });
+    expect(screen.getByText("Save as test case")).toBeTruthy();
+  });
+
+  it("notifies the parent when the selection changes", () => {
+    const onSelectionChange = vi.fn();
+    renderPanel({ onSelectionChange });
+    expect(onSelectionChange).toHaveBeenCalledWith({ type: "trace" });
+  });
+});
+
+describe("TraceViewerPanel tree/timeline behaviour", () => {
+  it("records collapse toggles from the tree", () => {
+    renderPanel();
+    expect(screen.getByTestId("collapsed-count").textContent).toBe("0");
+    fireEvent.click(screen.getByText("tree-toggle"));
+    expect(screen.getByTestId("collapsed-count").textContent).toBe("1");
+    fireEvent.click(screen.getByText("tree-toggle"));
+    expect(screen.getByTestId("collapsed-count").textContent).toBe("0");
+  });
+
+  it("selects directly from the tree in tree mode", () => {
+    const onSelectionChange = vi.fn();
+    renderPanel({ onSelectionChange });
+    fireEvent.click(screen.getByText("tree-select-trace"));
+    expect(onSelectionChange).toHaveBeenCalledWith({ type: "trace" });
+  });
+
+  it("returns to the tree and scrolls to the span when the timeline is clicked", async () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: /timeline/i }));
+    expect(screen.getByTestId("timeline")).toBeTruthy();
+    fireEvent.click(screen.getByText("timeline-select-span"));
+    // Back on the tree view, and the deferred scroll lands on the clicked span.
+    expect(screen.getByTestId("span-info")).toBeTruthy();
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(null)));
+    });
+    expect(scrollToSpan).toHaveBeenCalledWith("span-9");
+  });
+
+  it("mirrors scrolling between the tree and the timeline", async () => {
+    const { container } = renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: /timeline/i }));
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(null)));
+    });
+    const treeScroll = container.querySelector(".overflow-y-auto") as HTMLDivElement;
+    const timelineScroll = screen.getByTestId("timeline-scroll") as HTMLDivElement;
+
+    treeScroll.scrollTop = 120;
+    fireEvent.scroll(treeScroll);
+    expect(timelineScroll.scrollTop).toBe(120);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(() => r(null)));
+    });
+    timelineScroll.scrollTop = 260;
+    fireEvent.scroll(timelineScroll);
+    expect(treeScroll.scrollTop).toBe(260);
+  });
+});

--- a/frontend/ui/src/lib/eval/comparison-db.test.ts
+++ b/frontend/ui/src/lib/eval/comparison-db.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseScorers,
+  toComparisonRun,
+  toComparisonResults,
+  caseChangeToLegacy,
+} from "./comparison-db";
+
+describe("parseScorers", () => {
+  it("tolerates the legacy {name, version} shape (no metadata)", () => {
+    expect(parseScorers([{ name: "acc", version: "v1" }])).toEqual([
+      { name: "acc", version: "v1", valueType: null, direction: null, threshold: null },
+    ]);
+  });
+
+  it("reads richer metadata when present and ignores unknown values", () => {
+    expect(
+      parseScorers([
+        {
+          name: "lat",
+          version: "v2",
+          value_type: "numeric",
+          direction: "lower_is_better",
+          threshold: 0.5,
+        },
+        { name: "bad", version: "v1", value_type: "nonsense", direction: "sideways" },
+      ]),
+    ).toEqual([
+      {
+        name: "lat",
+        version: "v2",
+        valueType: "numeric",
+        direction: "lower_is_better",
+        threshold: 0.5,
+      },
+      { name: "bad", version: "v1", valueType: null, direction: null, threshold: null },
+    ]);
+  });
+
+  it("returns [] for null / non-array / malformed entries", () => {
+    expect(parseScorers(null)).toEqual([]);
+    expect(parseScorers("nope")).toEqual([]);
+    expect(parseScorers([{ version: "v1" }, 42, null])).toEqual([]);
+  });
+});
+
+describe("toComparisonRun", () => {
+  it("maps DB run fields and parses scorers", () => {
+    const run = toComparisonRun({
+      id: "r1",
+      runNumber: 3,
+      evaluationId: "e1",
+      datasetVersionId: "dsv1",
+      candidateVersion: "sonnet",
+      status: "completed",
+      mainScore: 0.8,
+      mainScoreName: "acc",
+      baselineRunId: "r0",
+      scorers: [{ name: "acc", version: "unversioned" }],
+    });
+    expect(run.mainScoreName).toBe("acc");
+    expect(run.scorers).toEqual([
+      { name: "acc", version: "unversioned", valueType: null, direction: null, threshold: null },
+    ]);
+  });
+});
+
+describe("toComparisonResults", () => {
+  it("maps results + scores to engine inputs", () => {
+    const [r] = toComparisonResults([
+      {
+        testCaseId: "t1",
+        status: "passed",
+        mainScore: 1,
+        candidateOutput: "out",
+        durationMs: 123,
+        scores: [
+          {
+            scorerName: "acc",
+            scorerVersion: "v1",
+            numericValue: 1,
+            boolValue: null,
+            stringValue: null,
+            error: null,
+          },
+        ],
+      },
+    ]);
+    expect(r.testCaseId).toBe("t1");
+    expect(r.durationMs).toBe(123);
+    expect(r.scores[0]).toMatchObject({ scorerName: "acc", numericValue: 1 });
+  });
+});
+
+describe("caseChangeToLegacy", () => {
+  it("passes through directional verdicts and nulls the rest", () => {
+    expect(caseChangeToLegacy("improved")).toBe("improved");
+    expect(caseChangeToLegacy("regressed")).toBe("regressed");
+    expect(caseChangeToLegacy("unchanged")).toBe("unchanged");
+    expect(caseChangeToLegacy("changed")).toBeNull();
+    expect(caseChangeToLegacy("unpaired")).toBeNull();
+    expect(caseChangeToLegacy("not_comparable")).toBeNull();
+  });
+});

--- a/frontend/ui/src/lib/eval/comparison-db.ts
+++ b/frontend/ui/src/lib/eval/comparison-db.ts
@@ -1,0 +1,110 @@
+/**
+ * Adapters from the stored (Prisma) eval shapes to the pure comparison engine's
+ * inputs. Kept separate so both the run-detail and run-list read paths derive
+ * comparison from the one engine (lib/eval/comparison.ts) without duplicating the
+ * mapping. These accept structurally-typed rows to avoid importing Prisma types.
+ */
+import type {
+  ComparisonRun,
+  ComparisonResult,
+  ComparisonScore,
+  ComparisonScorerMeta,
+} from "./comparison";
+
+interface DbScore {
+  scorerName: string;
+  scorerVersion: string;
+  numericValue: number | null;
+  boolValue: boolean | null;
+  stringValue: string | null;
+  error: string | null;
+}
+
+interface DbResult {
+  testCaseId: string;
+  status: string;
+  mainScore: number | null;
+  candidateOutput: string | null;
+  durationMs: number | null;
+  scores: DbScore[];
+}
+
+interface DbRun {
+  id: string;
+  runNumber: number;
+  evaluationId: string;
+  datasetVersionId: string;
+  candidateVersion: string;
+  status: string;
+  mainScore: number | null;
+  mainScoreName: string | null;
+  baselineRunId: string | null;
+  scorers: unknown; // Json: [{ name, version, value_type?, direction?, threshold? }]
+}
+
+/** Parse the run's `scorers` JSON into typed metadata, tolerating old `{name,version}`. */
+export function parseScorers(json: unknown): ComparisonScorerMeta[] {
+  if (!Array.isArray(json)) return [];
+  const out: ComparisonScorerMeta[] = [];
+  for (const raw of json) {
+    if (!raw || typeof raw !== "object") continue;
+    const o = raw as Record<string, unknown>;
+    if (typeof o.name !== "string") continue;
+    out.push({
+      name: o.name,
+      version: typeof o.version === "string" ? o.version : "",
+      valueType:
+        o.value_type === "numeric" || o.value_type === "boolean" || o.value_type === "categorical"
+          ? o.value_type
+          : null,
+      direction:
+        o.direction === "higher_is_better" ||
+        o.direction === "lower_is_better" ||
+        o.direction === "none"
+          ? o.direction
+          : null,
+      threshold: typeof o.threshold === "number" ? o.threshold : null,
+    });
+  }
+  return out;
+}
+
+export function toComparisonRun(r: DbRun): ComparisonRun {
+  return {
+    id: r.id,
+    runNumber: r.runNumber,
+    evaluationId: r.evaluationId,
+    datasetVersionId: r.datasetVersionId,
+    candidateVersion: r.candidateVersion,
+    status: r.status,
+    mainScore: r.mainScore,
+    mainScoreName: r.mainScoreName,
+    baselineRunId: r.baselineRunId,
+    scorers: parseScorers(r.scorers),
+  };
+}
+
+export function toComparisonResults(rows: DbResult[]): ComparisonResult[] {
+  return rows.map((r) => ({
+    testCaseId: r.testCaseId,
+    status: r.status,
+    mainScore: r.mainScore,
+    candidateOutput: r.candidateOutput,
+    durationMs: r.durationMs,
+    scores: r.scores.map(
+      (s): ComparisonScore => ({
+        scorerName: s.scorerName,
+        scorerVersion: s.scorerVersion,
+        numericValue: s.numericValue,
+        boolValue: s.boolValue,
+        stringValue: s.stringValue,
+        error: s.error,
+      }),
+    ),
+  }));
+}
+
+/** Map a derived case verdict back onto the legacy `change` enum (best effort). */
+export function caseChangeToLegacy(c: string): "improved" | "regressed" | "unchanged" | null {
+  return c === "improved" || c === "regressed" || c === "unchanged" ? c : null;
+}

--- a/frontend/ui/src/lib/eval/pass-rate.test.ts
+++ b/frontend/ui/src/lib/eval/pass-rate.test.ts
@@ -35,7 +35,8 @@ describe("countResultStatuses", () => {
 
 describe("passRate", () => {
   it("divides passed by passed + failed", () => {
-    expect(passRate(18, 4)).toBeCloseTo(0.8181, 3);
+    // Exact, not toBeCloseTo: a loose tolerance would also accept a subtly wrong formula.
+    expect(passRate(18, 4)).toBe(18 / 22);
   });
 
   // The load-bearing rule: an all-errored run must not read as a 0% quality collapse.

--- a/frontend/ui/src/lib/eval/pass-rate.test.ts
+++ b/frontend/ui/src/lib/eval/pass-rate.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { countResultStatuses, passRate, excludedSummary } from "./pass-rate";
+
+describe("countResultStatuses", () => {
+  it("counts each status independently", () => {
+    expect(
+      countResultStatuses([
+        { status: "passed" },
+        { status: "passed" },
+        { status: "failed" },
+        { status: "errored" },
+        { status: "not_scored" },
+      ]),
+    ).toEqual({ passedCount: 2, failedCount: 1, erroredCount: 1, notScoredCount: 1 });
+  });
+
+  it("returns all zeros for no results", () => {
+    expect(countResultStatuses([])).toEqual({
+      passedCount: 0,
+      failedCount: 0,
+      erroredCount: 0,
+      notScoredCount: 0,
+    });
+  });
+
+  it("ignores unrecognised status strings rather than throwing", () => {
+    expect(countResultStatuses([{ status: "weird" }, { status: "passed" }])).toEqual({
+      passedCount: 1,
+      failedCount: 0,
+      erroredCount: 0,
+      notScoredCount: 0,
+    });
+  });
+});
+
+describe("passRate", () => {
+  it("divides passed by passed + failed", () => {
+    expect(passRate(18, 4)).toBeCloseTo(0.8181, 3);
+  });
+
+  // The load-bearing rule: an all-errored run must not read as a 0% quality collapse.
+  it("returns null when nothing was judged", () => {
+    expect(passRate(0, 0)).toBeNull();
+  });
+
+  it("returns 0 when cases were judged and all failed", () => {
+    expect(passRate(0, 5)).toBe(0);
+  });
+
+  it("returns 1 when every judged case passed", () => {
+    expect(passRate(5, 0)).toBe(1);
+  });
+});
+
+describe("excludedSummary", () => {
+  it("returns null when nothing was excluded", () => {
+    expect(excludedSummary(0, 0)).toBeNull();
+  });
+
+  it("names both kinds when both are present", () => {
+    expect(excludedSummary(2, 1)).toBe("2 errored, 1 not scored");
+  });
+
+  it("omits a zero side", () => {
+    expect(excludedSummary(0, 3)).toBe("3 not scored");
+    expect(excludedSummary(4, 0)).toBe("4 errored");
+  });
+});

--- a/frontend/ui/src/lib/eval/pass-rate.ts
+++ b/frontend/ui/src/lib/eval/pass-rate.ts
@@ -1,0 +1,49 @@
+/**
+ * Run pass rate — derived from stored per-result statuses, never from the run's
+ * stored counters. See docs/offline-eval-run-pass-rate-design.md.
+ *
+ * The denominator is `passed + failed`, inherited from the SDK's own definition
+ * (`traceroot-py/traceroot/eval/results.py`: `scored_count = passed + failed`).
+ * `errored` (the candidate app broke) and `not_scored` (no numeric/boolean main
+ * score) are excluded from both sides: neither is a bad grade.
+ */
+
+export interface ResultStatusCounts {
+  passedCount: number;
+  failedCount: number;
+  erroredCount: number;
+  notScoredCount: number;
+}
+
+export function countResultStatuses(results: Array<{ status: string }>): ResultStatusCounts {
+  const counts: ResultStatusCounts = {
+    passedCount: 0,
+    failedCount: 0,
+    erroredCount: 0,
+    notScoredCount: 0,
+  };
+  for (const r of results) {
+    if (r.status === "passed") counts.passedCount += 1;
+    else if (r.status === "failed") counts.failedCount += 1;
+    else if (r.status === "errored") counts.erroredCount += 1;
+    else if (r.status === "not_scored") counts.notScoredCount += 1;
+  }
+  return counts;
+}
+
+/**
+ * Null when nothing was judged — an all-errored run must render "—", never "0%",
+ * which would read as a catastrophic quality regression rather than a broken harness.
+ */
+export function passRate(passedCount: number, failedCount: number): number | null {
+  const judged = passedCount + failedCount;
+  return judged === 0 ? null : passedCount / judged;
+}
+
+/** Human phrase for the cases the fraction excludes, or null when it excludes none. */
+export function excludedSummary(erroredCount: number, notScoredCount: number): string | null {
+  const parts: string[] = [];
+  if (erroredCount > 0) parts.push(`${erroredCount} errored`);
+  if (notScoredCount > 0) parts.push(`${notScoredCount} not scored`);
+  return parts.length > 0 ? parts.join(", ") : null;
+}

--- a/frontend/ui/src/lib/eval/pass-rate.ts
+++ b/frontend/ui/src/lib/eval/pass-rate.ts
@@ -15,7 +15,15 @@ export interface ResultStatusCounts {
   notScoredCount: number;
 }
 
-export function countResultStatuses(results: Array<{ status: string }>): ResultStatusCounts {
+/**
+ * Fold result statuses into per-status counts. Rows may be individual results or
+ * pre-aggregated groups: `count` defaults to 1, so the same fold serves both a list
+ * of result rows and a `groupBy(["runId", "status"])` projection, which is how the
+ * runs list gets these counts without materialising the rows.
+ */
+export function countResultStatuses(
+  results: Array<{ status: string; count?: number }>,
+): ResultStatusCounts {
   const counts: ResultStatusCounts = {
     passedCount: 0,
     failedCount: 0,
@@ -23,10 +31,11 @@ export function countResultStatuses(results: Array<{ status: string }>): ResultS
     notScoredCount: 0,
   };
   for (const r of results) {
-    if (r.status === "passed") counts.passedCount += 1;
-    else if (r.status === "failed") counts.failedCount += 1;
-    else if (r.status === "errored") counts.erroredCount += 1;
-    else if (r.status === "not_scored") counts.notScoredCount += 1;
+    const n = r.count ?? 1;
+    if (r.status === "passed") counts.passedCount += n;
+    else if (r.status === "failed") counts.failedCount += n;
+    else if (r.status === "errored") counts.erroredCount += n;
+    else if (r.status === "not_scored") counts.notScoredCount += n;
   }
   return counts;
 }


### PR DESCRIPTION
## Summary

Fixes: #1651

The runs-list endpoint the UI reads assembles each run with everything derivable computed at read time — per-status result counts, pass rate, total cost, and duration — so the list can never disagree with the underlying results. Cost aggregates by summing per-result cost, treating a null result cost as absent rather than zero, and duration comes from the run's started/completed timestamps. The list can be scoped to a single evaluation so a lineage can be grouped.

## What's included

### Backend (route handler)
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts` — project-scoped, paginated runs list. Filters on `evaluation_id`, `dataset_id`, `status`, and `search_query`. Per run it derives status counts and pass rate, sums cost across results (null when no result carries a cost — never a misleading `0`), computes `elapsedMs` from started/completed timestamps, and folds in a restrained comparison summary (`changeFromBaseline`, `regressedCaseCount`) from the shared engine, batched so the page costs a bounded number of queries.

### Derivation module (`frontend/ui/src/lib/eval`)
- `pass-rate.ts` — `countResultStatuses` (passed / failed / errored / not-scored), `passRate` (denominator is `passed + failed`; null when nothing was judged, so an all-errored run renders "—" not "0%"), and `excludedSummary` for the excluded-case phrasing.
- `frontend/ui/src/lib/eval/comparison-db.ts` — Adapters from the stored (Prisma) eval shapes to the pure comparison engine's inputs.

### Tests
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts` — derived per-status counts, zero-result runs, trustworthy delta + elapsed derivation, and preferring derived counts over a disagreeing stored counter.
- `frontend/ui/src/lib/eval/pass-rate.test.ts` — status counting and the zero-denominator rule.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/route.test.ts` — covers `route`.
- `frontend/ui/src/app/projects/[projectId]/traces/page.prefetch.test.tsx` — covers `page.prefetch`.
- `frontend/ui/src/features/traces/components/TraceViewerPanel.interactions.test.tsx` — covers `TraceViewerPanel.interactions`.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts` — covers `route.readback`.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.test.ts` — covers `route`.
- `frontend/ui/src/app/api/public/datasets/[datasetId]/route.test.ts` — covers `route`.
- `frontend/ui/src/lib/eval/comparison-db.test.ts` — covers `comparison-db`.

### Frontend
- `frontend/packages/core/prisma/migrations/20260731000000_add_eval_read_model_indexes/migration.sql` — CreateIndex: the runs list is `where project_id = ? [and evaluation_id = ?] [and dataset_id = ?] order by started_at desc` with offset pagination. With only.
- `frontend/packages/core/prisma/schema.prisma` — part of this change.
- `frontend/ui/src/features/evaluations/types.ts` — Client-side shapes for the server-backed evaluation feature. Timestamps arrive as ISO strings over JSON, so these mirror the Prisma rows with string dates.

### Routes
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/route.ts` — provides `GET`.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts` — provides `GET`.

## Test plan
- [ ] Each run row carries status counts, pass rate, cost, and duration with no stored copy.
- [ ] Scoping to one evaluation (`evaluation_id`) returns only that lineage.
- [ ] Pass rate excludes errored/not-scored cases and stays null when nothing was judged.
- [ ] Total cost stays null when no result carries a derived or reported cost — never shown as free.
- [ ] A run mid-flight (non-terminal status) returns coherent partial counts and a running duration.
- [ ] Confirm the endpoint is project-scoped and rejects cross-project access.
