### PR TITLE
feat(evaluations): run-detail read model and comparison assembly

### DIFF
--- a/frontend/packages/core/prisma/migrations/20260801010000_add_human_review_dimension/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260801010000_add_human_review_dimension/migration.sql
@@ -1,0 +1,19 @@
+-- Human review V1: one canonical review per (result, dimension).
+-- Add the dimension (default "overall"), a lifecycle status, and an update
+-- timestamp. All backfilled on existing rows via defaults.
+ALTER TABLE "human_scores" ADD COLUMN "dimension" VARCHAR NOT NULL DEFAULT 'overall';
+ALTER TABLE "human_scores" ADD COLUMN "status" VARCHAR NOT NULL DEFAULT 'reviewed';
+ALTER TABLE "human_scores" ADD COLUMN "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- The model was previously append-only (many reviews per result). Collapse any
+-- duplicates to the latest review per (result, dimension) so the unique index can
+-- be created; ties broken by id for determinism.
+DELETE FROM "human_scores" a
+USING "human_scores" b
+WHERE a."result_id" = b."result_id"
+  AND a."dimension" = b."dimension"
+  AND (a."create_time" < b."create_time"
+       OR (a."create_time" = b."create_time" AND a."id" < b."id"));
+
+-- One canonical review per (result, dimension); a re-review upserts in place.
+CREATE UNIQUE INDEX "uq_human_score_result_dimension" ON "human_scores" ("result_id", "dimension");

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -697,14 +697,25 @@ model HumanScore {
   id         String   @id @default(cuid()) @db.VarChar
   resultId   String   @map("result_id") @db.VarChar
   projectId  String   @map("project_id") @db.VarChar
+  // A named review dimension. V1 supports one canonical review per (result,
+  // dimension); "overall" is the default single dimension. A dimension becomes
+  // "configured/active" for a run once any result is reviewed on it.
+  dimension  String   @default("overall") @db.VarChar
   verdict    String   @db.VarChar // pass|fail|unsure
   quality    Int? // optional 1-5
   comment    String?  @db.Text
   reviewer   String   @db.VarChar
+  // Review lifecycle status. V1 writes "reviewed" on submit; kept as a field so the
+  // read model can carry it and future states extend without a migration.
+  status     String   @default("reviewed") @db.VarChar
   createTime DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime DateTime @updatedAt @map("update_time") @db.Timestamp(6)
 
   result EvaluationResult @relation(fields: [resultId], references: [id], onDelete: Cascade)
 
+  // One canonical review per (result, dimension): a re-review upserts in place
+  // rather than appending, so counts and disagreement are unambiguous.
+  @@unique([resultId, dimension], map: "uq_human_score_result_dimension")
   @@index([resultId], map: "ix_human_score_result_id")
   @@index([projectId], map: "ix_human_score_project_id")
   @@map("human_scores")

--- a/frontend/packages/core/src/__tests__/eval-contract-shape.json
+++ b/frontend/packages/core/src/__tests__/eval-contract-shape.json
@@ -707,6 +707,14 @@
       "kind": "object",
       "unknown_keys": "forbid",
       "fields": {
+        "dimension": {
+          "type": "string",
+          "min_length": 1,
+          "max_length": 100,
+          "required": false,
+          "nullable": false,
+          "default": "overall"
+        },
         "verdict": {
           "type": "enum",
           "enum": [

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -440,6 +440,8 @@ export type SaveResultToDatasetRequest = z.infer<typeof SaveResultToDatasetReque
 
 export const CreateHumanScoreRequestSchema = z
   .object({
+    /** Named review dimension; defaults to the single "overall" dimension. */
+    dimension: z.string().min(1).max(100).default("overall"),
     verdict: HumanVerdictSchema,
     quality: z.number().int().min(1).max(5).nullable().optional(),
     comment: z.string().max(5000).nullable().optional(),

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Dataset detail route: reading a dataset resolves WHICH immutable version is being
+ * viewed (`?version_id=`, falling back to current), presents stored JSON-encoded
+ * test-case values as human text, and edits/deletes touch only the dataset's own
+ * metadata — never a published snapshot. Auth + Prisma are mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  dataset: { findFirst: vi.fn(), update: vi.fn(), delete: vi.fn() },
+  testCase: { findMany: vi.fn() },
+  // A dataset with runs against it can't be deleted — the runs' FK still points at
+  // its versions, and the history would read as if those runs never happened.
+  evaluationRun: { count: vi.fn() },
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return { ...actual, prisma: prismaMock };
+});
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET, PATCH, DELETE } from "./route";
+
+const params = { params: Promise.resolve({ projectId: "p1", datasetId: "ds1" }) };
+
+const getReq = (qs = "") =>
+  ({ nextUrl: { searchParams: new URLSearchParams(qs) } }) as unknown as Parameters<typeof GET>[0];
+const jsonReq = (body: unknown) =>
+  ({ json: async () => body }) as unknown as Parameters<typeof PATCH>[0];
+const badJsonReq = () =>
+  ({
+    json: async () => {
+      throw new Error("bad json");
+    },
+  }) as unknown as Parameters<typeof PATCH>[0];
+
+const v1 = { id: "dv1", datasetId: "ds1", versionNumber: 1, label: "v1" };
+const v2 = { id: "dv2", datasetId: "ds1", versionNumber: 2, label: "v2" };
+
+function dataset(over: Record<string, unknown> = {}) {
+  return {
+    id: "ds1",
+    projectId: "p1",
+    name: "support",
+    currentVersionId: "dv2",
+    versions: [v2, v1],
+    ...over,
+  };
+}
+
+async function body(res: { json: () => Promise<unknown> }) {
+  return (await res.json()) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+  prismaMock.testCase.findMany.mockResolvedValue([]);
+  prismaMock.evaluationRun.count.mockResolvedValue(0);
+});
+
+describe("GET", () => {
+  it("returns the current version, its cases (newest first), and the version list", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue(dataset());
+    prismaMock.testCase.findMany.mockResolvedValue([
+      { id: "row1", testCaseId: "case-1", input: '"a ticket"', expected: '"billing"' },
+    ]);
+
+    const res = await GET(getReq(), params);
+    const b = await body(res);
+    expect(res.status).toBe(200);
+    expect(b.selectedVersion).toEqual(v2);
+    expect(b.currentVersion).toEqual(v2);
+    expect(b.isCurrentVersion).toBe(true);
+    expect(b.versions).toEqual([v2, v1]);
+    // Cases are read from the SELECTED version only.
+    expect(prismaMock.testCase.findMany).toHaveBeenCalledWith({
+      where: { datasetVersionId: "dv2" },
+      // Tiebroken on testCaseId: cases pushed in one SDK call share a createTime,
+      // so without it their order is whatever the database happens to return.
+      orderBy: [{ createTime: "desc" }, { testCaseId: "desc" }],
+    });
+  });
+
+  it("presents stored JSON values as human text, never as a bare quoted string", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue(dataset());
+    prismaMock.testCase.findMany.mockResolvedValue([
+      { testCaseId: "c1", input: '"a ticket"', expected: '{"label":"billing"}' },
+      { testCaseId: "c2", input: '"x"', expected: null },
+    ]);
+
+    const b = await body(await GET(getReq(), params));
+    const cases = b.testCases as Array<Record<string, unknown>>;
+    expect(cases[0].input).toBe("a ticket"); // unquoted
+    expect(cases[0].expected).toBe('{\n  "label": "billing"\n}'); // pretty JSON
+    expect(cases[1].expected).toBeNull(); // null stays null, not ""
+  });
+
+  it("views an older snapshot when ?version_id= names one of this dataset's versions", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue(dataset());
+
+    const b = await body(await GET(getReq("version_id=dv1"), params));
+    expect(b.selectedVersion).toEqual(v1);
+    expect(b.isCurrentVersion).toBe(false);
+    expect(prismaMock.testCase.findMany).toHaveBeenCalledWith({
+      where: { datasetVersionId: "dv1" },
+      // Tiebroken on testCaseId: cases pushed in one SDK call share a createTime,
+      // so without it their order is whatever the database happens to return.
+      orderBy: [{ createTime: "desc" }, { testCaseId: "desc" }],
+    });
+  });
+
+  it("falls back to the current version when ?version_id= is unknown", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue(dataset());
+
+    const b = await body(await GET(getReq("version_id=dv_other_dataset"), params));
+    expect(b.selectedVersion).toEqual(v2);
+    expect(b.isCurrentVersion).toBe(true);
+  });
+
+  it("reports no selected version (and reads no cases) for a dataset with none", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue(
+      dataset({ currentVersionId: null, versions: [] }),
+    );
+
+    const b = await body(await GET(getReq(), params));
+    expect(b.selectedVersion).toBeNull();
+    expect(b.currentVersion).toBeNull();
+    expect(b.testCases).toEqual([]);
+    expect(prismaMock.testCase.findMany).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown dataset", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue(null);
+    const res = await GET(getReq(), params);
+    expect(res.status).toBe(404);
+    expect(await body(res)).toEqual({ error: "Dataset not found" });
+  });
+
+  it("401s an unauthenticated caller before touching the database", async () => {
+    auth.requireAuth.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = await GET(getReq(), params);
+    expect(res.status).toBe(401);
+    expect(prismaMock.dataset.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("403s a caller without project access", async () => {
+    auth.requireProjectAccess.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    const res = await GET(getReq(), params);
+    expect(res.status).toBe(403);
+    expect(prismaMock.dataset.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe("PATCH", () => {
+  it("updates only the fields present in the body", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue({ id: "ds1" });
+    prismaMock.dataset.update.mockResolvedValue({ id: "ds1", name: "renamed" });
+
+    const res = await PATCH(jsonReq({ name: "renamed" }), params);
+    expect(res.status).toBe(200);
+    expect((await body(res)).dataset).toMatchObject({ name: "renamed" });
+    expect(prismaMock.dataset.update).toHaveBeenCalledWith({
+      where: { id: "ds1" },
+      data: { name: "renamed" }, // description untouched, not nulled
+    });
+  });
+
+  it("clears the description when it is explicitly null", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue({ id: "ds1" });
+    prismaMock.dataset.update.mockResolvedValue({ id: "ds1" });
+
+    await PATCH(jsonReq({ description: null }), params);
+    expect(prismaMock.dataset.update).toHaveBeenCalledWith({
+      where: { id: "ds1" },
+      data: { description: null },
+    });
+  });
+
+  it("400s an unparseable body", async () => {
+    const res = await PATCH(badJsonReq(), params);
+    expect(res.status).toBe(400);
+    expect(await body(res)).toEqual({ error: "Invalid JSON" });
+  });
+
+  it("400s a body that fails the contract schema", async () => {
+    const res = await PATCH(jsonReq({ name: "" }), params);
+    expect(res.status).toBe(400);
+    expect(prismaMock.dataset.update).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown dataset without updating", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue(null);
+    const res = await PATCH(jsonReq({ name: "renamed" }), params);
+    expect(res.status).toBe(404);
+    expect(prismaMock.dataset.update).not.toHaveBeenCalled();
+  });
+
+  it("401s an unauthenticated caller", async () => {
+    auth.requireAuth.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    expect((await PATCH(jsonReq({ name: "x" }), params)).status).toBe(401);
+  });
+
+  it("403s a viewer without write access", async () => {
+    auth.requireProjectAccess.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    expect((await PATCH(jsonReq({ name: "x" }), params)).status).toBe(403);
+    expect(prismaMock.dataset.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE", () => {
+  it("deletes a dataset that belongs to the project", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue({ id: "ds1" });
+    prismaMock.dataset.delete.mockResolvedValue({ id: "ds1" });
+
+    const res = await DELETE({} as never, params);
+    expect(res.status).toBe(200);
+    expect(await body(res)).toEqual({ deleted: true });
+    expect(prismaMock.dataset.delete).toHaveBeenCalledWith({ where: { id: "ds1" } });
+  });
+
+  it("404s an unknown dataset without deleting", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue(null);
+    const res = await DELETE({} as never, params);
+    expect(res.status).toBe(404);
+    expect(prismaMock.dataset.delete).not.toHaveBeenCalled();
+  });
+
+  it("401s an unauthenticated caller", async () => {
+    auth.requireAuth.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    expect((await DELETE({} as never, params)).status).toBe(401);
+    expect(prismaMock.dataset.delete).not.toHaveBeenCalled();
+  });
+
+  it("403s a viewer without write access", async () => {
+    auth.requireProjectAccess.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    expect((await DELETE({} as never, params)).status).toBe(403);
+    expect(prismaMock.dataset.delete).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/versions/[versionId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/versions/[versionId]/route.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Reading one immutable dataset version. The lookup is scoped by dataset AND project,
+ * so a version id from another dataset or project reads as "not found" rather than
+ * leaking a snapshot. Auth + Prisma are mocked.
+ */
+import { it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  datasetVersion: { findFirst: vi.fn() },
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return { ...actual, prisma: prismaMock };
+});
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET } from "./route";
+
+const params = {
+  params: Promise.resolve({ projectId: "p1", datasetId: "ds1", versionId: "dv1" }),
+};
+
+async function body(res: { json: () => Promise<unknown> }) {
+  return (await res.json()) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+});
+
+it("returns the version with the cases it snapshotted, oldest first", async () => {
+  const testCases = [
+    { id: "row1", testCaseId: "case-1", input: "a" },
+    { id: "row2", testCaseId: "case-2", input: "b" },
+  ];
+  prismaMock.datasetVersion.findFirst.mockResolvedValue({
+    id: "dv1",
+    datasetId: "ds1",
+    versionNumber: 1,
+    label: "v1",
+    testCases,
+  });
+
+  const res = await GET({} as never, params);
+  const b = await body(res);
+  expect(res.status).toBe(200);
+  expect((b.version as { label: string }).label).toBe("v1");
+  expect(b.testCases).toEqual(testCases);
+  expect(prismaMock.datasetVersion.findFirst).toHaveBeenCalledWith({
+    where: { id: "dv1", datasetId: "ds1", projectId: "p1" },
+    // Tiebroken on testCaseId (TEST_CASE_ORDER): a batch pushed in one SDK call
+    // shares a createTime, so createTime alone leaves their order to the database.
+    include: {
+      testCases: { orderBy: [{ createTime: "asc" }, { testCaseId: "asc" }] },
+    },
+  });
+});
+
+it("returns an empty case list for a version that snapshotted nothing", async () => {
+  prismaMock.datasetVersion.findFirst.mockResolvedValue({ id: "dv1", label: "v1", testCases: [] });
+  expect((await body(await GET({} as never, params))).testCases).toEqual([]);
+});
+
+it("404s a version that does not belong to this dataset/project", async () => {
+  prismaMock.datasetVersion.findFirst.mockResolvedValue(null);
+  const res = await GET({} as never, params);
+  expect(res.status).toBe(404);
+  expect(await body(res)).toEqual({ error: "Dataset version not found" });
+});
+
+it("401s an unauthenticated caller before touching the database", async () => {
+  auth.requireAuth.mockResolvedValue({
+    error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+  });
+  expect((await GET({} as never, params)).status).toBe(401);
+  expect(prismaMock.datasetVersion.findFirst).not.toHaveBeenCalled();
+});
+
+it("403s a caller without project access", async () => {
+  auth.requireProjectAccess.mockResolvedValue({
+    error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+  });
+  expect((await GET({} as never, params)).status).toBe(403);
+  expect(prismaMock.datasetVersion.findFirst).not.toHaveBeenCalled();
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Cross-run comparison (`?candidate=&baseline=`). The route assembles already-fetched
+ * rows and delegates all comparison MATH to the pure engine. Its own job is the
+ * assembly contract: canonical case content comes from the CANDIDATE's pinned dataset
+ * version (with a divergence flag when a run recorded something else), baseline-only
+ * cases are appended rather than silently dropped, and both run ids must be present,
+ * different, and readable in this project. Auth + Prisma are mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  evaluationRun: { findFirst: vi.fn() },
+  testCase: { findMany: vi.fn() },
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return { ...actual, prisma: prismaMock };
+});
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET } from "./route";
+
+const params = { params: Promise.resolve({ projectId: "p1" }) };
+const req = (qs: string) =>
+  ({ nextUrl: { searchParams: new URLSearchParams(qs) } }) as unknown as Parameters<typeof GET>[0];
+const BOTH = "candidate=run_c&baseline=run_b";
+
+interface Body {
+  candidate: Record<string, unknown>;
+  baseline: Record<string, unknown>;
+  comparison: Record<string, unknown>;
+  results: Record<string, unknown>[];
+}
+
+function score(name: string, numericValue: number | null) {
+  return {
+    scorerName: name,
+    scorerVersion: "unversioned",
+    numericValue,
+    boolValue: null,
+    stringValue: null,
+    passed: numericValue === 1,
+    explanation: `because ${numericValue}`,
+    error: null,
+  };
+}
+
+function resultRow(over: Record<string, unknown> = {}) {
+  return {
+    id: "r1",
+    testCaseId: "t0",
+    traceId: "tr_c0",
+    input: "a ticket",
+    expectedOutput: "billing",
+    candidateOutput: "billing",
+    status: "passed",
+    mainScore: 1,
+    taskError: null,
+    durationMs: 900,
+    cost: 0.01,
+    scores: [score("acc", 1)],
+    ...over,
+  };
+}
+
+function run(over: Record<string, unknown> = {}) {
+  return {
+    id: "run_c",
+    projectId: "p1",
+    evaluationId: "eval_1",
+    datasetId: "ds1",
+    datasetVersionId: "dv2",
+    runNumber: 2,
+    candidateVersion: "sonnet",
+    status: "completed",
+    baselineRunId: null,
+    mainScore: 0.5,
+    mainScoreName: "acc",
+    caseCount: 2,
+    scoredCount: 2,
+    taskErrorCount: 0,
+    scorerErrorCount: 0,
+    scorers: [{ name: "acc", version: "unversioned", value_type: "numeric" }],
+    startedAt: new Date("2026-07-21T00:00:00Z"),
+    completedAt: new Date("2026-07-21T00:00:06Z"),
+    evaluation: { name: "ticket-routing" },
+    datasetVersion: { label: "v2" },
+    results: [
+      resultRow(),
+      resultRow({
+        id: "r2",
+        testCaseId: "t5",
+        traceId: "tr_c5",
+        input: "another ticket",
+        expectedOutput: "technical",
+        candidateOutput: "general",
+        mainScore: 0,
+        durationMs: 1000,
+        scores: [score("acc", 0)],
+      }),
+    ],
+    ...over,
+  };
+}
+
+function baselineRun(over: Record<string, unknown> = {}) {
+  return run({
+    id: "run_b",
+    runNumber: 1,
+    candidateVersion: "opus",
+    mainScore: 1,
+    startedAt: new Date("2026-07-20T00:00:00Z"),
+    completedAt: new Date("2026-07-20T00:00:04Z"),
+    results: [
+      resultRow({ id: "b1", traceId: "tr_b0", cost: 0.02, durationMs: 800 }),
+      resultRow({
+        id: "b2",
+        testCaseId: "t5",
+        traceId: "tr_b5",
+        input: "another ticket",
+        expectedOutput: "technical",
+        candidateOutput: "technical",
+        mainScore: 1,
+        durationMs: 850,
+        scores: [score("acc", 1)],
+      }),
+    ],
+    ...over,
+  });
+}
+
+const canonicalRow = (over: Record<string, unknown> = {}) => ({
+  testCaseId: "t0",
+  input: "a ticket",
+  expected: "billing",
+  metadata: { locale: "en" },
+  sourceTraceId: "tr_origin",
+  sourceSpanName: "handle_ticket",
+  sourceSpanKind: "SERVER",
+  captureReason: "manual",
+  ...over,
+});
+
+async function body(res: { json: () => Promise<unknown> }) {
+  return (await res.json()) as Body;
+}
+
+/** Wire both loads: the route fires candidate + baseline in one Promise.all. */
+function loadRuns(candidate: unknown, baseline: unknown) {
+  prismaMock.evaluationRun.findFirst.mockImplementation(async (args: { where: { id: string } }) =>
+    args.where.id === "run_c" ? candidate : args.where.id === "run_b" ? baseline : null,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+  prismaMock.testCase.findMany.mockResolvedValue([
+    canonicalRow(),
+    canonicalRow({
+      testCaseId: "t5",
+      input: "another ticket",
+      expected: "technical",
+      metadata: null,
+      sourceTraceId: null,
+    }),
+  ]);
+});
+
+describe("assembly", () => {
+  it("pairs both sides per case with outputs, traces, costs, scores, and a verdict", async () => {
+    loadRuns(run(), baselineRun());
+
+    const res = await GET(req(BOTH), params);
+    expect(res.status).toBe(200);
+    const b = await body(res);
+
+    expect(b.candidate).toMatchObject({ id: "run_c", runNumber: 2, elapsedMs: 6000 });
+    expect(b.baseline).toMatchObject({ id: "run_b", runNumber: 1, elapsedMs: 4000 });
+    expect(b.comparison.available).toBe(true);
+
+    const t5 = b.results.find((r) => r.testCaseId === "t5")!;
+    expect(t5.candidateOutput).toBe("general");
+    expect(t5.baselineOutput).toBe("technical");
+    expect(t5.candidateTraceId).toBe("tr_c5");
+    expect(t5.baselineTraceId).toBe("tr_b5");
+    expect(t5.outputChanged).toBe(true);
+    expect(t5.change).toBe("regressed");
+    // Raw per-scorer values, including the judge's explanation, for the case drawer.
+    expect(t5.candidateScores).toEqual([
+      {
+        scorerName: "acc",
+        scorerVersion: "unversioned",
+        numericValue: 0,
+        boolValue: null,
+        stringValue: null,
+        passed: false,
+        explanation: "because 0",
+        error: null,
+      },
+    ]);
+    expect((t5.comparison as { regressedCellCount: number }).regressedCellCount).toBe(1);
+
+    const t0 = b.results.find((r) => r.testCaseId === "t0")!;
+    expect(t0.outputChanged).toBe(false);
+    expect(t0.candidateCost).toBe(0.01);
+    expect(t0.baselineCost).toBe(0.02);
+  });
+
+  it("takes input/expected/metadata/provenance from the candidate's pinned version", async () => {
+    loadRuns(
+      run({ results: [resultRow({ input: "STALE COPY", expectedOutput: "STALE" })] }),
+      baselineRun(),
+    );
+
+    const t0 = (await body(await GET(req(BOTH), params))).results[0];
+    expect(t0.input).toBe("a ticket"); // canonical, not the run's stale copy
+    expect(t0.expectedOutput).toBe("billing");
+    expect(t0.metadata).toEqual({ locale: "en" });
+    expect(t0.provenance).toMatchObject({ sourceTraceId: "tr_origin", captureReason: "manual" });
+    // ...and the divergence is flagged rather than hidden.
+    expect(t0.inputMatchesDataset).toBe(false);
+
+    // One canonical query for the whole comparison, scoped to the pinned version.
+    expect(prismaMock.testCase.findMany).toHaveBeenCalledTimes(1);
+    const where = prismaMock.testCase.findMany.mock.calls[0][0].where as {
+      datasetVersionId: string;
+      projectId: string;
+      testCaseId: { in: string[] };
+    };
+    expect(where.datasetVersionId).toBe("dv2");
+    expect(where.projectId).toBe("p1");
+    // Narrowed to the cases the two runs actually reference, so a comparison of a
+    // handful of cases doesn't read the whole pinned version.
+    expect(where.testCaseId.in).toEqual(["t0", "t5"]);
+  });
+
+  it("reports no provenance for a case that was not captured from a trace", async () => {
+    loadRuns(run(), baselineRun());
+    const t5 = (await body(await GET(req(BOTH), params))).results.find(
+      (r) => r.testCaseId === "t5",
+    )!;
+    expect(t5.provenance).toBeNull();
+    expect(t5.metadata).toBeNull();
+  });
+
+  it("falls back to a run's recorded content when the case is not in the pinned version", async () => {
+    prismaMock.testCase.findMany.mockResolvedValue([]); // nothing canonical
+    loadRuns(run(), baselineRun());
+
+    const t0 = (await body(await GET(req(BOTH), params))).results[0];
+    expect(t0.input).toBe("a ticket"); // from the candidate result row
+    expect(t0.expectedOutput).toBe("billing");
+    expect(t0.metadata).toBeNull();
+    // With no canonical case to diverge from, nothing is flagged.
+    expect(t0.inputMatchesDataset).toBe(true);
+  });
+
+  it("appends baseline-only cases instead of dropping them", async () => {
+    const droppedCase = resultRow({
+      id: "b3",
+      testCaseId: "t9",
+      traceId: "tr_b9",
+      input: "dropped ticket",
+      candidateOutput: "billing",
+    });
+    loadRuns(run(), baselineRun({ results: [...baselineRun().results, droppedCase] }));
+
+    const b = await body(await GET(req(BOTH), params));
+    const dropped = b.results.find((r) => r.testCaseId === "t9")!;
+    // Candidate-side cases keep their reported order; the dropped case comes last.
+    expect(b.results.map((r) => r.testCaseId)).toEqual(["t0", "t5", "t9"]);
+    expect(dropped.candidateStatus).toBeNull();
+    expect(dropped.candidateOutput).toBeNull();
+    expect(dropped.baselineOutput).toBe("billing");
+    expect(dropped.input).toBe("dropped ticket");
+    expect(dropped.outputChanged).toBe(true); // exactly one side has an output
+  });
+
+  it("reports outputChanged as null when neither side produced an output", async () => {
+    loadRuns(
+      run({
+        results: [resultRow({ candidateOutput: null, status: "errored", taskError: "boom" })],
+      }),
+      baselineRun({ results: [resultRow({ id: "b1", candidateOutput: null })] }),
+    );
+
+    const t0 = (await body(await GET(req(BOTH), params))).results[0];
+    expect(t0.outputChanged).toBeNull();
+    expect(t0.candidateTaskError).toBe("boom");
+    expect(t0.candidateStatus).toBe("errored");
+  });
+
+  it("reports a null elapsed time for a run that has not completed", async () => {
+    loadRuns(run({ status: "running", completedAt: null }), baselineRun());
+    const b = await body(await GET(req(BOTH), params));
+    expect(b.candidate.elapsedMs).toBeNull();
+    expect(b.baseline.elapsedMs).toBe(4000);
+  });
+
+  it("refuses to trust the comparison when the two runs pinned different snapshots", async () => {
+    loadRuns(run(), baselineRun({ datasetVersionId: "dv1" }));
+    const b = await body(await GET(req(BOTH), params));
+    expect(b.comparison.trustworthy).toBe(false);
+    expect(b.comparison.reasons).toContain("different_dataset_version");
+  });
+});
+
+describe("request validation", () => {
+  it("400s when the candidate id is missing", async () => {
+    const res = await GET(req("baseline=run_b"), params);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "Both candidate and baseline run ids are required",
+    });
+    expect(prismaMock.evaluationRun.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("400s when the baseline id is missing", async () => {
+    expect((await GET(req("candidate=run_c"), params)).status).toBe(400);
+  });
+
+  it("400s when both ids are the same run", async () => {
+    const res = await GET(req("candidate=run_c&baseline=run_c"), params);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Pick two different runs to compare" });
+  });
+
+  it("404s an unreadable candidate run", async () => {
+    loadRuns(null, baselineRun());
+    const res = await GET(req(BOTH), params);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Candidate run not found" });
+  });
+
+  it("404s an unreadable baseline run", async () => {
+    loadRuns(run(), null);
+    const res = await GET(req(BOTH), params);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "Baseline run not found" });
+  });
+
+  it("scopes both run loads to the project", async () => {
+    loadRuns(run(), baselineRun());
+    await GET(req(BOTH), params);
+    const wheres = prismaMock.evaluationRun.findFirst.mock.calls.map((c) => c[0].where);
+    expect(wheres).toEqual([
+      { id: "run_c", projectId: "p1" },
+      { id: "run_b", projectId: "p1" },
+    ]);
+  });
+
+  it("401s an unauthenticated caller before touching the database", async () => {
+    auth.requireAuth.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    expect((await GET(req(BOTH), params)).status).toBe(401);
+    expect(prismaMock.evaluationRun.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("403s a caller without project access", async () => {
+    auth.requireProjectAccess.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    expect((await GET(req(BOTH), params)).status).toBe(403);
+    expect(prismaMock.evaluationRun.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import {
+  requireAuth,
+  requireProjectAccess,
+  errorResponse,
+  successResponse,
+} from "@/lib/auth-helpers";
+import { compareRuns } from "@/lib/eval/comparison";
+import { toComparisonRun, toComparisonResults, caseChangeToLegacy } from "@/lib/eval/comparison-db";
+
+type RouteParams = { params: Promise<{ projectId: string }> };
+
+function elapsedMs(startedAt: Date, completedAt: Date | null): number | null {
+  if (!completedAt) return null;
+  const ms = completedAt.getTime() - startedAt.getTime();
+  return ms >= 0 ? ms : null;
+}
+
+const runInclude = {
+  evaluation: { select: { name: true } },
+  datasetVersion: { select: { label: true } },
+  results: {
+    orderBy: { createTime: "asc" as const },
+    include: { scores: { orderBy: { createTime: "asc" as const } } },
+  },
+};
+
+function runSummary(run: Awaited<ReturnType<typeof loadRun>>) {
+  if (!run) return null;
+  return {
+    id: run.id,
+    runNumber: run.runNumber,
+    evaluationId: run.evaluationId,
+    evaluationName: run.evaluation.name,
+    candidateVersion: run.candidateVersion,
+    datasetVersionId: run.datasetVersionId,
+    datasetVersionLabel: run.datasetVersion.label,
+    status: run.status,
+    mainScore: run.mainScore,
+    mainScoreName: run.mainScoreName,
+    caseCount: run.caseCount,
+    scoredCount: run.scoredCount,
+    taskErrorCount: run.taskErrorCount,
+    scorerErrorCount: run.scorerErrorCount,
+    startedAt: run.startedAt,
+    completedAt: run.completedAt,
+    elapsedMs: elapsedMs(run.startedAt, run.completedAt),
+  };
+}
+
+function loadRun(projectId: string, runId: string) {
+  return prisma.evaluationRun.findFirst({
+    where: { id: runId, projectId },
+    include: runInclude,
+  });
+}
+
+// GET — compare two arbitrary runs (candidate vs baseline) of the same evaluation.
+// Reuses the same derivation as the run-detail route (compareRuns over the two
+// runs' raw results/scores), but lets the caller choose both sides rather than
+// relying on the stored baselineRunId. `?candidate=<runId>&baseline=<runId>`.
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const candidateId = req.nextUrl.searchParams.get("candidate");
+  const baselineId = req.nextUrl.searchParams.get("baseline");
+  if (!candidateId || !baselineId) {
+    return errorResponse("Both candidate and baseline run ids are required", 400);
+  }
+  if (candidateId === baselineId) {
+    return errorResponse("Pick two different runs to compare", 400);
+  }
+
+  const [candidate, baseline] = await Promise.all([
+    loadRun(projectId, candidateId),
+    loadRun(projectId, baselineId),
+  ]);
+  if (!candidate) return errorResponse("Candidate run not found", 404);
+  if (!baseline) return errorResponse("Baseline run not found", 404);
+
+  const { comparison, results: resultComparisons } = compareRuns({
+    candidate: toComparisonRun(candidate),
+    candidateResults: toComparisonResults(candidate.results),
+    baseline: toComparisonRun(baseline),
+    baselineResults: toComparisonResults(baseline.results),
+  });
+
+  const cmpByCase = new Map(resultComparisons.map((c) => [c.testCaseId, c]));
+  const baselineTraceByCase = new Map(baseline.results.map((r) => [r.testCaseId, r.traceId]));
+
+  const results = candidate.results.map((r) => {
+    const cmp = cmpByCase.get(r.testCaseId);
+    return {
+      testCaseId: r.testCaseId,
+      status: r.status,
+      traceId: r.traceId,
+      candidateOutput: r.candidateOutput,
+      change: cmp ? caseChangeToLegacy(cmp.caseChange) : null,
+      comparison: cmp
+        ? {
+            caseChange: cmp.caseChange,
+            pairing: cmp.pairing,
+            mainScore: cmp.mainScore,
+            baselineOutput: cmp.baselineOutput,
+            baselineDurationMs: cmp.baselineDurationMs,
+            durationDeltaMs: cmp.durationDeltaMs,
+            baselineTraceId: baselineTraceByCase.get(r.testCaseId) ?? null,
+            scorerCells: cmp.scorerCells,
+            regressedCellCount: cmp.regressedCellCount,
+            comparableCellCount: cmp.comparableCellCount,
+          }
+        : null,
+    };
+  });
+
+  // Baseline-only cases (present in baseline, absent from candidate) so the table
+  // can show them as dropped rather than silently omitting them.
+  const candidateCaseIds = new Set(candidate.results.map((r) => r.testCaseId));
+  const baselineOnly = resultComparisons
+    .filter((c) => c.pairing === "baseline_only" && !candidateCaseIds.has(c.testCaseId))
+    .map((c) => ({
+      testCaseId: c.testCaseId,
+      status: c.status,
+      traceId: null,
+      candidateOutput: null,
+      change: caseChangeToLegacy(c.caseChange),
+      comparison: {
+        caseChange: c.caseChange,
+        pairing: c.pairing,
+        mainScore: c.mainScore,
+        baselineOutput: c.baselineOutput,
+        baselineDurationMs: c.baselineDurationMs,
+        durationDeltaMs: c.durationDeltaMs,
+        baselineTraceId: baselineTraceByCase.get(c.testCaseId) ?? null,
+        scorerCells: c.scorerCells,
+        regressedCellCount: c.regressedCellCount,
+        comparableCellCount: c.comparableCellCount,
+      },
+    }));
+
+  return successResponse({
+    candidate: runSummary(candidate),
+    baseline: runSummary(baseline),
+    comparison,
+    results: [...results, ...baselineOnly],
+  });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.ts
@@ -6,7 +6,7 @@ import {
   errorResponse,
   successResponse,
 } from "@/lib/auth-helpers";
-import { compareRuns } from "@/lib/eval/comparison";
+import { compareRuns, type ResultComparison } from "@/lib/eval/comparison";
 import { toComparisonRun, toComparisonResults, caseChangeToLegacy } from "@/lib/eval/comparison-db";
 
 type RouteParams = { params: Promise<{ projectId: string }> };
@@ -26,8 +26,11 @@ const runInclude = {
   },
 };
 
-function runSummary(run: Awaited<ReturnType<typeof loadRun>>) {
-  if (!run) return null;
+type LoadedRun = NonNullable<Awaited<ReturnType<typeof loadRun>>>;
+type ResultRow = LoadedRun["results"][number];
+type ScoreRow = ResultRow["scores"][number];
+
+function runSummary(run: LoadedRun) {
   return {
     id: run.id,
     runNumber: run.runNumber,
@@ -56,10 +59,47 @@ function loadRun(projectId: string, runId: string) {
   });
 }
 
-// GET — compare two arbitrary runs (candidate vs baseline) of the same evaluation.
-// Reuses the same derivation as the run-detail route (compareRuns over the two
-// runs' raw results/scores), but lets the caller choose both sides rather than
-// relying on the stored baselineRunId. `?candidate=<runId>&baseline=<runId>`.
+/** Raw per-scorer values (incl. explanation) for the case drawer's score breakdown. */
+function trimScore(s: ScoreRow) {
+  return {
+    scorerName: s.scorerName,
+    scorerVersion: s.scorerVersion,
+    numericValue: s.numericValue,
+    boolValue: s.boolValue,
+    stringValue: s.stringValue,
+    passed: s.passed,
+    explanation: s.explanation,
+    error: s.error,
+  };
+}
+
+/** Two outputs "changed" when both exist and differ, or exactly one exists. Null when
+ *  neither side has an output (nothing to compare). */
+function outputChanged(candidate: string | null, baseline: string | null): boolean | null {
+  if (candidate === null && baseline === null) return null;
+  return candidate !== baseline;
+}
+
+interface CanonicalCase {
+  input: string;
+  expectedOutput: string | null;
+  metadata: unknown;
+  provenance: {
+    sourceTraceId: string | null;
+    sourceSpanName: string | null;
+    sourceSpanKind: string | null;
+    captureReason: string;
+  } | null;
+}
+
+// GET — compare two runs (candidate vs baseline). Reuses the same derivation as the
+// run-detail route (compareRuns over both runs' raw results/scores) and surfaces the
+// read fields the comparison page needs: canonical dataset input/expected/metadata +
+// provenance (from the candidate run's PINNED dataset version), both sides' output/
+// status/cost/task-error, candidate + baseline trace ids, per-scorer comparisons +
+// raw explanations, duration, and an output-changed flag. All comparison MATH stays in
+// the pure engine; this route only assembles already-fetched rows (no N+1).
+// `?candidate=<runId>&baseline=<runId>`.
 export async function GET(req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
@@ -90,16 +130,76 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     baselineResults: toComparisonResults(baseline.results),
   });
 
-  const cmpByCase = new Map(resultComparisons.map((c) => [c.testCaseId, c]));
-  const baselineTraceByCase = new Map(baseline.results.map((r) => [r.testCaseId, r.traceId]));
+  // Canonical case content from the candidate run's PINNED dataset version (one query,
+  // no N+1) — the input/expected the engineer authored, not a per-run copy. If a run
+  // recorded a different input, we prefer the canonical and flag the discrepancy.
+  const canonicalRows = await prisma.testCase.findMany({
+    where: { datasetVersionId: candidate.datasetVersionId, projectId },
+    select: {
+      testCaseId: true,
+      input: true,
+      expected: true,
+      metadata: true,
+      sourceTraceId: true,
+      sourceSpanName: true,
+      sourceSpanKind: true,
+      captureReason: true,
+    },
+  });
+  const canonicalByCase = new Map<string, CanonicalCase>(
+    canonicalRows.map((t) => [
+      t.testCaseId,
+      {
+        input: t.input,
+        expectedOutput: t.expected,
+        metadata: t.metadata,
+        provenance: t.sourceTraceId
+          ? {
+              sourceTraceId: t.sourceTraceId,
+              sourceSpanName: t.sourceSpanName,
+              sourceSpanKind: t.sourceSpanKind,
+              captureReason: t.captureReason,
+            }
+          : null,
+      },
+    ]),
+  );
 
-  const results = candidate.results.map((r) => {
-    const cmp = cmpByCase.get(r.testCaseId);
+  const cmpByCase = new Map(resultComparisons.map((c) => [c.testCaseId, c]));
+  const candByCase = new Map(candidate.results.map((r) => [r.testCaseId, r]));
+  const baseByCase = new Map(baseline.results.map((r) => [r.testCaseId, r]));
+
+  const buildCase = (testCaseId: string, cmp: ResultComparison | undefined) => {
+    const cand = candByCase.get(testCaseId) ?? null;
+    const base = baseByCase.get(testCaseId) ?? null;
+    const canonical = canonicalByCase.get(testCaseId) ?? null;
+    const candidateOutput = cand?.candidateOutput ?? null;
+    const baselineOutput = cmp?.baselineOutput ?? base?.candidateOutput ?? null;
+    // Canonical input, falling back to whatever a run recorded when the case isn't in
+    // the candidate's pinned version (e.g. a baseline-only case from another version).
+    const input = canonical?.input ?? cand?.input ?? base?.input ?? "";
+    const recordedInput = cand?.input ?? base?.input ?? null;
     return {
-      testCaseId: r.testCaseId,
-      status: r.status,
-      traceId: r.traceId,
-      candidateOutput: r.candidateOutput,
+      testCaseId,
+      input,
+      expectedOutput: canonical?.expectedOutput ?? cand?.expectedOutput ?? null,
+      metadata: canonical?.metadata ?? null,
+      provenance: canonical?.provenance ?? null,
+      // True when a run's recorded input diverges from the pinned dataset case.
+      inputMatchesDataset: canonical ? recordedInput === null || recordedInput === input : true,
+      candidateStatus: cand?.status ?? null,
+      baselineStatus: base?.status ?? null,
+      candidateOutput,
+      baselineOutput,
+      candidateTraceId: cand?.traceId ?? null,
+      baselineTraceId: base?.traceId ?? null,
+      candidateCost: cand?.cost ?? null,
+      baselineCost: base?.cost ?? null,
+      candidateTaskError: cand?.taskError ?? null,
+      baselineTaskError: base?.taskError ?? null,
+      candidateScores: (cand?.scores ?? []).map(trimScore),
+      baselineScores: (base?.scores ?? []).map(trimScore),
+      outputChanged: outputChanged(candidateOutput, baselineOutput),
       change: cmp ? caseChangeToLegacy(cmp.caseChange) : null,
       comparison: cmp
         ? {
@@ -107,41 +207,27 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
             pairing: cmp.pairing,
             mainScore: cmp.mainScore,
             baselineOutput: cmp.baselineOutput,
+            durationMs: cmp.durationMs,
             baselineDurationMs: cmp.baselineDurationMs,
             durationDeltaMs: cmp.durationDeltaMs,
-            baselineTraceId: baselineTraceByCase.get(r.testCaseId) ?? null,
+            baselineTraceId: base?.traceId ?? null,
             scorerCells: cmp.scorerCells,
             regressedCellCount: cmp.regressedCellCount,
             comparableCellCount: cmp.comparableCellCount,
           }
         : null,
     };
-  });
+  };
 
-  // Baseline-only cases (present in baseline, absent from candidate) so the table
-  // can show them as dropped rather than silently omitting them.
+  // Candidate-side cases in their reported order, then baseline-only (dropped) cases so
+  // the table shows them rather than silently omitting them.
+  const results = candidate.results.map((r) =>
+    buildCase(r.testCaseId, cmpByCase.get(r.testCaseId)),
+  );
   const candidateCaseIds = new Set(candidate.results.map((r) => r.testCaseId));
   const baselineOnly = resultComparisons
     .filter((c) => c.pairing === "baseline_only" && !candidateCaseIds.has(c.testCaseId))
-    .map((c) => ({
-      testCaseId: c.testCaseId,
-      status: c.status,
-      traceId: null,
-      candidateOutput: null,
-      change: caseChangeToLegacy(c.caseChange),
-      comparison: {
-        caseChange: c.caseChange,
-        pairing: c.pairing,
-        mainScore: c.mainScore,
-        baselineOutput: c.baselineOutput,
-        baselineDurationMs: c.baselineDurationMs,
-        durationDeltaMs: c.durationDeltaMs,
-        baselineTraceId: baselineTraceByCase.get(c.testCaseId) ?? null,
-        scorerCells: c.scorerCells,
-        regressedCellCount: c.regressedCellCount,
-        comparableCellCount: c.comparableCellCount,
-      },
-    }));
+    .map((c) => buildCase(c.testCaseId, c));
 
   return successResponse({
     candidate: runSummary(candidate),

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.ts
@@ -17,11 +17,18 @@ function elapsedMs(startedAt: Date, completedAt: Date | null): number | null {
   return ms >= 0 ? ms : null;
 }
 
+// Both runs' result sets are unbounded in principle — a large run can have thousands
+// of cases, each carrying several @db.Text columns plus per-scorer rows. Capping keeps
+// the query size and response payload bounded; `resultsTruncated` in the response tells
+// the caller when they are looking at a partial comparison.
+const MAX_COMPARE_RESULTS = 1000;
+
 const runInclude = {
   evaluation: { select: { name: true } },
   datasetVersion: { select: { label: true } },
   results: {
     orderBy: { createTime: "asc" as const },
+    take: MAX_COMPARE_RESULTS,
     include: { scores: { orderBy: { createTime: "asc" as const } } },
   },
 };
@@ -132,9 +139,18 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
 
   // Canonical case content from the candidate run's PINNED dataset version (one query,
   // no N+1) — the input/expected the engineer authored, not a per-run copy. If a run
-  // recorded a different input, we prefer the canonical and flag the discrepancy.
+  // recorded a different input, we prefer the canonical and flag the discrepancy. Scoped
+  // to the test cases actually referenced by the (capped) result sets above, rather than
+  // the entire pinned dataset version — a shared dataset can far outgrow one run's cases.
+  const referencedCaseIds = [
+    ...new Set([...candidate.results, ...baseline.results].map((r) => r.testCaseId)),
+  ];
   const canonicalRows = await prisma.testCase.findMany({
-    where: { datasetVersionId: candidate.datasetVersionId, projectId },
+    where: {
+      datasetVersionId: candidate.datasetVersionId,
+      projectId,
+      testCaseId: { in: referencedCaseIds },
+    },
     select: {
       testCaseId: true,
       input: true,
@@ -234,5 +250,10 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     baseline: runSummary(baseline),
     comparison,
     results: [...results, ...baselineOnly],
+    // True when either side has more cases than the cap above — the comparison and
+    // `results` are a partial view.
+    resultsTruncated:
+      candidate.caseCount > candidate.results.length ||
+      baseline.caseCount > baseline.results.length,
   });
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/dataset-case/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/dataset-case/route.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Evaluation-result → dataset actions. Drives the real route against the in-memory
+ * fake prisma + versioning engine. Verifies the three explicit actions, the
+ * circular-save guard, idempotency, and that candidate output is never copied to
+ * expected implicitly.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  const { fakePrisma } = await import("@/lib/eval/__tests__/fake-prisma");
+  return { ...actual, prisma: fakePrisma };
+});
+
+import { fakePrisma } from "@/lib/eval/__tests__/fake-prisma";
+import { POST } from "./route";
+
+const PROJECT_ID = "proj_1";
+const params = (resultId: string) => ({
+  params: Promise.resolve({ projectId: PROJECT_ID, resultId }),
+});
+const req = (body: unknown) => ({ json: async () => body }) as unknown as Parameters<typeof POST>[0];
+const readJson = (res: { json: () => Promise<unknown> }) =>
+  res.json() as Promise<Record<string, unknown>>;
+
+const casesIn = (versionId: string) =>
+  fakePrisma.testCase.rows.filter((c) => c.datasetVersionId === versionId);
+const currentVersionId = (datasetId: string) =>
+  fakePrisma.dataset.rows.find((d) => d.id === datasetId)!.currentVersionId as string;
+
+beforeEach(() => {
+  fakePrisma.reset();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1", email: "e@x.com" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: PROJECT_ID } });
+
+  // Originating dataset ds1 @ v1 with one case "tc-A".
+  fakePrisma.dataset.rows.push({ id: "ds1", projectId: PROJECT_ID, currentVersionId: "dv1" });
+  fakePrisma.datasetVersion.rows.push({
+    id: "dv1",
+    datasetId: "ds1",
+    projectId: PROJECT_ID,
+    versionNumber: 1,
+    label: "v1",
+  });
+  fakePrisma.testCase.rows.push({
+    id: "tcrow-A",
+    testCaseId: "tc-A",
+    datasetVersionId: "dv1",
+    datasetId: "ds1",
+    projectId: PROJECT_ID,
+    input: "orig input",
+    expected: "orig expected",
+    recordedOutput: null,
+    metadata: null,
+    review: "ready",
+    captureReason: "manual",
+    sourceTraceId: null,
+    sourceSpanId: null,
+    sourceSpanName: null,
+    sourceSpanKind: null,
+    sourceRunId: null,
+    sourceResultId: null,
+    addedBy: null,
+    createTime: new Date("2026-07-01T00:00:00Z"),
+  });
+
+  // A second dataset ds2 @ v1 (empty) — a valid save-new target.
+  fakePrisma.dataset.rows.push({ id: "ds2", projectId: PROJECT_ID, currentVersionId: "dv2" });
+  fakePrisma.datasetVersion.rows.push({
+    id: "dv2",
+    datasetId: "ds2",
+    projectId: PROJECT_ID,
+    versionNumber: 1,
+    label: "v1",
+  });
+
+  // A run against ds1, and a result mapped to case "tc-A".
+  fakePrisma.evaluationRun.rows.push({
+    id: "run1",
+    projectId: PROJECT_ID,
+    datasetId: "ds1",
+    evaluationId: "eval1",
+  });
+  fakePrisma.evaluationResult.rows.push({
+    id: "res1",
+    runId: "run1",
+    projectId: PROJECT_ID,
+    testCaseId: "tc-A",
+    traceId: "trace-xyz",
+    input: "orig input",
+    expectedOutput: "orig expected",
+    candidateOutput: "the CANDIDATE answer",
+  });
+});
+
+describe("result → dataset: update_existing_case", () => {
+  it("updates the originating case in place, publishes a new version, no duplicate", async () => {
+    const res = await POST(req({ action: "update_existing_case", expected: "revised expected" }), params("res1"));
+    expect(res.status).toBe(201);
+    const body = await readJson(res);
+    expect(body.test_case_id).toBe("tc-A"); // stable logical id preserved
+    expect(body.version_number).toBe(2); // a NEW immutable version
+
+    const newVersion = currentVersionId("ds1");
+    const cases = casesIn(newVersion);
+    expect(cases).toHaveLength(1); // updated, not duplicated
+    expect(cases[0].testCaseId).toBe("tc-A");
+    expect(cases[0].expected).toBe("revised expected");
+    expect(cases[0].input).toBe("orig input"); // unsupplied input unchanged
+    // The old version's snapshot is untouched (immutability).
+    expect(casesIn("dv1")[0].expected).toBe("orig expected");
+  });
+});
+
+describe("result → dataset: save_new_case", () => {
+  it("saves a new case into another dataset with result provenance; candidate stays separate", async () => {
+    const res = await POST(req({ action: "save_new_case", dataset_id: "ds2" }), params("res1"));
+    expect(res.status).toBe(201);
+    const cases = casesIn(currentVersionId("ds2"));
+    expect(cases).toHaveLength(1);
+    const c = cases[0];
+    // Candidate output is recorded separately and is NEVER the expected output.
+    expect(c.recordedOutput).toBe("the CANDIDATE answer");
+    expect(c.expected).toBeNull();
+    // Result provenance is captured.
+    expect(c.sourceRunId).toBe("run1");
+    expect(c.sourceResultId).toBe("res1");
+    expect(c.sourceTraceId).toBe("trace-xyz");
+  });
+
+  it("refuses a save back into the originating dataset (circular) with an actionable 409", async () => {
+    const res = await POST(req({ action: "save_new_case", dataset_id: "ds1" }), params("res1"));
+    expect(res.status).toBe(409);
+    expect((await readJson(res)).error).toMatch(/update_existing_case/);
+    // No new version was published on ds1.
+    expect(currentVersionId("ds1")).toBe("dv1");
+  });
+
+  it("copies the candidate into expected ONLY on explicit opt-in", async () => {
+    const res = await POST(
+      req({ action: "save_new_case", dataset_id: "ds2", use_candidate_as_expected: true }),
+      params("res1"),
+    );
+    expect(res.status).toBe(201);
+    const c = casesIn(currentVersionId("ds2"))[0];
+    expect(c.expected).toBe("the CANDIDATE answer");
+    expect(c.recordedOutput).toBe("the CANDIDATE answer");
+  });
+});
+
+describe("result → dataset: duplicate_as_variant", () => {
+  it("adds a second logical case even in the originating dataset, retaining provenance", async () => {
+    const res = await POST(req({ action: "duplicate_as_variant", dataset_id: "ds1" }), params("res1"));
+    expect(res.status).toBe(201);
+    const cases = casesIn(currentVersionId("ds1"));
+    expect(cases).toHaveLength(2); // original tc-A + the new variant
+    const variant = cases.find((c) => c.testCaseId !== "tc-A")!;
+    expect(variant.testCaseId).not.toBe("tc-A"); // a NEW logical case
+    expect(variant.sourceResultId).toBe("res1");
+  });
+});
+
+describe("result → dataset: idempotency", () => {
+  it("a retried request with the same key returns the already-published version", async () => {
+    const first = await readJson(
+      await POST(req({ action: "save_new_case", dataset_id: "ds2", idempotency_key: "k1" }), params("res1")),
+    );
+    const second = await readJson(
+      await POST(req({ action: "save_new_case", dataset_id: "ds2", idempotency_key: "k1" }), params("res1")),
+    );
+    expect(second.version_id).toBe(first.version_id);
+    expect(second.replayed).toBe(true);
+    // Only one new case exists — the retry did not duplicate.
+    expect(casesIn(currentVersionId("ds2"))).toHaveLength(1);
+  });
+});
+
+describe("result → dataset: guards", () => {
+  it("404s an unknown result", async () => {
+    expect((await POST(req({ action: "save_new_case", dataset_id: "ds2" }), params("nope"))).status).toBe(404);
+  });
+  it("400s save_new_case without a target dataset_id", async () => {
+    expect((await POST(req({ action: "save_new_case" }), params("res1"))).status).toBe(400);
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Human-scoring one evaluation result. This is a SCORING action, not a dataset edit:
+ * it appends a HumanScore row scoped to the project and never touches the case's
+ * expected output. The result must belong to the caller's project. Auth + Prisma mocked.
+ */
+import { it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  evaluationResult: { findFirst: vi.fn() },
+  humanScore: { create: vi.fn() },
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return { ...actual, prisma: prismaMock };
+});
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { POST } from "./route";
+
+const params = { params: Promise.resolve({ projectId: "p1", resultId: "res_1" }) };
+
+const req = (body: unknown) =>
+  ({ json: async () => body }) as unknown as Parameters<typeof POST>[0];
+const badJsonReq = () =>
+  ({
+    json: async () => {
+      throw new Error("bad json");
+    },
+  }) as unknown as Parameters<typeof POST>[0];
+
+const valid = { verdict: "pass", quality: 4, comment: "reads well", reviewer: "hao" };
+
+async function body(res: { json: () => Promise<unknown> }) {
+  return (await res.json()) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+  prismaMock.evaluationResult.findFirst.mockResolvedValue({ id: "res_1" });
+  prismaMock.humanScore.create.mockImplementation(async (args: { data: unknown }) => ({
+    id: "hs_1",
+    ...(args.data as Record<string, unknown>),
+  }));
+});
+
+it("appends a human score to a result in the caller's project and 201s", async () => {
+  const res = await POST(req(valid), params);
+  expect(res.status).toBe(201);
+  expect((await body(res)).humanScore).toMatchObject({ id: "hs_1", verdict: "pass", quality: 4 });
+  expect(prismaMock.humanScore.create).toHaveBeenCalledWith({
+    data: {
+      resultId: "res_1",
+      projectId: "p1",
+      verdict: "pass",
+      quality: 4,
+      comment: "reads well",
+      // The session identity is authoritative: a body `reviewer` is ignored, so a
+      // member cannot attribute their judgment to someone else.
+      reviewer: "u1",
+    },
+  });
+  // Scoped lookup — a result id from another project cannot be scored.
+  expect(prismaMock.evaluationResult.findFirst.mock.calls[0][0].where).toEqual({
+    id: "res_1",
+    projectId: "p1",
+  });
+});
+
+it("attributes the score to the signed-in reviewer, not a body-supplied one", async () => {
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1", email: "hao@example.com" } });
+  await POST(req({ ...valid, reviewer: "someone-else" }), params);
+  expect(prismaMock.humanScore.create.mock.calls[0][0].data.reviewer).toBe("hao@example.com");
+});
+
+it("stores null for an omitted quality and comment", async () => {
+  await POST(req({ verdict: "unsure", reviewer: "hao" }), params);
+  expect(prismaMock.humanScore.create.mock.calls[0][0].data).toMatchObject({
+    quality: null,
+    comment: null,
+  });
+});
+
+it("400s an unparseable body", async () => {
+  const res = await POST(badJsonReq(), params);
+  expect(res.status).toBe(400);
+  expect(await body(res)).toEqual({ error: "Invalid JSON" });
+  expect(prismaMock.humanScore.create).not.toHaveBeenCalled();
+});
+
+it("400s an unknown verdict", async () => {
+  const res = await POST(req({ verdict: "maybe", reviewer: "hao" }), params);
+  expect(res.status).toBe(400);
+  expect(prismaMock.humanScore.create).not.toHaveBeenCalled();
+});
+
+it("400s a missing reviewer", async () => {
+  expect((await POST(req({ verdict: "fail" }), params)).status).toBe(400);
+});
+
+it("400s an out-of-range quality", async () => {
+  expect((await POST(req({ ...valid, quality: 9 }), params)).status).toBe(400);
+});
+
+it("404s a result that is not in this project", async () => {
+  prismaMock.evaluationResult.findFirst.mockResolvedValue(null);
+  const res = await POST(req(valid), params);
+  expect(res.status).toBe(404);
+  expect(await body(res)).toEqual({ error: "Evaluation result not found" });
+  expect(prismaMock.humanScore.create).not.toHaveBeenCalled();
+});
+
+it("401s an unauthenticated caller before touching the database", async () => {
+  auth.requireAuth.mockResolvedValue({
+    error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+  });
+  expect((await POST(req(valid), params)).status).toBe(401);
+  expect(prismaMock.evaluationResult.findFirst).not.toHaveBeenCalled();
+});
+
+it("403s a viewer without write access", async () => {
+  auth.requireProjectAccess.mockResolvedValue({
+    error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+  });
+  expect((await POST(req(valid), params)).status).toBe(403);
+  expect(prismaMock.humanScore.create).not.toHaveBeenCalled();
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.test.ts
@@ -1,13 +1,14 @@
 /**
  * Human-scoring one evaluation result. This is a SCORING action, not a dataset edit:
- * it appends a HumanScore row scoped to the project and never touches the case's
- * expected output. The result must belong to the caller's project. Auth + Prisma mocked.
+ * it writes ONE canonical HumanScore per (result, dimension), scoped to the project,
+ * and never touches the case's expected output or the automated score. Re-reviewing
+ * upserts in place. The result must belong to the caller's project. Auth + Prisma mocked.
  */
 import { it, expect, vi, beforeEach } from "vitest";
 
 const prismaMock = vi.hoisted(() => ({
   evaluationResult: { findFirst: vi.fn() },
-  humanScore: { create: vi.fn() },
+  humanScore: { upsert: vi.fn() },
 }));
 const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
 
@@ -49,26 +50,36 @@ beforeEach(() => {
   auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
   auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
   prismaMock.evaluationResult.findFirst.mockResolvedValue({ id: "res_1" });
-  prismaMock.humanScore.create.mockImplementation(async (args: { data: unknown }) => ({
+  prismaMock.humanScore.upsert.mockImplementation(async (args: { create: unknown }) => ({
     id: "hs_1",
-    ...(args.data as Record<string, unknown>),
+    ...(args.create as Record<string, unknown>),
   }));
 });
 
-it("appends a human score to a result in the caller's project and 201s", async () => {
+it("writes one canonical review per (result, dimension) via upsert and 201s", async () => {
   const res = await POST(req(valid), params);
   expect(res.status).toBe(201);
   expect((await body(res)).humanScore).toMatchObject({ id: "hs_1", verdict: "pass", quality: 4 });
-  expect(prismaMock.humanScore.create).toHaveBeenCalledWith({
-    data: {
+  expect(prismaMock.humanScore.upsert).toHaveBeenCalledWith({
+    // Canonical key: the default "overall" dimension.
+    where: { resultId_dimension: { resultId: "res_1", dimension: "overall" } },
+    create: {
       resultId: "res_1",
       projectId: "p1",
+      dimension: "overall",
       verdict: "pass",
       quality: 4,
       comment: "reads well",
-      // The session identity is authoritative: a body `reviewer` is ignored, so a
-      // member cannot attribute their judgment to someone else.
+      // The session identity is authoritative: a body `reviewer` is ignored.
       reviewer: "u1",
+      status: "reviewed",
+    },
+    update: {
+      verdict: "pass",
+      quality: 4,
+      comment: "reads well",
+      reviewer: "u1",
+      status: "reviewed",
     },
   });
   // Scoped lookup — a result id from another project cannot be scored.
@@ -78,15 +89,22 @@ it("appends a human score to a result in the caller's project and 201s", async (
   });
 });
 
+it("keys the canonical review on an explicit dimension", async () => {
+  await POST(req({ ...valid, dimension: "safety" }), params);
+  const call = prismaMock.humanScore.upsert.mock.calls[0][0];
+  expect(call.where).toEqual({ resultId_dimension: { resultId: "res_1", dimension: "safety" } });
+  expect(call.create.dimension).toBe("safety");
+});
+
 it("attributes the score to the signed-in reviewer, not a body-supplied one", async () => {
   auth.requireAuth.mockResolvedValue({ user: { id: "u1", email: "hao@example.com" } });
   await POST(req({ ...valid, reviewer: "someone-else" }), params);
-  expect(prismaMock.humanScore.create.mock.calls[0][0].data.reviewer).toBe("hao@example.com");
+  expect(prismaMock.humanScore.upsert.mock.calls[0][0].create.reviewer).toBe("hao@example.com");
 });
 
 it("stores null for an omitted quality and comment", async () => {
   await POST(req({ verdict: "unsure", reviewer: "hao" }), params);
-  expect(prismaMock.humanScore.create.mock.calls[0][0].data).toMatchObject({
+  expect(prismaMock.humanScore.upsert.mock.calls[0][0].create).toMatchObject({
     quality: null,
     comment: null,
   });
@@ -96,13 +114,13 @@ it("400s an unparseable body", async () => {
   const res = await POST(badJsonReq(), params);
   expect(res.status).toBe(400);
   expect(await body(res)).toEqual({ error: "Invalid JSON" });
-  expect(prismaMock.humanScore.create).not.toHaveBeenCalled();
+  expect(prismaMock.humanScore.upsert).not.toHaveBeenCalled();
 });
 
 it("400s an unknown verdict", async () => {
   const res = await POST(req({ verdict: "maybe", reviewer: "hao" }), params);
   expect(res.status).toBe(400);
-  expect(prismaMock.humanScore.create).not.toHaveBeenCalled();
+  expect(prismaMock.humanScore.upsert).not.toHaveBeenCalled();
 });
 
 it("400s a missing reviewer", async () => {
@@ -118,7 +136,7 @@ it("404s a result that is not in this project", async () => {
   const res = await POST(req(valid), params);
   expect(res.status).toBe(404);
   expect(await body(res)).toEqual({ error: "Evaluation result not found" });
-  expect(prismaMock.humanScore.create).not.toHaveBeenCalled();
+  expect(prismaMock.humanScore.upsert).not.toHaveBeenCalled();
 });
 
 it("401s an unauthenticated caller before touching the database", async () => {
@@ -134,5 +152,5 @@ it("403s a viewer without write access", async () => {
     error: { status: 403, json: async () => ({ error: "Forbidden" }) },
   });
   expect((await POST(req(valid), params)).status).toBe(403);
-  expect(prismaMock.humanScore.create).not.toHaveBeenCalled();
+  expect(prismaMock.humanScore.upsert).not.toHaveBeenCalled();
 });

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.ts
@@ -40,7 +40,9 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
       verdict: parsed.data.verdict,
       quality: parsed.data.quality ?? null,
       comment: parsed.data.comment ?? null,
-      reviewer: parsed.data.reviewer,
+      // The authenticated session identity is authoritative, never the request body —
+      // otherwise any MEMBER could attribute a human score to someone else.
+      reviewer: authResult.user.email ?? authResult.user.id,
     },
   });
   return successResponse({ humanScore }, 201);

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.ts
@@ -33,17 +33,24 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   });
   if (!result) return errorResponse("Evaluation result not found", 404);
 
-  const humanScore = await prisma.humanScore.create({
-    data: {
-      resultId,
-      projectId,
-      verdict: parsed.data.verdict,
-      quality: parsed.data.quality ?? null,
-      comment: parsed.data.comment ?? null,
-      // The authenticated session identity is authoritative, never the request body —
-      // otherwise any MEMBER could attribute a human score to someone else.
-      reviewer: authResult.user.email ?? authResult.user.id,
-    },
+  // The authenticated session identity is authoritative, never the request body —
+  // otherwise any MEMBER could attribute a human score to someone else.
+  const reviewer = authResult.user.email ?? authResult.user.id;
+  const { dimension, verdict, quality, comment } = parsed.data;
+  // One canonical review per (result, dimension): re-reviewing replaces in place.
+  // This never touches the automated score, comparison, or run status — human
+  // review is a separate, co-equal signal.
+  const fields = {
+    verdict,
+    quality: quality ?? null,
+    comment: comment ?? null,
+    reviewer,
+    status: "reviewed",
+  };
+  const humanScore = await prisma.humanScore.upsert({
+    where: { resultId_dimension: { resultId, dimension } },
+    create: { resultId, projectId, dimension, ...fields },
+    update: fields,
   });
   return successResponse({ humanScore }, 201);
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
@@ -21,13 +21,22 @@ vi.mock("@/lib/auth-helpers", () => ({
   successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
 }));
 
-const db = vi.hoisted(() => ({ run: null as unknown, dataset: null as unknown }));
+const db = vi.hoisted(() => ({
+  run: null as unknown,
+  baseline: null as unknown,
+  dataset: null as unknown,
+}));
 vi.mock("@traceroot/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@traceroot/core")>();
   return {
     ...actual,
     prisma: {
-      evaluationRun: { findFirst: vi.fn(async () => db.run) },
+      // The route fetches the candidate (id run1) and then the baseline (id run0).
+      evaluationRun: {
+        findFirst: vi.fn(async (args: { where: { id: string } }) =>
+          args.where.id === "run0" ? db.baseline : args.where.id === "run1" ? db.run : null,
+        ),
+      },
       dataset: { findFirst: vi.fn(async () => db.dataset) },
     },
   };
@@ -54,12 +63,13 @@ beforeEach(() => {
     candidateVersion: "git:4a91c02",
     status: "completed_with_errors",
     mainScore: 0.9,
-    mainScoreName: "Routing accuracy",
+    mainScoreName: "routing-accuracy",
     caseCount: 3,
     scoredCount: 2,
     taskErrorCount: 1,
     scorerErrorCount: 1,
     baselineRunId: "run0",
+    scorers: [{ name: "routing-accuracy", version: "v3" }],
     evaluation: { name: "Billing routing" },
     datasetVersion: { label: "v12" },
     baselineRun: {
@@ -117,6 +127,44 @@ beforeEach(() => {
       },
     ],
   };
+  // The baseline run (fetched separately by the route) with raw results/scores that
+  // pair on the main scorer so the derived comparison is trustworthy.
+  db.baseline = {
+    id: "run0",
+    projectId: PROJECT_ID,
+    evaluationId: "eval1",
+    datasetId: "ds1",
+    datasetVersionId: "dv12",
+    runNumber: 26,
+    candidateVersion: "git:0000000",
+    status: "completed",
+    baselineRunId: null,
+    mainScore: 0.75,
+    mainScoreName: "routing-accuracy",
+    scorers: [{ name: "routing-accuracy", version: "v3" }],
+    results: [
+      {
+        testCaseId: "case-1",
+        status: "passed",
+        mainScore: 0.5,
+        candidateOutput: "billing",
+        durationMs: 700,
+        scores: [
+          { scorerName: "routing-accuracy", scorerVersion: "v3", numericValue: 0.5, error: null },
+        ],
+      },
+      {
+        testCaseId: "case-2",
+        status: "passed",
+        mainScore: 1,
+        candidateOutput: "technical",
+        durationMs: 720,
+        scores: [
+          { scorerName: "routing-accuracy", scorerVersion: "v3", numericValue: 1, error: null },
+        ],
+      },
+    ],
+  };
 });
 
 async function read(runId = "run1") {
@@ -142,7 +190,13 @@ describe("run/result read-back", () => {
     const run = (await read()).body.run as Record<string, unknown>;
     expect(run.baselineRunId).toBe("run0");
     expect(run.baselineComparable).toBe(true);
-    expect(run.changeFromBaseline).toBeCloseTo(0.15); // 0.9 - 0.75
+    // NOT the raw run.mainScore subtraction (0.9 - 0.75 = 0.15): case-2's candidate
+    // task errored (no routing-accuracy score), so it is excluded from the paired
+    // aggregate. The only actually-comparable case is case-1 (candidate 1 vs
+    // baseline 0.5), so the trustworthy headline delta is 0.5 — derived the same way
+    // as every per-scorer aggregate, never a subtraction of the two runs' raw
+    // SDK-reported aggregates, which can silently cover different case sets.
+    expect(run.changeFromBaseline).toBeCloseTo(0.5);
   });
 
   it("exposes result trace id, task error, scores with independent scorer errors, and human scores", async () => {
@@ -165,10 +219,13 @@ describe("run/result read-back", () => {
   });
 
   it("marks an incompatible baseline (different dataset version) as not comparable", async () => {
-    (db.run as { baselineRun: { datasetVersionId: string } }).baselineRun.datasetVersionId = "dv11";
+    (db.baseline as { datasetVersionId: string }).datasetVersionId = "dv11";
     const run = (await read()).body.run as Record<string, unknown>;
     expect(run.baselineComparable).toBe(false);
     expect(run.changeFromBaseline).toBeNull();
+    expect((run.comparison as { reasons: string[] }).reasons).toContain(
+      "different_dataset_version",
+    );
   });
 
   it("404s an unknown run", async () => {

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
@@ -109,7 +109,15 @@ beforeEach(() => {
           },
         ],
         humanScores: [
-          { id: "h1", verdict: "pass", quality: 4, comment: "looks right", reviewer: "e@x.com" },
+          {
+            id: "h1",
+            dimension: "overall",
+            verdict: "pass",
+            quality: 4,
+            comment: "looks right",
+            reviewer: "e@x.com",
+            status: "reviewed",
+          },
         ],
       },
       {
@@ -236,6 +244,37 @@ describe("run/result read-back", () => {
     expect(prov.sdk_language).toBe("python");
     // The dropped orphan `model` column no longer appears on the read model.
     expect("model" in run).toBe(false);
+  });
+
+  it("derives the human-review summary read-only, without touching automated signals", async () => {
+    // res1 (auto passed) carries an "overall" human pass; res2 (auto errored) has none.
+    const run = (await read()).body.run as Record<string, unknown>;
+    const hr = run.humanReview as Record<string, number | string[]>;
+    expect(hr.dimensions).toEqual(["overall"]);
+    expect(hr.reviewedCount).toBe(1);
+    expect(hr.pendingCount).toBe(1); // res2 not reviewed on the active "overall" dimension
+    expect(hr.passCount).toBe(1);
+    expect(hr.failCount).toBe(0);
+    expect(hr.disagreementCount).toBe(0); // human pass agrees with the automated pass
+    // Automated signals are exactly what the comparison/status produce — never rewritten.
+    expect(run.status).toBe("completed_with_errors");
+    expect(run.changeFromBaseline).toBeCloseTo(0.5);
+    expect(run.baselineComparable).toBe(true);
+  });
+
+  it("counts a human-vs-automated disagreement without changing the automated verdict", async () => {
+    // Flip the human verdict on the auto-passed result to a fail → one disagreement.
+    (
+      db.run as { results: Array<{ humanScores: Array<{ verdict: string }> }> }
+    ).results[0].humanScores[0].verdict = "fail";
+    const run = (await read()).body.run as Record<string, unknown>;
+    const hr = run.humanReview as Record<string, number>;
+    expect(hr.disagreementCount).toBe(1);
+    expect(hr.failCount).toBe(1);
+    // The automated main score / status / comparison are untouched by the disagreement.
+    expect(run.mainScore).toBe(0.9);
+    expect(run.status).toBe("completed_with_errors");
+    expect(run.changeFromBaseline).toBeCloseTo(0.5);
   });
 
   it("marks an incompatible baseline (different dataset version) as not comparable", async () => {

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
@@ -21,22 +21,13 @@ vi.mock("@/lib/auth-helpers", () => ({
   successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
 }));
 
-const db = vi.hoisted(() => ({
-  run: null as unknown,
-  baseline: null as unknown,
-  dataset: null as unknown,
-}));
+const db = vi.hoisted(() => ({ run: null as unknown, dataset: null as unknown }));
 vi.mock("@traceroot/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@traceroot/core")>();
   return {
     ...actual,
     prisma: {
-      // The route fetches the candidate (id run1) and then the baseline (id run0).
-      evaluationRun: {
-        findFirst: vi.fn(async (args: { where: { id: string } }) =>
-          args.where.id === "run0" ? db.baseline : args.where.id === "run1" ? db.run : null,
-        ),
-      },
+      evaluationRun: { findFirst: vi.fn(async () => db.run) },
       dataset: { findFirst: vi.fn(async () => db.dataset) },
     },
   };
@@ -63,13 +54,12 @@ beforeEach(() => {
     candidateVersion: "git:4a91c02",
     status: "completed_with_errors",
     mainScore: 0.9,
-    mainScoreName: "routing-accuracy",
+    mainScoreName: "Routing accuracy",
     caseCount: 3,
     scoredCount: 2,
     taskErrorCount: 1,
     scorerErrorCount: 1,
     baselineRunId: "run0",
-    scorers: [{ name: "routing-accuracy", version: "v3" }],
     evaluation: { name: "Billing routing" },
     datasetVersion: { label: "v12" },
     baselineRun: {
@@ -127,44 +117,6 @@ beforeEach(() => {
       },
     ],
   };
-  // The baseline run (fetched separately by the route) with raw results/scores that
-  // pair on the main scorer so the derived comparison is trustworthy.
-  db.baseline = {
-    id: "run0",
-    projectId: PROJECT_ID,
-    evaluationId: "eval1",
-    datasetId: "ds1",
-    datasetVersionId: "dv12",
-    runNumber: 26,
-    candidateVersion: "git:0000000",
-    status: "completed",
-    baselineRunId: null,
-    mainScore: 0.75,
-    mainScoreName: "routing-accuracy",
-    scorers: [{ name: "routing-accuracy", version: "v3" }],
-    results: [
-      {
-        testCaseId: "case-1",
-        status: "passed",
-        mainScore: 0.5,
-        candidateOutput: "billing",
-        durationMs: 700,
-        scores: [
-          { scorerName: "routing-accuracy", scorerVersion: "v3", numericValue: 0.5, error: null },
-        ],
-      },
-      {
-        testCaseId: "case-2",
-        status: "passed",
-        mainScore: 1,
-        candidateOutput: "technical",
-        durationMs: 720,
-        scores: [
-          { scorerName: "routing-accuracy", scorerVersion: "v3", numericValue: 1, error: null },
-        ],
-      },
-    ],
-  };
 });
 
 async function read(runId = "run1") {
@@ -213,13 +165,10 @@ describe("run/result read-back", () => {
   });
 
   it("marks an incompatible baseline (different dataset version) as not comparable", async () => {
-    (db.baseline as { datasetVersionId: string }).datasetVersionId = "dv11";
+    (db.run as { baselineRun: { datasetVersionId: string } }).baselineRun.datasetVersionId = "dv11";
     const run = (await read()).body.run as Record<string, unknown>;
     expect(run.baselineComparable).toBe(false);
     expect(run.changeFromBaseline).toBeNull();
-    expect((run.comparison as { reasons: string[] }).reasons).toContain(
-      "different_dataset_version",
-    );
   });
 
   it("404s an unknown run", async () => {

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
@@ -218,6 +218,26 @@ describe("run/result read-back", () => {
     expect((errored.scores as unknown[]).length).toBe(0);
   });
 
+  it("surfaces structured run provenance in the read model", async () => {
+    (db.run as Record<string, unknown>).provenance = {
+      git_repository: "github.com/acme/agent",
+      git_commit: "4a91c02",
+      git_dirty: false,
+      ci_provider: "github-actions",
+      sdk_language: "python",
+      sdk_version: "0.4.1",
+      declared_model: "gpt-4o-2024-08-06",
+      declared_prompt_version: "router-v7",
+    };
+    const run = (await read()).body.run as Record<string, unknown>;
+    const prov = run.provenance as Record<string, unknown>;
+    expect(prov.git_commit).toBe("4a91c02");
+    expect(prov.declared_model).toBe("gpt-4o-2024-08-06");
+    expect(prov.sdk_language).toBe("python");
+    // The dropped orphan `model` column no longer appears on the read model.
+    expect("model" in run).toBe(false);
+  });
+
   it("marks an incompatible baseline (different dataset version) as not comparable", async () => {
     (db.baseline as { datasetVersionId: string }).datasetVersionId = "dv11";
     const run = (await read()).body.run as Record<string, unknown>;

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.test.ts
@@ -206,3 +206,32 @@ it("404s an unknown run", async () => {
   const res = await GET({} as never, params);
   expect(res.status).toBe(404);
 });
+
+it("derives per-status counts from the run's own results", async () => {
+  // baselineRunId: null keeps this to a single findFirst — no baseline fetch.
+  prismaMock.evaluationRun.findFirst.mockResolvedValueOnce(
+    candidate({
+      baselineRunId: null,
+      results: [
+        { id: "r1", testCaseId: "t0", status: "passed", mainScore: 1, scores: [], humanScores: [] },
+        { id: "r2", testCaseId: "t1", status: "failed", mainScore: 0, scores: [], humanScores: [] },
+        {
+          id: "r3",
+          testCaseId: "t2",
+          status: "errored",
+          mainScore: null,
+          scores: [],
+          humanScores: [],
+        },
+      ],
+    }),
+  );
+
+  const body = (await (await GET({} as never, params)).json()) as {
+    run: Record<string, unknown>;
+  };
+  expect(body.run.passedCount).toBe(1);
+  expect(body.run.failedCount).toBe(1);
+  expect(body.run.erroredCount).toBe(1);
+  expect(body.run.notScoredCount).toBe(0);
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { prisma } from "@traceroot/core";
+import { prisma, Role } from "@traceroot/core";
 import {
   requireAuth,
   requireProjectAccess,
@@ -116,4 +116,23 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
     },
     results,
   });
+}
+
+// DELETE — remove a run (cascades its results + scores; other runs that used it as
+// a baseline have their baselineRunId set to null). Editing access required.
+export async function DELETE(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, runId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId, Role.MEMBER);
+  if (accessResult.error) return accessResult.error;
+
+  const existing = await prisma.evaluationRun.findFirst({
+    where: { id: runId, projectId },
+    select: { id: true },
+  });
+  if (!existing) return errorResponse("Evaluation run not found", 404);
+
+  await prisma.evaluationRun.delete({ where: { id: runId } });
+  return successResponse({ deleted: true });
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/auth-helpers";
 import { compareRuns } from "@/lib/eval/comparison";
 import { toComparisonRun, toComparisonResults, caseChangeToLegacy } from "@/lib/eval/comparison-db";
+import { countResultStatuses } from "@/lib/eval/pass-rate";
 
 type RouteParams = { params: Promise<{ projectId: string; runId: string }> };
 
@@ -117,6 +118,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
       baselineComparable: comparison.trustworthy,
       errorCount: run.taskErrorCount + run.scorerErrorCount,
       elapsedMs: elapsedMs(run.startedAt, run.completedAt),
+      ...countResultStatuses(run.results),
       comparison,
     },
     results,

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
@@ -88,6 +88,8 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
             caseChange: cmp.caseChange,
             pairing: cmp.pairing,
             mainScore: cmp.mainScore,
+            baselineDurationMs: cmp.baselineDurationMs,
+            durationDeltaMs: cmp.durationDeltaMs,
             scorerCells: cmp.scorerCells,
             regressedCellCount: cmp.regressedCellCount,
             comparableCellCount: cmp.comparableCellCount,

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
@@ -9,6 +9,7 @@ import {
 import { compareRuns } from "@/lib/eval/comparison";
 import { toComparisonRun, toComparisonResults, caseChangeToLegacy } from "@/lib/eval/comparison-db";
 import { countResultStatuses } from "@/lib/eval/pass-rate";
+import { deriveHumanReviewSummary, type HumanVerdict } from "@/lib/eval/human-review";
 
 type RouteParams = { params: Promise<{ projectId: string; runId: string }> };
 
@@ -127,6 +128,19 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
     _count: { _all: true },
   });
 
+  // Derived human-review summary: reviewed/pending over active dimensions, human
+  // pass/fail, and human-vs-automated disagreement. Read-only — computing this never
+  // touches the automated score, comparison, or run status.
+  const humanReview = deriveHumanReviewSummary(
+    run.results.map((r) => ({
+      automatedPass: r.status === "passed" ? true : r.status === "failed" ? false : null,
+      reviews: r.humanScores.map((h) => ({
+        dimension: h.dimension,
+        verdict: h.verdict as HumanVerdict,
+      })),
+    })),
+  );
+
   const { results: _omit, ...runFields } = run;
   return successResponse({
     run: {
@@ -142,6 +156,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
       errorCount: run.taskErrorCount + run.scorerErrorCount,
       elapsedMs: elapsedMs(run.startedAt, run.completedAt),
       ...countResultStatuses(statusGroups.map((g) => ({ status: g.status, count: g._count._all }))),
+      humanReview,
       comparison,
       // True when `results` (and the comparison derived from it) is a partial view —
       // the run has more cases than the cap above.

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
@@ -12,6 +12,14 @@ import { countResultStatuses } from "@/lib/eval/pass-rate";
 
 type RouteParams = { params: Promise<{ projectId: string; runId: string }> };
 
+// A run's (and its baseline's) result set is unbounded in principle — a large run can
+// have thousands of cases, each carrying several @db.Text columns plus per-scorer rows.
+// Capping keeps a single request's query size and response payload bounded; `resultsTruncated`
+// tells the caller when they are looking at a partial view. This is a stopgap, not real
+// pagination — see the finding this addresses for the fuller fix (page `results`, keep the
+// aggregate `comparison` over the full set).
+const MAX_RUN_DETAIL_RESULTS = 1000;
+
 function elapsedMs(startedAt: Date, completedAt: Date | null): number | null {
   if (!completedAt) return null;
   const ms = completedAt.getTime() - startedAt.getTime();
@@ -45,6 +53,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
       },
       results: {
         orderBy: { createTime: "asc" },
+        take: MAX_RUN_DETAIL_RESULTS,
         include: {
           scores: { orderBy: { createTime: "asc" } },
           humanScores: { orderBy: { createTime: "desc" } },
@@ -54,11 +63,11 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
   });
   if (!run) return errorResponse("Evaluation run not found", 404);
 
-  // The baseline's raw results + scores, in one bounded query (no per-row N+1).
+  // The baseline's raw results + scores (no per-row N+1), capped the same way.
   const baselineRun = run.baselineRunId
     ? await prisma.evaluationRun.findFirst({
         where: { id: run.baselineRunId, projectId },
-        include: { results: { include: { scores: true } } },
+        include: { results: { take: MAX_RUN_DETAIL_RESULTS, include: { scores: true } } },
       })
     : null;
 
@@ -88,19 +97,23 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
       // Derived values win over the stored columns.
       change: cmp ? caseChangeToLegacy(cmp.caseChange) : null,
       baselineOutput: cmp ? cmp.baselineOutput : null,
-      comparison: cmp
-        ? {
-            caseChange: cmp.caseChange,
-            pairing: cmp.pairing,
-            mainScore: cmp.mainScore,
-            baselineDurationMs: cmp.baselineDurationMs,
-            durationDeltaMs: cmp.durationDeltaMs,
-            baselineTraceId: baselineTraceByCase.get(r.testCaseId) ?? null,
-            scorerCells: cmp.scorerCells,
-            regressedCellCount: cmp.regressedCellCount,
-            comparableCellCount: cmp.comparableCellCount,
-          }
-        : null,
+      // Without a baseline, every case's comparison would be the same "candidate_only,
+      // all cells unpaired" object — zero information, so omit it rather than inflate
+      // the common (no-baseline) case's payload.
+      comparison:
+        cmp && baselineRun
+          ? {
+              caseChange: cmp.caseChange,
+              pairing: cmp.pairing,
+              mainScore: cmp.mainScore,
+              baselineDurationMs: cmp.baselineDurationMs,
+              durationDeltaMs: cmp.durationDeltaMs,
+              baselineTraceId: baselineTraceByCase.get(r.testCaseId) ?? null,
+              scorerCells: cmp.scorerCells,
+              regressedCellCount: cmp.regressedCellCount,
+              comparableCellCount: cmp.comparableCellCount,
+            }
+          : null,
     };
   });
 
@@ -120,6 +133,9 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
       elapsedMs: elapsedMs(run.startedAt, run.completedAt),
       ...countResultStatuses(run.results),
       comparison,
+      // True when `results` (and the comparison derived from it) is a partial view —
+      // the run has more cases than the cap above.
+      resultsTruncated: run.caseCount > run.results.length,
     },
     results,
   });

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
@@ -75,6 +75,10 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
     baselineResults: baselineRun ? toComparisonResults(baselineRun.results) : [],
   });
   const cmpByCase = new Map(resultComparisons.map((c) => [c.testCaseId, c]));
+  // The baseline case's trace id, so the UI can fetch it to diff tokens/cost/latency.
+  const baselineTraceByCase = new Map(
+    (baselineRun?.results ?? []).map((r) => [r.testCaseId, r.traceId]),
+  );
 
   const results = run.results.map((r) => {
     const cmp = cmpByCase.get(r.testCaseId);
@@ -90,6 +94,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
             mainScore: cmp.mainScore,
             baselineDurationMs: cmp.baselineDurationMs,
             durationDeltaMs: cmp.durationDeltaMs,
+            baselineTraceId: baselineTraceByCase.get(r.testCaseId) ?? null,
             scorerCells: cmp.scorerCells,
             regressedCellCount: cmp.regressedCellCount,
             comparableCellCount: cmp.comparableCellCount,

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
@@ -117,6 +117,16 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
     };
   });
 
+  // Run-wide status counts from a grouped aggregate — NOT the capped `results` page,
+  // which would under-count pass/fail/errored for a run over MAX_RUN_DETAIL_RESULTS.
+  // `resultsTruncated` below still flags that the detail table + derived comparison are
+  // a partial view of a very large run.
+  const statusGroups = await prisma.evaluationResult.groupBy({
+    by: ["status"],
+    where: { runId, projectId },
+    _count: { _all: true },
+  });
+
   const { results: _omit, ...runFields } = run;
   return successResponse({
     run: {
@@ -131,7 +141,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
       baselineComparable: comparison.trustworthy,
       errorCount: run.taskErrorCount + run.scorerErrorCount,
       elapsedMs: elapsedMs(run.startedAt, run.completedAt),
-      ...countResultStatuses(run.results),
+      ...countResultStatuses(statusGroups.map((g) => ({ status: g.status, count: g._count._all }))),
       comparison,
       // True when `results` (and the comparison derived from it) is a partial view —
       // the run has more cases than the cap above.

--- a/frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts
@@ -283,3 +283,101 @@ describe("SDK reporting: full run lifecycle", () => {
     expect(run.completedAt).toBeInstanceOf(Date);
   });
 });
+
+describe("SDK reporting: concurrent registration", () => {
+  it("never assigns two runs the same run_number when two registrations race", async () => {
+    // Every fake-prisma method is async, so two registerRun calls driven with
+    // Promise.all genuinely interleave at the awaits between the run_number
+    // read and the insert — the same race a real database sees under READ
+    // COMMITTED. uq_run_evaluation_run_number must catch whichever one loses
+    // (the route's retry loop replays it), not let both insert run_number 1.
+    const register = () =>
+      registerRun(
+        req({
+          evaluation_name: "Concurrent eval",
+          dataset_id: "ds1",
+          candidate_version: "git:abc123",
+        }),
+      );
+    const [a, b] = await Promise.all([register(), register()]);
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+    const [aBody, bBody] = await Promise.all([readJson(a), readJson(b)]);
+
+    // One evaluation lineage, two distinct runs, no run_number collision.
+    expect(fakePrisma.evaluation.rows).toHaveLength(1);
+    expect(fakePrisma.evaluationRun.rows).toHaveLength(2);
+    expect(aBody.evaluation_run_id).not.toBe(bBody.evaluation_run_id);
+    expect(new Set([aBody.run_number, bBody.run_number])).toEqual(new Set([1, 2]));
+  });
+});
+
+describe("SDK reporting: run provenance", () => {
+  const PROVENANCE = {
+    git_repository: "github.com/acme/agent",
+    git_ref: "refs/heads/main",
+    git_commit: "4a91c02",
+    git_dirty: false,
+    ci_provider: "github-actions",
+    ci_build_id: "run-9182",
+    sdk_language: "python",
+    sdk_version: "0.4.1",
+    declared_model: "gpt-4o-2024-08-06",
+    declared_prompt_version: "router-v7",
+  };
+
+  it("persists structured provenance, kept distinct from free-form metadata", async () => {
+    const reg = await registerRun(
+      req({
+        evaluation_name: "Provenance eval",
+        dataset_id: "ds1",
+        candidate_version: "git:abc123",
+        provenance: PROVENANCE,
+        metadata: { experiment: "temp-sweep", note: "arbitrary user data" },
+      }),
+    );
+    expect(reg.status).toBe(201);
+    const runId = (await readJson(reg)).evaluation_run_id as string;
+    const run = fakePrisma.evaluationRun.rows.find((r) => r.id === runId)!;
+    // Typed provenance rides its own column, verbatim...
+    expect(run.provenance).toEqual(PROVENANCE);
+    // ...and is never conflated with the free-form metadata blob.
+    expect(run.metadata).toEqual({ experiment: "temp-sweep", note: "arbitrary user data" });
+    // The declared model lives in provenance — not inferred from candidate_version.
+    expect((run.provenance as Record<string, unknown>).declared_model).toBe("gpt-4o-2024-08-06");
+  });
+
+  it("registers with no provenance — absence stores null and never rejects", async () => {
+    const reg = await registerRun(
+      req({
+        evaluation_name: "No-provenance eval",
+        dataset_id: "ds1",
+        candidate_version: "git:abc123",
+      }),
+    );
+    expect(reg.status).toBe(201);
+    const runId = (await readJson(reg)).evaluation_run_id as string;
+    const run = fakePrisma.evaluationRun.rows.find((r) => r.id === runId)!;
+    expect(run.provenance ?? null).toBeNull();
+  });
+
+  it("accepts a partial provenance block — unreported fields stay absent, never invented", async () => {
+    const reg = await registerRun(
+      req({
+        evaluation_name: "Partial provenance eval",
+        dataset_id: "ds1",
+        candidate_version: "git:abc123",
+        provenance: { git_commit: "deadbeef", sdk_language: "typescript" },
+      }),
+    );
+    expect(reg.status).toBe(201);
+    const runId = (await readJson(reg)).evaluation_run_id as string;
+    const run = fakePrisma.evaluationRun.rows.find((r) => r.id === runId)!;
+    const prov = run.provenance as Record<string, unknown>;
+    expect(prov.git_commit).toBe("deadbeef");
+    expect(prov.sdk_language).toBe("typescript");
+    // Fields the SDK didn't report are absent — not defaulted, not inferred.
+    expect(prov.declared_model ?? null).toBeNull();
+    expect(prov.ci_provider ?? null).toBeNull();
+  });
+});

--- a/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/[testCaseId]/human-score/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/[testCaseId]/human-score/route.ts
@@ -34,15 +34,19 @@ export async function POST(request: Request, { params }: RouteParams) {
   }
   const h = parsed.data;
 
-  const created = await prisma.humanScore.create({
-    data: {
-      resultId: result.id,
-      projectId,
-      verdict: h.verdict,
-      quality: h.quality ?? null,
-      comment: h.comment ?? null,
-      reviewer: h.reviewer,
-    },
+  // One canonical review per (result, dimension): re-reviewing replaces in place,
+  // and this never rewrites the automated score, comparison, or run status.
+  const fields = {
+    verdict: h.verdict,
+    quality: h.quality ?? null,
+    comment: h.comment ?? null,
+    reviewer: h.reviewer,
+    status: "reviewed",
+  };
+  const created = await prisma.humanScore.upsert({
+    where: { resultId_dimension: { resultId: result.id, dimension: h.dimension } },
+    create: { resultId: result.id, projectId, dimension: h.dimension, ...fields },
+    update: fields,
     select: { id: true },
   });
 

--- a/frontend/ui/src/features/evaluations/compare-derive.test.ts
+++ b/frontend/ui/src/features/evaluations/compare-derive.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveVerdict,
+  matchesFilter,
+  filterCounts,
+  sortCases,
+  caseStatus,
+  type CaseFilterId,
+} from "./compare-derive";
+import type { CompareResultRow, RunComparison } from "./types";
+
+function counts(p: Partial<RunComparison["caseCounts"]> = {}) {
+  return {
+    improved: 0,
+    regressed: 0,
+    unchanged: 0,
+    changed: 0,
+    unpaired: 0,
+    not_comparable: 0,
+    ...p,
+  };
+}
+function comparison(p: Partial<RunComparison> = {}): RunComparison {
+  return {
+    available: true,
+    trustworthy: true,
+    reasons: [],
+    baseline: { runId: "b", runNumber: 1, candidateVersion: "opus" },
+    mainScore: { candidate: null, baseline: null, delta: null },
+    caseCounts: counts(),
+    scoreCellCounts: counts(),
+    scorers: [],
+    duration: { candidateMeanMs: null, baselineMeanMs: null, deltaMs: null, pairedCount: 0 },
+    ...p,
+  };
+}
+
+// Minimal case row builder.
+function row(p: Partial<CompareResultRow> = {}): CompareResultRow {
+  return {
+    testCaseId: "tc",
+    input: "in",
+    expectedOutput: null,
+    metadata: null,
+    provenance: null,
+    inputMatchesDataset: true,
+    candidateStatus: "passed",
+    baselineStatus: "passed",
+    candidateOutput: "billing",
+    baselineOutput: "billing",
+    candidateTraceId: "tc-cand",
+    baselineTraceId: "tc-base",
+    candidateCost: null,
+    baselineCost: null,
+    candidateTaskError: null,
+    baselineTaskError: null,
+    candidateScores: [],
+    baselineScores: [],
+    outputChanged: false,
+    change: "unchanged",
+    comparison: {
+      caseChange: "unchanged",
+      pairing: "paired",
+      mainScore: { candidate: 1, baseline: 1, delta: 0 },
+      baselineOutput: "billing",
+      durationMs: null,
+      baselineDurationMs: null,
+      durationDeltaMs: null,
+      baselineTraceId: "tc-base",
+      scorerCells: [],
+      regressedCellCount: 0,
+      comparableCellCount: 1,
+    },
+    ...p,
+  };
+}
+
+describe("deriveVerdict", () => {
+  it("regression: main score down", () => {
+    const v = deriveVerdict(
+      comparison({
+        mainScore: { candidate: 6 / 7, baseline: 1, delta: 6 / 7 - 1 },
+        caseCounts: counts({ regressed: 1, unchanged: 6 }),
+        scoreCellCounts: counts({ regressed: 2, unchanged: 19 }),
+      }),
+      "completed",
+      "completed",
+    );
+    expect(v.verdict).toBe("regression");
+    expect(v.reasons.join(" ")).toMatch(/decreased by 14\.3 pp/);
+    expect(v.reasons.join(" ")).toMatch(/1 of 7 test cases regressed/);
+    expect(v.reasons.join(" ")).toMatch(/2 scorer values regressed/);
+  });
+
+  it("improvement: main up, no regressions", () => {
+    const v = deriveVerdict(
+      comparison({
+        mainScore: { candidate: 1, baseline: 0.8, delta: 0.2 },
+        caseCounts: counts({ improved: 2, unchanged: 5 }),
+      }),
+      "completed",
+      "completed",
+    );
+    expect(v.verdict).toBe("improvement");
+  });
+
+  it("tradeoff: quality up but ops worsened", () => {
+    const v = deriveVerdict(
+      comparison({ mainScore: { candidate: 1, baseline: 0.8, delta: 0.2 } }),
+      "completed",
+      "completed",
+      true,
+    );
+    expect(v.verdict).toBe("tradeoff");
+    expect(v.reasons.join(" ")).toMatch(/duration\/cost increased/);
+  });
+
+  it("tie: everything flat", () => {
+    const v = deriveVerdict(
+      comparison({ mainScore: { candidate: 1, baseline: 1, delta: 0 } }),
+      "completed",
+      "completed",
+    );
+    expect(v.verdict).toBe("tie");
+  });
+
+  it("not_comparable: different dataset version, with reason", () => {
+    const v = deriveVerdict(
+      comparison({ reasons: ["different_dataset_version"], trustworthy: false }),
+      "completed",
+      "completed",
+    );
+    expect(v.verdict).toBe("not_comparable");
+    expect(v.reasons[0]).toMatch(/different immutable dataset versions/);
+  });
+
+  it("pending: a run is still running", () => {
+    const v = deriveVerdict(comparison(), "running", "completed");
+    expect(v.verdict).toBe("pending");
+  });
+});
+
+describe("filters + counts", () => {
+  const rows = [
+    row({
+      testCaseId: "reg",
+      change: "regressed",
+      comparison: {
+        ...row().comparison!,
+        caseChange: "regressed",
+        regressedCellCount: 2,
+        mainScore: { candidate: 0, baseline: 1, delta: -1 },
+      },
+    }),
+    row({
+      testCaseId: "imp",
+      change: "improved",
+      comparison: { ...row().comparison!, caseChange: "improved" },
+    }),
+    row({ testCaseId: "err", candidateTaskError: "boom" }),
+    row({ testCaseId: "out", outputChanged: true, candidateOutput: "x", baselineOutput: "y" }),
+    row({ testCaseId: "same" }),
+  ];
+  it("each filter selects the right rows", () => {
+    const ids = (f: CaseFilterId) =>
+      rows.filter((r) => matchesFilter(r, f)).map((r) => r.testCaseId);
+    expect(ids("regressions")).toEqual(["reg"]);
+    expect(ids("improvements")).toEqual(["imp"]);
+    expect(ids("errors")).toEqual(["err"]);
+    expect(ids("changed_outputs")).toEqual(["out"]);
+    expect(ids("all")).toHaveLength(5);
+  });
+  it("filterCounts labels", () => {
+    const c = filterCounts(rows);
+    expect(c.all).toBe(5);
+    expect(c.regressions).toBe(1);
+    expect(c.errors).toBe(1);
+  });
+});
+
+describe("default sort", () => {
+  it("orders task errors, then main regressions, then improvements, then unchanged", () => {
+    const rows = [
+      row({ testCaseId: "same" }),
+      row({ testCaseId: "imp", comparison: { ...row().comparison!, caseChange: "improved" } }),
+      row({ testCaseId: "reg", comparison: { ...row().comparison!, caseChange: "regressed" } }),
+      row({ testCaseId: "err", candidateTaskError: "boom" }),
+    ];
+    expect(sortCases(rows, "default").map((r) => r.testCaseId)).toEqual([
+      "err",
+      "reg",
+      "imp",
+      "same",
+    ]);
+  });
+});
+
+describe("caseStatus distinguishes task vs scorer error", () => {
+  it("task error", () => {
+    expect(caseStatus(row({ candidateTaskError: "boom" }))).toBe("task_error");
+  });
+  it("scorer error (not a task error)", () => {
+    const r = row({
+      candidateScores: [
+        {
+          scorerName: "s",
+          scorerVersion: "v1",
+          numericValue: null,
+          boolValue: null,
+          stringValue: null,
+          passed: null,
+          explanation: null,
+          error: "judge failed",
+        },
+      ],
+      comparison: { ...row().comparison!, caseChange: "not_comparable" },
+    });
+    expect(caseStatus(r)).toBe("scorer_error");
+  });
+});

--- a/frontend/ui/src/features/evaluations/compare-derive.ts
+++ b/frontend/ui/src/features/evaluations/compare-derive.ts
@@ -84,18 +84,15 @@ export function deriveVerdict(
   const mainDelta = comparison.mainScore.delta;
   const reasons: string[] = [];
 
-  // Main-scorer direction.
+  // Main-scorer direction, taken from the per-case classifications — which the engine
+  // already computed WITH each scorer's direction, so a lower-is-better main scorer
+  // reads a score DECREASE as an improvement. Deriving direction from the raw mainDelta
+  // sign (as before) mislabeled every lower-is-better run's improvements as regressions.
+  // (mainDelta is still used below for the human-readable magnitude, not the verdict.)
   let mainVerdict: "up" | "down" | "flat";
-  if (mainDelta === null) {
-    // Categorical / no numeric main delta — fall back to case verdicts.
-    if (cases.regressed > 0 && cases.improved === 0) mainVerdict = "down";
-    else if (cases.improved > 0 && cases.regressed === 0) mainVerdict = "up";
-    else if (cases.regressed > 0 && cases.improved > 0)
-      mainVerdict = "flat"; // mixed → decided below
-    else mainVerdict = "flat";
-  } else if (mainDelta < 0) mainVerdict = "down";
-  else if (mainDelta > 0) mainVerdict = "up";
-  else mainVerdict = "flat";
+  if (cases.regressed > 0 && cases.improved === 0) mainVerdict = "down";
+  else if (cases.improved > 0 && cases.regressed === 0) mainVerdict = "up";
+  else mainVerdict = "flat"; // none changed, or mixed → decided below
 
   const casesPaired = cases.improved + cases.regressed + cases.unchanged + cases.changed;
   if (mainDelta !== null) {

--- a/frontend/ui/src/features/evaluations/compare-derive.ts
+++ b/frontend/ui/src/features/evaluations/compare-derive.ts
@@ -1,0 +1,255 @@
+/**
+ * Pure presentation-derivation for the comparison page. Everything here is derived
+ * transparently from the backend comparison output (RunComparison / CompareResultRow) —
+ * no comparison MATH is done here (that stays in `lib/eval/comparison.ts`). This module
+ * only turns those numbers into a verdict, a filter/sort order, and label helpers, so
+ * the view stays thin and this logic is unit-testable.
+ */
+import type { CompareResultRow, RunComparison, Classification } from "./types";
+
+// Reasons that make deltas untrustworthy → "Not comparable". `different_evaluation`
+// alone is cross-evaluation (allowed + labeled), not an incompatibility.
+export const BLOCKING_REASONS = new Set([
+  "different_dataset_version",
+  "baseline_not_terminal",
+  "baseline_missing",
+  "no_baseline",
+  "main_scorer_incompatible",
+]);
+
+export const REASON_LABEL: Record<string, string> = {
+  no_baseline: "No baseline was chosen.",
+  baseline_missing: "The baseline run wasn't found.",
+  different_evaluation: "The runs are from different evaluations.",
+  different_dataset_version:
+    "The runs used different immutable dataset versions, so their cases don't line up.",
+  baseline_not_terminal: "The baseline run hasn't finished.",
+  main_scorer_incompatible:
+    "The main scorer's name/version differs, so there's no comparable pair.",
+};
+
+export type Verdict =
+  | "improvement"
+  | "regression"
+  | "tradeoff"
+  | "tie"
+  | "not_comparable"
+  | "pending";
+
+export const VERDICT_META: Record<
+  Verdict,
+  { label: string; tone: "good" | "bad" | "warn" | "neutral" }
+> = {
+  improvement: { label: "Improvement", tone: "good" },
+  regression: { label: "Regression", tone: "bad" },
+  tradeoff: { label: "Tradeoff", tone: "warn" },
+  tie: { label: "Tie", tone: "neutral" },
+  not_comparable: { label: "Not comparable", tone: "neutral" },
+  pending: { label: "Comparison pending", tone: "neutral" },
+};
+
+const TERMINAL = new Set([
+  "completed",
+  "completed_with_errors",
+  "failed",
+  "incomplete",
+  "cancelled",
+]);
+
+/**
+ * Transparent, backend-sourced verdict. `opsWorsened` is a UI-computed hint (duration
+ * or cost went up) that promotes a quality improvement to a Tradeoff; when it's not
+ * yet known the verdict is main-scorer-only and operational changes are listed apart.
+ */
+export function deriveVerdict(
+  comparison: RunComparison,
+  candidateStatus: string,
+  baselineStatus: string,
+  opsWorsened?: boolean,
+): { verdict: Verdict; reasons: string[] } {
+  const blocking = comparison.reasons.filter((r) => BLOCKING_REASONS.has(r));
+  if (!comparison.available || blocking.length > 0) {
+    const rs = blocking.length > 0 ? blocking : (["no_baseline"] as const);
+    return { verdict: "not_comparable", reasons: rs.map((r) => REASON_LABEL[r] ?? r) };
+  }
+  if (!TERMINAL.has(candidateStatus) || !TERMINAL.has(baselineStatus)) {
+    return {
+      verdict: "pending",
+      reasons: ["A run hasn't finished, so the comparison isn't final."],
+    };
+  }
+
+  const cases = comparison.caseCounts;
+  const cells = comparison.scoreCellCounts;
+  const mainDelta = comparison.mainScore.delta;
+  const reasons: string[] = [];
+
+  // Main-scorer direction.
+  let mainVerdict: "up" | "down" | "flat";
+  if (mainDelta === null) {
+    // Categorical / no numeric main delta — fall back to case verdicts.
+    if (cases.regressed > 0 && cases.improved === 0) mainVerdict = "down";
+    else if (cases.improved > 0 && cases.regressed === 0) mainVerdict = "up";
+    else if (cases.regressed > 0 && cases.improved > 0)
+      mainVerdict = "flat"; // mixed → decided below
+    else mainVerdict = "flat";
+  } else if (mainDelta < 0) mainVerdict = "down";
+  else if (mainDelta > 0) mainVerdict = "up";
+  else mainVerdict = "flat";
+
+  const casesPaired = cases.improved + cases.regressed + cases.unchanged + cases.changed;
+  if (mainDelta !== null) {
+    const mag = `${Math.abs(mainDelta * 100).toFixed(1)} pp`;
+    reasons.push(
+      mainDelta < 0
+        ? `Main score decreased by ${mag}.`
+        : mainDelta > 0
+          ? `Main score increased by ${mag}.`
+          : "Main score was unchanged.",
+    );
+  }
+  if (cases.regressed > 0)
+    reasons.push(
+      `${cases.regressed} of ${casesPaired} test case${casesPaired === 1 ? "" : "s"} regressed on the main scorer.`,
+    );
+  if (cases.improved > 0) reasons.push(`${cases.improved} improved.`);
+  if (cells.regressed > 0)
+    reasons.push(`${cells.regressed} scorer value${cells.regressed === 1 ? "" : "s"} regressed.`);
+
+  let verdict: Verdict;
+  if (mainVerdict === "down") verdict = "regression";
+  else if (mainVerdict === "up") {
+    // Quality up, but a secondary scorer regressed or ops worsened → tradeoff.
+    verdict = cells.regressed > 0 || opsWorsened ? "tradeoff" : "improvement";
+  } else {
+    // Main flat. A secondary regression is a tradeoff; a truly-flat run is a tie.
+    if (cells.regressed > 0 && cells.improved > 0) verdict = "tradeoff";
+    else if (cells.regressed > 0) verdict = "regression";
+    else if (cases.improved > 0 && cases.regressed > 0) verdict = "tradeoff";
+    else if (cells.improved > 0) verdict = "improvement";
+    else verdict = "tie";
+  }
+  if (verdict === "tradeoff" && opsWorsened && cells.regressed === 0)
+    reasons.push("Quality held or improved, but duration/cost increased.");
+  if (verdict === "tie") reasons.push("No change on the main scorer or any scorer cell.");
+  return { verdict, reasons };
+}
+
+// ── Case filters + ordering ───────────────────────────────────────────────
+
+export type CaseFilterId =
+  | "all"
+  | "regressions"
+  | "improvements"
+  | "errors"
+  | "changed_outputs"
+  | "unpaired";
+
+export function caseHasError(r: CompareResultRow): boolean {
+  return (
+    !!r.candidateTaskError ||
+    !!r.baselineTaskError ||
+    r.candidateScores.some((s) => s.error) ||
+    r.baselineScores.some((s) => s.error)
+  );
+}
+
+export const CASE_FILTERS: Array<{ id: CaseFilterId; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "regressions", label: "Regressions" },
+  { id: "improvements", label: "Improvements" },
+  { id: "errors", label: "Errors" },
+  { id: "changed_outputs", label: "Changed outputs" },
+  { id: "unpaired", label: "Unpaired" },
+];
+
+export function matchesFilter(r: CompareResultRow, f: CaseFilterId): boolean {
+  const change = r.comparison?.caseChange ?? null;
+  switch (f) {
+    case "all":
+      return true;
+    case "regressions":
+      return change === "regressed" || (r.comparison?.regressedCellCount ?? 0) > 0;
+    case "improvements":
+      return change === "improved";
+    case "errors":
+      return caseHasError(r);
+    case "changed_outputs":
+      return r.outputChanged === true;
+    case "unpaired":
+      return r.comparison?.pairing !== "paired" || change === "not_comparable";
+  }
+}
+
+export function filterCounts(rows: CompareResultRow[]): Record<CaseFilterId, number> {
+  const out = {} as Record<CaseFilterId, number>;
+  for (const f of CASE_FILTERS) out[f.id] = rows.filter((r) => matchesFilter(r, f.id)).length;
+  return out;
+}
+
+export type CaseSortId =
+  | "default"
+  | "worst_regression"
+  | "most_scorer_regressions"
+  | "duration_increase"
+  | "cost_increase"
+  | "dataset";
+
+/** Default priority: task errors → main regressions → other scorer regressions →
+ *  improvements → changed-but-neutral → unchanged. Lower rank sorts first. */
+function defaultRank(r: CompareResultRow): number {
+  if (r.candidateTaskError || r.baselineTaskError) return 0;
+  const change = r.comparison?.caseChange ?? null;
+  if (change === "regressed") return 1;
+  if ((r.comparison?.regressedCellCount ?? 0) > 0) return 2;
+  if (change === "improved") return 3;
+  if (r.outputChanged === true || change === "changed") return 4;
+  if (change === "unpaired" || change === "not_comparable") return 6;
+  return 5; // unchanged
+}
+
+export function sortCases(rows: CompareResultRow[], sort: CaseSortId): CompareResultRow[] {
+  const withIndex = rows.map((r, i) => ({ r, i }));
+  const cmp: Record<
+    CaseSortId,
+    (a: { r: CompareResultRow; i: number }, b: { r: CompareResultRow; i: number }) => number
+  > = {
+    default: (a, b) => defaultRank(a.r) - defaultRank(b.r) || a.i - b.i,
+    worst_regression: (a, b) =>
+      (a.r.comparison?.mainScore.delta ?? 0) - (b.r.comparison?.mainScore.delta ?? 0),
+    most_scorer_regressions: (a, b) =>
+      (b.r.comparison?.regressedCellCount ?? 0) - (a.r.comparison?.regressedCellCount ?? 0),
+    duration_increase: (a, b) =>
+      (b.r.comparison?.durationDeltaMs ?? -Infinity) -
+      (a.r.comparison?.durationDeltaMs ?? -Infinity),
+    cost_increase: (a, b) => costDelta(b.r) - costDelta(a.r),
+    dataset: (a, b) => a.i - b.i,
+  };
+  return [...withIndex].sort(cmp[sort]).map((x) => x.r);
+}
+
+function costDelta(r: CompareResultRow): number {
+  if (r.candidateCost === null || r.baselineCost === null) return -Infinity;
+  return r.candidateCost - r.baselineCost;
+}
+
+export const CASE_SORTS: Array<{ id: CaseSortId; label: string }> = [
+  { id: "default", label: "Most impactful" },
+  { id: "worst_regression", label: "Worst main regression" },
+  { id: "most_scorer_regressions", label: "Most scorer regressions" },
+  { id: "duration_increase", label: "Duration increase" },
+  { id: "cost_increase", label: "Cost increase" },
+  { id: "dataset", label: "Dataset order" },
+];
+
+// ── Case-level status (distinct task vs scorer error) ─────────────────────
+
+export type CaseStatus = Classification | "task_error" | "scorer_error" | "pending";
+
+export function caseStatus(r: CompareResultRow): CaseStatus {
+  if (r.candidateTaskError || r.baselineTaskError) return "task_error";
+  const change = r.comparison?.caseChange ?? null;
+  if (change === "not_comparable" && caseHasError(r)) return "scorer_error";
+  if (r.candidateStatus === null || r.baselineStatus === null) return "unpaired";
+  return change ?? "unchanged";
+}

--- a/frontend/ui/src/features/evaluations/compare-runs.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/compare-runs.smoke.test.tsx
@@ -1,0 +1,319 @@
+// @vitest-environment jsdom
+/**
+ * The redesigned comparison page against a fixture reproducing the real
+ * ticket-routing lab (Opus baseline → Sonnet candidate): ticket-05 regresses on
+ * routing_accuracy + routing_report. Asserts baseline-left orientation, the verdict,
+ * the case-vs-scorer-cell distinction, the actual input as the primary label,
+ * default sort (ticket-05 first), and the case drawer.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, screen, fireEvent, within } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+vi.mock("./views/evaluations-view", () => ({
+  RunStatusBadge: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+vi.mock("@/features/traces/components", () => ({
+  TraceViewerPanel: ({ headerIdentity }: { headerIdentity?: { label: string } }) => (
+    <div data-testid="trace-panel">{headerIdentity?.label}</div>
+  ),
+}));
+vi.mock("@/features/traces/hooks", () => ({ useTrace: () => ({ data: undefined }) }));
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: { user: { id: "u", email: "e" } } }),
+}));
+vi.mock("@/lib/api", () => ({ getTrace: vi.fn(async () => ({ spans: [] })) }));
+vi.mock("@tanstack/react-query", () => ({
+  useQueries: ({ queries }: { queries: unknown[] }) =>
+    queries.map(() => ({ data: undefined, isLoading: false, isFetching: false })),
+}));
+
+const hooks = vi.hoisted(() => ({
+  useEvaluations: vi.fn(),
+  useEvaluationRuns: vi.fn(),
+  useCompareRuns: vi.fn(),
+}));
+vi.mock("./hooks", () => hooks);
+
+import { CompareRunsView } from "./views/compare-runs-view";
+
+const runSummary = (id: string, runNumber: number, ver: string, mainScore: number) => ({
+  id,
+  runNumber,
+  evaluationId: "ev1",
+  evaluationName: "ticket-routing-quality",
+  candidateVersion: ver,
+  datasetVersionId: "dv1",
+  datasetVersionLabel: "v3",
+  status: "completed",
+  mainScore,
+  mainScoreName: "routing_accuracy",
+  caseCount: 7,
+  scoredCount: 7,
+  taskErrorCount: 0,
+  scorerErrorCount: 0,
+  startedAt: "2026-07-26T10:00:00.000Z",
+  completedAt: "2026-07-26T10:02:00.000Z",
+  elapsedMs: 120000,
+});
+
+const counts = (p: Record<string, number> = {}) => ({
+  improved: 0,
+  regressed: 0,
+  unchanged: 0,
+  changed: 0,
+  unpaired: 0,
+  not_comparable: 0,
+  ...p,
+});
+
+const SCORERS = ["routing_accuracy", "routing_report", "is_known_category"];
+
+// One unchanged case (all three scorers 1→1), used to pad to 7.
+const unchangedCase = (n: number) => ({
+  testCaseId: `ticket-0${n}`,
+  input: `Ticket ${n}: my invoice looks wrong`,
+  expectedOutput: "billing",
+  metadata: null,
+  provenance: null,
+  inputMatchesDataset: true,
+  candidateStatus: "passed",
+  baselineStatus: "passed",
+  candidateOutput: "billing",
+  baselineOutput: "billing",
+  candidateTraceId: `t-c-0${n}`,
+  baselineTraceId: `t-b-0${n}`,
+  candidateCost: 0.01,
+  baselineCost: 0.011,
+  candidateTaskError: null,
+  baselineTaskError: null,
+  candidateScores: SCORERS.map((s) => ({
+    scorerName: s,
+    scorerVersion: "v1",
+    numericValue: 1,
+    boolValue: null,
+    stringValue: null,
+    passed: null,
+    explanation: "ok",
+    error: null,
+  })),
+  baselineScores: SCORERS.map((s) => ({
+    scorerName: s,
+    scorerVersion: "v1",
+    numericValue: 1,
+    boolValue: null,
+    stringValue: null,
+    passed: null,
+    explanation: "ok",
+    error: null,
+  })),
+  outputChanged: false,
+  change: "unchanged",
+  comparison: {
+    caseChange: "unchanged",
+    pairing: "paired",
+    mainScore: { candidate: 1, baseline: 1, delta: 0 },
+    baselineOutput: "billing",
+    durationMs: 2100,
+    baselineDurationMs: 2000,
+    durationDeltaMs: 100,
+    baselineTraceId: `t-b-0${n}`,
+    scorerCells: SCORERS.map((s) => ({
+      scorerName: s,
+      scorerVersion: "v1",
+      valueType: "numeric",
+      direction: "higher_is_better",
+      candidateValue: 1,
+      baselineValue: 1,
+      delta: 0,
+      classification: "unchanged",
+    })),
+    regressedCellCount: 0,
+    comparableCellCount: 3,
+  },
+});
+
+// ticket-05: routing_accuracy 1→0 + routing_report 1→0 regressed, is_known_category unchanged.
+const ticket05 = {
+  ...unchangedCase(5),
+  input: "Ticket 5: my card was double-charged and I want a refund",
+  candidateOutput: "account_management",
+  baselineOutput: "billing",
+  outputChanged: true,
+  change: "regressed",
+  comparison: {
+    caseChange: "regressed",
+    pairing: "paired",
+    mainScore: { candidate: 0, baseline: 1, delta: -1 },
+    baselineOutput: "billing",
+    durationMs: 2800,
+    baselineDurationMs: 2100,
+    durationDeltaMs: 700,
+    baselineTraceId: "t-b-05",
+    scorerCells: [
+      {
+        scorerName: "routing_accuracy",
+        scorerVersion: "v1",
+        valueType: "numeric",
+        direction: "higher_is_better",
+        candidateValue: 0,
+        baselineValue: 1,
+        delta: -1,
+        classification: "regressed",
+      },
+      {
+        scorerName: "routing_report",
+        scorerVersion: "v1",
+        valueType: "numeric",
+        direction: "higher_is_better",
+        candidateValue: 0,
+        baselineValue: 1,
+        delta: -1,
+        classification: "regressed",
+      },
+      {
+        scorerName: "is_known_category",
+        scorerVersion: "v1",
+        valueType: "numeric",
+        direction: "higher_is_better",
+        candidateValue: 1,
+        baselineValue: 1,
+        delta: 0,
+        classification: "unchanged",
+      },
+    ],
+    regressedCellCount: 2,
+    comparableCellCount: 3,
+  },
+};
+
+const labData = {
+  candidate: runSummary("sonnet", 42, "sonnet", 6 / 7),
+  baseline: runSummary("opus", 41, "opus", 1),
+  comparison: {
+    available: true,
+    trustworthy: true,
+    reasons: [],
+    baseline: { runId: "opus", runNumber: 41, candidateVersion: "opus" },
+    mainScore: { candidate: 6 / 7, baseline: 1, delta: 6 / 7 - 1 },
+    caseCounts: counts({ regressed: 1, unchanged: 6 }),
+    scoreCellCounts: counts({ regressed: 2, unchanged: 19 }),
+    scorers: [
+      {
+        name: "routing_accuracy",
+        version: "v1",
+        valueType: "numeric",
+        direction: "higher_is_better",
+        candidateMean: 6 / 7,
+        baselineMean: 1,
+        delta: 6 / 7 - 1,
+        pairedCount: 7,
+      },
+      {
+        name: "routing_report",
+        version: "v1",
+        valueType: "numeric",
+        direction: "higher_is_better",
+        candidateMean: 6 / 7,
+        baselineMean: 1,
+        delta: 6 / 7 - 1,
+        pairedCount: 7,
+      },
+      {
+        name: "is_known_category",
+        version: "v1",
+        valueType: "numeric",
+        direction: "higher_is_better",
+        candidateMean: 1,
+        baselineMean: 1,
+        delta: 0,
+        pairedCount: 7,
+      },
+    ],
+    duration: { candidateMeanMs: 2300, baselineMeanMs: 2050, deltaMs: 250, pairedCount: 7 },
+  },
+  results: [
+    unchangedCase(1),
+    unchangedCase(2),
+    unchangedCase(3),
+    unchangedCase(4),
+    ticket05,
+    unchangedCase(6),
+    unchangedCase(7),
+  ],
+};
+
+beforeEach(() => {
+  hooks.useEvaluations.mockReturnValue({
+    data: { data: [{ id: "ev1", name: "ticket-routing-quality" }] },
+  });
+  hooks.useEvaluationRuns.mockReturnValue({ data: { data: [] } });
+  hooks.useCompareRuns.mockReturnValue({ isLoading: false, error: null, data: labData });
+});
+afterEach(() => cleanup());
+
+const mount = () =>
+  render(
+    <CompareRunsView projectId="p1" candidateId="sonnet" baselineId="opus" onChange={vi.fn()} />,
+  );
+
+describe("CompareRunsView — Opus → Sonnet lab", () => {
+  it("reads Baseline (opus) → Candidate (sonnet) in that order", () => {
+    mount();
+    const labels = screen.getAllByText(/^(Baseline|Candidate)$/).map((el) => el.textContent);
+    expect(labels[0]).toBe("Baseline");
+    expect(labels[1]).toBe("Candidate");
+    expect(screen.getByText("Run #41")).toBeTruthy(); // baseline
+    expect(screen.getByText("Run #42")).toBeTruthy(); // candidate
+  });
+
+  it("verdict is a Regression with transparent reasons", () => {
+    mount();
+    expect(screen.getByText("Regression")).toBeTruthy();
+    expect(screen.getByText(/1 of 7 test cases regressed/)).toBeTruthy();
+    expect(screen.getByText(/2 scorer values regressed/)).toBeTruthy();
+  });
+
+  it("separates regressed test cases (1) from regressed scorer cells (2)", () => {
+    mount();
+    expect(screen.getByText("Regressed test cases")).toBeTruthy();
+    // The per-scorer summary names the two affected scorers.
+    expect(screen.getAllByText("routing_accuracy").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("routing_report").length).toBeGreaterThan(0);
+  });
+
+  it("shows the actual ticket input as the primary label, id secondary; ticket-05 sorted first", () => {
+    mount();
+    expect(screen.getByText(/double-charged and I want a refund/)).toBeTruthy();
+    // Default sort puts the regression first: within the CASE table (the one with the
+    // "Input" header), the first body row's input is ticket-05's.
+    const caseTable = screen.getByText("Input").closest("table") as HTMLTableElement;
+    const bodyRows = within(caseTable).getAllByRole("row").slice(1); // drop header row
+    expect(within(bodyRows[0]).getByText(/double-charged/)).toBeTruthy();
+  });
+
+  it("opens a case drawer with baseline/candidate outputs and per-scorer breakdown", () => {
+    mount();
+    fireEvent.click(screen.getByText(/double-charged and I want a refund/));
+    expect(screen.getByText("Case comparison")).toBeTruthy();
+    // Baseline output "billing" and candidate output "account_management" are shown.
+    expect(screen.getAllByText(/account_management/).length).toBeGreaterThan(0);
+    // Trace access buttons.
+    expect(screen.getByRole("button", { name: /Open candidate trace/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Open baseline trace/ })).toBeTruthy();
+  });
+
+  it("switches to a trace panel without leaving the page", () => {
+    mount();
+    fireEvent.click(screen.getByText(/double-charged and I want a refund/));
+    fireEvent.click(screen.getByRole("button", { name: /Open candidate trace/ }));
+    expect(screen.getByTestId("trace-panel").textContent).toBe("Candidate trace");
+    expect(screen.getByText("Case comparison")).toBeTruthy(); // drawer still mounted
+  });
+
+  it("does not label a same-evaluation pair as cross-evaluation", () => {
+    mount();
+    expect(screen.queryByText("Cross-evaluation comparison")).toBeNull();
+  });
+});

--- a/frontend/ui/src/features/evaluations/types.ts
+++ b/frontend/ui/src/features/evaluations/types.ts
@@ -130,11 +130,28 @@ export interface ScoreRow {
 
 export interface HumanScoreRow {
   id: string;
+  /** Named review dimension (default "overall"); one canonical review per (result, dimension). */
+  dimension: string;
   verdict: string;
   quality: number | null;
   comment: string | null;
   reviewer: string;
+  /** Review lifecycle status (V1: "reviewed"). */
+  status: string;
   createTime: string;
+  updateTime: string;
+}
+
+/** Run-level human-review summary, derived read-only from reviews + automated status. */
+export interface HumanReviewSummary {
+  /** Dimensions with at least one review in the run — the active/configured set. */
+  dimensions: string[];
+  reviewedCount: number;
+  pendingCount: number;
+  passCount: number;
+  failCount: number;
+  /** Reviews whose human pass/fail verdict disagrees with the automated pass/fail. */
+  disagreementCount: number;
 }
 
 export interface ResultRow {
@@ -213,6 +230,8 @@ export interface RunDetail extends RunRow {
   elapsedMs: number | null;
   /** The backend-derived run-level comparison (single source of truth). */
   comparison: RunComparison;
+  /** Derived human-review summary; automated signals are never affected by it. */
+  humanReview: HumanReviewSummary;
 }
 
 export interface RunDetailResponse {

--- a/frontend/ui/src/features/evaluations/views/compare-case-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-case-drawer.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import * as React from "react";
+import { X, Copy, ArrowRight } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
+import { cn } from "@/lib/utils";
+import { changeSentiment, SENTIMENT_CLASS } from "@/features/offline-eval/utils";
+import { TraceIOSection } from "@/features/traces/components/TraceIOValue";
+import { TraceIODiffSection } from "@/features/traces/components/TraceIODiff";
+import { useTrace } from "@/features/traces/hooks";
+import { attributeTraceUsage, type TraceUsage, type UsageSpan } from "@/lib/eval/trace-usage";
+import type {
+  CompareResultRow,
+  CompareRunSummary,
+  CompareRawScore,
+  ScorerCellComparison,
+} from "../types";
+
+/** A scorer value rendered by its real type — numeric / boolean / categorical. */
+function scorerValueText(v: number | boolean | string | null): string {
+  if (v === null) return "—";
+  if (typeof v === "boolean") return v ? "Pass" : "Fail";
+  if (typeof v === "number") return Number.isInteger(v) ? String(v) : v.toFixed(3);
+  return v;
+}
+
+function fmtMs(ms: number | null): string {
+  if (ms === null) return "Unknown";
+  return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+function fmtCost(c: number | null): string {
+  return c === null ? "Unknown" : `$${c.toFixed(4)}`;
+}
+
+/** One scorer row in the breakdown: baseline → candidate with typed transition + explanations. */
+function ScorerBreakdownRow({
+  cell,
+  candidateExplanation,
+  baselineExplanation,
+}: {
+  cell: ScorerCellComparison;
+  candidateExplanation: string | null;
+  baselineExplanation: string | null;
+}) {
+  const dirBetter = cell.direction !== "lower_is_better";
+  const deltaClass =
+    cell.delta === null || cell.delta === 0
+      ? "text-muted-foreground"
+      : SENTIMENT_CLASS[changeSentiment(dirBetter ? cell.delta : -cell.delta)];
+  return (
+    <div className="rounded border border-border px-2.5 py-2">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+        <span className="flex items-baseline gap-1.5">
+          <span className="font-medium">{cell.scorerName}</span>
+          <span className="text-[11px] text-muted-foreground">{cell.scorerVersion}</span>
+          {cell.direction && cell.direction !== "none" && (
+            <span className="text-[10px] text-muted-foreground">
+              {cell.direction === "higher_is_better" ? "↑ better" : "↓ better"}
+            </span>
+          )}
+        </span>
+        <span className="flex items-center gap-1.5 tabular-nums">
+          <span className="text-muted-foreground">{scorerValueText(cell.baselineValue)}</span>
+          <ArrowRight className="h-3 w-3 text-muted-foreground" aria-hidden />
+          <span className="font-medium">{scorerValueText(cell.candidateValue)}</span>
+          {cell.transition ? (
+            <span className={cn("text-[11px]", deltaClass)}>{cell.classification}</span>
+          ) : cell.delta !== null && cell.delta !== 0 ? (
+            <span className={cn("text-[11px]", deltaClass)}>
+              {cell.delta > 0 ? "+" : "−"}
+              {Math.abs(cell.delta).toFixed(cell.valueType === "numeric" ? 3 : 0)}
+            </span>
+          ) : (
+            <span className="text-[11px] text-muted-foreground">{cell.classification}</span>
+          )}
+        </span>
+      </div>
+      {(baselineExplanation || candidateExplanation) && (
+        <div className="mt-1.5 grid grid-cols-2 gap-2 text-[11px] text-muted-foreground">
+          <div>
+            <div className="text-[9px] uppercase tracking-wide">Baseline</div>
+            <div className="leading-relaxed">{baselineExplanation ?? "—"}</div>
+          </div>
+          <div>
+            <div className="text-[9px] uppercase tracking-wide">Candidate</div>
+            <div className="leading-relaxed">{candidateExplanation ?? "—"}</div>
+          </div>
+        </div>
+      )}
+      {cell.reason && (
+        <div className="mt-1 text-[11px] text-amber-700 dark:text-amber-300">
+          {cell.reason.replace(/_/g, " ")}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function explanationOf(scores: CompareRawScore[], name: string, version: string): string | null {
+  const s = scores.find((x) => x.scorerName === name && x.scorerVersion === version);
+  return s?.error ?? s?.explanation ?? null;
+}
+
+function OpMetric({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-0.5">
+      <span className="text-[11px] text-muted-foreground">{label}</span>
+      <span className="text-[12px] tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+/** Trace-derived tokens for one side (task + scorer + combined), with pending/unknown. */
+function useUsage(projectId: string, traceId: string | null): TraceUsage {
+  const q = useTrace(projectId, traceId ?? "", !!traceId);
+  return React.useMemo(
+    () => attributeTraceUsage(q.data?.spans as UsageSpan[] | undefined),
+    [q.data],
+  );
+}
+
+function tokenText(u: TraceUsage): string {
+  if (u.state === "pending") return "Pending";
+  if (u.state === "unknown") return "Unknown";
+  return u.combined.totalTokens.toLocaleString("en-US");
+}
+
+/**
+ * Selected-case diagnosis drawer: context, Baseline|Candidate outputs, per-scorer
+ * breakdown with explanations, operational metrics (duration server-derived; cost
+ * stored; tokens trace-derived with pending/unknown), and trace access. Reuses the
+ * standard right-side drawer chrome and the trace value/diff renderers.
+ */
+export function CompareCaseDrawer({
+  projectId,
+  row,
+  candidate,
+  baseline,
+  onClose,
+  traceSlot,
+}: {
+  projectId: string;
+  row: CompareResultRow;
+  candidate: CompareRunSummary;
+  baseline: CompareRunSummary;
+  onClose: () => void;
+  /** Trace-access controls (candidate/baseline), wired by the page. */
+  traceSlot?: React.ReactNode;
+}) {
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onClose]);
+
+  const candUsage = useUsage(projectId, row.candidateTraceId);
+  const baseUsage = useUsage(projectId, row.baselineTraceId);
+  const cells = row.comparison?.scorerCells ?? [];
+  const outputSame = row.outputChanged === false;
+
+  return (
+    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[620px] max-w-[96vw] flex-col border-l border-border bg-background text-[12px] shadow-xl">
+      <div className="flex shrink-0 items-start justify-between gap-2 border-b border-border px-4 py-3">
+        <div className="min-w-0">
+          <div className="text-[13px] font-medium">Case comparison</div>
+          <div className="mt-0.5 flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground">
+            <span className="truncate">{row.testCaseId}</span>
+            <CopyButton
+              value={row.testCaseId}
+              className="h-4 w-4 text-muted-foreground hover:text-foreground"
+              iconClassName="h-3 w-3"
+              title="Copy test-case id"
+            />
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded-sm text-muted-foreground hover:text-foreground"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-3 overflow-auto p-4">
+        {/* Context */}
+        <TraceIOSection title="Input" content={row.input} defaultOpen />
+        {row.expectedOutput && (
+          <TraceIOSection title="Expected output" content={row.expectedOutput} />
+        )}
+        {row.provenance && (
+          <div className="flex items-center gap-1.5 rounded border border-border bg-muted/20 px-2.5 py-1.5 text-[11px] text-muted-foreground">
+            <Copy className="h-3 w-3 shrink-0" aria-hidden />
+            Saved from a production trace ({row.provenance.captureReason})
+            {row.provenance.sourceSpanName && ` · ${row.provenance.sourceSpanName}`}
+          </div>
+        )}
+        {!row.inputMatchesDataset && (
+          <div className="rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-300">
+            A run recorded a different input than the pinned dataset case; showing the dataset
+            input.
+          </div>
+        )}
+
+        {/* Baseline → Candidate output */}
+        <div>
+          <div className="mb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+            Baseline → Candidate output
+          </div>
+          {outputSame ? (
+            <div className="rounded border border-border px-2.5 py-2 text-[11px] text-muted-foreground">
+              No output change.
+            </div>
+          ) : (
+            <TraceIODiffSection
+              title="Output"
+              baseline={row.baselineOutput}
+              candidate={row.candidateOutput}
+            />
+          )}
+          {row.candidateTaskError && (
+            <div className="mt-1.5 rounded border border-red-300 bg-red-50 px-2.5 py-1.5 text-[11px] text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+              Candidate task error — {row.candidateTaskError}
+            </div>
+          )}
+          {row.baselineTaskError && (
+            <div className="mt-1.5 rounded border border-red-300 bg-red-50 px-2.5 py-1.5 text-[11px] text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+              Baseline task error — {row.baselineTaskError}
+            </div>
+          )}
+        </div>
+
+        {/* Score breakdown */}
+        {cells.length > 0 && (
+          <div>
+            <div className="mb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+              Scorers (baseline → candidate)
+            </div>
+            <div className="space-y-1.5">
+              {cells.map((cell) => (
+                <ScorerBreakdownRow
+                  key={`${cell.scorerName}@${cell.scorerVersion}`}
+                  cell={cell}
+                  candidateExplanation={explanationOf(
+                    row.candidateScores,
+                    cell.scorerName,
+                    cell.scorerVersion,
+                  )}
+                  baselineExplanation={explanationOf(
+                    row.baselineScores,
+                    cell.scorerName,
+                    cell.scorerVersion,
+                  )}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Operational metrics */}
+        <div className="rounded border border-border px-2.5 py-2">
+          <div className="mb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+            Operational (baseline → candidate)
+          </div>
+          <OpMetric
+            label="Case duration"
+            value={
+              <span>
+                {fmtMs(row.comparison?.baselineDurationMs ?? null)} →{" "}
+                {fmtMs(row.comparison?.durationMs ?? null)}
+              </span>
+            }
+          />
+          <OpMetric
+            label="Cost"
+            value={
+              <span>
+                {fmtCost(row.baselineCost)} → {fmtCost(row.candidateCost)}
+              </span>
+            }
+          />
+          <OpMetric
+            label="Tokens (trace)"
+            value={
+              <span>
+                {tokenText(baseUsage)} → {tokenText(candUsage)}
+              </span>
+            }
+          />
+        </div>
+
+        {/* Trace access (wired by the page) */}
+        {traceSlot && (
+          <div className="rounded border border-border px-2.5 py-2">
+            <div className="mb-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+              Traces
+            </div>
+            {traceSlot}
+          </div>
+        )}
+      </div>
+
+      <div className="flex shrink-0 items-center justify-between gap-2 border-t border-border px-4 py-2 text-[11px] text-muted-foreground">
+        <span>
+          Baseline Run #{baseline.runNumber} · {baseline.candidateVersion}
+        </span>
+        <ArrowRight className="h-3 w-3" aria-hidden />
+        <span>
+          Candidate Run #{candidate.runNumber} · {candidate.candidateVersion}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { ArrowRight, Info } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
+import { EmptyState, Timestamp } from "@/features/offline-eval/components";
+import {
+  changeSentiment,
+  pctFraction,
+  SENTIMENT_CLASS,
+  signedPoints,
+} from "@/features/offline-eval/utils";
+import { useCompareRuns, useEvaluationRuns, useEvaluations } from "../hooks";
+import type { CompareRunSummary, RunComparison, Classification } from "../types";
+import { RunStatusBadge } from "./evaluations-view";
+
+const ALL = "";
+
+const REASON_LABEL: Record<string, string> = {
+  no_baseline: "No baseline chosen.",
+  baseline_missing: "The baseline run wasn't found.",
+  different_evaluation: "These runs are from different evaluations.",
+  different_dataset_version: "The runs used different dataset versions — cases may not line up.",
+  baseline_not_terminal: "The baseline run hasn't finished.",
+};
+
+const CHANGE_LABEL: Record<Classification, { label: string; className: string }> = {
+  improved: { label: "Improved", className: SENTIMENT_CLASS.good },
+  regressed: { label: "Regressed", className: SENTIMENT_CLASS.bad },
+  unchanged: { label: "Unchanged", className: "text-muted-foreground" },
+  changed: { label: "Changed", className: "text-foreground" },
+  unpaired: { label: "Unpaired", className: "text-muted-foreground" },
+  not_comparable: { label: "Not comparable", className: "text-amber-600 dark:text-amber-400" },
+};
+
+function fmtScore(v: number | null): string {
+  return v === null ? "—" : pctFraction(v);
+}
+
+/** One run's picker (candidate / baseline), listing the evaluation's runs newest-first. */
+function RunPicker({
+  label,
+  runs,
+  value,
+  onChange,
+  disabledId,
+}: {
+  label: string;
+  runs: Array<{ id: string; runNumber: number; candidateVersion: string }>;
+  value: string;
+  onChange: (id: string) => void;
+  disabledId?: string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="text-[11px] text-muted-foreground">{label}</span>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger className="h-7 w-[220px] text-[12px]">
+          <SelectValue placeholder="Select a run" />
+        </SelectTrigger>
+        <SelectContent>
+          {runs.map((r) => (
+            <SelectItem
+              key={r.id}
+              value={r.id}
+              className="text-[12px]"
+              disabled={r.id === disabledId}
+            >
+              Run #{r.runNumber} · {r.candidateVersion}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+/** Candidate | Baseline | Δ summary row (higher-is-better metrics like the main score). */
+function StatRow({
+  label,
+  candidate,
+  baseline,
+  delta,
+  format,
+  higherIsBetter = true,
+}: {
+  label: string;
+  candidate: number | null;
+  baseline: number | null;
+  delta: number | null;
+  format: (n: number) => string;
+  higherIsBetter?: boolean;
+}) {
+  return (
+    <tr>
+      <td className="py-1 pr-2 text-muted-foreground">{label}</td>
+      <td className="py-1 text-right tabular-nums">
+        {candidate === null ? "—" : format(candidate)}
+      </td>
+      <td className="py-1 text-right tabular-nums text-muted-foreground">
+        {baseline === null ? "—" : format(baseline)}
+      </td>
+      <td className="py-1 pl-2 pr-2.5 text-right tabular-nums">
+        {delta === null || delta === 0 ? (
+          <span className="text-muted-foreground">{delta === 0 ? "±0" : "—"}</span>
+        ) : (
+          <span className={SENTIMENT_CLASS[changeSentiment(higherIsBetter ? delta : -delta)]}>
+            {delta > 0 ? "+" : "−"}
+            {format(Math.abs(delta))}
+          </span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function RunHeaderCard({ run, role }: { run: CompareRunSummary; role: "Candidate" | "Baseline" }) {
+  return (
+    <div className="min-w-0 flex-1 rounded border border-border bg-muted/20 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{role}</span>
+        <RunStatusBadge status={run.status} />
+      </div>
+      <div className="mt-1 flex items-baseline gap-1.5">
+        <span className="text-[13px] font-semibold">Run #{run.runNumber}</span>
+        <span className="truncate font-mono text-[11px] text-muted-foreground">
+          {run.candidateVersion}
+        </span>
+      </div>
+      <div className="mt-0.5 text-[11px] text-muted-foreground">
+        {run.datasetVersionLabel} · <Timestamp iso={run.startedAt} />
+      </div>
+    </div>
+  );
+}
+
+function fmtMs(n: number): string {
+  return n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`;
+}
+
+function SummaryTable({ comparison }: { comparison: RunComparison }) {
+  const c = comparison;
+  return (
+    <div className="overflow-hidden rounded border border-border">
+      <table className="w-full text-[12px]">
+        <thead>
+          <tr className="text-[10px] text-muted-foreground">
+            <th className="py-1 pl-2.5 text-left font-normal"></th>
+            <th className="py-1 text-right font-normal">Candidate</th>
+            <th className="py-1 text-right font-normal">Baseline</th>
+            <th className="py-1 pr-2.5 text-right font-normal">Δ</th>
+          </tr>
+        </thead>
+        <tbody className="[&_td:first-child]:pl-2.5">
+          <StatRow
+            label="Main score"
+            candidate={c.mainScore.candidate}
+            baseline={c.mainScore.baseline}
+            delta={c.mainScore.delta}
+            format={(n) => pctFraction(n)}
+          />
+          {c.scorers.map((s) => (
+            <StatRow
+              key={`${s.name}@${s.version}`}
+              label={`${s.name}`}
+              candidate={s.candidateMean}
+              baseline={s.baselineMean}
+              delta={s.delta}
+              format={(n) => pctFraction(n)}
+              higherIsBetter={s.direction !== "lower_is_better"}
+            />
+          ))}
+          <StatRow
+            label="Avg case duration"
+            candidate={c.duration.candidateMeanMs}
+            baseline={c.duration.baselineMeanMs}
+            delta={c.duration.deltaMs}
+            format={fmtMs}
+            higherIsBetter={false}
+          />
+        </tbody>
+      </table>
+      <div className="flex flex-wrap gap-x-4 gap-y-0.5 border-t border-border px-2.5 py-1.5 text-[11px] text-muted-foreground">
+        <span>
+          <span className={SENTIMENT_CLASS.good}>{c.caseCounts.improved} improved</span> ·{" "}
+          <span className={SENTIMENT_CLASS.bad}>{c.caseCounts.regressed} regressed</span> ·{" "}
+          {c.caseCounts.unchanged} unchanged
+        </span>
+        {(c.caseCounts.unpaired > 0 || c.caseCounts.not_comparable > 0) && (
+          <span>
+            {c.caseCounts.unpaired} unpaired · {c.caseCounts.not_comparable} not comparable
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function CompareTab({ projectId }: { projectId: string }) {
+  const router = useRouter();
+  const { data: evalData } = useEvaluations(projectId);
+  const evaluations = React.useMemo(() => evalData?.data ?? [], [evalData]);
+
+  const [evaluationId, setEvaluationId] = React.useState<string>(ALL);
+  const [candidateId, setCandidateId] = React.useState<string>("");
+  const [baselineId, setBaselineId] = React.useState<string>("");
+
+  const { data: runsData } = useEvaluationRuns(
+    projectId,
+    evaluationId ? { evaluation_id: evaluationId } : undefined,
+  );
+  const runs = React.useMemo(() => runsData?.data ?? [], [runsData]);
+
+  // Seed the evaluation to the first one, and the pickers to the two newest runs.
+  React.useEffect(() => {
+    if (!evaluationId && evaluations.length > 0) setEvaluationId(evaluations[0].id);
+  }, [evaluations, evaluationId]);
+  React.useEffect(() => {
+    setCandidateId(runs[0]?.id ?? "");
+    setBaselineId(runs[1]?.id ?? "");
+  }, [runs]);
+
+  const compare = useCompareRuns(projectId, candidateId || null, baselineId || null);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-wrap items-center gap-3 border-b border-border px-3 py-2">
+        <Select
+          value={evaluationId}
+          onValueChange={(v) => {
+            setEvaluationId(v);
+            setCandidateId("");
+            setBaselineId("");
+          }}
+        >
+          <SelectTrigger className="h-7 w-[200px] text-[12px]">
+            <SelectValue placeholder="Evaluation" />
+          </SelectTrigger>
+          <SelectContent>
+            {evaluations.map((e) => (
+              <SelectItem key={e.id} value={e.id} className="text-[12px]">
+                {e.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <RunPicker
+          label="Candidate"
+          runs={runs}
+          value={candidateId}
+          onChange={setCandidateId}
+          disabledId={baselineId}
+        />
+        <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+        <RunPicker
+          label="Baseline"
+          runs={runs}
+          value={baselineId}
+          onChange={setBaselineId}
+          disabledId={candidateId}
+        />
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-3 overflow-auto p-3 text-[12px]">
+        {runs.length < 2 ? (
+          <EmptyState>This evaluation needs at least two runs to compare.</EmptyState>
+        ) : !candidateId || !baselineId ? (
+          <EmptyState>Pick a candidate and a baseline run.</EmptyState>
+        ) : compare.isLoading ? (
+          <EmptyState>Comparing…</EmptyState>
+        ) : compare.error || !compare.data ? (
+          <EmptyState>Couldn’t compare these runs.</EmptyState>
+        ) : (
+          <>
+            <div className="flex items-stretch gap-2">
+              <RunHeaderCard run={compare.data.candidate} role="Candidate" />
+              <RunHeaderCard run={compare.data.baseline} role="Baseline" />
+            </div>
+
+            {!compare.data.comparison.trustworthy && (
+              <div className="flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-300">
+                <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+                <span>
+                  {compare.data.comparison.reasons.map((r) => REASON_LABEL[r] ?? r).join(" ")}{" "}
+                  Deltas are shown but may not be meaningful.
+                </span>
+              </div>
+            )}
+
+            <SummaryTable comparison={compare.data.comparison} />
+
+            <div className="overflow-hidden rounded border border-border">
+              <Table>
+                <THead>
+                  <TRHead>
+                    <Th>Test case</Th>
+                    <Th className="w-[110px] text-right">Candidate</Th>
+                    <Th className="w-[110px] text-right">Baseline</Th>
+                    <Th className="w-[120px]">Change</Th>
+                  </TRHead>
+                </THead>
+                <TBody>
+                  {compare.data.results.map((r) => {
+                    const cmp = r.comparison;
+                    const change = cmp?.caseChange ?? null;
+                    return (
+                      <TR
+                        key={r.testCaseId}
+                        interactive={!!r.traceId}
+                        onClick={() =>
+                          r.traceId &&
+                          router.push(
+                            `/projects/${projectId}/evaluations/${candidateId}?result=${r.testCaseId}`,
+                          )
+                        }
+                      >
+                        <Td className="font-mono text-[11px]">{r.testCaseId}</Td>
+                        <Td className="text-right tabular-nums">
+                          {fmtScore(cmp?.mainScore.candidate ?? null)}
+                        </Td>
+                        <Td className="text-right tabular-nums text-muted-foreground">
+                          {fmtScore(cmp?.mainScore.baseline ?? null)}
+                        </Td>
+                        <Td>
+                          {change ? (
+                            <span className={CHANGE_LABEL[change].className}>
+                              {CHANGE_LABEL[change].label}
+                              {cmp && cmp.mainScore.delta !== null && cmp.mainScore.delta !== 0 && (
+                                <span className="ml-1 text-[11px]">
+                                  ({signedPoints(cmp.mainScore.delta)} pp)
+                                </span>
+                              )}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </Td>
+                      </TR>
+                    );
+                  })}
+                </TBody>
+              </Table>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
-import { ArrowRight, Info } from "lucide-react";
+import { ArrowLeftRight, ArrowRight, Info } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -10,8 +10,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { EmptyState, Timestamp } from "@/features/offline-eval/components";
+import { ProjectBreadcrumb } from "@/features/projects/components";
 import {
   changeSentiment,
   pctFraction,
@@ -22,14 +24,27 @@ import { useCompareRuns, useEvaluationRuns, useEvaluations } from "../hooks";
 import type { CompareRunSummary, RunComparison, Classification } from "../types";
 import { RunStatusBadge } from "./evaluations-view";
 
-const ALL = "";
+/** Reasons that make a comparison's deltas untrustworthy. `different_evaluation` is
+ *  intentionally NOT here — cross-evaluation comparison is allowed and merely labeled;
+ *  what disables trusted deltas is a dataset-version mismatch, a non-terminal baseline,
+ *  a missing baseline, or an incompatible main scorer. */
+const BLOCKING_REASONS = new Set([
+  "different_dataset_version",
+  "baseline_not_terminal",
+  "baseline_missing",
+  "no_baseline",
+  "main_scorer_incompatible",
+]);
 
 const REASON_LABEL: Record<string, string> = {
   no_baseline: "No baseline chosen.",
   baseline_missing: "The baseline run wasn't found.",
   different_evaluation: "These runs are from different evaluations.",
-  different_dataset_version: "The runs used different dataset versions — cases may not line up.",
+  different_dataset_version:
+    "The runs used different immutable dataset versions — their cases don't line up.",
   baseline_not_terminal: "The baseline run hasn't finished.",
+  main_scorer_incompatible:
+    "The main scorer's name/version differs, so no comparable pair exists — trusted deltas are disabled.",
 };
 
 const CHANGE_LABEL: Record<Classification, { label: string; className: string }> = {
@@ -44,46 +59,10 @@ const CHANGE_LABEL: Record<Classification, { label: string; className: string }>
 function fmtScore(v: number | null): string {
   return v === null ? "—" : pctFraction(v);
 }
-
-/** One run's picker (candidate / baseline), listing the evaluation's runs newest-first. */
-function RunPicker({
-  label,
-  runs,
-  value,
-  onChange,
-  disabledId,
-}: {
-  label: string;
-  runs: Array<{ id: string; runNumber: number; candidateVersion: string }>;
-  value: string;
-  onChange: (id: string) => void;
-  disabledId?: string;
-}) {
-  return (
-    <div className="flex items-center gap-1.5">
-      <span className="text-[11px] text-muted-foreground">{label}</span>
-      <Select value={value} onValueChange={onChange}>
-        <SelectTrigger className="h-7 w-[220px] text-[12px]">
-          <SelectValue placeholder="Select a run" />
-        </SelectTrigger>
-        <SelectContent>
-          {runs.map((r) => (
-            <SelectItem
-              key={r.id}
-              value={r.id}
-              className="text-[12px]"
-              disabled={r.id === disabledId}
-            >
-              Run #{r.runNumber} · {r.candidateVersion}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  );
+function fmtMs(n: number): string {
+  return n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`;
 }
 
-/** Candidate | Baseline | Δ summary row (higher-is-better metrics like the main score). */
 function StatRow({
   label,
   candidate,
@@ -122,13 +101,23 @@ function StatRow({
   );
 }
 
-function RunHeaderCard({ run, role }: { run: CompareRunSummary; role: "Candidate" | "Baseline" }) {
+function RunHeaderCard({
+  run,
+  role,
+  crossEval,
+}: {
+  run: CompareRunSummary;
+  role: "Candidate" | "Baseline";
+  crossEval: boolean;
+}) {
   return (
     <div className="min-w-0 flex-1 rounded border border-border bg-muted/20 px-3 py-2">
       <div className="flex items-center justify-between gap-2">
         <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{role}</span>
         <RunStatusBadge status={run.status} />
       </div>
+      {/* In a cross-evaluation comparison both evaluation names are shown prominently. */}
+      {crossEval && <div className="mt-1 text-[12px] font-medium">{run.evaluationName}</div>}
       <div className="mt-1 flex items-baseline gap-1.5">
         <span className="text-[13px] font-semibold">Run #{run.runNumber}</span>
         <span className="truncate font-mono text-[11px] text-muted-foreground">
@@ -140,10 +129,6 @@ function RunHeaderCard({ run, role }: { run: CompareRunSummary; role: "Candidate
       </div>
     </div>
   );
-}
-
-function fmtMs(n: number): string {
-  return n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`;
 }
 
 function SummaryTable({ comparison }: { comparison: RunComparison }) {
@@ -170,7 +155,7 @@ function SummaryTable({ comparison }: { comparison: RunComparison }) {
           {c.scorers.map((s) => (
             <StatRow
               key={`${s.name}@${s.version}`}
-              label={`${s.name}`}
+              label={s.name}
               candidate={s.candidateMean}
               baseline={s.baselineMean}
               delta={s.delta}
@@ -204,98 +189,169 @@ function SummaryTable({ comparison }: { comparison: RunComparison }) {
   );
 }
 
-export function CompareTab({ projectId }: { projectId: string }) {
-  const router = useRouter();
+/** An evaluation + run picker for one side (candidate or baseline). Supports picking a
+ *  run from ANY evaluation, so a cross-evaluation pair can be assembled here too. */
+function RunChooser({
+  projectId,
+  label,
+  seedEvaluationId,
+  runId,
+  otherRunId,
+  onPick,
+}: {
+  projectId: string;
+  label: string;
+  seedEvaluationId: string | null;
+  runId: string | null;
+  otherRunId: string | null;
+  onPick: (runId: string) => void;
+}) {
   const { data: evalData } = useEvaluations(projectId);
   const evaluations = React.useMemo(() => evalData?.data ?? [], [evalData]);
-
-  const [evaluationId, setEvaluationId] = React.useState<string>(ALL);
-  const [candidateId, setCandidateId] = React.useState<string>("");
-  const [baselineId, setBaselineId] = React.useState<string>("");
-
+  const [evalId, setEvalId] = React.useState<string>(seedEvaluationId ?? "");
+  React.useEffect(() => {
+    if (seedEvaluationId) setEvalId(seedEvaluationId);
+  }, [seedEvaluationId]);
   const { data: runsData } = useEvaluationRuns(
     projectId,
-    evaluationId ? { evaluation_id: evaluationId } : undefined,
+    evalId ? { evaluation_id: evalId } : undefined,
   );
   const runs = React.useMemo(() => runsData?.data ?? [], [runsData]);
 
-  // Seed the evaluation to the first one, and the pickers to the two newest runs.
-  React.useEffect(() => {
-    if (!evaluationId && evaluations.length > 0) setEvaluationId(evaluations[0].id);
-  }, [evaluations, evaluationId]);
-  React.useEffect(() => {
-    setCandidateId(runs[0]?.id ?? "");
-    setBaselineId(runs[1]?.id ?? "");
-  }, [runs]);
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="text-[11px] text-muted-foreground">{label}</span>
+      <Select value={evalId} onValueChange={setEvalId}>
+        <SelectTrigger className="h-7 w-[170px] text-[12px]">
+          <SelectValue placeholder="Evaluation" />
+        </SelectTrigger>
+        <SelectContent>
+          {evaluations.map((e) => (
+            <SelectItem key={e.id} value={e.id} className="text-[12px]">
+              {e.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select value={runId ?? ""} onValueChange={onPick}>
+        <SelectTrigger className="h-7 w-[200px] text-[12px]">
+          <SelectValue placeholder="Run" />
+        </SelectTrigger>
+        <SelectContent>
+          {runs.map((r) => (
+            <SelectItem
+              key={r.id}
+              value={r.id}
+              className="text-[12px]"
+              disabled={r.id === otherRunId}
+            >
+              Run #{r.runNumber} · {r.candidateVersion}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
 
-  const compare = useCompareRuns(projectId, candidateId || null, baselineId || null);
+/**
+ * The shareable comparison view: `?baseline=&candidate=` in the URL. Baseline and
+ * candidate roles are explicit and swappable. Reuses the server-derived comparison
+ * engine (via the compare route) — no comparison logic here. Cross-evaluation pairs
+ * are allowed and clearly labeled; trusted deltas are disabled (with the exact reason)
+ * only for a genuine incompatibility, never merely because the evaluations differ.
+ */
+export function CompareRunsView({
+  projectId,
+  candidateId,
+  baselineId,
+  onChange,
+}: {
+  projectId: string;
+  candidateId: string | null;
+  baselineId: string | null;
+  onChange: (baseline: string | null, candidate: string | null) => void;
+}) {
+  const router = useRouter();
+  const compare = useCompareRuns(projectId, candidateId, baselineId);
+  const data = compare.data;
+
+  const candEval = data?.candidate.evaluationId ?? null;
+  const baseEval = data?.baseline.evaluationId ?? null;
+  const crossEval = !!data && candEval !== baseEval;
+  const blocking = (data?.comparison.reasons ?? []).filter((r) => BLOCKING_REASONS.has(r));
+  const deltasTrusted = !!data?.comparison.available && blocking.length === 0;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div className="flex h-full flex-col text-[12px]">
+      <ProjectBreadcrumb projectId={projectId} current="Compare runs" />
+
       <div className="flex flex-wrap items-center gap-3 border-b border-border px-3 py-2">
-        <Select
-          value={evaluationId}
-          onValueChange={(v) => {
-            setEvaluationId(v);
-            setCandidateId("");
-            setBaselineId("");
-          }}
-        >
-          <SelectTrigger className="h-7 w-[200px] text-[12px]">
-            <SelectValue placeholder="Evaluation" />
-          </SelectTrigger>
-          <SelectContent>
-            {evaluations.map((e) => (
-              <SelectItem key={e.id} value={e.id} className="text-[12px]">
-                {e.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <RunPicker
+        <RunChooser
+          projectId={projectId}
           label="Candidate"
-          runs={runs}
-          value={candidateId}
-          onChange={setCandidateId}
-          disabledId={baselineId}
+          seedEvaluationId={candEval}
+          runId={candidateId}
+          otherRunId={baselineId}
+          onPick={(id) => onChange(baselineId, id)}
         />
-        <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
-        <RunPicker
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 gap-1.5 text-[12px]"
+          disabled={!candidateId || !baselineId}
+          onClick={() => onChange(candidateId, baselineId)}
+          title="Swap baseline and candidate"
+        >
+          <ArrowLeftRight className="h-3.5 w-3.5" aria-hidden />
+          Swap
+        </Button>
+        <RunChooser
+          projectId={projectId}
           label="Baseline"
-          runs={runs}
-          value={baselineId}
-          onChange={setBaselineId}
-          disabledId={candidateId}
+          seedEvaluationId={baseEval}
+          runId={baselineId}
+          otherRunId={candidateId}
+          onPick={(id) => onChange(id, candidateId)}
         />
       </div>
 
-      <div className="min-h-0 flex-1 space-y-3 overflow-auto p-3 text-[12px]">
-        {runs.length < 2 ? (
-          <EmptyState>This evaluation needs at least two runs to compare.</EmptyState>
-        ) : !candidateId || !baselineId ? (
-          <EmptyState>Pick a candidate and a baseline run.</EmptyState>
+      <div className="min-h-0 flex-1 space-y-3 overflow-auto p-3">
+        {!candidateId || !baselineId ? (
+          <EmptyState>Pick a candidate and a baseline run to compare.</EmptyState>
+        ) : candidateId === baselineId ? (
+          <EmptyState>Pick two different runs.</EmptyState>
         ) : compare.isLoading ? (
           <EmptyState>Comparing…</EmptyState>
-        ) : compare.error || !compare.data ? (
+        ) : compare.error || !data ? (
           <EmptyState>Couldn’t compare these runs.</EmptyState>
         ) : (
           <>
             <div className="flex items-stretch gap-2">
-              <RunHeaderCard run={compare.data.candidate} role="Candidate" />
-              <RunHeaderCard run={compare.data.baseline} role="Baseline" />
+              <RunHeaderCard run={data.candidate} role="Candidate" crossEval={crossEval} />
+              <ArrowRight className="mt-6 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+              <RunHeaderCard run={data.baseline} role="Baseline" crossEval={crossEval} />
             </div>
 
-            {!compare.data.comparison.trustworthy && (
-              <div className="flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-300">
-                <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+            {crossEval && (
+              <div className="flex items-start gap-1.5 rounded border border-border bg-muted/30 px-2.5 py-1.5 text-[11px]">
+                <Info className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" aria-hidden />
                 <span>
-                  {compare.data.comparison.reasons.map((r) => REASON_LABEL[r] ?? r).join(" ")}{" "}
-                  Deltas are shown but may not be meaningful.
+                  <span className="font-medium">Cross-evaluation comparison</span> —{" "}
+                  {data.candidate.evaluationName} vs {data.baseline.evaluationName}. No baseline
+                  relationship is saved.
                 </span>
               </div>
             )}
 
-            <SummaryTable comparison={compare.data.comparison} />
+            {!deltasTrusted && blocking.length > 0 && (
+              <div className="flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-300">
+                <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+                <span>{blocking.map((r) => REASON_LABEL[r] ?? r).join(" ")}</span>
+              </div>
+            )}
+
+            <SummaryTable comparison={data.comparison} />
 
             <div className="overflow-hidden rounded border border-border">
               <Table>
@@ -304,19 +360,19 @@ export function CompareTab({ projectId }: { projectId: string }) {
                     <Th>Test case</Th>
                     <Th className="w-[110px] text-right">Candidate</Th>
                     <Th className="w-[110px] text-right">Baseline</Th>
-                    <Th className="w-[120px]">Change</Th>
+                    <Th className="w-[130px]">Change</Th>
                   </TRHead>
                 </THead>
                 <TBody>
-                  {compare.data.results.map((r) => {
+                  {data.results.map((r) => {
                     const cmp = r.comparison;
                     const change = cmp?.caseChange ?? null;
                     return (
                       <TR
                         key={r.testCaseId}
-                        interactive={!!r.traceId}
+                        interactive={!!r.candidateTraceId}
                         onClick={() =>
-                          r.traceId &&
+                          r.candidateTraceId &&
                           router.push(
                             `/projects/${projectId}/evaluations/${candidateId}?result=${r.testCaseId}`,
                           )

--- a/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { useRouter } from "next/navigation";
-import { ArrowLeftRight, ArrowRight, Info } from "lucide-react";
+import { useQueries } from "@tanstack/react-query";
+import { ArrowLeftRight, ArrowRight, ChevronDown, ChevronRight, Info } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -14,37 +14,50 @@ import { Button } from "@/components/ui/button";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { EmptyState, Timestamp } from "@/features/offline-eval/components";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import {
-  changeSentiment,
-  pctFraction,
-  SENTIMENT_CLASS,
-  signedPoints,
-} from "@/features/offline-eval/utils";
+import { changeSentiment, pctFraction, SENTIMENT_CLASS } from "@/features/offline-eval/utils";
+import { cn } from "@/lib/utils";
+import { getTrace } from "@/lib/api";
+import { useSession as useAuthSession } from "@/lib/auth-client";
+import { TraceViewerPanel } from "@/features/traces/components";
+import { attributeTraceUsage, type TraceUsage, type UsageSpan } from "@/lib/eval/trace-usage";
 import { useCompareRuns, useEvaluationRuns, useEvaluations } from "../hooks";
-import type { CompareRunSummary, RunComparison, Classification } from "../types";
+import type {
+  CompareRunSummary,
+  RunComparison,
+  Classification,
+  CompareResultRow,
+  ScorerCellComparison,
+} from "../types";
 import { RunStatusBadge } from "./evaluations-view";
+import { CompareCaseDrawer } from "./compare-case-drawer";
+import {
+  deriveVerdict,
+  VERDICT_META,
+  BLOCKING_REASONS,
+  REASON_LABEL,
+  CASE_FILTERS,
+  CASE_SORTS,
+  matchesFilter,
+  filterCounts,
+  sortCases,
+  caseStatus,
+  type CaseFilterId,
+  type CaseSortId,
+  type CaseStatus,
+} from "../compare-derive";
 
-/** Reasons that make a comparison's deltas untrustworthy. `different_evaluation` is
- *  intentionally NOT here — cross-evaluation comparison is allowed and merely labeled;
- *  what disables trusted deltas is a dataset-version mismatch, a non-terminal baseline,
- *  a missing baseline, or an incompatible main scorer. */
-const BLOCKING_REASONS = new Set([
-  "different_dataset_version",
-  "baseline_not_terminal",
-  "baseline_missing",
-  "no_baseline",
-  "main_scorer_incompatible",
-]);
+// ── Small formatters ──────────────────────────────────────────────────────
+const fmtScore = (v: number | null) => (v === null ? "—" : pctFraction(v));
+const fmtMs = (n: number | null) =>
+  n === null ? "Unknown" : n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`;
+const fmtCost = (n: number | null) => (n === null ? "Unknown" : `$${n.toFixed(4)}`);
+const truncate = (s: string, n = 90) => (s.length > n ? `${s.slice(0, n)}…` : s);
 
-const REASON_LABEL: Record<string, string> = {
-  no_baseline: "No baseline chosen.",
-  baseline_missing: "The baseline run wasn't found.",
-  different_evaluation: "These runs are from different evaluations.",
-  different_dataset_version:
-    "The runs used different immutable dataset versions — their cases don't line up.",
-  baseline_not_terminal: "The baseline run hasn't finished.",
-  main_scorer_incompatible:
-    "The main scorer's name/version differs, so no comparable pair exists — trusted deltas are disabled.",
+const VERDICT_TONE: Record<"good" | "bad" | "warn" | "neutral", string> = {
+  good: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  bad: "border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300",
+  warn: "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  neutral: "border-border bg-muted/30 text-foreground",
 };
 
 const CHANGE_LABEL: Record<Classification, { label: string; className: string }> = {
@@ -56,141 +69,15 @@ const CHANGE_LABEL: Record<Classification, { label: string; className: string }>
   not_comparable: { label: "Not comparable", className: "text-amber-600 dark:text-amber-400" },
 };
 
-function fmtScore(v: number | null): string {
-  return v === null ? "—" : pctFraction(v);
-}
-function fmtMs(n: number): string {
-  return n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`;
-}
+const STATUS_LABEL: Record<CaseStatus, { label: string; className: string }> = {
+  ...CHANGE_LABEL,
+  task_error: { label: "Task error", className: "text-red-600 dark:text-red-400" },
+  scorer_error: { label: "Scorer error", className: "text-amber-600 dark:text-amber-400" },
+  pending: { label: "Pending", className: "text-muted-foreground" },
+};
 
-function StatRow({
-  label,
-  candidate,
-  baseline,
-  delta,
-  format,
-  higherIsBetter = true,
-}: {
-  label: string;
-  candidate: number | null;
-  baseline: number | null;
-  delta: number | null;
-  format: (n: number) => string;
-  higherIsBetter?: boolean;
-}) {
-  return (
-    <tr>
-      <td className="py-1 pr-2 text-muted-foreground">{label}</td>
-      <td className="py-1 text-right tabular-nums">
-        {candidate === null ? "—" : format(candidate)}
-      </td>
-      <td className="py-1 text-right tabular-nums text-muted-foreground">
-        {baseline === null ? "—" : format(baseline)}
-      </td>
-      <td className="py-1 pl-2 pr-2.5 text-right tabular-nums">
-        {delta === null || delta === 0 ? (
-          <span className="text-muted-foreground">{delta === 0 ? "±0" : "—"}</span>
-        ) : (
-          <span className={SENTIMENT_CLASS[changeSentiment(higherIsBetter ? delta : -delta)]}>
-            {delta > 0 ? "+" : "−"}
-            {format(Math.abs(delta))}
-          </span>
-        )}
-      </td>
-    </tr>
-  );
-}
+// ── Layer 1: run identity (Baseline → Candidate) ──────────────────────────
 
-function RunHeaderCard({
-  run,
-  role,
-  crossEval,
-}: {
-  run: CompareRunSummary;
-  role: "Candidate" | "Baseline";
-  crossEval: boolean;
-}) {
-  return (
-    <div className="min-w-0 flex-1 rounded border border-border bg-muted/20 px-3 py-2">
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{role}</span>
-        <RunStatusBadge status={run.status} />
-      </div>
-      {/* In a cross-evaluation comparison both evaluation names are shown prominently. */}
-      {crossEval && <div className="mt-1 text-[12px] font-medium">{run.evaluationName}</div>}
-      <div className="mt-1 flex items-baseline gap-1.5">
-        <span className="text-[13px] font-semibold">Run #{run.runNumber}</span>
-        <span className="truncate font-mono text-[11px] text-muted-foreground">
-          {run.candidateVersion}
-        </span>
-      </div>
-      <div className="mt-0.5 text-[11px] text-muted-foreground">
-        {run.datasetVersionLabel} · <Timestamp iso={run.startedAt} />
-      </div>
-    </div>
-  );
-}
-
-function SummaryTable({ comparison }: { comparison: RunComparison }) {
-  const c = comparison;
-  return (
-    <div className="overflow-hidden rounded border border-border">
-      <table className="w-full text-[12px]">
-        <thead>
-          <tr className="text-[10px] text-muted-foreground">
-            <th className="py-1 pl-2.5 text-left font-normal"></th>
-            <th className="py-1 text-right font-normal">Candidate</th>
-            <th className="py-1 text-right font-normal">Baseline</th>
-            <th className="py-1 pr-2.5 text-right font-normal">Δ</th>
-          </tr>
-        </thead>
-        <tbody className="[&_td:first-child]:pl-2.5">
-          <StatRow
-            label="Main score"
-            candidate={c.mainScore.candidate}
-            baseline={c.mainScore.baseline}
-            delta={c.mainScore.delta}
-            format={(n) => pctFraction(n)}
-          />
-          {c.scorers.map((s) => (
-            <StatRow
-              key={`${s.name}@${s.version}`}
-              label={s.name}
-              candidate={s.candidateMean}
-              baseline={s.baselineMean}
-              delta={s.delta}
-              format={(n) => pctFraction(n)}
-              higherIsBetter={s.direction !== "lower_is_better"}
-            />
-          ))}
-          <StatRow
-            label="Avg case duration"
-            candidate={c.duration.candidateMeanMs}
-            baseline={c.duration.baselineMeanMs}
-            delta={c.duration.deltaMs}
-            format={fmtMs}
-            higherIsBetter={false}
-          />
-        </tbody>
-      </table>
-      <div className="flex flex-wrap gap-x-4 gap-y-0.5 border-t border-border px-2.5 py-1.5 text-[11px] text-muted-foreground">
-        <span>
-          <span className={SENTIMENT_CLASS.good}>{c.caseCounts.improved} improved</span> ·{" "}
-          <span className={SENTIMENT_CLASS.bad}>{c.caseCounts.regressed} regressed</span> ·{" "}
-          {c.caseCounts.unchanged} unchanged
-        </span>
-        {(c.caseCounts.unpaired > 0 || c.caseCounts.not_comparable > 0) && (
-          <span>
-            {c.caseCounts.unpaired} unpaired · {c.caseCounts.not_comparable} not comparable
-          </span>
-        )}
-      </div>
-    </div>
-  );
-}
-
-/** An evaluation + run picker for one side (candidate or baseline). Supports picking a
- *  run from ANY evaluation, so a cross-evaluation pair can be assembled here too. */
 function RunChooser({
   projectId,
   label,
@@ -217,12 +104,11 @@ function RunChooser({
     evalId ? { evaluation_id: evalId } : undefined,
   );
   const runs = React.useMemo(() => runsData?.data ?? [], [runsData]);
-
   return (
     <div className="flex items-center gap-1.5">
       <span className="text-[11px] text-muted-foreground">{label}</span>
       <Select value={evalId} onValueChange={setEvalId}>
-        <SelectTrigger className="h-7 w-[170px] text-[12px]">
+        <SelectTrigger className="h-7 w-[160px] text-[12px]">
           <SelectValue placeholder="Evaluation" />
         </SelectTrigger>
         <SelectContent>
@@ -234,7 +120,7 @@ function RunChooser({
         </SelectContent>
       </Select>
       <Select value={runId ?? ""} onValueChange={onPick}>
-        <SelectTrigger className="h-7 w-[200px] text-[12px]">
+        <SelectTrigger className="h-7 w-[190px] text-[12px]">
           <SelectValue placeholder="Run" />
         </SelectTrigger>
         <SelectContent>
@@ -254,13 +140,477 @@ function RunChooser({
   );
 }
 
-/**
- * The shareable comparison view: `?baseline=&candidate=` in the URL. Baseline and
- * candidate roles are explicit and swappable. Reuses the server-derived comparison
- * engine (via the compare route) — no comparison logic here. Cross-evaluation pairs
- * are allowed and clearly labeled; trusted deltas are disabled (with the exact reason)
- * only for a genuine incompatibility, never merely because the evaluations differ.
- */
+function RunHeaderCard({
+  run,
+  role,
+  crossEval,
+}: {
+  run: CompareRunSummary;
+  role: "Baseline" | "Candidate";
+  crossEval: boolean;
+}) {
+  return (
+    <div className="min-w-0 flex-1 rounded border border-border bg-muted/20 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{role}</span>
+        <RunStatusBadge status={run.status} />
+      </div>
+      <div className="mt-1 text-[12px] font-medium">{run.evaluationName}</div>
+      <div className="mt-0.5 flex items-baseline gap-1.5">
+        <span className="text-[13px] font-semibold">Run #{run.runNumber}</span>
+        <span className="truncate font-mono text-[11px] text-muted-foreground">
+          {run.candidateVersion}
+        </span>
+      </div>
+      <div className="mt-0.5 text-[11px] text-muted-foreground">
+        {run.datasetVersionLabel} · <Timestamp iso={run.startedAt} />
+      </div>
+      {crossEval && (
+        <div className="mt-0.5 text-[10px] text-muted-foreground">{run.evaluationName}</div>
+      )}
+    </div>
+  );
+}
+
+// ── Layer 3: decision metrics ─────────────────────────────────────────────
+
+type MetricState = "present" | "unknown" | "pending";
+
+function MetricCard({
+  label,
+  baseline,
+  candidate,
+  delta,
+  format,
+  lowerIsBetter = false,
+  state = "present",
+  sub,
+}: {
+  label: string;
+  baseline: number | null;
+  candidate: number | null;
+  delta: number | null;
+  format: (n: number) => string;
+  lowerIsBetter?: boolean;
+  state?: MetricState;
+  sub?: string;
+}) {
+  const stateNote = state === "pending" ? "Pending" : state === "unknown" ? "Unknown" : null;
+  return (
+    <div className="rounded border border-border px-2.5 py-2">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      {stateNote ? (
+        <div className="mt-0.5 text-[13px] text-muted-foreground">{stateNote}</div>
+      ) : (
+        <>
+          <div className="mt-0.5 flex items-baseline gap-1.5 tabular-nums">
+            <span className="text-muted-foreground">
+              {baseline === null ? "—" : format(baseline)}
+            </span>
+            <ArrowRight className="h-3 w-3 text-muted-foreground" aria-hidden />
+            <span className="text-[15px] font-medium">
+              {candidate === null ? "—" : format(candidate)}
+            </span>
+          </div>
+          <div className="mt-0.5 text-[11px] tabular-nums">
+            {delta === null || delta === 0 ? (
+              <span className="text-muted-foreground">{delta === 0 ? "±0" : (sub ?? "—")}</span>
+            ) : (
+              <span className={SENTIMENT_CLASS[changeSentiment(lowerIsBetter ? -delta : delta)]}>
+                {delta > 0 ? "+" : "−"}
+                {format(Math.abs(delta))}
+              </span>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Count card (regressed/improved cases, errors) — a plain baseline→candidate/Δ tile. */
+function CountCard({
+  label,
+  baseline,
+  candidate,
+  badTone = false,
+}: {
+  label: string;
+  baseline: number;
+  candidate: number;
+  badTone?: boolean;
+}) {
+  const delta = candidate - baseline;
+  return (
+    <div className="rounded border border-border px-2.5 py-2">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className="mt-0.5 flex items-baseline gap-1.5 tabular-nums">
+        <span className="text-muted-foreground">{baseline}</span>
+        <ArrowRight className="h-3 w-3 text-muted-foreground" aria-hidden />
+        <span
+          className={cn("text-[15px] font-medium", badTone && candidate > 0 && SENTIMENT_CLASS.bad)}
+        >
+          {candidate}
+        </span>
+      </div>
+      <div className="mt-0.5 text-[11px] tabular-nums text-muted-foreground">
+        {delta === 0 ? "±0" : delta > 0 ? `+${delta}` : `−${Math.abs(delta)}`}
+      </div>
+    </div>
+  );
+}
+
+/** Sums trace-derived tokens across cases (candidate/baseline), with pending/unknown. */
+function useTokenTotals(projectId: string, rows: CompareResultRow[]) {
+  const { data: authSession } = useAuthSession();
+  const user = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
+  const ids = React.useMemo(
+    () => [
+      ...new Set(
+        rows
+          .flatMap((r) => [r.candidateTraceId, r.baselineTraceId])
+          .filter((x): x is string => !!x),
+      ),
+    ],
+    [rows],
+  );
+  const queries = useQueries({
+    queries: ids.map((id) => ({
+      queryKey: ["trace", projectId, id],
+      queryFn: () => getTrace(projectId, id, "", user),
+      enabled: !!user,
+    })),
+  });
+  const usageById = new Map<string, TraceUsage>();
+  let loading = false;
+  ids.forEach((id, i) => {
+    const q = queries[i];
+    if (q.isLoading || q.isFetching) loading = true;
+    usageById.set(id, attributeTraceUsage(q.data?.spans as UsageSpan[] | undefined));
+  });
+  const sum = (getId: (r: CompareResultRow) => string | null) => {
+    let total = 0;
+    let any = false;
+    for (const r of rows) {
+      const id = getId(r);
+      const u = id ? usageById.get(id) : undefined;
+      if (u && u.state === "present") {
+        total += u.combined.totalTokens;
+        any = true;
+      }
+    }
+    return any ? total : null;
+  };
+  const candidate = sum((r) => r.candidateTraceId);
+  const baseline = sum((r) => r.baselineTraceId);
+  const state: MetricState =
+    ids.length === 0
+      ? "unknown"
+      : loading
+        ? "pending"
+        : candidate === null && baseline === null
+          ? "unknown"
+          : "present";
+  return { candidate, baseline, state };
+}
+
+function DecisionMetrics({
+  projectId,
+  comparison,
+  candidate,
+  baseline,
+  rows,
+}: {
+  projectId: string;
+  comparison: RunComparison;
+  candidate: CompareRunSummary;
+  baseline: CompareRunSummary;
+  rows: CompareResultRow[];
+}) {
+  const tokens = useTokenTotals(projectId, rows);
+  const costCand = rows.reduce<number | null>(
+    (acc, r) => (r.candidateCost === null ? acc : (acc ?? 0) + r.candidateCost),
+    null,
+  );
+  const costBase = rows.reduce<number | null>(
+    (acc, r) => (r.baselineCost === null ? acc : (acc ?? 0) + r.baselineCost),
+    null,
+  );
+  const costDelta = costCand !== null && costBase !== null ? costCand - costBase : null;
+  const dur = comparison.duration;
+  const candErrors = candidate.taskErrorCount + candidate.scorerErrorCount;
+  const baseErrors = baseline.taskErrorCount + baseline.scorerErrorCount;
+  return (
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+      <MetricCard
+        label={comparison.scorers[0] ? "Main score" : "Main score"}
+        baseline={comparison.mainScore.baseline}
+        candidate={comparison.mainScore.candidate}
+        delta={comparison.mainScore.delta}
+        format={(n) => pctFraction(n)}
+      />
+      <CountCard
+        label="Regressed test cases"
+        baseline={0}
+        candidate={comparison.caseCounts.regressed}
+        badTone
+      />
+      <CountCard
+        label="Improved test cases"
+        baseline={0}
+        candidate={comparison.caseCounts.improved}
+      />
+      <CountCard label="Errors" baseline={baseErrors} candidate={candErrors} badTone />
+      <MetricCard
+        label="Avg case duration"
+        baseline={dur.baselineMeanMs}
+        candidate={dur.candidateMeanMs}
+        delta={dur.deltaMs}
+        format={fmtMs}
+        lowerIsBetter
+        state={dur.pairedCount === 0 ? "unknown" : "present"}
+      />
+      <MetricCard
+        label="Total cost"
+        baseline={costBase}
+        candidate={costCand}
+        delta={costDelta}
+        format={(n) => `$${n.toFixed(4)}`}
+        lowerIsBetter
+        state={costCand === null && costBase === null ? "unknown" : "present"}
+      />
+      <MetricCard
+        label="Total tokens"
+        baseline={tokens.baseline}
+        candidate={tokens.candidate}
+        delta={
+          tokens.candidate !== null && tokens.baseline !== null
+            ? tokens.candidate - tokens.baseline
+            : null
+        }
+        format={(n) => Math.round(n).toLocaleString("en-US")}
+        lowerIsBetter
+        state={tokens.state}
+      />
+    </div>
+  );
+}
+
+// ── Layer 3b: per-scorer summary ──────────────────────────────────────────
+
+function ScorerSummary({ comparison }: { comparison: RunComparison }) {
+  const [open, setOpen] = React.useState(true);
+  const scorers = comparison.scorers;
+  if (scorers.length === 0) return null;
+  // Per-scorer improved/regressed cell counts from the cell tally isn't per-scorer in
+  // RunComparison; derive from the aggregate's transitions/means only. Show means +
+  // paired; categorical shows changed/unchanged.
+  return (
+    <div className="overflow-hidden rounded border border-border">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-1.5 border-b border-border bg-muted/40 px-2.5 py-1.5 text-left text-[12px] font-medium hover:bg-muted"
+      >
+        {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+        Scorers
+      </button>
+      {open && (
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr className="text-[10px] text-muted-foreground">
+              <th className="py-1 pl-2.5 text-left font-normal">Scorer</th>
+              <th className="py-1 text-right font-normal">Baseline</th>
+              <th className="py-1 text-right font-normal">Candidate</th>
+              <th className="py-1 text-right font-normal">Δ</th>
+              <th className="py-1 pr-2.5 text-right font-normal">Paired</th>
+            </tr>
+          </thead>
+          <tbody className="[&_td:first-child]:pl-2.5 [&_td:last-child]:pr-2.5">
+            {scorers.map((s) => {
+              const better = s.direction !== "lower_is_better";
+              const numeric = s.valueType !== "categorical";
+              return (
+                <tr key={`${s.name}@${s.version}`}>
+                  <td className="py-1">
+                    <span className="font-medium">{s.name}</span>{" "}
+                    <span className="text-[10px] text-muted-foreground">{s.version}</span>
+                  </td>
+                  {numeric ? (
+                    <>
+                      <td className="py-1 text-right tabular-nums text-muted-foreground">
+                        {s.baselineMean === null ? "—" : pctFraction(s.baselineMean)}
+                      </td>
+                      <td className="py-1 text-right tabular-nums">
+                        {s.candidateMean === null ? "—" : pctFraction(s.candidateMean)}
+                      </td>
+                      <td className="py-1 text-right tabular-nums">
+                        {s.delta === null || s.delta === 0 ? (
+                          <span className="text-muted-foreground">
+                            {s.delta === 0 ? "±0" : "—"}
+                          </span>
+                        ) : (
+                          <span
+                            className={
+                              SENTIMENT_CLASS[changeSentiment(better ? s.delta : -s.delta)]
+                            }
+                          >
+                            {s.delta > 0 ? "+" : "−"}
+                            {pctFraction(Math.abs(s.delta))}
+                          </span>
+                        )}
+                      </td>
+                    </>
+                  ) : (
+                    <>
+                      <td className="py-1 text-right text-[11px] text-muted-foreground" colSpan={2}>
+                        categorical
+                      </td>
+                      <td className="py-1 text-right text-[11px] tabular-nums">
+                        {s.transitions ? `${s.transitions.changed} changed` : "—"}
+                      </td>
+                    </>
+                  )}
+                  <td className="py-1 text-right tabular-nums text-muted-foreground">
+                    {s.pairedCount}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+// ── Layer 4: case table ───────────────────────────────────────────────────
+
+function scorerCellText(c: ScorerCellComparison): string {
+  const v = (x: number | boolean | string | null) =>
+    x === null
+      ? "—"
+      : typeof x === "boolean"
+        ? x
+          ? "pass"
+          : "fail"
+        : typeof x === "number"
+          ? Number.isInteger(x)
+            ? String(x)
+            : x.toFixed(2)
+          : x;
+  return `${v(c.baselineValue)} → ${v(c.candidateValue)}`;
+}
+
+function CaseRow({ r, onOpen }: { r: CompareResultRow; onOpen: () => void }) {
+  const cmp = r.comparison;
+  const st = caseStatus(r);
+  const changedCells = (cmp?.scorerCells ?? []).filter(
+    (c) =>
+      c.classification === "regressed" ||
+      c.classification === "improved" ||
+      c.classification === "changed" ||
+      c.reason,
+  );
+  const mainDelta = cmp?.mainScore.delta ?? null;
+  const mainChange = cmp?.caseChange ?? null;
+  return (
+    <TR interactive onClick={onOpen}>
+      {/* Input (primary) + expected + id secondary */}
+      <Td>
+        <div className="max-w-[280px] truncate" title={r.input}>
+          {truncate(r.input, 120)}
+        </div>
+        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+          <span className="font-mono">{r.testCaseId}</span>
+          {r.provenance && <span title="Saved from a production trace">· from trace</span>}
+        </div>
+      </Td>
+      {/* Output change */}
+      <Td className="max-w-[220px]">
+        {r.outputChanged === false ? (
+          <span className="text-[11px] text-muted-foreground">No output change</span>
+        ) : (
+          <div className="text-[11px]">
+            <div className="truncate text-muted-foreground" title={r.baselineOutput ?? ""}>
+              {r.baselineOutput === null ? "—" : truncate(r.baselineOutput, 40)}
+            </div>
+            <div className="truncate" title={r.candidateOutput ?? ""}>
+              {r.candidateOutput === null ? "—" : truncate(r.candidateOutput, 40)}
+            </div>
+          </div>
+        )}
+      </Td>
+      {/* Main score (typed) */}
+      <Td className="text-[11px]">
+        {cmp ? (
+          <>
+            <div className="tabular-nums">
+              {fmtScore(cmp.mainScore.baseline)} → {fmtScore(cmp.mainScore.candidate)}
+            </div>
+            {mainChange && (
+              <div className={CHANGE_LABEL[mainChange].className}>
+                {mainDelta !== null && mainDelta !== 0
+                  ? `${mainDelta > 0 ? "+" : "−"}${pctFraction(Math.abs(mainDelta))} · `
+                  : ""}
+                {CHANGE_LABEL[mainChange].label}
+              </div>
+            )}
+          </>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </Td>
+      {/* Scorer changes (only changed/error cells) */}
+      <Td className="text-[11px]">
+        {changedCells.length === 0 ? (
+          <span className="text-muted-foreground">—</span>
+        ) : changedCells.length <= 2 ? (
+          <div className="space-y-0.5">
+            {changedCells.map((c) => (
+              <div key={`${c.scorerName}@${c.scorerVersion}`} className="tabular-nums">
+                <span className="text-muted-foreground">{c.scorerName}</span> {scorerCellText(c)}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <span className={SENTIMENT_CLASS.bad}>
+            {cmp?.regressedCellCount ?? 0} scorer regressions
+          </span>
+        )}
+      </Td>
+      {/* Duration */}
+      <Td className="whitespace-nowrap text-right text-[11px] tabular-nums">
+        {cmp?.durationDeltaMs != null ? (
+          <span className={SENTIMENT_CLASS[changeSentiment(-cmp.durationDeltaMs)]}>
+            {fmtMs(cmp.durationMs ?? null)}
+          </span>
+        ) : (
+          <span className="text-muted-foreground">{fmtMs(cmp?.durationMs ?? null)}</span>
+        )}
+      </Td>
+      {/* Cost */}
+      <Td className="whitespace-nowrap text-right text-[11px] tabular-nums">
+        {r.candidateCost === null && r.baselineCost === null ? (
+          <span className="text-muted-foreground">Unknown</span>
+        ) : (
+          <span>{fmtCost(r.candidateCost)}</span>
+        )}
+      </Td>
+      {/* Status */}
+      <Td>
+        <span className={cn("text-[11px]", STATUS_LABEL[st].className)}>
+          {STATUS_LABEL[st].label}
+        </span>
+      </Td>
+    </TR>
+  );
+}
+
+// ── The page ──────────────────────────────────────────────────────────────
+
 export function CompareRunsView({
   projectId,
   candidateId,
@@ -272,25 +622,51 @@ export function CompareRunsView({
   baselineId: string | null;
   onChange: (baseline: string | null, candidate: string | null) => void;
 }) {
-  const router = useRouter();
   const compare = useCompareRuns(projectId, candidateId, baselineId);
   const data = compare.data;
+  const [filter, setFilter] = React.useState<CaseFilterId>("all");
+  const [sort, setSort] = React.useState<CaseSortId>("default");
+  const [openCaseId, setOpenCaseId] = React.useState<string | null>(null);
+  const [traceView, setTraceView] = React.useState<{ traceId: string; label: string } | null>(null);
 
-  const candEval = data?.candidate.evaluationId ?? null;
-  const baseEval = data?.baseline.evaluationId ?? null;
-  const crossEval = !!data && candEval !== baseEval;
+  const crossEval = !!data && data.candidate.evaluationId !== data.baseline.evaluationId;
   const blocking = (data?.comparison.reasons ?? []).filter((r) => BLOCKING_REASONS.has(r));
-  const deltasTrusted = !!data?.comparison.available && blocking.length === 0;
+
+  const rows = React.useMemo(() => data?.results ?? [], [data]);
+  const durationWorsened = (data?.comparison.duration.deltaMs ?? 0) > 0;
+  const verdict = data
+    ? deriveVerdict(data.comparison, data.candidate.status, data.baseline.status, durationWorsened)
+    : null;
+  const counts = React.useMemo(() => filterCounts(rows), [rows]);
+  const visible = React.useMemo(
+    () =>
+      sortCases(
+        rows.filter((r) => matchesFilter(r, filter)),
+        sort,
+      ),
+    [rows, filter, sort],
+  );
+  const openCase = openCaseId ? (rows.find((r) => r.testCaseId === openCaseId) ?? null) : null;
 
   return (
     <div className="flex h-full flex-col text-[12px]">
       <ProjectBreadcrumb projectId={projectId} current="Compare runs" />
 
+      {/* Chooser — Baseline first, then Candidate */}
       <div className="flex flex-wrap items-center gap-3 border-b border-border px-3 py-2">
         <RunChooser
           projectId={projectId}
+          label="Baseline"
+          seedEvaluationId={data?.baseline.evaluationId ?? null}
+          runId={baselineId}
+          otherRunId={candidateId}
+          onPick={(id) => onChange(id, candidateId)}
+        />
+        <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+        <RunChooser
+          projectId={projectId}
           label="Candidate"
-          seedEvaluationId={candEval}
+          seedEvaluationId={data?.candidate.evaluationId ?? null}
           runId={candidateId}
           otherRunId={baselineId}
           onPick={(id) => onChange(baselineId, id)}
@@ -306,19 +682,11 @@ export function CompareRunsView({
           <ArrowLeftRight className="h-3.5 w-3.5" aria-hidden />
           Swap
         </Button>
-        <RunChooser
-          projectId={projectId}
-          label="Baseline"
-          seedEvaluationId={baseEval}
-          runId={baselineId}
-          otherRunId={candidateId}
-          onPick={(id) => onChange(id, candidateId)}
-        />
       </div>
 
       <div className="min-h-0 flex-1 space-y-3 overflow-auto p-3">
         {!candidateId || !baselineId ? (
-          <EmptyState>Pick a candidate and a baseline run to compare.</EmptyState>
+          <EmptyState>Pick a baseline and a candidate run to compare.</EmptyState>
         ) : candidateId === baselineId ? (
           <EmptyState>Pick two different runs.</EmptyState>
         ) : compare.isLoading ? (
@@ -327,10 +695,14 @@ export function CompareRunsView({
           <EmptyState>Couldn’t compare these runs.</EmptyState>
         ) : (
           <>
-            <div className="flex items-stretch gap-2">
-              <RunHeaderCard run={data.candidate} role="Candidate" crossEval={crossEval} />
-              <ArrowRight className="mt-6 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+            {/* Layer 1 — identity, Baseline → Candidate */}
+            <div className="flex flex-col items-stretch gap-2 sm:flex-row">
               <RunHeaderCard run={data.baseline} role="Baseline" crossEval={crossEval} />
+              <ArrowRight
+                className="mx-auto h-4 w-4 shrink-0 rotate-90 self-center text-muted-foreground sm:mt-6 sm:rotate-0"
+                aria-hidden
+              />
+              <RunHeaderCard run={data.candidate} role="Candidate" crossEval={crossEval} />
             </div>
 
             {crossEval && (
@@ -338,76 +710,186 @@ export function CompareRunsView({
                 <Info className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" aria-hidden />
                 <span>
                   <span className="font-medium">Cross-evaluation comparison</span> —{" "}
-                  {data.candidate.evaluationName} vs {data.baseline.evaluationName}. No baseline
+                  {data.baseline.evaluationName} → {data.candidate.evaluationName}. No baseline
                   relationship is saved.
                 </span>
               </div>
             )}
 
-            {!deltasTrusted && blocking.length > 0 && (
-              <div className="flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-300">
-                <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
-                <span>{blocking.map((r) => REASON_LABEL[r] ?? r).join(" ")}</span>
+            {/* Layer 2 — verdict */}
+            {verdict && (
+              <div
+                className={cn(
+                  "rounded border px-3 py-2",
+                  VERDICT_TONE[VERDICT_META[verdict.verdict].tone],
+                )}
+              >
+                <div className="text-[13px] font-semibold">
+                  {VERDICT_META[verdict.verdict].label}
+                </div>
+                <div className="mt-0.5 space-y-0.5 text-[11px] leading-relaxed">
+                  {verdict.reasons.map((line, i) => (
+                    <div key={i}>{line}</div>
+                  ))}
+                  {verdict.verdict === "not_comparable" &&
+                    blocking.length === 0 &&
+                    data.comparison.reasons.map((r) => <div key={r}>{REASON_LABEL[r] ?? r}</div>)}
+                </div>
               </div>
             )}
 
-            <SummaryTable comparison={data.comparison} />
+            {/* Layer 3 — aggregate metrics + per-scorer */}
+            <DecisionMetrics
+              projectId={projectId}
+              comparison={data.comparison}
+              candidate={data.candidate}
+              baseline={data.baseline}
+              rows={rows}
+            />
+            <ScorerSummary comparison={data.comparison} />
 
-            <div className="overflow-hidden rounded border border-border">
-              <Table>
-                <THead>
-                  <TRHead>
-                    <Th>Test case</Th>
-                    <Th className="w-[110px] text-right">Candidate</Th>
-                    <Th className="w-[110px] text-right">Baseline</Th>
-                    <Th className="w-[130px]">Change</Th>
-                  </TRHead>
-                </THead>
-                <TBody>
-                  {data.results.map((r) => {
-                    const cmp = r.comparison;
-                    const change = cmp?.caseChange ?? null;
-                    return (
-                      <TR
-                        key={r.testCaseId}
-                        interactive={!!r.candidateTraceId}
-                        onClick={() =>
-                          r.candidateTraceId &&
-                          router.push(
-                            `/projects/${projectId}/evaluations/${candidateId}?result=${r.testCaseId}`,
-                          )
-                        }
-                      >
-                        <Td className="font-mono text-[11px]">{r.testCaseId}</Td>
-                        <Td className="text-right tabular-nums">
-                          {fmtScore(cmp?.mainScore.candidate ?? null)}
-                        </Td>
-                        <Td className="text-right tabular-nums text-muted-foreground">
-                          {fmtScore(cmp?.mainScore.baseline ?? null)}
-                        </Td>
-                        <Td>
-                          {change ? (
-                            <span className={CHANGE_LABEL[change].className}>
-                              {CHANGE_LABEL[change].label}
-                              {cmp && cmp.mainScore.delta !== null && cmp.mainScore.delta !== 0 && (
-                                <span className="ml-1 text-[11px]">
-                                  ({signedPoints(cmp.mainScore.delta)} pp)
-                                </span>
-                              )}
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground">—</span>
-                          )}
-                        </Td>
-                      </TR>
-                    );
-                  })}
-                </TBody>
-              </Table>
+            {/* Layer 4 — case table */}
+            <div>
+              <div className="mb-1.5 flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <div className="text-[12px] font-medium">Test cases</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    Each row is one dataset input run through both the baseline and candidate ·{" "}
+                    {data.baseline.datasetVersionLabel === data.candidate.datasetVersionLabel
+                      ? data.candidate.datasetVersionLabel
+                      : `${data.baseline.datasetVersionLabel} vs ${data.candidate.datasetVersionLabel}`}{" "}
+                    · matched by test-case id
+                  </div>
+                </div>
+                <Select value={sort} onValueChange={(v) => setSort(v as CaseSortId)}>
+                  <SelectTrigger className="h-7 w-[190px] text-[12px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CASE_SORTS.map((s) => (
+                      <SelectItem key={s.id} value={s.id} className="text-[12px]">
+                        {s.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Filters with counts */}
+              <div className="mb-1.5 flex flex-wrap gap-1">
+                {CASE_FILTERS.map((f) => (
+                  <button
+                    key={f.id}
+                    type="button"
+                    onClick={() => setFilter(f.id)}
+                    className={cn(
+                      "flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-[12px] transition-colors",
+                      filter === f.id
+                        ? "border-foreground/30 bg-muted text-foreground"
+                        : "border-input text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {f.label}
+                    <span className="tabular-nums text-muted-foreground">{counts[f.id]}</span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="overflow-x-auto rounded border border-border">
+                <Table>
+                  <THead>
+                    <TRHead>
+                      <Th>Input</Th>
+                      <Th>Output change</Th>
+                      <Th className="w-[130px]">Main score</Th>
+                      <Th className="w-[150px]">Scorer changes</Th>
+                      <Th className="w-[90px] text-right">Duration</Th>
+                      <Th className="w-[90px] text-right">Cost</Th>
+                      <Th className="w-[110px]">Status</Th>
+                    </TRHead>
+                  </THead>
+                  <TBody>
+                    {visible.length === 0 ? (
+                      <tr>
+                        <td colSpan={7}>
+                          <EmptyState>No cases match this filter.</EmptyState>
+                        </td>
+                      </tr>
+                    ) : (
+                      visible.map((r) => (
+                        <CaseRow
+                          key={r.testCaseId}
+                          r={r}
+                          onOpen={() => setOpenCaseId(r.testCaseId)}
+                        />
+                      ))
+                    )}
+                  </TBody>
+                </Table>
+              </div>
             </div>
           </>
         )}
       </div>
+
+      {/* Layer 5 — selected-case diagnosis drawer */}
+      {openCase && data && (
+        <CompareCaseDrawer
+          projectId={projectId}
+          row={openCase}
+          candidate={data.candidate}
+          baseline={data.baseline}
+          onClose={() => setOpenCaseId(null)}
+          traceSlot={
+            <div className="flex flex-wrap gap-1.5">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-[12px]"
+                disabled={!openCase.candidateTraceId}
+                onClick={() =>
+                  openCase.candidateTraceId &&
+                  setTraceView({ traceId: openCase.candidateTraceId, label: "Candidate trace" })
+                }
+              >
+                Open candidate trace
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-[12px]"
+                disabled={!openCase.baselineTraceId}
+                onClick={() =>
+                  openCase.baselineTraceId &&
+                  setTraceView({ traceId: openCase.baselineTraceId, label: "Baseline trace" })
+                }
+              >
+                Open baseline trace
+              </Button>
+              {!openCase.candidateTraceId && !openCase.baselineTraceId && (
+                <span className="text-[11px] text-muted-foreground">
+                  No trace was emitted for this case.
+                </span>
+              )}
+            </div>
+          }
+        />
+      )}
+
+      {/* Trace viewer — opens over the drawer; switching baseline/candidate keeps the
+          case drawer mounted underneath. */}
+      {traceView && (
+        <TraceViewerPanel
+          key={traceView.traceId}
+          projectId={projectId}
+          traceId={traceView.traceId}
+          headerIdentity={{ label: traceView.label, value: traceView.traceId }}
+          onClose={() => setTraceView(null)}
+          onNavigate={() => {}}
+          canNavigateUp={false}
+          canNavigateDown={false}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/ui/src/features/offline-eval/components/component-kit.test.tsx
+++ b/frontend/ui/src/features/offline-eval/components/component-kit.test.tsx
@@ -1,0 +1,377 @@
+// @vitest-environment jsdom
+/**
+ * Unit coverage for the shared offline-eval component kit — the page chrome,
+ * the form shells, the row-selection primitives, and the upload control. These
+ * are the pieces the dataset/evaluation surfaces are assembled from, so they are
+ * exercised directly rather than only through a view mount.
+ */
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import * as React from "react";
+import { render, cleanup, screen, fireEvent, within, waitFor } from "@testing-library/react";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import {
+  EvalPageHeader,
+  EvalBody,
+  DetailsSection,
+  DetailRow,
+  QuietAction,
+  EmptyState,
+} from "./page-chrome";
+import { CreateDrawer, FormCard, AdvancedSection } from "./form-kit";
+import { useRowSelection, SelectAllHeaderCell, SelectRowCell, BulkActionBar } from "./selection";
+import { UploadControl } from "./upload-control";
+
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  window.HTMLElement.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+});
+
+afterEach(() => cleanup());
+
+describe("page chrome", () => {
+  it("EvalPageHeader renders a parent breadcrumb, a purpose sentence, and one action", () => {
+    render(
+      <EvalPageHeader
+        parent={{ label: "Datasets", href: "/projects/p1/datasets" }}
+        title="Billing routing"
+        purpose="A dataset is a versioned set of test cases."
+        action={<button type="button">New</button>}
+      />,
+    );
+    const parent = screen.getByText("Datasets");
+    expect(parent.getAttribute("href")).toBe("/projects/p1/datasets");
+    expect(screen.getByRole("heading").textContent).toBe("Billing routing");
+    expect(screen.getByText(/versioned set of test cases/)).toBeDefined();
+    expect(screen.getByRole("button", { name: "New" })).toBeDefined();
+  });
+
+  it("EvalPageHeader falls back to a Back link when there is no parent", () => {
+    render(<EvalPageHeader title="Run #27" backHref="/projects/p1/evaluations" />);
+    const back = screen.getByText("Back");
+    expect(back.getAttribute("href")).toBe("/projects/p1/evaluations");
+  });
+
+  it("EvalPageHeader honours a custom back label and drops it once a parent is given", () => {
+    const { rerender } = render(
+      <EvalPageHeader title="Run #27" backHref="/x" backLabel="All runs" />,
+    );
+    expect(screen.getByText("All runs")).toBeDefined();
+    // A parent breadcrumb replaces the back link entirely.
+    rerender(
+      <EvalPageHeader title="Run #27" backHref="/x" parent={{ label: "Runs", href: "/x" }} />,
+    );
+    expect(screen.queryByText("All runs")).toBeNull();
+    expect(screen.getByText("Runs")).toBeDefined();
+  });
+
+  it("EvalBody, EmptyState, DetailsSection, DetailRow and QuietAction render their content", () => {
+    const onClick = vi.fn();
+    render(
+      <EvalBody className="custom">
+        <DetailsSection label="Run details" className="mt-2">
+          <dl>
+            <DetailRow label="Environment" value="ci" />
+            <DetailRow label="Cases" value={24} />
+          </dl>
+        </DetailsSection>
+        <EmptyState>Nothing here yet.</EmptyState>
+        <QuietAction onClick={onClick}>View SDK example</QuietAction>
+      </EvalBody>,
+    );
+
+    // The details summary is a native disclosure, so it is keyboard-reachable.
+    const summary = screen.getByText("Run details");
+    expect(summary.tagName).toBe("SUMMARY");
+    expect(screen.getByText("Environment")).toBeDefined();
+    expect(screen.getByText("24")).toBeDefined();
+    expect(screen.getByText("Nothing here yet.")).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "View SDK example" }));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("DetailsSection defaults its label to Details", () => {
+    render(
+      <DetailsSection>
+        <span>body</span>
+      </DetailsSection>,
+    );
+    expect(screen.getByText("Details")).toBeDefined();
+  });
+});
+
+describe("form kit", () => {
+  it("FormCard shows its label and optional hint", () => {
+    const { rerender } = render(
+      <FormCard label="Dataset" hint="required">
+        <input aria-label="dataset name" />
+      </FormCard>,
+    );
+    expect(screen.getByText("Dataset")).toBeDefined();
+    expect(screen.getByText("required")).toBeDefined();
+
+    // Without a hint the strip carries only the label.
+    rerender(
+      <FormCard label="Dataset" className="mt-2">
+        <input aria-label="dataset name" />
+      </FormCard>,
+    );
+    expect(screen.queryByText("required")).toBeNull();
+  });
+
+  it("AdvancedSection is a collapsed native disclosure with a default label", () => {
+    const { rerender } = render(
+      <AdvancedSection>
+        <span>hidden field</span>
+      </AdvancedSection>,
+    );
+    expect(screen.getByText("Advanced").tagName).toBe("SUMMARY");
+    rerender(
+      <AdvancedSection label="Scorer options">
+        <span>hidden field</span>
+      </AdvancedSection>,
+    );
+    expect(screen.getByText("Scorer options")).toBeDefined();
+  });
+
+  it("CreateDrawer wires Save and Cancel, and honours saveDisabled", () => {
+    const onSave = vi.fn();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <CreateDrawer
+        title="New evaluation"
+        open
+        onOpenChange={onOpenChange}
+        onSave={onSave}
+        saveLabel="Create"
+        saveDisabled
+        width="w-[480px]"
+      >
+        <FormCard label="Name">
+          <input aria-label="name" />
+        </FormCard>
+      </CreateDrawer>,
+    );
+
+    expect(screen.getByText("New evaluation")).toBeDefined();
+    const save = screen.getByRole("button", { name: "Create" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(save);
+    expect(onSave).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    // Enabled, with the default Save label.
+    rerender(
+      <CreateDrawer title="New evaluation" open onOpenChange={onOpenChange} onSave={onSave}>
+        <span>fields</span>
+      </CreateDrawer>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSave).toHaveBeenCalled();
+  });
+
+  it("CreateDrawer renders nothing while closed", () => {
+    render(
+      <CreateDrawer title="New evaluation" open={false} onOpenChange={vi.fn()} onSave={vi.fn()}>
+        <span>fields</span>
+      </CreateDrawer>,
+    );
+    expect(screen.queryByText("New evaluation")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Row selection
+// ---------------------------------------------------------------------------
+
+function SelectionHarness({ ids, onDelete }: { ids: string[]; onDelete?: () => Promise<void> }) {
+  const selection = useRowSelection(ids);
+  return (
+    <div>
+      <BulkActionBar
+        count={selection.count}
+        onDelete={onDelete}
+        onClear={selection.clear}
+        extra={<button type="button">Export</button>}
+      />
+      <table>
+        <thead>
+          <tr>
+            <SelectAllHeaderCell
+              checked={selection.allSelected}
+              indeterminate={selection.someSelected}
+              onToggle={selection.toggleAll}
+            />
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ids.map((id) => (
+            <tr key={id}>
+              <SelectRowCell
+                checked={selection.has(id)}
+                onToggle={() => selection.toggle(id)}
+                label={`Select ${id}`}
+              />
+              <td>{id}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button type="button" onClick={() => selection.setMany(ids, true)}>
+        Select batch
+      </button>
+      <button type="button" onClick={() => selection.setMany(ids, false)}>
+        Deselect batch
+      </button>
+    </div>
+  );
+}
+
+describe("row selection", () => {
+  it("toggles rows, shows the bulk bar, and clears", async () => {
+    const onDelete = vi.fn().mockResolvedValue(undefined);
+    render(<SelectionHarness ids={["a", "b", "c"]} onDelete={onDelete} />);
+
+    // Nothing selected: no bar.
+    expect(screen.queryByText(/selected/)).toBeNull();
+
+    fireEvent.click(screen.getByLabelText("Select a"));
+    expect(screen.getByText("1 selected")).toBeDefined();
+    // Partial selection puts the header checkbox in its indeterminate state.
+    expect(screen.getByLabelText("Select all")).toBeDefined();
+
+    fireEvent.click(screen.getByLabelText("Select b"));
+    expect(screen.getByText("2 selected")).toBeDefined();
+    // Toggling the same row off again.
+    fireEvent.click(screen.getByLabelText("Select b"));
+    expect(screen.getByText("1 selected")).toBeDefined();
+
+    // The bar owns the confirmation, so Delete opens the dialog and only the
+    // confirm inside it performs the deletion.
+    fireEvent.click(screen.getByRole("button", { name: "Delete 1 selected" }));
+    expect(onDelete).not.toHaveBeenCalled();
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete 1 selected" })[1]);
+    expect(onDelete).toHaveBeenCalled();
+    // The bar disables itself while the delete is in flight, so wait for it to
+    // settle before driving anything else.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Clear" }).hasAttribute("disabled")).toBe(false),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    // Scoped to the bar: the confirmation dialog's own copy also says "selected".
+    expect(within(screen.getByRole("status")).queryByText(/\d+ selected/)).toBeNull();
+  });
+
+  it("select-all toggles the whole page on and back off", () => {
+    render(<SelectionHarness ids={["a", "b"]} />);
+    fireEvent.click(screen.getByLabelText("Select all"));
+    expect(screen.getByText("2 selected")).toBeDefined();
+    // Now labelled for the inverse action.
+    fireEvent.click(screen.getByLabelText("Deselect all"));
+    expect(screen.queryByText(/selected/)).toBeNull();
+  });
+
+  it("setMany adds or removes a batch at once", () => {
+    render(<SelectionHarness ids={["a", "b", "c"]} />);
+    fireEvent.click(screen.getByRole("button", { name: "Select batch" }));
+    expect(screen.getByText("3 selected")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Deselect batch" }));
+    expect(screen.queryByText(/selected/)).toBeNull();
+  });
+
+  it("drops selected ids that no longer exist", () => {
+    const { rerender } = render(<SelectionHarness ids={["a", "b"]} />);
+    fireEvent.click(screen.getByLabelText("Select all"));
+    expect(screen.getByText("2 selected")).toBeDefined();
+    // "b" is deleted upstream; the selection shrinks to match.
+    rerender(<SelectionHarness ids={["a"]} />);
+    expect(screen.getByText("1 selected")).toBeDefined();
+  });
+
+  it("the row checkbox does not bubble a click up to the row", () => {
+    const onRowClick = vi.fn();
+    render(
+      <table>
+        <tbody>
+          <tr onClick={onRowClick}>
+            <SelectRowCell checked={false} onToggle={vi.fn()} label="Select a" />
+          </tr>
+        </tbody>
+      </table>,
+    );
+    fireEvent.click(screen.getByLabelText("Select a"));
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it("BulkActionBar omits Delete on lists with no delete API", () => {
+    render(<BulkActionBar count={3} onClear={vi.fn()} />);
+    const bar = screen.getByText("3 selected").parentElement as HTMLElement;
+    expect(within(bar).queryByRole("button", { name: /^Delete/ })).toBeNull();
+    expect(within(bar).getByRole("button", { name: "Clear" })).toBeDefined();
+  });
+});
+
+describe("upload control", () => {
+  const file = () => new File(["input,expected\na,b\n"], "cases.csv", { type: "text/csv" });
+
+  it("reports a chosen file and switches to the chosen-file affordance", () => {
+    const onFile = vi.fn();
+    render(<UploadControl onFile={onFile} className="mt-2" />);
+
+    expect(screen.getByText(/Drop a CSV or JSON file/)).toBeDefined();
+    fireEvent.change(screen.getByLabelText("Upload CSV or JSON"), {
+      target: { files: [file()] },
+    });
+
+    expect(onFile).toHaveBeenCalledWith("cases.csv");
+    expect(screen.getByText("cases.csv")).toBeDefined();
+    expect(screen.getByText("Click to choose a different file")).toBeDefined();
+  });
+
+  it("accepts a dropped file and highlights while dragging", () => {
+    const onFile = vi.fn();
+    render(<UploadControl onFile={onFile} />);
+    const zone = screen.getByRole("button");
+
+    fireEvent.dragOver(zone);
+    fireEvent.dragLeave(zone);
+    fireEvent.dragOver(zone);
+    fireEvent.drop(zone, { dataTransfer: { files: [file()] } });
+
+    expect(onFile).toHaveBeenCalledWith("cases.csv");
+    expect(screen.getByText("cases.csv")).toBeDefined();
+  });
+
+  it("ignores a drop that carries no file, and works without an onFile handler", () => {
+    render(<UploadControl />);
+    const zone = screen.getByRole("button");
+    fireEvent.drop(zone, { dataTransfer: { files: [] } });
+    expect(screen.getByText(/Drop a CSV or JSON file/)).toBeDefined();
+
+    fireEvent.change(screen.getByLabelText("Upload CSV or JSON"), {
+      target: { files: [file()] },
+    });
+    expect(screen.getByText("cases.csv")).toBeDefined();
+  });
+
+  it("clicking the drop zone opens the hidden file picker", () => {
+    render(<UploadControl />);
+    const input = screen.getByLabelText("Upload CSV or JSON");
+    const click = vi.spyOn(input, "click");
+    fireEvent.click(screen.getByRole("button"));
+    expect(click).toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/lib/eval/comparison.test.ts
+++ b/frontend/ui/src/lib/eval/comparison.test.ts
@@ -1,0 +1,538 @@
+import { describe, it, expect } from "vitest";
+import {
+  compareRuns,
+  type ComparisonRun,
+  type ComparisonResult,
+  type ComparisonScore,
+  type ComparisonScorerMeta,
+  type CompareRunsInput,
+} from "./comparison";
+
+// ── builders ─────────────────────────────────────────────────────────────
+
+function score(name: string, opts: Partial<ComparisonScore> = {}): ComparisonScore {
+  return {
+    scorerName: name,
+    scorerVersion: opts.scorerVersion ?? "unversioned",
+    numericValue: opts.numericValue ?? null,
+    boolValue: opts.boolValue ?? null,
+    stringValue: opts.stringValue ?? null,
+    error: opts.error ?? null,
+  };
+}
+const num = (name: string, v: number, version = "unversioned") =>
+  score(name, { numericValue: v, scorerVersion: version });
+
+function result(testCaseId: string, opts: Partial<ComparisonResult> = {}): ComparisonResult {
+  return {
+    testCaseId,
+    status: opts.status ?? "passed",
+    mainScore: opts.mainScore ?? null,
+    candidateOutput: opts.candidateOutput ?? null,
+    durationMs: opts.durationMs ?? null,
+    scores: opts.scores ?? [],
+  };
+}
+
+function run(opts: Partial<ComparisonRun> = {}): ComparisonRun {
+  return {
+    id: opts.id ?? "run_cand",
+    runNumber: opts.runNumber ?? 2,
+    evaluationId: opts.evaluationId ?? "eval_1",
+    datasetVersionId: opts.datasetVersionId ?? "dsv_1",
+    candidateVersion: opts.candidateVersion ?? "sonnet",
+    status: opts.status ?? "completed",
+    mainScore: opts.mainScore ?? null,
+    mainScoreName: opts.mainScoreName ?? "acc",
+    baselineRunId: opts.baselineRunId === undefined ? "run_base" : opts.baselineRunId,
+    scorers: opts.scorers ?? [{ name: "acc", version: "unversioned" }],
+  };
+}
+
+function build(over: Partial<CompareRunsInput> = {}): CompareRunsInput {
+  return {
+    candidate: over.candidate ?? run(),
+    candidateResults: over.candidateResults ?? [],
+    baseline: over.baseline === undefined ? run({ id: "run_base", runNumber: 1 }) : over.baseline,
+    baselineResults: over.baselineResults ?? [],
+  };
+}
+
+// ── numeric, higher-is-better ─────────────────────────────────────────────
+
+describe("numeric higher-is-better", () => {
+  it("classifies improved / regressed / unchanged by the sign of the delta", () => {
+    const out = compareRuns(
+      build({
+        candidateResults: [
+          result("a", { mainScore: 0.9, scores: [num("acc", 0.9)] }),
+          result("b", { mainScore: 0.2, scores: [num("acc", 0.2)] }),
+          result("c", { mainScore: 0.5, scores: [num("acc", 0.5)] }),
+        ],
+        baselineResults: [
+          result("a", { mainScore: 0.5, scores: [num("acc", 0.5)] }),
+          result("b", { mainScore: 0.8, scores: [num("acc", 0.8)] }),
+          result("c", { mainScore: 0.5, scores: [num("acc", 0.5)] }),
+        ],
+      }),
+    );
+    const byCase = Object.fromEntries(out.results.map((r) => [r.testCaseId, r]));
+    expect(byCase.a.caseChange).toBe("improved");
+    expect(byCase.a.mainScore.delta).toBeCloseTo(0.4);
+    expect(byCase.b.caseChange).toBe("regressed");
+    expect(byCase.c.caseChange).toBe("unchanged");
+    expect(out.comparison.caseCounts).toMatchObject({ improved: 1, regressed: 1, unchanged: 1 });
+    expect(out.comparison.scoreCellCounts).toMatchObject({
+      improved: 1,
+      regressed: 1,
+      unchanged: 1,
+    });
+  });
+});
+
+describe("numeric lower-is-better", () => {
+  it("flips the direction (a smaller candidate is an improvement)", () => {
+    const scorers: ComparisonScorerMeta[] = [
+      { name: "latency", version: "v1", valueType: "numeric", direction: "lower_is_better" },
+    ];
+    const out = compareRuns(
+      build({
+        candidate: run({ mainScoreName: "latency", scorers }),
+        baseline: run({ id: "run_base", runNumber: 1, mainScoreName: "latency", scorers }),
+        candidateResults: [result("a", { mainScore: 100, scores: [num("latency", 100, "v1")] })],
+        baselineResults: [result("a", { mainScore: 200, scores: [num("latency", 200, "v1")] })],
+      }),
+    );
+    expect(out.results[0].caseChange).toBe("improved");
+    expect(out.results[0].scorerCells[0].delta).toBe(-100);
+  });
+});
+
+// ── boolean ───────────────────────────────────────────────────────────────
+
+describe("boolean main scorer", () => {
+  it("false→true is improved, true→false is regressed (higher-is-better)", () => {
+    const scorers: ComparisonScorerMeta[] = [{ name: "pass", version: "v1", valueType: "boolean" }];
+    const out = compareRuns(
+      build({
+        candidate: run({ mainScoreName: "pass", scorers }),
+        baseline: run({ id: "run_base", runNumber: 1, mainScoreName: "pass", scorers }),
+        candidateResults: [
+          result("up", { scores: [score("pass", { boolValue: true, scorerVersion: "v1" })] }),
+          result("down", { scores: [score("pass", { boolValue: false, scorerVersion: "v1" })] }),
+          result("same", { scores: [score("pass", { boolValue: true, scorerVersion: "v1" })] }),
+        ],
+        baselineResults: [
+          result("up", { scores: [score("pass", { boolValue: false, scorerVersion: "v1" })] }),
+          result("down", { scores: [score("pass", { boolValue: true, scorerVersion: "v1" })] }),
+          result("same", { scores: [score("pass", { boolValue: true, scorerVersion: "v1" })] }),
+        ],
+      }),
+    );
+    const byCase = Object.fromEntries(out.results.map((r) => [r.testCaseId, r]));
+    expect(byCase.up.caseChange).toBe("improved");
+    expect(byCase.down.caseChange).toBe("regressed");
+    expect(byCase.same.caseChange).toBe("unchanged");
+    // Boolean values preserved for display.
+    expect(byCase.up.scorerCells[0].candidateValue).toBe(true);
+    expect(byCase.up.scorerCells[0].baselineValue).toBe(false);
+  });
+});
+
+// ── categorical ─────────────────────────────────────────────────────────
+
+describe("categorical (direction none)", () => {
+  it("returns a baseline→candidate transition; changed is not a regression", () => {
+    const scorers: ComparisonScorerMeta[] = [
+      { name: "label", version: "v1", valueType: "categorical" },
+    ];
+    const out = compareRuns(
+      build({
+        candidate: run({ mainScoreName: "label", scorers }),
+        baseline: run({ id: "run_base", runNumber: 1, mainScoreName: "label", scorers }),
+        candidateResults: [
+          result("x", {
+            scores: [score("label", { stringValue: "billing", scorerVersion: "v1" })],
+          }),
+          result("y", {
+            scores: [score("label", { stringValue: "general", scorerVersion: "v1" })],
+          }),
+        ],
+        baselineResults: [
+          result("x", {
+            scores: [score("label", { stringValue: "billing", scorerVersion: "v1" })],
+          }),
+          result("y", {
+            scores: [score("label", { stringValue: "billing", scorerVersion: "v1" })],
+          }),
+        ],
+      }),
+    );
+    const byCase = Object.fromEntries(out.results.map((r) => [r.testCaseId, r]));
+    expect(byCase.x.caseChange).toBe("unchanged");
+    expect(byCase.y.caseChange).toBe("changed");
+    expect(byCase.y.scorerCells[0].transition).toEqual({ from: "billing", to: "general" });
+    expect(byCase.y.scorerCells[0].delta).toBeNull();
+    // Never improved/regressed for a categorical scorer.
+    expect(out.comparison.caseCounts.regressed).toBe(0);
+    expect(out.comparison.caseCounts.improved).toBe(0);
+    expect(out.comparison.caseCounts.changed).toBe(1);
+    const agg = out.comparison.scorers.find((s) => s.name === "label")!;
+    expect(agg.transitions).toEqual({ changed: 1, unchanged: 1 });
+    expect(agg.candidateMean).toBeNull();
+  });
+});
+
+// ── missing case on one side ──────────────────────────────────────────────
+
+describe("missing case on one side", () => {
+  it("is unpaired, never unchanged", () => {
+    const out = compareRuns(
+      build({
+        candidateResults: [
+          result("a", { mainScore: 1, scores: [num("acc", 1)] }),
+          result("only_cand", { mainScore: 1, scores: [num("acc", 1)] }),
+        ],
+        baselineResults: [
+          result("a", { mainScore: 1, scores: [num("acc", 1)] }),
+          result("only_base", { mainScore: 1, scores: [num("acc", 1)] }),
+        ],
+      }),
+    );
+    const byCase = Object.fromEntries(out.results.map((r) => [r.testCaseId, r]));
+    expect(byCase.only_cand.pairing).toBe("candidate_only");
+    expect(byCase.only_cand.caseChange).toBe("unpaired");
+    expect(byCase.only_base.pairing).toBe("baseline_only");
+    expect(byCase.only_base.caseChange).toBe("unpaired");
+    expect(byCase.only_base.candidateOutput).toBeNull();
+    expect(out.comparison.caseCounts.unpaired).toBe(2);
+    expect(out.comparison.caseCounts.unchanged).toBe(1); // only "a"
+  });
+});
+
+// ── missing scorer on one side (paired case) ──────────────────────────────
+
+describe("missing scorer on one side", () => {
+  it("marks that cell unpaired without affecting the main-scorer case verdict", () => {
+    const out = compareRuns(
+      build({
+        candidate: run({
+          scorers: [
+            { name: "acc", version: "v1" },
+            { name: "extra", version: "v1" },
+          ],
+        }),
+        candidateResults: [
+          result("a", {
+            mainScore: 1,
+            scores: [num("acc", 1, "v1"), num("extra", 0.5, "v1")],
+          }),
+        ],
+        baselineResults: [result("a", { mainScore: 1, scores: [num("acc", 1, "v1")] })],
+      }),
+    );
+    const cells = Object.fromEntries(out.results[0].scorerCells.map((c) => [c.scorerName, c]));
+    expect(cells.acc.classification).toBe("unchanged");
+    expect(cells.extra.classification).toBe("unpaired");
+    expect(cells.extra.reason).toBe("baseline_missing");
+    expect(out.results[0].caseChange).toBe("unchanged"); // main scorer only
+    expect(out.comparison.scoreCellCounts.unpaired).toBe(1);
+  });
+});
+
+// ── changed scorer version ────────────────────────────────────────────────
+
+describe("changed scorer version", () => {
+  it("never computes a trusted delta across versions", () => {
+    const out = compareRuns(
+      build({
+        candidateResults: [result("a", { mainScore: 0.9, scores: [num("acc", 0.9, "v2")] })],
+        baselineResults: [result("a", { mainScore: 0.5, scores: [num("acc", 0.5, "v1")] })],
+      }),
+    );
+    const cell = out.results[0].scorerCells[0];
+    expect(cell.classification).toBe("not_comparable");
+    expect(cell.reason).toBe("version_mismatch");
+    expect(cell.delta).toBeNull();
+    expect(out.results[0].caseChange).toBe("not_comparable");
+    // No paired main-scorer cell was comparable → flagged.
+    expect(out.comparison.trustworthy).toBe(false);
+    expect(out.comparison.reasons).toContain("main_scorer_incompatible");
+  });
+});
+
+// ── task error / scorer error ─────────────────────────────────────────────
+
+describe("errors are explicit, never zero", () => {
+  it("a scorer error makes the cell not_comparable (not a 0)", () => {
+    const out = compareRuns(
+      build({
+        candidateResults: [
+          result("a", {
+            status: "passed",
+            mainScore: null,
+            scores: [score("acc", { error: "judge failed" })],
+          }),
+        ],
+        baselineResults: [result("a", { mainScore: 1, scores: [num("acc", 1)] })],
+      }),
+    );
+    const cell = out.results[0].scorerCells[0];
+    expect(cell.classification).toBe("not_comparable");
+    expect(cell.reason).toBe("candidate_error");
+    expect(cell.candidateValue).toBeNull(); // not coerced to 0
+    expect(out.results[0].caseChange).toBe("not_comparable");
+  });
+
+  it("a task error (errored status, no scores) yields an unpaired/not_comparable main cell", () => {
+    const out = compareRuns(
+      build({
+        candidateResults: [result("a", { status: "errored", candidateOutput: null, scores: [] })],
+        baselineResults: [result("a", { mainScore: 1, scores: [num("acc", 1)] })],
+      }),
+    );
+    // The candidate has no acc score → the acc cell is unpaired (candidate side missing).
+    const cell = out.results[0].scorerCells.find((c) => c.scorerName === "acc")!;
+    expect(cell.classification).toBe("unpaired");
+    expect(out.results[0].caseChange).not.toBe("unchanged");
+  });
+});
+
+// ── run-level comparability ──────────────────────────────────────────────
+
+describe("run comparability", () => {
+  it("no baseline → unavailable with reason no_baseline", () => {
+    const out = compareRuns(
+      build({
+        candidate: run({ baselineRunId: null }),
+        baseline: null,
+        candidateResults: [result("a", { mainScore: 1, scores: [num("acc", 1)] })],
+      }),
+    );
+    expect(out.comparison.available).toBe(false);
+    expect(out.comparison.trustworthy).toBe(false);
+    expect(out.comparison.reasons).toEqual(["no_baseline"]);
+    expect(out.results[0].caseChange).toBe("unpaired");
+  });
+
+  it("baseline_run_id set but baseline not found → baseline_missing", () => {
+    const out = compareRuns(
+      build({ candidate: run({ baselineRunId: "run_base" }), baseline: null }),
+    );
+    expect(out.comparison.reasons).toEqual(["baseline_missing"]);
+  });
+
+  it("different dataset version → available but not trustworthy", () => {
+    const out = compareRuns(
+      build({
+        baseline: run({ id: "run_base", runNumber: 1, datasetVersionId: "dsv_OTHER" }),
+        candidateResults: [result("a", { mainScore: 0.9, scores: [num("acc", 0.9)] })],
+        baselineResults: [result("a", { mainScore: 0.5, scores: [num("acc", 0.5)] })],
+      }),
+    );
+    expect(out.comparison.available).toBe(true);
+    expect(out.comparison.trustworthy).toBe(false);
+    expect(out.comparison.reasons).toContain("different_dataset_version");
+    // It still shows what changed.
+    expect(out.results[0].caseChange).toBe("improved");
+  });
+
+  it("different evaluation → not trustworthy", () => {
+    const out = compareRuns(
+      build({ baseline: run({ id: "run_base", runNumber: 1, evaluationId: "eval_OTHER" }) }),
+    );
+    expect(out.comparison.reasons).toContain("different_evaluation");
+  });
+
+  it("incomplete/running baseline → baseline_not_terminal", () => {
+    const out = compareRuns(
+      build({
+        baseline: run({ id: "run_base", runNumber: 1, status: "running" }),
+        candidateResults: [result("a", { mainScore: 0.9, scores: [num("acc", 0.9)] })],
+        baselineResults: [result("a", { mainScore: 0.5, scores: [num("acc", 0.5)] })],
+      }),
+    );
+    expect(out.comparison.reasons).toContain("baseline_not_terminal");
+    expect(out.comparison.trustworthy).toBe(false);
+  });
+});
+
+// ── per-scorer aggregate denominators ─────────────────────────────────────
+
+describe("per-scorer aggregate uses paired, successfully-scored cells only", () => {
+  it("excludes errored/missing/unpaired cells symmetrically and reports the denominator", () => {
+    const out = compareRuns(
+      build({
+        candidate: run({ scorers: [{ name: "acc", version: "v1" }] }),
+        candidateResults: [
+          result("a", { mainScore: 1, scores: [num("acc", 1, "v1")] }),
+          result("b", { mainScore: 0, scores: [num("acc", 0, "v1")] }),
+          result("c", { scores: [score("acc", { error: "boom", scorerVersion: "v1" })] }),
+        ],
+        baselineResults: [
+          result("a", { mainScore: 1, scores: [num("acc", 1, "v1")] }),
+          result("b", { mainScore: 1, scores: [num("acc", 1, "v1")] }),
+          result("c", { mainScore: 1, scores: [num("acc", 1, "v1")] }),
+        ],
+      }),
+    );
+    const agg = out.comparison.scorers.find((s) => s.name === "acc")!;
+    expect(agg.pairedCount).toBe(2); // c excluded (candidate errored)
+    expect(agg.candidateMean).toBeCloseTo(0.5); // (1 + 0) / 2
+    expect(agg.baselineMean).toBeCloseTo(1); // (1 + 1) / 2
+    expect(agg.delta).toBeCloseTo(-0.5);
+  });
+});
+
+// ── duration ──────────────────────────────────────────────────────────────
+
+describe("duration comparison", () => {
+  it("returns per-case candidate/baseline duration + delta, and a paired case-duration mean", () => {
+    const out = compareRuns(
+      build({
+        candidateResults: [
+          result("a", { mainScore: 1, durationMs: 1200, scores: [num("acc", 1)] }),
+          result("b", { mainScore: 1, durationMs: 800, scores: [num("acc", 1)] }),
+          result("c", { mainScore: 1, durationMs: null, scores: [num("acc", 1)] }), // unknown
+        ],
+        baselineResults: [
+          result("a", { mainScore: 1, durationMs: 1000, scores: [num("acc", 1)] }),
+          result("b", { mainScore: 1, durationMs: 900, scores: [num("acc", 1)] }),
+          result("c", { mainScore: 1, durationMs: 700, scores: [num("acc", 1)] }),
+        ],
+      }),
+    );
+    const byCase = Object.fromEntries(out.results.map((r) => [r.testCaseId, r]));
+    expect(byCase.a.durationMs).toBe(1200);
+    expect(byCase.a.baselineDurationMs).toBe(1000);
+    expect(byCase.a.durationDeltaMs).toBe(200);
+    // Unknown candidate duration → delta null, never 0.
+    expect(byCase.c.durationMs).toBeNull();
+    expect(byCase.c.durationDeltaMs).toBeNull();
+    // Aggregate case-duration mean over the two paired-with-both-known cases (a, b).
+    expect(out.comparison.duration.pairedCount).toBe(2);
+    expect(out.comparison.duration.candidateMeanMs).toBe((1200 + 800) / 2);
+    expect(out.comparison.duration.baselineMeanMs).toBe((1000 + 900) / 2);
+    expect(out.comparison.duration.deltaMs).toBe((1200 + 800 - 1000 - 900) / 2);
+  });
+});
+
+// ── the seven-case lab ────────────────────────────────────────────────────
+
+describe("seven-case ticket-routing lab", () => {
+  const SCORERS: ComparisonScorerMeta[] = [
+    { name: "routing_accuracy", version: "unversioned" },
+    { name: "routing_report", version: "unversioned" },
+    { name: "is_known_category", version: "unversioned" },
+  ];
+  const CASES = [
+    "ticket-00",
+    "ticket-01",
+    "ticket-02",
+    "ticket-03",
+    "ticket-04",
+    "ticket-05",
+    "ticket-06",
+  ];
+
+  function cellScores(routing: number, report: number, known: number): ComparisonScore[] {
+    return [
+      num("routing_accuracy", routing),
+      num("routing_report", report),
+      num("is_known_category", known),
+    ];
+  }
+
+  it("derives 1 regressed case, 2 regressed cells, 0 improved, 19 unchanged, delta ≈ -0.143", () => {
+    // Baseline (opus): every case correct → all scorers 1.0.
+    const baselineResults = CASES.map((id) =>
+      result(id, {
+        mainScore: 1,
+        candidateOutput: '{"route":"technical"}',
+        scores: cellScores(1, 1, 1),
+      }),
+    );
+    // Candidate (sonnet): identical except ticket-05 misrouted to a still-valid category
+    // → routing_accuracy 0, routing_report 0, is_known_category stays 1.
+    const candidateResults = CASES.map((id) => {
+      const regress = id === "ticket-05";
+      return result(id, {
+        mainScore: regress ? 0 : 1,
+        candidateOutput: regress ? '{"route":"general"}' : '{"route":"technical"}',
+        scores: cellScores(regress ? 0 : 1, regress ? 0 : 1, 1),
+      });
+    });
+
+    const out = compareRuns({
+      candidate: run({
+        id: "run_sonnet",
+        runNumber: 2,
+        candidateVersion: "sonnet",
+        mainScore: 6 / 7,
+        mainScoreName: "routing_accuracy",
+        baselineRunId: "run_opus",
+        scorers: SCORERS,
+      }),
+      baseline: run({
+        id: "run_opus",
+        runNumber: 1,
+        candidateVersion: "opus",
+        mainScore: 1,
+        mainScoreName: "routing_accuracy",
+        baselineRunId: null,
+        scorers: SCORERS,
+      }),
+      candidateResults,
+      baselineResults,
+    });
+
+    expect(out.comparison.available).toBe(true);
+    expect(out.comparison.trustworthy).toBe(true);
+    expect(out.comparison.reasons).toEqual([]);
+
+    // 1 regressed test case (by the main scorer).
+    expect(out.comparison.caseCounts).toMatchObject({
+      improved: 0,
+      regressed: 1,
+      unchanged: 6,
+      unpaired: 0,
+      not_comparable: 0,
+    });
+
+    // 2 regressed score cells, 0 improved, 19 unchanged (21 total).
+    expect(out.comparison.scoreCellCounts).toMatchObject({
+      improved: 0,
+      regressed: 2,
+      unchanged: 19,
+      changed: 0,
+      unpaired: 0,
+      not_comparable: 0,
+    });
+    const cellTotal = Object.values(out.comparison.scoreCellCounts).reduce((a, b) => a + b, 0);
+    expect(cellTotal).toBe(21);
+
+    // ticket-05 shows both affected scorers regressed with baseline/candidate values.
+    const t5 = out.results.find((r) => r.testCaseId === "ticket-05")!;
+    expect(t5.caseChange).toBe("regressed");
+    const t5cells = Object.fromEntries(t5.scorerCells.map((c) => [c.scorerName, c]));
+    expect(t5cells.routing_accuracy).toMatchObject({
+      classification: "regressed",
+      candidateValue: 0,
+      baselineValue: 1,
+      delta: -1,
+    });
+    expect(t5cells.routing_report).toMatchObject({ classification: "regressed", delta: -1 });
+    expect(t5cells.is_known_category.classification).toBe("unchanged");
+    expect(t5.regressedCellCount).toBe(2);
+
+    // Run-level main-score delta agrees with the main-scorer case result.
+    expect(out.comparison.mainScore.delta).toBeCloseTo(6 / 7 - 1); // ≈ -0.142857
+    expect(out.comparison.mainScore.delta).toBeLessThan(0);
+
+    // Per-scorer aggregate denominators.
+    const acc = out.comparison.scorers.find((s) => s.name === "routing_accuracy")!;
+    expect(acc.pairedCount).toBe(7);
+    expect(acc.candidateMean).toBeCloseTo(6 / 7);
+    expect(acc.baselineMean).toBeCloseTo(1);
+  });
+});

--- a/frontend/ui/src/lib/eval/comparison.ts
+++ b/frontend/ui/src/lib/eval/comparison.ts
@@ -1,0 +1,585 @@
+/**
+ * Candidate-vs-baseline comparison engine — the single source of truth.
+ *
+ * Pure, deterministic, and free of Prisma/HTTP: it takes DB-shaped inputs (a
+ * candidate run + its results/scores, and the baseline run + its results/scores)
+ * and derives the comparison the run-detail and run-list read paths return. See
+ * `docs/offline-eval-comparison-contract.md` for the product semantics.
+ *
+ * The backend owns comparison: the SDK reports raw scores and a `baseline_run_id`
+ * only. Stored `EvaluationResult.change` / `baselineOutput` are NOT consulted here —
+ * everything is derived from the two runs' raw results and scores.
+ */
+
+// ── Vocabularies ────────────────────────────────────────────────────────
+
+export type ScorerValueType = "numeric" | "boolean" | "categorical";
+export type ScorerDirection = "higher_is_better" | "lower_is_better" | "none";
+
+/**
+ * A cell/case verdict. `changed` is the non-directional categorical transition
+ * (baseline → candidate differ) — distinct from improved/regressed, which require a
+ * direction. `unpaired` = present on one side only; `not_comparable` = paired but
+ * un-trustable (version mismatch, missing value, error).
+ */
+export type Classification =
+  | "improved"
+  | "regressed"
+  | "unchanged"
+  | "changed"
+  | "unpaired"
+  | "not_comparable";
+
+/** Why a cell could not be directionally compared. */
+export type CellReason =
+  | "candidate_missing"
+  | "baseline_missing"
+  | "candidate_error"
+  | "baseline_error"
+  | "not_scored"
+  | "version_mismatch";
+
+/** Why a run comparison is unavailable or untrustworthy. */
+export type RunComparabilityReason =
+  | "no_baseline"
+  | "baseline_missing"
+  | "different_evaluation"
+  | "different_dataset_version"
+  | "baseline_not_terminal"
+  | "main_scorer_incompatible";
+
+// ── Inputs (DB-shaped, decoupled from Prisma) ───────────────────────────
+
+export interface ComparisonScorerMeta {
+  name: string;
+  version: string;
+  /** Optional richer metadata (a future SDK may send it); absence → inferred/defaulted. */
+  valueType?: ScorerValueType | null;
+  direction?: ScorerDirection | null;
+  threshold?: number | null;
+}
+
+export interface ComparisonScore {
+  scorerName: string;
+  scorerVersion: string;
+  numericValue: number | null;
+  boolValue: boolean | null;
+  stringValue: string | null;
+  error: string | null;
+}
+
+export interface ComparisonResult {
+  testCaseId: string;
+  status: string; // passed | failed | errored | not_scored
+  mainScore: number | null;
+  candidateOutput: string | null;
+  durationMs: number | null;
+  scores: ComparisonScore[];
+}
+
+export interface ComparisonRun {
+  id: string;
+  runNumber: number;
+  evaluationId: string;
+  datasetVersionId: string;
+  candidateVersion: string;
+  status: string; // running | completed | completed_with_errors | failed | incomplete | cancelled
+  mainScore: number | null;
+  mainScoreName: string | null;
+  baselineRunId: string | null;
+  /** Declared scorers (`[{name, version}]` from the run, optionally enriched). */
+  scorers: ComparisonScorerMeta[];
+}
+
+export interface CompareRunsInput {
+  candidate: ComparisonRun;
+  candidateResults: ComparisonResult[];
+  /** null when no baseline is configured OR the referenced baseline run was not found. */
+  baseline: ComparisonRun | null;
+  baselineResults: ComparisonResult[];
+}
+
+// ── Outputs ─────────────────────────────────────────────────────────────
+
+/** Count block. `changed` is 0 for directional (numeric/boolean) scorers. */
+export interface CountBlock {
+  improved: number;
+  regressed: number;
+  unchanged: number;
+  changed: number;
+  unpaired: number;
+  not_comparable: number;
+}
+
+export interface ScorerAggregate {
+  name: string;
+  version: string;
+  valueType: ScorerValueType;
+  direction: ScorerDirection;
+  /** Means over paired, successfully-scored cells only (null for categorical). */
+  candidateMean: number | null;
+  baselineMean: number | null;
+  delta: number | null;
+  /** How many paired cells were included in the means (the denominator). */
+  pairedCount: number;
+  /** Categorical only: transition tallies over paired, successfully-scored cells. */
+  transitions?: { changed: number; unchanged: number };
+}
+
+export interface ScorerCellComparison {
+  scorerName: string;
+  scorerVersion: string;
+  valueType: ScorerValueType | null;
+  direction: ScorerDirection | null;
+  candidateValue: number | boolean | string | null;
+  baselineValue: number | boolean | string | null;
+  /** Numeric only; null otherwise. */
+  delta: number | null;
+  /** Categorical only. */
+  transition?: { from: string | null; to: string | null };
+  classification: Classification;
+  reason?: CellReason;
+}
+
+export interface ResultComparison {
+  testCaseId: string;
+  status: string;
+  candidateOutput: string | null;
+  /** Derived from the baseline result (never the stored candidate column). */
+  baselineOutput: string | null;
+  mainScore: { candidate: number | null; baseline: number | null; delta: number | null };
+  caseChange: Classification;
+  pairing: "paired" | "candidate_only" | "baseline_only";
+  /** SDK-measured candidate case duration (task + scorers); null → Unknown, never 0. */
+  durationMs: number | null;
+  /** The baseline case's duration, from the baseline result; null → Unknown. */
+  baselineDurationMs: number | null;
+  /** candidate − baseline case duration; null unless both are known. */
+  durationDeltaMs: number | null;
+  scorerCells: ScorerCellComparison[];
+  /** Convenience for the "regressed on N of M scorer cells" secondary label. */
+  regressedCellCount: number;
+  comparableCellCount: number;
+}
+
+export interface RunComparison {
+  available: boolean;
+  trustworthy: boolean;
+  reasons: RunComparabilityReason[];
+  baseline: { runId: string; runNumber: number; candidateVersion: string } | null;
+  mainScore: { candidate: number | null; baseline: number | null; delta: number | null };
+  caseCounts: CountBlock;
+  scoreCellCounts: CountBlock;
+  scorers: ScorerAggregate[];
+  /**
+   * Aggregate CASE-duration statistics over paired cases where both sides reported a
+   * duration. This is a mean of per-case wall-clock (task + scorers), explicitly NOT
+   * the run's wall-clock elapsed time — concurrent cases are not summed here.
+   */
+  duration: {
+    candidateMeanMs: number | null;
+    baselineMeanMs: number | null;
+    deltaMs: number | null;
+    pairedCount: number;
+  };
+}
+
+export interface CompareRunsOutput {
+  comparison: RunComparison;
+  results: ResultComparison[];
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+const TERMINAL_STATUSES = new Set([
+  "completed",
+  "completed_with_errors",
+  "failed",
+  "incomplete",
+  "cancelled",
+]);
+
+function emptyCounts(): CountBlock {
+  return { improved: 0, regressed: 0, unchanged: 0, changed: 0, unpaired: 0, not_comparable: 0 };
+}
+
+type TypedValue =
+  | { kind: "value"; valueType: ScorerValueType; value: number | boolean | string }
+  | { kind: "error" }
+  | { kind: "missing" };
+
+/** Resolve one score row into a typed value / error / missing. */
+function readScore(score: ComparisonScore | undefined | null): TypedValue {
+  if (!score) return { kind: "missing" };
+  if (score.error !== null && score.error !== undefined) return { kind: "error" };
+  if (score.boolValue !== null && score.boolValue !== undefined) {
+    return { kind: "value", valueType: "boolean", value: score.boolValue };
+  }
+  if (score.numericValue !== null && score.numericValue !== undefined) {
+    return { kind: "value", valueType: "numeric", value: score.numericValue };
+  }
+  if (score.stringValue !== null && score.stringValue !== undefined) {
+    return { kind: "value", valueType: "categorical", value: score.stringValue };
+  }
+  return { kind: "missing" }; // present row, no value and no error → nothing to compare
+}
+
+/** Default direction when the SDK didn't declare one. */
+function defaultDirection(valueType: ScorerValueType): ScorerDirection {
+  return valueType === "categorical" ? "none" : "higher_is_better";
+}
+
+function resolveMeta(
+  scorerName: string,
+  metaByName: Map<string, ComparisonScorerMeta>,
+  valueType: ScorerValueType,
+): { valueType: ScorerValueType; direction: ScorerDirection } {
+  const meta = metaByName.get(scorerName);
+  const vt = meta?.valueType ?? valueType;
+  const direction = meta?.direction ?? defaultDirection(vt);
+  return { valueType: vt, direction };
+}
+
+/** Directional numeric/boolean verdict. */
+function directionalVerdict(
+  candidate: number,
+  baseline: number,
+  direction: ScorerDirection,
+): Classification {
+  if (candidate === baseline) return "unchanged";
+  if (direction === "none") return "changed";
+  const higher = candidate > baseline;
+  const better = direction === "higher_is_better" ? higher : !higher;
+  return better ? "improved" : "regressed";
+}
+
+// ── The engine ──────────────────────────────────────────────────────────
+
+export function compareRuns(input: CompareRunsInput): CompareRunsOutput {
+  const { candidate, candidateResults, baseline, baselineResults } = input;
+
+  // Availability + trust.
+  const reasons: RunComparabilityReason[] = [];
+  const available = baseline !== null;
+  if (!available) {
+    reasons.push(candidate.baselineRunId ? "baseline_missing" : "no_baseline");
+  } else {
+    if (baseline.evaluationId !== candidate.evaluationId) reasons.push("different_evaluation");
+    if (baseline.datasetVersionId !== candidate.datasetVersionId) {
+      reasons.push("different_dataset_version");
+    }
+    if (!TERMINAL_STATUSES.has(baseline.status)) reasons.push("baseline_not_terminal");
+  }
+
+  // Main scorer + scorer metadata (candidate's declaration wins; baseline fills gaps).
+  const mainScoreName =
+    candidate.mainScoreName ?? baseline?.mainScoreName ?? candidate.scorers[0]?.name ?? null;
+  const metaByName = new Map<string, ComparisonScorerMeta>();
+  for (const s of [...(baseline?.scorers ?? []), ...candidate.scorers]) {
+    metaByName.set(s.name, s); // candidate last → candidate wins
+  }
+
+  // Index baseline results + scores by test-case and scorer name.
+  const baselineByCase = new Map<string, ComparisonResult>();
+  for (const r of baselineResults) baselineByCase.set(r.testCaseId, r);
+  const candidateByCase = new Map<string, ComparisonResult>();
+  for (const r of candidateResults) candidateByCase.set(r.testCaseId, r);
+
+  const caseCounts = emptyCounts();
+  const scoreCellCounts = emptyCounts();
+  const results: ResultComparison[] = [];
+
+  // Per-scorer aggregate accumulators over paired, successfully-scored cells.
+  interface Agg {
+    valueType: ScorerValueType;
+    direction: ScorerDirection;
+    candSum: number;
+    baseSum: number;
+    n: number;
+    changed: number;
+    unchanged: number;
+  }
+  const aggByScorer = new Map<string, Agg>();
+  let mainScorerComparablePairs = 0;
+  let durCandSum = 0;
+  let durBaseSum = 0;
+  let durPairs = 0;
+
+  const scoreByName = (r: ComparisonResult | undefined) => {
+    const m = new Map<string, ComparisonScore>();
+    if (r) for (const s of r.scores) m.set(s.scorerName, s);
+    return m;
+  };
+
+  // Iterate the union of test-case ids so an unpaired case on either side is counted.
+  const allCaseIds = new Set<string>([
+    ...candidateResults.map((r) => r.testCaseId),
+    ...(available ? baselineResults.map((r) => r.testCaseId) : []),
+  ]);
+
+  for (const testCaseId of allCaseIds) {
+    const cand = candidateByCase.get(testCaseId);
+    const base = available ? baselineByCase.get(testCaseId) : undefined;
+    const pairing: ResultComparison["pairing"] = cand
+      ? base
+        ? "paired"
+        : "candidate_only"
+      : "baseline_only";
+
+    const candScores = scoreByName(cand);
+    const baseScores = scoreByName(base);
+    const scorerNames = new Set<string>([...candScores.keys(), ...baseScores.keys()]);
+
+    const scorerCells: ScorerCellComparison[] = [];
+    for (const scorerName of scorerNames) {
+      const cs = candScores.get(scorerName);
+      const bs = baseScores.get(scorerName);
+      const candV = readScore(cs);
+      const baseV = readScore(bs);
+      const vtGuess: ScorerValueType =
+        (candV.kind === "value" && candV.valueType) ||
+        (baseV.kind === "value" && baseV.valueType) ||
+        "numeric";
+      const { valueType, direction } = resolveMeta(scorerName, metaByName, vtGuess);
+
+      const cell: ScorerCellComparison = {
+        scorerName,
+        scorerVersion: cs?.scorerVersion ?? bs?.scorerVersion ?? "",
+        valueType: candV.kind === "value" || baseV.kind === "value" ? valueType : null,
+        direction: candV.kind === "value" || baseV.kind === "value" ? direction : null,
+        candidateValue: candV.kind === "value" ? candV.value : null,
+        baselineValue: baseV.kind === "value" ? baseV.value : null,
+        delta: null,
+        classification: "not_comparable",
+      };
+
+      if (pairing !== "paired" || candV.kind === "missing" || baseV.kind === "missing") {
+        // A scorer present on one side only (or a case present on one side only) is unpaired.
+        cell.classification = "unpaired";
+        cell.reason = !cand || candV.kind === "missing" ? "candidate_missing" : "baseline_missing";
+      } else if (candV.kind === "error" || baseV.kind === "error") {
+        cell.classification = "not_comparable";
+        cell.reason = candV.kind === "error" ? "candidate_error" : "baseline_error";
+      } else if (cs && bs && cs.scorerVersion !== bs.scorerVersion) {
+        // Never compare across scorer versions — the measuring instrument changed.
+        cell.classification = "not_comparable";
+        cell.reason = "version_mismatch";
+      } else {
+        // Both sides have a value, versions match → typed comparison.
+        if (valueType === "categorical" || direction === "none") {
+          const c = String(candV.value);
+          const b = String(baseV.value);
+          cell.transition = { from: b, to: c };
+          cell.classification = c === b ? "unchanged" : "changed";
+        } else if (valueType === "boolean") {
+          const c = candV.value ? 1 : 0;
+          const b = baseV.value ? 1 : 0;
+          cell.delta = c - b;
+          cell.classification = directionalVerdict(c, b, direction);
+        } else {
+          const c = candV.value as number;
+          const b = baseV.value as number;
+          cell.delta = c - b;
+          cell.classification = directionalVerdict(c, b, direction);
+        }
+
+        // Accumulate the per-scorer aggregate (paired, successfully-scored only).
+        const agg =
+          aggByScorer.get(scorerName) ??
+          ({
+            valueType,
+            direction,
+            candSum: 0,
+            baseSum: 0,
+            n: 0,
+            changed: 0,
+            unchanged: 0,
+          } as Agg);
+        if (valueType === "categorical" || direction === "none") {
+          if (cell.classification === "changed") agg.changed += 1;
+          else agg.unchanged += 1;
+        } else {
+          agg.candSum += valueType === "boolean" ? (candV.value ? 1 : 0) : (candV.value as number);
+          agg.baseSum += valueType === "boolean" ? (baseV.value ? 1 : 0) : (baseV.value as number);
+        }
+        agg.n += 1;
+        aggByScorer.set(scorerName, agg);
+
+        if (scorerName === mainScoreName) mainScorerComparablePairs += 1;
+      }
+
+      scorerCells.push(cell);
+      scoreCellCounts[cell.classification] += 1;
+    }
+
+    // Case rollup: the main scorer's cell decides (never a secondary scorer).
+    const mainCell = mainScoreName
+      ? scorerCells.find((c) => c.scorerName === mainScoreName)
+      : undefined;
+    let caseChange: Classification;
+    if (pairing !== "paired") {
+      caseChange = "unpaired";
+    } else if (mainCell) {
+      caseChange = mainCell.classification;
+    } else {
+      // Paired case but the main scorer produced no comparable cell either side.
+      caseChange = "not_comparable";
+    }
+    caseCounts[caseChange] += 1;
+
+    // Case-duration comparison (paired, both known) — never sum, never zero-fill.
+    const baselineDurationMs = base?.durationMs ?? null;
+    const durationDeltaMs =
+      cand?.durationMs != null && base?.durationMs != null
+        ? cand.durationMs - base.durationMs
+        : null;
+    if (pairing === "paired" && cand?.durationMs != null && base?.durationMs != null) {
+      durCandSum += cand.durationMs;
+      durBaseSum += base.durationMs;
+      durPairs += 1;
+    }
+
+    const regressedCellCount = scorerCells.filter((c) => c.classification === "regressed").length;
+    const comparableCellCount = scorerCells.filter(
+      (c) =>
+        c.classification === "improved" ||
+        c.classification === "regressed" ||
+        c.classification === "unchanged" ||
+        c.classification === "changed",
+    ).length;
+
+    results.push({
+      testCaseId,
+      status: cand?.status ?? base?.status ?? "not_scored",
+      candidateOutput: cand?.candidateOutput ?? null,
+      baselineOutput: base?.candidateOutput ?? null, // the baseline run's output for this case
+      mainScore: {
+        candidate: cand?.mainScore ?? null,
+        baseline: base?.mainScore ?? null,
+        delta:
+          cand?.mainScore !== null &&
+          cand?.mainScore !== undefined &&
+          base?.mainScore !== null &&
+          base?.mainScore !== undefined
+            ? cand.mainScore - base.mainScore
+            : null,
+      },
+      caseChange,
+      pairing,
+      durationMs: cand?.durationMs ?? null,
+      baselineDurationMs,
+      durationDeltaMs,
+      scorerCells,
+      regressedCellCount,
+      comparableCellCount,
+    });
+  }
+
+  // main_scorer_incompatible: available + no paired case had a comparable main-scorer cell.
+  if (available && mainScorerComparablePairs === 0) reasons.push("main_scorer_incompatible");
+
+  const trustworthy = available && reasons.length === 0;
+
+  // Per-scorer aggregate projection (declared scorers first, then any others seen).
+  const scorerOrder: string[] = [];
+  const seen = new Set<string>();
+  for (const s of candidate.scorers) {
+    if (!seen.has(s.name)) {
+      scorerOrder.push(s.name);
+      seen.add(s.name);
+    }
+  }
+  for (const name of aggByScorer.keys()) {
+    if (!seen.has(name)) {
+      scorerOrder.push(name);
+      seen.add(name);
+    }
+  }
+
+  const scorers: ScorerAggregate[] = scorerOrder.map((name) => {
+    const agg = aggByScorer.get(name);
+    const meta = metaByName.get(name);
+    const valueType = agg?.valueType ?? meta?.valueType ?? "numeric";
+    const direction = agg?.direction ?? meta?.direction ?? defaultDirection(valueType);
+    const version = meta?.version ?? "";
+    if (!agg || agg.n === 0) {
+      return {
+        name,
+        version,
+        valueType,
+        direction,
+        candidateMean: null,
+        baselineMean: null,
+        delta: null,
+        pairedCount: 0,
+        ...(valueType === "categorical" || direction === "none"
+          ? { transitions: { changed: 0, unchanged: 0 } }
+          : {}),
+      };
+    }
+    if (valueType === "categorical" || direction === "none") {
+      return {
+        name,
+        version,
+        valueType,
+        direction,
+        candidateMean: null,
+        baselineMean: null,
+        delta: null,
+        pairedCount: agg.n,
+        transitions: { changed: agg.changed, unchanged: agg.unchanged },
+      };
+    }
+    const candidateMean = agg.candSum / agg.n;
+    const baselineMean = agg.baseSum / agg.n;
+    return {
+      name,
+      version,
+      valueType,
+      direction,
+      candidateMean,
+      baselineMean,
+      delta: candidateMean - baselineMean,
+      pairedCount: agg.n,
+    };
+  });
+
+  const comparison: RunComparison = {
+    available,
+    trustworthy,
+    reasons,
+    baseline: baseline
+      ? {
+          runId: baseline.id,
+          runNumber: baseline.runNumber,
+          candidateVersion: baseline.candidateVersion,
+        }
+      : null,
+    mainScore: {
+      candidate: candidate.mainScore,
+      baseline: baseline?.mainScore ?? null,
+      delta:
+        candidate.mainScore !== null && baseline?.mainScore != null
+          ? candidate.mainScore - baseline.mainScore
+          : null,
+    },
+    caseCounts,
+    scoreCellCounts,
+    scorers,
+    duration: {
+      candidateMeanMs: durPairs > 0 ? durCandSum / durPairs : null,
+      baselineMeanMs: durPairs > 0 ? durBaseSum / durPairs : null,
+      deltaMs: durPairs > 0 ? (durCandSum - durBaseSum) / durPairs : null,
+      pairedCount: durPairs,
+    },
+  };
+
+  // Stable result ordering: candidate order first, then baseline-only cases.
+  const order = new Map<string, number>();
+  candidateResults.forEach((r, i) => order.set(r.testCaseId, i));
+  let tail = candidateResults.length;
+  for (const r of baselineResults) if (!order.has(r.testCaseId)) order.set(r.testCaseId, tail++);
+  results.sort((a, b) => (order.get(a.testCaseId) ?? 0) - (order.get(b.testCaseId) ?? 0));
+
+  return { comparison, results };
+}

--- a/frontend/ui/src/lib/eval/human-review.test.ts
+++ b/frontend/ui/src/lib/eval/human-review.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { deriveHumanReviewSummary } from "./human-review";
+
+describe("deriveHumanReviewSummary", () => {
+  it("an unreviewed run has no active dimension and nothing pending", () => {
+    const s = deriveHumanReviewSummary([
+      { automatedPass: true, reviews: [] },
+      { automatedPass: false, reviews: [] },
+    ]);
+    expect(s).toEqual({
+      dimensions: [],
+      reviewedCount: 0,
+      pendingCount: 0,
+      passCount: 0,
+      failCount: 0,
+      disagreementCount: 0,
+    });
+  });
+
+  it("counts reviewed vs pending only for the active dimension", () => {
+    // 3 results, "overall" reviewed on 1 → it's active, so the other 2 are pending.
+    const s = deriveHumanReviewSummary([
+      { automatedPass: true, reviews: [{ dimension: "overall", verdict: "pass" }] },
+      { automatedPass: true, reviews: [] },
+      { automatedPass: false, reviews: [] },
+    ]);
+    expect(s.dimensions).toEqual(["overall"]);
+    expect(s.reviewedCount).toBe(1);
+    expect(s.pendingCount).toBe(2);
+    expect(s.passCount).toBe(1);
+  });
+
+  it("disagreement requires a boolean on BOTH sides; unsure and quality never coerce", () => {
+    const s = deriveHumanReviewSummary([
+      // human fail vs automated pass → disagreement
+      { automatedPass: true, reviews: [{ dimension: "overall", verdict: "fail" }] },
+      // human pass vs automated pass → agree
+      { automatedPass: true, reviews: [{ dimension: "overall", verdict: "pass" }] },
+      // human unsure → never a disagreement, even against a boolean automated verdict
+      { automatedPass: false, reviews: [{ dimension: "overall", verdict: "unsure" }] },
+      // automated has no boolean (errored/not-scored) → never a disagreement
+      { automatedPass: null, reviews: [{ dimension: "overall", verdict: "fail" }] },
+    ]);
+    expect(s.disagreementCount).toBe(1);
+    expect(s.passCount).toBe(1);
+    expect(s.failCount).toBe(2);
+  });
+
+  it("sums pending across multiple active dimensions independently", () => {
+    // 2 results. "overall" reviewed on both (0 pending); "safety" reviewed on 1 (1 pending).
+    const s = deriveHumanReviewSummary([
+      {
+        automatedPass: true,
+        reviews: [
+          { dimension: "overall", verdict: "pass" },
+          { dimension: "safety", verdict: "pass" },
+        ],
+      },
+      { automatedPass: true, reviews: [{ dimension: "overall", verdict: "pass" }] },
+    ]);
+    expect(s.dimensions).toEqual(["overall", "safety"]);
+    expect(s.reviewedCount).toBe(2); // both results have at least one review
+    expect(s.pendingCount).toBe(1); // overall:0 + safety:1
+  });
+});

--- a/frontend/ui/src/lib/eval/human-review.ts
+++ b/frontend/ui/src/lib/eval/human-review.ts
@@ -1,0 +1,88 @@
+/**
+ * Derived human-review summaries for a run.
+ *
+ * Human review is a separate, co-equal signal — this module only *reads* review
+ * rows and the automated pass/fail judgment; it never mutates either. The summary
+ * is intentionally conservative:
+ *
+ *  - "Configured/active dimensions" are the dimensions that actually have a review
+ *    in the run. A dimension with no reviews contributes nothing (so a run nobody
+ *    has reviewed reports no pending work — only explicitly-reviewed dimensions do).
+ *  - `pending` counts (result × active-dimension) pairs with no canonical review.
+ *  - `disagreement` is defined ONLY when a human pass/fail verdict AND a comparable
+ *    automated pass/fail both exist and differ. A quality score (1–5) or an "unsure"
+ *    verdict is never coerced into a boolean, so it never produces a disagreement.
+ */
+export type HumanVerdict = "pass" | "fail" | "unsure";
+
+export interface ResultReviewInput {
+  /**
+   * The automated pass/fail judgment for the result: `true` when the automated
+   * status is "passed", `false` when "failed", and `null` when there is no
+   * comparable boolean (errored / not-scored). Only a non-null value can disagree.
+   */
+  automatedPass: boolean | null;
+  /** The result's canonical reviews (at most one per dimension). */
+  reviews: Array<{ dimension: string; verdict: HumanVerdict }>;
+}
+
+export interface HumanReviewSummary {
+  /** Dimensions with at least one review in the run — the active/configured set. */
+  dimensions: string[];
+  /** Results carrying a canonical review in at least one active dimension. */
+  reviewedCount: number;
+  /**
+   * (result × active-dimension) pairs still lacking a review. Zero when no
+   * dimension is active — an unreviewed run has nothing "pending".
+   */
+  pendingCount: number;
+  /** Canonical reviews with a pass verdict. */
+  passCount: number;
+  /** Canonical reviews with a fail verdict. */
+  failCount: number;
+  /**
+   * Reviews whose human pass/fail verdict disagrees with the result's automated
+   * pass/fail. "unsure" and quality-only reviews never count.
+   */
+  disagreementCount: number;
+}
+
+export function deriveHumanReviewSummary(results: ResultReviewInput[]): HumanReviewSummary {
+  const activeDimensions = new Set<string>();
+  const reviewedByDimension = new Map<string, number>();
+  let reviewedCount = 0;
+  let passCount = 0;
+  let failCount = 0;
+  let disagreementCount = 0;
+
+  for (const result of results) {
+    const dimsOnThisResult = new Set<string>();
+    for (const review of result.reviews) {
+      activeDimensions.add(review.dimension);
+      dimsOnThisResult.add(review.dimension);
+      if (review.verdict === "pass") passCount++;
+      else if (review.verdict === "fail") failCount++;
+      // Disagreement needs BOTH a boolean human verdict and a boolean automated one.
+      if (
+        result.automatedPass !== null &&
+        (review.verdict === "pass" || review.verdict === "fail")
+      ) {
+        const humanPass = review.verdict === "pass";
+        if (humanPass !== result.automatedPass) disagreementCount++;
+      }
+    }
+    if (dimsOnThisResult.size > 0) reviewedCount++;
+    for (const dim of dimsOnThisResult) {
+      reviewedByDimension.set(dim, (reviewedByDimension.get(dim) ?? 0) + 1);
+    }
+  }
+
+  const total = results.length;
+  const dimensions = [...activeDimensions].sort();
+  const pendingCount = dimensions.reduce(
+    (sum, dim) => sum + (total - (reviewedByDimension.get(dim) ?? 0)),
+    0,
+  );
+
+  return { dimensions, reviewedCount, pendingCount, passCount, failCount, disagreementCount };
+}


### PR DESCRIPTION
## Summary

Fixes: #1652

The run-detail endpoint returns the run, its results, and — when a baseline is selected — the full candidate-vs-baseline comparison from the shared engine. A companion compare endpoint compares any candidate run against a chosen baseline run, pairing cases by test-case id and surfacing per-case and aggregate deltas. Both compute the comparison live on each read from the two runs' raw results and scores; the baseline relationship is never persisted as a lineage on the run.

## What's included

### Backend (route handlers)
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts` — the run with its results, scores, and human scores, plus the derived comparison when the run has a baseline. Loads both runs' raw results/scores in one bounded query (no per-row N+1), maps them through `toComparisonRun` / `toComparisonResults`, and derives the comparison via `compareRuns` — never the stored change columns. Also exposes each baseline case's trace id so the UI can diff tokens/cost/latency.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.ts` — `?candidate=<runId>&baseline=<runId>`. Reuses the same `compareRuns` derivation, pairs cases by test-case id (unpaired cases reported, not dropped), and returns per-case output/status/cost/task-error, both sides' trace ids, per-scorer comparisons, and aggregate + per-case cost deltas. A cross-evaluation or cross-version comparison is allowed and returned (flagged not-trustworthy), never persisted.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.ts` — provides `POST`.

### Derivation module (`frontend/ui/src/lib/eval`)
- `frontend/ui/src/lib/eval/comparison.ts` — Candidate-vs-baseline comparison engine — the single source of truth.

### Tests
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts` — run identity, exact dataset version, baseline relationship + comparable delta, result trace id / task error / independent scorer errors / human scores, and an incompatible-baseline case flagged not comparable.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.test.ts` — covers `route`.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.test.ts` — covers `route`.
- `frontend/ui/src/features/evaluations/compare-derive.test.ts` — covers `compare-derive`.
- `frontend/ui/src/features/evaluations/compare-runs.smoke.test.tsx` — covers `compare-runs.smoke`.
- `frontend/ui/src/features/offline-eval/components/component-kit.test.tsx` — covers `component-kit`.
- `frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts` — covers `route`.
- `frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/versions/[versionId]/route.test.ts` — covers `route`.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.test.ts` — covers `route`.
- `frontend/ui/src/lib/eval/comparison.test.ts` — covers `comparison`.

### Frontend
- `frontend/ui/src/features/evaluations/compare-derive.ts` — Pure presentation-derivation for the comparison page.

### UI
- `frontend/ui/src/features/evaluations/views/compare-case-drawer.tsx` — provides `CompareCaseDrawer`.
- `frontend/ui/src/features/evaluations/views/compare-runs-view.tsx` — provides `CompareRunsView`.

## Test plan
- [ ] Run detail returns results and, with a baseline selected, a full comparison payload.
- [ ] The compare endpoint pairs cases and reports per-case and aggregate deltas.
- [ ] A cross-evaluation comparison is allowed but never persisted.
- [ ] A baseline on a different dataset version still returns a comparison, flagged not-trustworthy rather than omitted.
- [ ] Duration deltas report per-case, run-elapsed, and paired-mean figures over cases present in both runs.
- [ ] Confirm both endpoints are project-scoped and reuse the comparison engine (no bespoke math).
