### PR TITLE
feat(runs): evaluations run table

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts
@@ -454,3 +454,149 @@ it("prefers the derived counts over a stored scoredCount that disagrees", async 
   // The stored counter is passed through untouched — it is not reconciled in v1.
   expect(body.data[0].scoredCount).toBe(9);
 });
+
+// ── sort/order whitelist + started_after/started_before ────────────────────
+
+function run(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "run_x",
+    projectId: "p1",
+    evaluationId: "e1",
+    datasetId: "ds1",
+    datasetVersionId: "dv1",
+    runNumber: 1,
+    candidateVersion: "sonnet",
+    status: "completed",
+    baselineRunId: null,
+    mainScore: 0.5,
+    mainScoreName: "acc",
+    taskErrorCount: 0,
+    scorerErrorCount: 0,
+    scorers: [],
+    startedAt: new Date("2026-07-21T00:00:00Z"),
+    completedAt: new Date("2026-07-21T00:00:05Z"),
+    evaluation: { name: "ticket-routing" },
+    datasetVersion: { label: "v1" },
+    ...overrides,
+  };
+}
+
+it("whitelists sort — an unrecognized value falls back to startedAt desc, never reaching orderBy raw", async () => {
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run()]);
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+
+  await GET(nextUrl("sort=%27%3B%20DROP%20TABLE%20runs%3B--&order=asc") as never, params);
+
+  // sort is unrecognized, so it falls back to the default field (startedAt);
+  // order is independently valid ("asc") and still applies to that field —
+  // the point is that the raw sort value never reaches `orderBy`.
+  expect(prismaMock.evaluationRun.findMany).toHaveBeenCalledWith(
+    expect.objectContaining({ orderBy: { startedAt: "asc" } }),
+  );
+});
+
+it("sorts by mainScore ascending via the DB when sort=mainScore&order=asc", async () => {
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run()]);
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+
+  await GET(nextUrl("sort=mainScore&order=asc") as never, params);
+
+  expect(prismaMock.evaluationRun.findMany).toHaveBeenCalledWith(
+    expect.objectContaining({ orderBy: { mainScore: "asc" } }),
+  );
+});
+
+it("sorts by cost across the FULL filtered set (not just the fetched page), nulls last", async () => {
+  const cheap = run({ id: "run_cheap" });
+  const pricey = run({ id: "run_pricey" });
+  const noCost = run({ id: "run_no_cost" });
+  // No skip/take here — the cost/elapsedMs branch fetches the whole filtered
+  // set once (not paginated) so it can sort before slicing to a page.
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([cheap, pricey, noCost]);
+  // The route asks for `_count: { _all: true }` alongside `_sum`, and reads
+  // `g._count._all` to derive the per-status counts — so the group rows must
+  // carry it or the handler throws before the sort is ever exercised.
+  prismaMock.evaluationResult.groupBy.mockResolvedValue([
+    { runId: "run_cheap", status: "passed", _count: { _all: 1 }, _sum: { cost: 1.5 } },
+    { runId: "run_pricey", status: "passed", _count: { _all: 1 }, _sum: { cost: 42 } },
+    // run_no_cost has no group row at all (no results with a non-null cost).
+  ]);
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+
+  const body = (await (await GET(nextUrl("sort=cost&order=desc") as never, params)).json()) as {
+    data: Record<string, unknown>[];
+    meta: { total: number };
+  };
+
+  expect(body.data.map((r) => r.id)).toEqual(["run_pricey", "run_cheap", "run_no_cost"]);
+  expect(body.meta.total).toBe(3);
+  // This branch never asks the DB to order/paginate directly — it derives the
+  // sort key itself and slices after.
+  expect(prismaMock.evaluationRun.count).not.toHaveBeenCalled();
+});
+
+it("sorts by elapsedMs, treating a still-running run (no completedAt) as sorting last", async () => {
+  const slow = run({
+    id: "run_slow",
+    startedAt: new Date("2026-07-21T00:00:00Z"),
+    completedAt: new Date("2026-07-21T00:10:00Z"),
+  });
+  const fast = run({
+    id: "run_fast",
+    startedAt: new Date("2026-07-21T00:00:00Z"),
+    completedAt: new Date("2026-07-21T00:00:01Z"),
+  });
+  const running = run({
+    id: "run_running",
+    startedAt: new Date("2026-07-21T00:00:00Z"),
+    completedAt: null,
+  });
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([slow, fast, running]);
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+
+  const body = (await (await GET(nextUrl("sort=elapsedMs&order=asc") as never, params)).json()) as {
+    data: Record<string, unknown>[];
+  };
+
+  expect(body.data.map((r) => r.id)).toEqual(["run_fast", "run_slow", "run_running"]);
+});
+
+it("narrows to a startedAt window via started_after/started_before", async () => {
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run()]);
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+
+  await GET(
+    nextUrl(
+      "started_after=2026-07-01T00:00:00.000Z&started_before=2026-07-31T00:00:00.000Z",
+    ) as never,
+    params,
+  );
+
+  expect(prismaMock.evaluationRun.findMany).toHaveBeenCalledWith(
+    expect.objectContaining({
+      where: expect.objectContaining({
+        startedAt: {
+          gte: new Date("2026-07-01T00:00:00.000Z"),
+          lte: new Date("2026-07-31T00:00:00.000Z"),
+        },
+      }),
+    }),
+  );
+});
+
+it("drops an unparseable started_after instead of erroring", async () => {
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run()]);
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+
+  await GET(nextUrl("started_after=not-a-date") as never, params);
+
+  expect(prismaMock.evaluationRun.findMany).toHaveBeenCalledWith(
+    expect.objectContaining({
+      where: expect.not.objectContaining({ startedAt: expect.anything() }),
+    }),
+  );
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
@@ -129,7 +129,10 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     [runs, total] = await prisma.$transaction([
       prisma.evaluationRun.findMany({
         where,
-        orderBy: { [sort]: order },
+        // Secondary sort on the unique id so ties (equal mainScore/status) have a
+        // stable total order — otherwise skip/take pagination can duplicate or drop
+        // runs across pages.
+        orderBy: [{ [sort]: order }, { id: order }],
         skip: page * limit,
         take: limit,
         include,
@@ -171,15 +174,19 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     }
 
     const dir = order === "asc" ? 1 : -1;
+    // Break every tie on the unique id so the order is total and deterministic —
+    // an unstable sort re-orders equal values (or all-nulls) between requests, which
+    // slices into duplicated/skipped runs across pages.
+    const byId = (a: (typeof all)[number], b: (typeof all)[number]) => a.id.localeCompare(b.id);
     all.sort((a, b) => {
       const av = sortValue(a);
       const bv = sortValue(b);
       // Unknown (still running / no cost reported) always sorts last, in
       // either direction — never a misleading position for missing data.
-      if (av === null && bv === null) return 0;
+      if (av === null && bv === null) return byId(a, b);
       if (av === null) return 1;
       if (bv === null) return -1;
-      return (av - bv) * dir;
+      return (av - bv) * dir || byId(a, b);
     });
 
     runs = all.slice(page * limit, page * limit + limit);

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
@@ -64,6 +64,12 @@ function parseDateParam(value: string | null): Date | null {
 // that would already have been fetched.
 const DB_SORTABLE = new Set<SortField>(["startedAt", "mainScore", "status"]);
 
+// cost/elapsed can't be ordered in the DB (cost is a sum over related results; elapsed
+// is derived), so they're sorted in Node. Bound how many runs that pulls so a large
+// project history can't load every run — and every run's results for the cost sum —
+// into memory to serve one page.
+const MAX_INMEMORY_SORT = 500;
+
 // GET — evaluation runs (executions) for the project. Filters: evaluation_id,
 // dataset_id, status, search_query, started_after, started_before. Sort:
 // sort/order over startedAt|mainScore|cost|elapsedMs|status.
@@ -131,7 +137,20 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       prisma.evaluationRun.count({ where }),
     ]);
   } else {
-    const all = await prisma.evaluationRun.findMany({ where, include });
+    // Bound the set pulled for the Node-side sort (and thus the cost groupBy over its
+    // ids) to the most recent runs, so this can't OOM on a large project history.
+    const all = await prisma.evaluationRun.findMany({
+      where,
+      include,
+      orderBy: { runNumber: "desc" },
+      take: MAX_INMEMORY_SORT + 1,
+    });
+    if (all.length > MAX_INMEMORY_SORT) {
+      all.length = MAX_INMEMORY_SORT;
+      console.warn(
+        `runs list: cost/duration sort bounded to the ${MAX_INMEMORY_SORT} most recent runs`,
+      );
+    }
     total = all.length;
 
     let sortValue: (r: (typeof all)[number]) => number | null;

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
@@ -31,8 +31,42 @@ function sumOrNull(values: Array<number | null>): number | null {
   return present.length > 0 ? present.reduce((a, b) => a + b, 0) : null;
 }
 
+// Whitelist for `sort` — never let a raw query-string value reach `orderBy` or
+// an object-key lookup. Anything outside this set (or absent) falls back to
+// the default, it never errors.
+const SORT_FIELDS = ["startedAt", "mainScore", "cost", "elapsedMs", "status"] as const;
+type SortField = (typeof SORT_FIELDS)[number];
+const DEFAULT_SORT: SortField = "startedAt";
+
+function parseSort(value: string | null): SortField {
+  return (SORT_FIELDS as readonly string[]).includes(value ?? "")
+    ? (value as SortField)
+    : DEFAULT_SORT;
+}
+
+function parseOrder(value: string | null): "asc" | "desc" {
+  return value === "asc" ? "asc" : "desc";
+}
+
+/** A valid `Date`, or null for anything missing/unparseable — a bad bound is
+ * dropped rather than surfaced as an error, matching `limit`/`page` above. */
+function parseDateParam(value: string | null): Date | null {
+  if (!value) return null;
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+// startedAt/mainScore/status are real columns — sort + paginate in the DB.
+// cost/elapsedMs are derived (a per-run cost aggregate and a completedAt -
+// startedAt difference), so they're computed and sorted over the FULL
+// filtered set here on the server, then sliced to the requested page. That
+// keeps ordering correct across pages — never just a reorder of the page
+// that would already have been fetched.
+const DB_SORTABLE = new Set<SortField>(["startedAt", "mainScore", "status"]);
+
 // GET — evaluation runs (executions) for the project. Filters: evaluation_id,
-// dataset_id, status, search_query.
+// dataset_id, status, search_query, started_after, started_before. Sort:
+// sort/order over startedAt|mainScore|cost|elapsedMs|status.
 export async function GET(req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
@@ -49,6 +83,10 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
   const datasetId = searchParams.get("dataset_id")?.trim() || null;
   const status = searchParams.get("status")?.trim() || null;
   const searchQuery = searchParams.get("search_query")?.trim() || null;
+  const sort = parseSort(searchParams.get("sort"));
+  const order = parseOrder(searchParams.get("order"));
+  const startedAfter = parseDateParam(searchParams.get("started_after"));
+  const startedBefore = parseDateParam(searchParams.get("started_before"));
 
   const where = {
     projectId,
@@ -63,21 +101,70 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
           ],
         }
       : {}),
+    ...(startedAfter || startedBefore
+      ? {
+          startedAt: {
+            ...(startedAfter ? { gte: startedAfter } : {}),
+            ...(startedBefore ? { lte: startedBefore } : {}),
+          },
+        }
+      : {}),
   };
 
-  const [runs, total] = await prisma.$transaction([
-    prisma.evaluationRun.findMany({
-      where,
-      orderBy: { startedAt: "desc" },
-      skip: page * limit,
-      take: limit,
-      include: {
-        evaluation: { select: { name: true } },
-        datasetVersion: { select: { label: true } },
-      },
-    }),
-    prisma.evaluationRun.count({ where }),
-  ]);
+  const include = {
+    evaluation: { select: { name: true } },
+    datasetVersion: { select: { label: true } },
+  };
+
+  let runs: Awaited<ReturnType<typeof prisma.evaluationRun.findMany<{ include: typeof include }>>>;
+  let total: number;
+
+  if (DB_SORTABLE.has(sort)) {
+    [runs, total] = await prisma.$transaction([
+      prisma.evaluationRun.findMany({
+        where,
+        orderBy: { [sort]: order },
+        skip: page * limit,
+        take: limit,
+        include,
+      }),
+      prisma.evaluationRun.count({ where }),
+    ]);
+  } else {
+    const all = await prisma.evaluationRun.findMany({ where, include });
+    total = all.length;
+
+    let sortValue: (r: (typeof all)[number]) => number | null;
+    if (sort === "elapsedMs") {
+      sortValue = (r) => elapsedMs(r.startedAt, r.completedAt);
+    } else {
+      const ids = all.map((r) => r.id);
+      const costSums =
+        ids.length > 0
+          ? await prisma.evaluationResult.groupBy({
+              by: ["runId"],
+              where: { runId: { in: ids }, projectId, cost: { not: null } },
+              _sum: { cost: true },
+            })
+          : [];
+      const costByRun = new Map(costSums.map((c) => [c.runId, c._sum.cost]));
+      sortValue = (r) => costByRun.get(r.id) ?? null;
+    }
+
+    const dir = order === "asc" ? 1 : -1;
+    all.sort((a, b) => {
+      const av = sortValue(a);
+      const bv = sortValue(b);
+      // Unknown (still running / no cost reported) always sorts last, in
+      // either direction — never a misleading position for missing data.
+      if (av === null && bv === null) return 0;
+      if (av === null) return 1;
+      if (bv === null) return -1;
+      return (av - bv) * dir;
+    });
+
+    runs = all.slice(page * limit, page * limit + limit);
+  }
 
   const datasetIds = [...new Set(runs.map((r) => r.datasetId))];
   const datasets =

--- a/frontend/ui/src/components/icons/domain-icons.ts
+++ b/frontend/ui/src/components/icons/domain-icons.ts
@@ -46,6 +46,7 @@ export const DOMAIN_ICONS = {
   assistant: BotMessageSquare,
   user: Users,
   session: Layers,
+  lineage: Layers,
   trace: Workflow,
   id: Hash,
   // Distinct concept from `id` (a count of things vs. an identifier) that

--- a/frontend/ui/src/features/evaluations/components/pass-rate.test.tsx
+++ b/frontend/ui/src/features/evaluations/components/pass-rate.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { PassRate } from "./pass-rate";
+
+const counts = (p: number, f: number, e = 0, n = 0) => ({
+  passedCount: p,
+  failedCount: f,
+  erroredCount: e,
+  notScoredCount: n,
+});
+
+afterEach(() => cleanup());
+
+describe("PassRate", () => {
+  it("renders the fraction and the percentage", () => {
+    render(<PassRate counts={counts(18, 4)} />);
+    expect(screen.getByText("18/22")).toBeDefined();
+    expect(screen.getByText("81.8%")).toBeDefined();
+  });
+
+  // The load-bearing rule from the spec.
+  it("renders an em dash, never 0%, when nothing was judged", () => {
+    render(<PassRate counts={counts(0, 0, 25, 0)} />);
+    expect(screen.getByText("—")).toBeDefined();
+    expect(screen.queryByText("0.0%")).toBeNull();
+  });
+
+  it("renders 0.0% when cases were judged and all failed", () => {
+    render(<PassRate counts={counts(0, 5)} />);
+    expect(screen.getByText("0.0%")).toBeDefined();
+  });
+
+  it("exposes excluded cases via the title attribute", () => {
+    const { container } = render(<PassRate counts={counts(18, 4, 2, 1)} />);
+    expect(container.querySelector("[title]")?.getAttribute("title")).toBe(
+      "2 errored, 1 not scored",
+    );
+  });
+
+  it("adds the word 'passed' in label form", () => {
+    render(<PassRate counts={counts(18, 4)} withLabel />);
+    expect(screen.getByText(/18\/22 passed/)).toBeDefined();
+  });
+});

--- a/frontend/ui/src/features/evaluations/components/pass-rate.tsx
+++ b/frontend/ui/src/features/evaluations/components/pass-rate.tsx
@@ -1,0 +1,49 @@
+import { pctFraction } from "@/features/offline-eval/utils";
+import { passRate, excludedSummary, type ResultStatusCounts } from "@/lib/eval/pass-rate";
+
+/**
+ * Share of judgeable cases that passed. Errored and not-scored cases are excluded
+ * from both sides of the fraction and surfaced in the title instead.
+ *
+ * `withLabel` is the run-detail filter-bar form ("18/22 passed · 81.8%"); the bare
+ * form is the runs-table cell (fraction over percentage).
+ */
+export function PassRate({
+  counts,
+  withLabel = false,
+}: {
+  counts: ResultStatusCounts;
+  withLabel?: boolean;
+}) {
+  const rate = passRate(counts.passedCount, counts.failedCount);
+  const title = excludedSummary(counts.erroredCount, counts.notScoredCount) ?? undefined;
+
+  // No case was judged: an all-errored run is not a 0% run.
+  if (rate === null) {
+    return (
+      <span className="text-muted-foreground" title={title}>
+        —
+      </span>
+    );
+  }
+
+  const judged = counts.passedCount + counts.failedCount;
+  const fraction = `${counts.passedCount}/${judged}`;
+
+  if (withLabel) {
+    return (
+      <span className="text-[12px] tabular-nums text-muted-foreground" title={title}>
+        <span className="text-foreground">{fraction} passed</span> · {pctFraction(rate)}
+      </span>
+    );
+  }
+
+  // A block wrapper, not a span: the two stacked lines are divs and a span may not
+  // contain block-level children.
+  return (
+    <div title={title}>
+      <div>{fraction}</div>
+      <div className="text-[11px] text-muted-foreground">{pctFraction(rate)}</div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
@@ -201,7 +201,9 @@ export function RunEvaluationDrawer({
           </div>
           <HighlightedCode
             code={code}
-            className="overflow-x-auto whitespace-pre px-3 py-2.5 font-mono text-[11px] leading-relaxed"
+            // Extra bottom padding so the last line clears the border — and the
+            // horizontal scrollbar, which otherwise sits right on top of it.
+            className="overflow-x-auto whitespace-pre px-3 pb-5 pt-2.5 font-mono text-[11px] leading-relaxed"
           />
         </div>
 

--- a/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
@@ -199,11 +199,12 @@ export function RunEvaluationDrawer({
               title="Copy"
             />
           </div>
+          {/* Self-contained scroll box: the code scrolls WITHIN a bounded height
+              (independent of the drawer body's scroll), and pb-6 keeps the last line
+              clear of the horizontal scrollbar at the pre's bottom edge. */}
           <HighlightedCode
             code={code}
-            // Extra bottom padding so the last line clears the border — and the
-            // horizontal scrollbar, which otherwise sits right on top of it.
-            className="overflow-x-auto whitespace-pre px-3 pb-5 pt-2.5 font-mono text-[11px] leading-relaxed"
+            className="max-h-[55vh] overflow-auto whitespace-pre px-3 pb-6 pt-2.5 font-mono text-[11px] leading-relaxed"
           />
         </div>
 

--- a/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
@@ -18,20 +18,49 @@ import { useDatasets } from "../hooks";
 import type { DatasetRow } from "../types";
 
 /**
- * "Run evaluation" — a copyable SDK starter snippet (not a form). Faithful port
- * of the prototype's drawer, wired to real datasets: the snippet references the
+ * "Run evaluation" — a copyable SDK starter snippet (not a form), wired to real
+ * datasets: the snippet references the
  * selected dataset's real id and current version id. Evaluations run in the
  * customer's app/CI and report back; this panel configures nothing.
  */
 
 type Lang = "python" | "typescript";
 
+/** Strip control characters (including newlines) before embedding free-form
+ * text in a source snippet — they have no legitimate reason to appear in a
+ * one-line string literal and would otherwise break the snippet across lines. */
+function stripControlChars(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[\u0000-\u001f\u007f]/g, "");
+}
+
+/** Render as a double-quoted Python string literal. Dataset names are
+ * free-form (`z.string().min(1).max(200)`, no character restrictions), so a
+ * name containing `"` or `\` must be escaped or the generated snippet is
+ * either invalid Python or — worse — breaks out of the string literal. */
+function pyStringLiteral(value: string): string {
+  const escaped = stripControlChars(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+/** Render as a double-quoted TS/JS string literal. `JSON.stringify` already
+ * produces a valid, fully-escaped double-quoted JS string literal. */
+function tsStringLiteral(value: string): string {
+  return JSON.stringify(stripControlChars(value));
+}
+
 function snippet(lang: Lang, dataset: DatasetRow | undefined): string {
   const name = dataset?.name ?? "My dataset";
   const datasetId = dataset?.id ?? "ds_...";
   const versionId = dataset?.currentVersionId ?? "dsv_...";
+  // Plain (comment-safe) values: control characters/newlines stripped so a
+  // free-form name can't break out of a `#`/`//` comment onto a new line.
+  const commentDatasetId = stripControlChars(datasetId);
+  const commentVersionId = stripControlChars(versionId);
 
   if (lang === "python") {
+    const pyName = pyStringLiteral(name);
+    const pyDatasetId = pyStringLiteral(datasetId);
     return `import traceroot
 from traceroot import evaluate, pull_dataset
 
@@ -45,16 +74,16 @@ from evals.scorers import routing_accuracy
 traceroot.initialize()
 
 # 3. Pull the dataset this run measures (its current published version).
-#    dataset_id:         ${datasetId}
-#    dataset_version_id: ${versionId}
-dataset = pull_dataset("${datasetId}")
+#    dataset_id:         ${commentDatasetId}
+#    dataset_version_id: ${commentVersionId}
+dataset = pull_dataset(${pyDatasetId})
 
 # 4. The task receives EvalCase.input and returns your application's output.
 def run_candidate(ticket):
     return handle_ticket(ticket)
 
 result = evaluate(
-    name="${name}",
+    name=${pyName},
     data=dataset,
     task=run_candidate,
     scorers=[routing_accuracy],
@@ -64,6 +93,7 @@ result = evaluate(
 print(result.to_dict())`;
   }
 
+  const tsName = tsStringLiteral(name);
   return `import * as traceroot from "traceroot";
 import { Dataset, evaluate } from "traceroot";
 
@@ -76,9 +106,9 @@ import { routingAccuracy } from "./evals/scorers";
 traceroot.initialize();
 
 // 3. The dataset this run measures.
-//    datasetId:        ${datasetId}
-//    datasetVersionId: ${versionId}
-const dataset = new Dataset("${name}");
+//    datasetId:        ${commentDatasetId}
+//    datasetVersionId: ${commentVersionId}
+const dataset = new Dataset(${tsName});
 
 // 4. The task receives EvalCase.input and returns your application's output.
 async function runCandidate(ticket) {
@@ -86,7 +116,7 @@ async function runCandidate(ticket) {
 }
 
 const result = await evaluate({
-  name: "${name}",
+  name: ${tsName},
   data: dataset,
   task: runCandidate,
   scorers: [routingAccuracy],

--- a/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
@@ -18,8 +18,8 @@ import { useDatasets } from "../hooks";
 import type { DatasetRow } from "../types";
 
 /**
- * "Run evaluation" — a copyable SDK starter snippet (not a form), wired to real
- * datasets: the snippet references the
+ * "Run evaluation" — a copyable SDK starter snippet (not a form). Faithful port
+ * of the prototype's drawer, wired to real datasets: the snippet references the
  * selected dataset's real id and current version id. Evaluations run in the
  * customer's app/CI and report back; this panel configures nothing.
  */
@@ -199,12 +199,9 @@ export function RunEvaluationDrawer({
               title="Copy"
             />
           </div>
-          {/* Self-contained scroll box: the code scrolls WITHIN a bounded height
-              (independent of the drawer body's scroll), and pb-6 keeps the last line
-              clear of the horizontal scrollbar at the pre's bottom edge. */}
           <HighlightedCode
             code={code}
-            className="max-h-[55vh] overflow-auto whitespace-pre px-3 pb-6 pt-2.5 font-mono text-[11px] leading-relaxed"
+            className="overflow-x-auto whitespace-pre px-3 py-2.5 font-mono text-[11px] leading-relaxed"
           />
         </div>
 

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import * as React from "react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   ArrowDown,
   ArrowUp,
   ChevronDown,
+  ChevronLeft,
   ChevronRight,
   Layers,
   ListChecks,
@@ -25,6 +27,7 @@ import {
 } from "@/components/ui/select";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
+import { useKeywordSearch } from "@/lib/hooks/use-keyword-search";
 import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
 import { Input } from "@/components/ui/input";
 import { CopyButton } from "@/components/ui/copy-button";
@@ -107,6 +110,9 @@ export function EvaluationsView({ projectId }: { projectId: string }) {
 // ---------------------------------------------------------------------------
 
 const RUNS_COLUMN_COUNT = 8;
+// Matches the route's default `limit` (runs/route.ts) so the page-count math
+// here lines up with what the server actually returns per page.
+const RUNS_PAGE_LIMIT = 50;
 
 /** Human elapsed duration; "—" when unknown (never 0). */
 export function formatElapsed(ms: number | null | undefined): string {
@@ -168,7 +174,14 @@ function RunTableRow({
           </button>
         )}
         <div className="text-[11px] text-muted-foreground">
-          Run #{r.runNumber} · <span className="font-mono">{r.candidateVersion}</span>
+          <Link
+            href={`/projects/${projectId}/evaluations/${r.id}`}
+            className="rounded hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            onClick={(e) => e.stopPropagation()}
+          >
+            Run #{r.runNumber}
+          </Link>{" "}
+          · <span className="font-mono">{r.candidateVersion}</span>
         </div>
       </Td>
       <Td className="text-muted-foreground">
@@ -419,7 +432,7 @@ function RunsTab({ projectId }: { projectId: string }) {
   // browser back/forward and sharing work.
   const scopedEvalId = searchParams.get("evaluation");
 
-  const [keyword, setKeyword] = React.useState("");
+  const { keyword, setKeyword, searchQuery } = useKeywordSearch();
   const [datasetFilter, setDatasetFilter] = React.useState(ALL);
   const [statusFilter, setStatusFilter] = React.useState(ALL);
   const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
@@ -430,15 +443,27 @@ function RunsTab({ projectId }: { projectId: string }) {
   const [latestOnly, setLatestOnly] = React.useState(false);
   const [groupBy, setGroupBy] = React.useState(false);
   const [expanded, setExpanded] = React.useState<Set<string>>(new Set());
+  const [page, setPage] = React.useState(0);
+  // Any change to scope/filters invalidates the current page — otherwise a
+  // narrower filter can land on a page past the end of its (now shorter) result set.
+  React.useEffect(() => {
+    setPage(0);
+  }, [scopedEvalId, searchQuery, datasetFilter, statusFilter]);
 
   const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
   const { data, isLoading, error } = useEvaluationRuns(projectId, {
     evaluation_id: scopedEvalId ?? undefined,
-    search_query: keyword.trim() || undefined,
+    search_query: searchQuery,
     dataset_id: datasetFilter === ALL ? undefined : datasetFilter,
     status: statusFilter === ALL ? undefined : statusFilter,
+    page,
+    limit: RUNS_PAGE_LIMIT,
   });
   const allRuns = React.useMemo(() => data?.data ?? [], [data]);
+  const total: number = data?.meta?.total ?? 0;
+  // Keys off the immediate `keyword`, not the debounced `searchQuery`, so the
+  // empty-state copy doesn't flicker to "no runs yet" for the 300ms before the
+  // debounced value catches up.
   const filtered = !!keyword || datasetFilter !== ALL || statusFilter !== ALL;
 
   // Latest-only is a client-side convenience over the loaded page (newest-first);
@@ -581,6 +606,35 @@ function RunsTab({ projectId }: { projectId: string }) {
           </TBody>
         </Table>
       </div>
+
+      {!isLoading && !error && total > 0 && (
+        <div className="flex shrink-0 items-center justify-between border-t border-border px-3 py-1.5 text-[11px] text-muted-foreground">
+          <span>
+            Showing {page * RUNS_PAGE_LIMIT + 1}–{Math.min((page + 1) * RUNS_PAGE_LIMIT, total)} of{" "}
+            {total}
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              aria-label="Previous page"
+              className="rounded p-1 hover:bg-muted disabled:pointer-events-none disabled:opacity-40"
+            >
+              <ChevronLeft className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={(page + 1) * RUNS_PAGE_LIMIT >= total}
+              aria-label="Next page"
+              className="rounded p-1 hover:bg-muted disabled:pointer-events-none disabled:opacity-40"
+            >
+              <ChevronRight className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -9,12 +9,12 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
-  Layers,
   ListChecks,
   Ruler,
   Search,
   X,
 } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ModelSelector } from "@/features/ai-assistant/components/model-selector";
@@ -536,7 +536,7 @@ function RunsTab({ projectId }: { projectId: string }) {
         </Toggle>
         {!scopedEvalId && (
           <Toggle active={groupBy} onClick={() => setGroupBy((v) => !v)}>
-            <Layers className="h-3.5 w-3.5" aria-hidden />
+            <DOMAIN_ICONS.lineage className="h-3.5 w-3.5" aria-hidden />
             Group by evaluation
           </Toggle>
         )}


### PR DESCRIPTION
## Summary

Fixes: #1661

Adds the home of the Evaluations surface: a single run table, one row per run, with the canonical columns — Evaluation / Run, Dataset, Main score, Passed, Cost, Duration, Status, Timestamp. It reads entirely from the derived runs-list read model and is searchable and filterable by dataset and status. Main score renders as a 0–100% rate, Passed reads as a pass rate over the run's judgeable cases, and Status carries a badge so a running, completed, or failed run is legible without opening it. The empty state points at the SDK rather than offering an in-UI create flow.

## How it works

The tab bar mirrors the Traces page (Evaluations / Scorers). Runs arrive newest-first from the read model; the dataset and status selects and the search box narrow the list server-side. Each row opens the run detail on click, and the evaluation name scopes the list to that lineage. Cost shows "—" rather than a misleading $0 when no case reported a cost, and duration shows "—" when unmeasured.

## What's included

### Routes
- `app/api/projects/[projectId]/evaluations/runs/route.ts` — provides `GET`.

### UI
- `features/evaluations/views/evaluations-view.tsx` — the Evaluations/Scorers tab shell and the `RunsTab` run table: the canonical columns, dataset/status filters and search, the `RunTableRow` (evaluation name + run number/candidate version, dataset + version label, main score, pass rate, cost, duration, status, timestamp), `RunStatusBadge`, `ScoreValue`, and the `formatCost` / `formatElapsed` helpers. Loading, error, and SDK-pointing empty states are handled, and the change-vs-baseline column is absent here (it only appears while comparing).
- `features/evaluations/components/run-evaluation-drawer.tsx` — provides `RunEvaluationDrawer`.

### Shared components
- `features/evaluations/components/pass-rate.tsx` — `PassRate`, the Passed cell (fraction over percentage; errored/not-scored cases excluded from both sides and surfaced in the title).

### Hooks / data

### Tests
- `app/api/projects/[projectId]/evaluations/runs/route.test.ts` — covers `route`.
- `features/evaluations/components/pass-rate.test.tsx` — covers `pass-rate`.

## Test plan

- [ ] Columns match the canonical set; no change column appears when not comparing.
- [ ] Main score renders as a 0–100% rate; cost, duration, status, and timestamp are correct, with "—" for unreported cost/duration.
- [ ] The status badge distinguishes running / completed / failed, and Passed shows the pass rate over judgeable cases.
- [ ] The dataset and status filters and the search box narrow the table.
- [ ] The default order is newest-first by timestamp.
- [ ] The empty state tells the user to report a run from the SDK.
- [ ] Clicking a run opens its detail; clicking an evaluation name scopes the list to that lineage.
