### PR TITLE
feat(evaluations): pure candidate-vs-baseline comparison engine

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
@@ -191,10 +191,10 @@ describe("run/result read-back", () => {
     expect(run.baselineRunId).toBe("run0");
     expect(run.baselineComparable).toBe(true);
     // NOT the raw run.mainScore subtraction (0.9 - 0.75 = 0.15): case-2's candidate
-    // task errored (no routing-accuracy score), so it is excluded from the paired
+    // task errored (no routing-accuracy score), so it's excluded from the paired
     // aggregate. The only actually-comparable case is case-1 (candidate 1 vs
-    // baseline 0.5), so the trustworthy headline delta is 0.5 — derived the same way
-    // as every per-scorer aggregate, never a subtraction of the two runs' raw
+    // baseline 0.5), so the trustworthy headline delta is 0.5, derived the same way
+    // as every per-scorer aggregate — never a subtraction of the two runs' raw
     // SDK-reported aggregates, which can silently cover different case sets.
     expect(run.changeFromBaseline).toBeCloseTo(0.5);
   });

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
@@ -282,9 +282,11 @@ describe("run/result read-back", () => {
     const run = (await read()).body.run as Record<string, unknown>;
     expect(run.baselineComparable).toBe(false);
     expect(run.changeFromBaseline).toBeNull();
-    expect((run.comparison as { reasons: string[] }).reasons).toContain(
-      "different_dataset_version",
-    );
+    const cmp = run.comparison as { reasons: string[]; state: string };
+    expect(cmp.reasons).toContain("different_dataset_version");
+    // Computed but non-authoritative → the explicit `exploratory` state, distinct on
+    // the wire from a still-running `pending` comparison.
+    expect(cmp.state).toBe("exploratory");
   });
 
   it("404s an unknown run", async () => {

--- a/frontend/ui/src/lib/eval/comparison.test.ts
+++ b/frontend/ui/src/lib/eval/comparison.test.ts
@@ -213,7 +213,7 @@ describe("missing case on one side", () => {
 // ── missing scorer on one side (paired case) ──────────────────────────────
 
 describe("missing scorer on one side", () => {
-  it("marks that cell unpaired without affecting the main-scorer case verdict", () => {
+  it("marks that cell not_comparable (the case IS paired) without affecting the main-scorer case verdict", () => {
     const out = compareRuns(
       build({
         candidate: run({
@@ -233,10 +233,14 @@ describe("missing scorer on one side", () => {
     );
     const cells = Object.fromEntries(out.results[0].scorerCells.map((c) => [c.scorerName, c]));
     expect(cells.acc.classification).toBe("unchanged");
-    expect(cells.extra.classification).toBe("unpaired");
+    // The case exists on both sides — only the "extra" scorer's value is missing on
+    // the baseline — so this is `not_comparable`, never `unpaired` (that's reserved
+    // for a case that isn't in both runs at all).
+    expect(cells.extra.classification).toBe("not_comparable");
     expect(cells.extra.reason).toBe("baseline_missing");
     expect(out.results[0].caseChange).toBe("unchanged"); // main scorer only
-    expect(out.comparison.scoreCellCounts.unpaired).toBe(1);
+    expect(out.comparison.scoreCellCounts.not_comparable).toBe(1);
+    expect(out.comparison.scoreCellCounts.unpaired).toBe(0);
   });
 });
 
@@ -284,17 +288,23 @@ describe("errors are explicit, never zero", () => {
     expect(out.results[0].caseChange).toBe("not_comparable");
   });
 
-  it("a task error (errored status, no scores) yields an unpaired/not_comparable main cell", () => {
+  it("a task error (errored status, no scores) yields a not_comparable main cell — the case IS paired, so it must never land in `unpaired`", () => {
     const out = compareRuns(
       build({
         candidateResults: [result("a", { status: "errored", candidateOutput: null, scores: [] })],
         baselineResults: [result("a", { mainScore: 1, scores: [num("acc", 1)] })],
       }),
     );
-    // The candidate has no acc score → the acc cell is unpaired (candidate side missing).
+    // The case exists in both runs — the candidate's task just errored and produced no
+    // acc score. `not_comparable` (candidate_missing), never `unpaired`: `unpaired`
+    // means "not in both runs", and this case is, so a crash here must not be
+    // indistinguishable from a case that's simply absent from the baseline.
     const cell = out.results[0].scorerCells.find((c) => c.scorerName === "acc")!;
-    expect(cell.classification).toBe("unpaired");
+    expect(cell.classification).toBe("not_comparable");
+    expect(cell.reason).toBe("candidate_missing");
     expect(out.results[0].caseChange).not.toBe("unchanged");
+    expect(out.results[0].caseChange).not.toBe("unpaired");
+    expect(out.comparison.caseCounts.unpaired).toBe(0);
   });
 });
 
@@ -381,6 +391,39 @@ describe("per-scorer aggregate uses paired, successfully-scored cells only", () 
     expect(agg.candidateMean).toBeCloseTo(0.5); // (1 + 0) / 2
     expect(agg.baselineMean).toBeCloseTo(1); // (1 + 1) / 2
     expect(agg.delta).toBeCloseTo(-0.5);
+  });
+});
+
+// ── duration ──────────────────────────────────────────────────────────────
+
+describe("duration comparison", () => {
+  it("returns per-case candidate/baseline duration + delta, and a paired case-duration mean", () => {
+    const out = compareRuns(
+      build({
+        candidateResults: [
+          result("a", { mainScore: 1, durationMs: 1200, scores: [num("acc", 1)] }),
+          result("b", { mainScore: 1, durationMs: 800, scores: [num("acc", 1)] }),
+          result("c", { mainScore: 1, durationMs: null, scores: [num("acc", 1)] }), // unknown
+        ],
+        baselineResults: [
+          result("a", { mainScore: 1, durationMs: 1000, scores: [num("acc", 1)] }),
+          result("b", { mainScore: 1, durationMs: 900, scores: [num("acc", 1)] }),
+          result("c", { mainScore: 1, durationMs: 700, scores: [num("acc", 1)] }),
+        ],
+      }),
+    );
+    const byCase = Object.fromEntries(out.results.map((r) => [r.testCaseId, r]));
+    expect(byCase.a.durationMs).toBe(1200);
+    expect(byCase.a.baselineDurationMs).toBe(1000);
+    expect(byCase.a.durationDeltaMs).toBe(200);
+    // Unknown candidate duration → delta null, never 0.
+    expect(byCase.c.durationMs).toBeNull();
+    expect(byCase.c.durationDeltaMs).toBeNull();
+    // Aggregate case-duration mean over the two paired-with-both-known cases (a, b).
+    expect(out.comparison.duration.pairedCount).toBe(2);
+    expect(out.comparison.duration.candidateMeanMs).toBe((1200 + 800) / 2);
+    expect(out.comparison.duration.baselineMeanMs).toBe((1000 + 900) / 2);
+    expect(out.comparison.duration.deltaMs).toBe((1200 + 800 - 1000 - 900) / 2);
   });
 });
 
@@ -501,5 +544,202 @@ describe("seven-case ticket-routing lab", () => {
     expect(acc.pairedCount).toBe(7);
     expect(acc.candidateMean).toBeCloseTo(6 / 7);
     expect(acc.baselineMean).toBeCloseTo(1);
+  });
+});
+
+// ── cross-side / declared-vs-observed type drift ───────────────────────────
+
+describe("cross-side type mismatch", () => {
+  it("a numeric candidate value against a categorical baseline value is not_comparable, never a fabricated verdict", () => {
+    const out = compareRuns(
+      build({
+        candidateResults: [result("a", { scores: [num("acc", 0.9)] })],
+        baselineResults: [result("a", { scores: [score("acc", { stringValue: "good" })] })],
+      }),
+    );
+    const cell = out.results[0].scorerCells[0];
+    expect(cell.classification).toBe("not_comparable");
+    expect(cell.reason).toBe("type_mismatch");
+    expect(cell.delta).toBeNull();
+    expect(out.results[0].caseChange).toBe("not_comparable");
+    // Excluded from the aggregate denominator, not silently coerced into it.
+    expect(out.comparison.scorers.find((s) => s.name === "acc")?.pairedCount ?? 0).toBe(0);
+  });
+
+  it("a declared boolean scorer whose stored values are actually numeric is compared as numeric, not coerced through truthiness", () => {
+    const scorers: ComparisonScorerMeta[] = [{ name: "acc", version: "v1", valueType: "boolean" }];
+    const out = compareRuns(
+      build({
+        candidate: run({ scorers }),
+        baseline: run({ id: "run_base", runNumber: 1, scorers }),
+        candidateResults: [result("a", { scores: [num("acc", 0.3, "v1")] })],
+        baselineResults: [result("a", { scores: [num("acc", 0.9, "v1")] })],
+      }),
+    );
+    const cell = out.results[0].scorerCells[0];
+    // Both sides are observed as numeric despite the declared metadata — the delta
+    // reflects the real numbers, not a `value ? 1 : 0` coercion that would collapse
+    // both truthy values to "unchanged".
+    expect(cell.delta).toBeCloseTo(-0.6);
+    expect(cell.classification).toBe("regressed");
+  });
+});
+
+describe("non-finite stored values", () => {
+  it("a non-finite numeric value can never yield a directional verdict or feed a mean", () => {
+    const out = compareRuns(
+      build({
+        candidateResults: [result("a", { scores: [num("acc", NaN)] })],
+        baselineResults: [result("a", { scores: [num("acc", 0.5)] })],
+      }),
+    );
+    const cell = out.results[0].scorerCells[0];
+    expect(cell.classification).toBe("not_comparable");
+    expect(cell.reason).toBe("not_scored");
+    expect(cell.delta).toBeNull();
+    expect(out.comparison.scorers.find((s) => s.name === "acc")?.pairedCount ?? 0).toBe(0);
+  });
+});
+
+// ── headline main-score delta ───────────────────────────────────────────────
+
+describe("headline main-score delta is derived from paired cells, never a raw run-aggregate subtraction", () => {
+  it("agrees with the paired scorer aggregate even when the two runs report different main scorers", () => {
+    const bothScorers: ComparisonScorerMeta[] = [
+      { name: "acc", version: "v1" },
+      { name: "f1", version: "v1" },
+    ];
+    const out = compareRuns(
+      build({
+        candidate: run({
+          mainScoreName: "acc",
+          mainScore: 1.0,
+          scorers: bothScorers,
+        }),
+        baseline: run({
+          id: "run_base",
+          runNumber: 1,
+          mainScoreName: "f1",
+          mainScore: 0.2,
+          scorers: bothScorers,
+        }),
+        candidateResults: [result("a", { scores: [num("acc", 1, "v1"), num("f1", 1, "v1")] })],
+        baselineResults: [result("a", { scores: [num("acc", 1, "v1"), num("f1", 1, "v1")] })],
+      }),
+    );
+    // The candidate's mainScoreName ("acc") wins for case/cell rollup; both runs
+    // scored it identically → the paired delta is 0, not the +0.8 a raw 1.0 - 0.2
+    // subtraction of the two runs' reported (and DIFFERENT) main scores would give.
+    expect(out.comparison.mainScore.delta).toBe(0);
+    expect(out.comparison.reportedMainScore).toEqual({ candidate: 1.0, baseline: 0.2 });
+  });
+
+  it("agrees with the paired scorer aggregate even when the two runs scored only partially-overlapping case sets", () => {
+    const out = compareRuns(
+      build({
+        candidate: run({ mainScore: 1.0 }),
+        baseline: run({ id: "run_base", runNumber: 1, mainScore: 0.667 }),
+        candidateResults: [
+          result("a", { scores: [num("acc", 1)] }),
+          result("b", { scores: [num("acc", 1)] }),
+        ],
+        baselineResults: [
+          result("a", { scores: [num("acc", 1)] }),
+          result("b", { scores: [num("acc", 1)] }),
+          result("c", { scores: [num("acc", 0)] }),
+        ],
+      }),
+    );
+    // Paired cases (a, b) are unchanged on the merits — delta 0 — even though the
+    // runs' raw reported main scores (1.0 vs 0.667) would subtract to +0.333.
+    expect(out.comparison.mainScore.delta).toBe(0);
+    expect(out.comparison.caseCounts.unpaired).toBe(1); // "c" is baseline-only
+    expect(out.comparison.reasons).toContain("case_set_mismatch");
+    expect(out.comparison.trustworthy).toBe(false);
+  });
+});
+
+// ── run-level trust: candidate status, non-terminal statuses, case-set drift ──
+
+describe("candidate_not_terminal", () => {
+  it("a live/running candidate is not trustworthy even against a terminal baseline", () => {
+    const out = compareRuns(
+      build({
+        candidate: run({ status: "running", mainScore: 1.0 }),
+        baseline: run({ id: "run_base", runNumber: 1, mainScore: 0.5 }),
+        candidateResults: [result("a", { scores: [num("acc", 1)] })],
+        baselineResults: [result("a", { scores: [num("acc", 0.5)] })],
+      }),
+    );
+    expect(out.comparison.reasons).toContain("candidate_not_terminal");
+    expect(out.comparison.trustworthy).toBe(false);
+  });
+});
+
+describe("incomplete/cancelled runs are not terminal for comparison purposes", () => {
+  it("a cancelled baseline is flagged, not silently treated as a complete result set", () => {
+    const out = compareRuns(
+      build({
+        baseline: run({ id: "run_base", runNumber: 1, status: "cancelled" }),
+        candidateResults: [result("a", { scores: [num("acc", 0.9)] })],
+        baselineResults: [result("a", { scores: [num("acc", 0.5)] })],
+      }),
+    );
+    expect(out.comparison.reasons).toContain("baseline_not_terminal");
+    expect(out.comparison.trustworthy).toBe(false);
+  });
+
+  it("an incomplete candidate is flagged the same way", () => {
+    const out = compareRuns(
+      build({
+        candidate: run({ status: "incomplete", mainScore: 0.9 }),
+        candidateResults: [result("a", { scores: [num("acc", 0.9)] })],
+        baselineResults: [result("a", { scores: [num("acc", 0.5)] })],
+      }),
+    );
+    expect(out.comparison.reasons).toContain("candidate_not_terminal");
+    expect(out.comparison.trustworthy).toBe(false);
+  });
+});
+
+describe("case_set_mismatch", () => {
+  it("flags a comparison where most cases are unpaired, even though the main scorer is otherwise comparable", () => {
+    const candidateResults = [
+      result("a", { scores: [num("acc", 1)] }),
+      ...Array.from({ length: 9 }, (_, i) => result(`only_cand_${i}`, { scores: [num("acc", 1)] })),
+    ];
+    const out = compareRuns(
+      build({
+        candidateResults,
+        baselineResults: [result("a", { scores: [num("acc", 1)] })],
+      }),
+    );
+    expect(out.comparison.caseCounts.unpaired).toBe(9);
+    expect(out.comparison.reasons).toContain("case_set_mismatch");
+    expect(out.comparison.trustworthy).toBe(false);
+  });
+});
+
+// ── deterministic dedup of duplicate scorer rows ────────────────────────────
+
+describe("duplicate scorer rows for the same scorer name (a version bump or a delayed re-score)", () => {
+  it("picks a winner deterministically, independent of the input array order", () => {
+    const forward = compareRuns(
+      build({
+        candidateResults: [result("a", { scores: [num("acc", 0.5, "v1"), num("acc", 0.9, "v2")] })],
+        baselineResults: [result("a", { scores: [num("acc", 0.9, "v2")] })],
+      }),
+    );
+    const reversed = compareRuns(
+      build({
+        candidateResults: [result("a", { scores: [num("acc", 0.9, "v2"), num("acc", 0.5, "v1")] })],
+        baselineResults: [result("a", { scores: [num("acc", 0.9, "v2")] })],
+      }),
+    );
+    // Same outcome regardless of row order — the higher scorerVersion ("v2") wins,
+    // never whichever row happened to come first in an unordered DB read.
+    expect(forward.results[0].scorerCells[0]).toEqual(reversed.results[0].scorerCells[0]);
+    expect(forward.results[0].scorerCells[0].classification).toBe("unchanged");
+    expect(forward.results[0].scorerCells[0].candidateValue).toBe(0.9);
   });
 });

--- a/frontend/ui/src/lib/eval/comparison.test.ts
+++ b/frontend/ui/src/lib/eval/comparison.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   compareRuns,
+  deriveComparisonState,
   type ComparisonRun,
   type ComparisonResult,
   type ComparisonScore,
@@ -741,5 +742,30 @@ describe("duplicate scorer rows for the same scorer name (a version bump or a de
     expect(forward.results[0].scorerCells[0]).toEqual(reversed.results[0].scorerCells[0]);
     expect(forward.results[0].scorerCells[0].classification).toBe("unchanged");
     expect(forward.results[0].scorerCells[0].candidateValue).toBe(0.9);
+  });
+});
+
+describe("deriveComparisonState (four-state discriminant)", () => {
+  it("unavailable when there is no baseline", () => {
+    expect(deriveComparisonState(false, false, ["no_baseline"])).toBe("unavailable");
+    expect(deriveComparisonState(false, false, ["baseline_missing"])).toBe("unavailable");
+  });
+  it("trustworthy only when available with no reasons", () => {
+    expect(deriveComparisonState(true, true, [])).toBe("trustworthy");
+  });
+  it("pending when a run is not terminal", () => {
+    expect(deriveComparisonState(true, false, ["candidate_not_terminal"])).toBe("pending");
+    expect(deriveComparisonState(true, false, ["baseline_not_terminal"])).toBe("pending");
+  });
+  it("exploratory for a computed-but-incompatible comparison (different evaluation, etc.)", () => {
+    expect(deriveComparisonState(true, false, ["different_evaluation"])).toBe("exploratory");
+    expect(deriveComparisonState(true, false, ["different_dataset_version"])).toBe("exploratory");
+    expect(deriveComparisonState(true, false, ["case_set_mismatch"])).toBe("exploratory");
+    expect(deriveComparisonState(true, false, ["main_scorer_incompatible"])).toBe("exploratory");
+  });
+  it("pending wins when a run is both not-terminal and would be incompatible", () => {
+    expect(
+      deriveComparisonState(true, false, ["candidate_not_terminal", "different_evaluation"]),
+    ).toBe("pending");
   });
 });

--- a/frontend/ui/src/lib/eval/comparison.test.ts
+++ b/frontend/ui/src/lib/eval/comparison.test.ts
@@ -384,39 +384,6 @@ describe("per-scorer aggregate uses paired, successfully-scored cells only", () 
   });
 });
 
-// ── duration ──────────────────────────────────────────────────────────────
-
-describe("duration comparison", () => {
-  it("returns per-case candidate/baseline duration + delta, and a paired case-duration mean", () => {
-    const out = compareRuns(
-      build({
-        candidateResults: [
-          result("a", { mainScore: 1, durationMs: 1200, scores: [num("acc", 1)] }),
-          result("b", { mainScore: 1, durationMs: 800, scores: [num("acc", 1)] }),
-          result("c", { mainScore: 1, durationMs: null, scores: [num("acc", 1)] }), // unknown
-        ],
-        baselineResults: [
-          result("a", { mainScore: 1, durationMs: 1000, scores: [num("acc", 1)] }),
-          result("b", { mainScore: 1, durationMs: 900, scores: [num("acc", 1)] }),
-          result("c", { mainScore: 1, durationMs: 700, scores: [num("acc", 1)] }),
-        ],
-      }),
-    );
-    const byCase = Object.fromEntries(out.results.map((r) => [r.testCaseId, r]));
-    expect(byCase.a.durationMs).toBe(1200);
-    expect(byCase.a.baselineDurationMs).toBe(1000);
-    expect(byCase.a.durationDeltaMs).toBe(200);
-    // Unknown candidate duration → delta null, never 0.
-    expect(byCase.c.durationMs).toBeNull();
-    expect(byCase.c.durationDeltaMs).toBeNull();
-    // Aggregate case-duration mean over the two paired-with-both-known cases (a, b).
-    expect(out.comparison.duration.pairedCount).toBe(2);
-    expect(out.comparison.duration.candidateMeanMs).toBe((1200 + 800) / 2);
-    expect(out.comparison.duration.baselineMeanMs).toBe((1000 + 900) / 2);
-    expect(out.comparison.duration.deltaMs).toBe((1200 + 800 - 1000 - 900) / 2);
-  });
-});
-
 // ── the seven-case lab ────────────────────────────────────────────────────
 
 describe("seven-case ticket-routing lab", () => {

--- a/frontend/ui/src/lib/eval/comparison.ts
+++ b/frontend/ui/src/lib/eval/comparison.ts
@@ -48,6 +48,37 @@ export type RunComparabilityReason =
   | "baseline_not_terminal"
   | "main_scorer_incompatible";
 
+/**
+ * The four-state comparison discriminant, derived from `available`/`trustworthy`/
+ * `reasons` so a client never has to re-classify the reason vocabulary itself:
+ *  - `trustworthy`: paired, same evaluation, both terminal — an authoritative verdict.
+ *  - `exploratory`: computed but NON-authoritative (different evaluation / dataset
+ *    version, mismatched case set, incompatible main scorer). Shown for exploration,
+ *    never as an ordinary verdict.
+ *  - `pending`: a run is still running or was stopped early (not terminal).
+ *  - `unavailable`: there is no baseline to compare against.
+ */
+export type ComparisonState = "trustworthy" | "exploratory" | "pending" | "unavailable";
+
+const PENDING_REASONS: ReadonlySet<RunComparabilityReason> = new Set([
+  "candidate_not_terminal",
+  "baseline_not_terminal",
+]);
+
+/** Collapse available/trustworthy/reasons into the single non-overlapping state. */
+export function deriveComparisonState(
+  available: boolean,
+  trustworthy: boolean,
+  reasons: readonly RunComparabilityReason[],
+): ComparisonState {
+  if (!available) return "unavailable";
+  if (trustworthy) return "trustworthy";
+  // A non-terminal run is pending until it settles — even if it would also be
+  // incompatible once complete, "still running" is the more actionable state.
+  if (reasons.some((r) => PENDING_REASONS.has(r))) return "pending";
+  return "exploratory";
+}
+
 // ── Inputs (DB-shaped, decoupled from Prisma) ───────────────────────────
 
 export interface ComparisonScorerMeta {
@@ -165,6 +196,13 @@ export interface ResultComparison {
 export interface RunComparison {
   available: boolean;
   trustworthy: boolean;
+  /**
+   * Four-state discriminant derived from available/trustworthy/reasons. Clients
+   * should switch on this rather than re-deriving intent from `reasons`; in
+   * particular `exploratory` and `pending` are otherwise wire-identical
+   * (available:true, trustworthy:false).
+   */
+  state: ComparisonState;
   reasons: RunComparabilityReason[];
   baseline: { runId: string; runNumber: number; candidateVersion: string } | null;
   mainScore: { candidate: number | null; baseline: number | null; delta: number | null };
@@ -547,6 +585,7 @@ export function compareRuns(input: CompareRunsInput): CompareRunsOutput {
   const comparison: RunComparison = {
     available,
     trustworthy,
+    state: deriveComparisonState(available, trustworthy, reasons),
     reasons,
     baseline: baseline
       ? {


### PR DESCRIPTION
## Summary

Fixes: #1653

A single pure, unit-testable engine (`lib/eval/comparison.ts`) is the source of truth for candidate-vs-baseline math and for whether a comparison is trustworthy. Both the read routes and the UI consume its output and neither recomputes it, so the whole product agrees on what "improved", "regressed", and "not comparable" mean. Outcomes and trustworthiness travel together in one payload so callers never re-derive either.

## What's included

### Derivation module (`frontend/ui/src/lib/eval`)

### Tests
- `frontend/ui/src/lib/eval/comparison.test.ts` — no baseline, dataset-version mismatch, different evaluation, non-terminal baseline, missing/errored scores, main-scorer incompatibility, per-case outcome classification, and paired-mean duration over matched cases.
- `app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts` — covers `route.readback`.

## Test plan
- [ ] `compareRuns` is a pure function with no I/O.
- [ ] `trustworthy` is false with an explicit reason list whenever a blocking condition holds (no baseline, different dataset version, different evaluation, non-terminal baseline, unmatchable main scorer).
- [ ] Per-case outcomes and the aggregate case counts are internally consistent.
- [ ] Given the same inputs it always returns the same result.
- [ ] The paired-mean duration and paired counts reflect only cases matched on both sides.
- [ ] Per-scorer cells carry candidate value, baseline value, and delta so a scorer table renders without recomputation.
