### PR TITLE
feat(runs): run-detail results table opening the real trace

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/evaluations/[runId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/evaluations/[runId]/page.tsx
@@ -5,5 +5,8 @@ import { RunDetailView } from "@/features/evaluations/views/run-detail-view";
 
 export default function RunDetailPage() {
   const params = useParams();
-  return <RunDetailView projectId={params.projectId as string} runId={params.runId as string} />;
+  const runId = params.runId as string;
+  // Key on runId so switching runs (same dynamic route) fully remounts the view —
+  // fresh data + reset panel/filter state — instead of reusing a stale instance.
+  return <RunDetailView key={runId} projectId={params.projectId as string} runId={runId} />;
 }

--- a/frontend/ui/src/components/search-filter-bar.test.tsx
+++ b/frontend/ui/src/components/search-filter-bar.test.tsx
@@ -48,4 +48,17 @@ describe("SearchFilterBar", () => {
     const input = screen.getByPlaceholderText("Search...") as HTMLInputElement;
     expect(input.value).toBe("checkout");
   });
+
+  it("omits the date filter entirely when the caller has no time range to filter by", () => {
+    render(
+      <SearchFilterBar searchValue="" onSearchChange={vi.fn()}>
+        <button type="button">Live</button>
+      </SearchFilterBar>,
+    );
+
+    expect(screen.getByText("Live")).toBeTruthy();
+    for (const option of DATE_FILTER_OPTIONS) {
+      expect(screen.queryByText(option.label)).toBeNull();
+    }
+  });
 });

--- a/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import * as React from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Database } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerBody,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
+import { useToast } from "@/components/ui/toast";
+import { cn } from "@/lib/utils";
+import { useDatasets } from "../hooks";
+
+/** The three result→dataset actions the backend `dataset-case` route accepts. */
+export type ResultDatasetAction =
+  | "update_existing_case"
+  | "save_new_case"
+  | "duplicate_as_variant";
+
+export interface ResultForDataset {
+  id: string;
+  input: string;
+  expectedOutput: string | null;
+  candidateOutput: string | null;
+  testCaseId: string;
+}
+
+const ACTION_META: Record<
+  ResultDatasetAction,
+  { title: string; blurb: string; cta: string; picksDataset: boolean }
+> = {
+  update_existing_case: {
+    title: "Update source case",
+    blurb:
+      "Publishes a new immutable version of this run's dataset with this case updated. Runs already recorded keep pointing at the version they used.",
+    cta: "Publish update",
+    picksDataset: false,
+  },
+  save_new_case: {
+    title: "Save as a new case",
+    blurb:
+      "Adds a brand-new case to the chosen dataset. Blocked if it would just recreate this result's own source case — use “Update source case” for that.",
+    cta: "Save new case",
+    picksDataset: true,
+  },
+  duplicate_as_variant: {
+    title: "Duplicate as a variant",
+    blurb:
+      "Adds a new case tagged as a variant of the source case. Always allowed — useful for exploring a tweak without touching the original.",
+    cta: "Duplicate case",
+    picksDataset: true,
+  },
+};
+
+const FIELD_CLASS =
+  "w-full rounded-md border border-input bg-background px-2.5 py-1.5 text-[12px] font-mono leading-relaxed shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60";
+
+function newIdempotencyKey(): string {
+  try {
+    return crypto.randomUUID();
+  } catch {
+    // A stable-enough fallback for environments without crypto (older jsdom); the
+    // server treats the key as opaque, so any per-open unique string is fine.
+    return `res-ds-${performance.now()}`;
+  }
+}
+
+/**
+ * Save one evaluation RESULT back into a dataset — update its source case, save a
+ * new case, or duplicate it as a variant. The action is chosen upstream (the
+ * result's "Add to dataset" menu); this drawer only collects the case fields and
+ * POSTs to the `results/[resultId]/dataset-case` route, which publishes a new
+ * immutable dataset version.
+ *
+ * Two invariants are enforced HERE in the UI, matching the backend: a candidate's
+ * output never becomes the expected answer unless the reviewer explicitly opts in
+ * (the toggle, off by default), and "update" derives its dataset from the result
+ * while "save/duplicate" require an explicit target dataset.
+ */
+export function SaveResultToDatasetDrawer({
+  projectId,
+  open,
+  onOpenChange,
+  action,
+  result,
+  sourceDatasetId,
+  sourceDatasetName,
+}: {
+  projectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  action: ResultDatasetAction;
+  result: ResultForDataset;
+  sourceDatasetId: string;
+  sourceDatasetName: string;
+}) {
+  const meta = ACTION_META[action];
+  const qc = useQueryClient();
+  const { toast } = useToast();
+  const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
+  const datasets = datasetsData?.data ?? [];
+
+  const [targetDatasetId, setTargetDatasetId] = React.useState(sourceDatasetId);
+  const [input, setInput] = React.useState(result.input);
+  const [expected, setExpected] = React.useState(result.expectedOutput ?? "");
+  const [useCandidateAsExpected, setUseCandidateAsExpected] = React.useState(false);
+  const [idempotencyKey, setIdempotencyKey] = React.useState("");
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Reseed every field when the drawer (re)opens for a result/action, and mint a
+  // fresh idempotency key so a genuinely new save is never deduped against the last.
+  React.useEffect(() => {
+    if (!open) return;
+    setTargetDatasetId(sourceDatasetId);
+    setInput(result.input);
+    setExpected(result.expectedOutput ?? "");
+    setUseCandidateAsExpected(false);
+    setIdempotencyKey(newIdempotencyKey());
+    setError(null);
+  }, [open, action, result.id, result.input, result.expectedOutput, sourceDatasetId]);
+
+  const save = useMutation({
+    mutationFn: async () => {
+      const body = {
+        action,
+        dataset_id: meta.picksDataset ? targetDatasetId : undefined,
+        input,
+        // The candidate output only lands in `expected` through the explicit flag —
+        // never by copying the field. When the flag is off we send the typed expected
+        // (empty string → no reference answer, not the candidate's text).
+        expected: useCandidateAsExpected ? undefined : expected,
+        use_candidate_as_expected: useCandidateAsExpected,
+        idempotency_key: idempotencyKey,
+      };
+      const res = await fetch(
+        `/api/projects/${projectId}/evaluations/results/${result.id}/dataset-case`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+      const payload = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) throw new Error(payload.error || "Could not save to the dataset.");
+      return payload;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["datasets"] });
+      toast({
+        title: action === "update_existing_case" ? "Dataset updated" : "Case added",
+        description:
+          action === "update_existing_case"
+            ? "A new dataset version was published."
+            : "The case was added and a new dataset version was published.",
+        tone: "success",
+      });
+      onOpenChange(false);
+    },
+    onError: (e: unknown) => {
+      setError(e instanceof Error ? e.message : "Could not save to the dataset.");
+    },
+  });
+
+  const canSave = !save.isPending && (!meta.picksDataset || !!targetDatasetId);
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent width="sm:max-w-lg">
+        <DrawerHeader>
+          <DrawerTitle className="flex items-center gap-2">
+            <Database className="h-4 w-4 text-muted-foreground" aria-hidden />
+            {meta.title}
+          </DrawerTitle>
+          <DrawerDescription>{meta.blurb}</DrawerDescription>
+        </DrawerHeader>
+
+        <DrawerBody className="space-y-4">
+          {/* Target dataset — fixed for update, chosen for save/duplicate. */}
+          <div className="space-y-1.5">
+            <div className="text-[11px] font-medium text-muted-foreground">Dataset</div>
+            {meta.picksDataset ? (
+              <Select value={targetDatasetId} onValueChange={setTargetDatasetId}>
+                <SelectTrigger className="h-8 text-[12px]">
+                  <SelectValue placeholder="Choose a dataset" />
+                </SelectTrigger>
+                <SelectContent>
+                  {datasets.map((d) => (
+                    <SelectItem key={d.id} value={d.id} className="text-[12px]">
+                      {d.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <div className="rounded-md border border-input bg-muted/40 px-2.5 py-1.5 text-[12px]">
+                <span className="font-medium">{sourceDatasetName}</span>
+                <span className="text-muted-foreground">
+                  {" "}
+                  · case <span className="font-mono">{result.testCaseId}</span>
+                </span>
+              </div>
+            )}
+          </div>
+
+          {/* Input — the stable scenario this case tests. */}
+          <label className="block space-y-1.5">
+            <span className="text-[11px] font-medium text-muted-foreground">Input</span>
+            <textarea
+              className={cn(FIELD_CLASS, "min-h-[72px] resize-y")}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              aria-label="Input"
+            />
+          </label>
+
+          {/* Expected — the reference answer, kept SEPARATE from the candidate output. */}
+          <div className="space-y-2 rounded-md border border-border p-2.5">
+            <label className="flex items-start justify-between gap-3">
+              <span className="min-w-0">
+                <span className="text-[12px] font-medium">
+                  Use this candidate output as the expected answer
+                </span>
+                <span className="mt-0.5 block text-[11px] text-muted-foreground">
+                  Off by default — a candidate&rsquo;s output never becomes the expected answer
+                  unless you say so.
+                </span>
+              </span>
+              <Switch
+                checked={useCandidateAsExpected}
+                onCheckedChange={setUseCandidateAsExpected}
+              />
+            </label>
+
+            {useCandidateAsExpected ? (
+              <div className="space-y-1">
+                <div className="text-[11px] font-medium text-muted-foreground">
+                  Expected (from candidate output)
+                </div>
+                <pre className={cn(FIELD_CLASS, "max-h-40 overflow-auto whitespace-pre-wrap")}>
+                  {result.candidateOutput ?? "(this result produced no output)"}
+                </pre>
+              </div>
+            ) : (
+              <label className="block space-y-1">
+                <span className="text-[11px] font-medium text-muted-foreground">
+                  Expected answer <span className="font-normal">(optional)</span>
+                </span>
+                <textarea
+                  className={cn(FIELD_CLASS, "min-h-[72px] resize-y")}
+                  value={expected}
+                  onChange={(e) => setExpected(e.target.value)}
+                  placeholder="Leave blank if this scorer needs no reference answer"
+                  aria-label="Expected answer"
+                />
+              </label>
+            )}
+          </div>
+
+          {error && (
+            <div
+              role="alert"
+              className="rounded-md border border-destructive/50 bg-destructive/10 px-2.5 py-1.5 text-[11px] text-destructive"
+            >
+              {error}
+            </div>
+          )}
+        </DrawerBody>
+
+        <DrawerFooter>
+          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button size="sm" disabled={!canSave} onClick={() => save.mutate()}>
+            {save.isPending ? "Saving…" : meta.cta}
+          </Button>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/frontend/ui/src/features/evaluations/dataset-panels.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/dataset-panels.smoke.test.tsx
@@ -1,0 +1,259 @@
+// @vitest-environment jsdom
+/**
+ * View-mount smoke for the New-dataset and Edit-dataset slide-in panels, driven
+ * from the real Datasets list (the only place they open from) against a stubbed
+ * fetch. Covers the shared DatasetFormFields — including the schema toggles that
+ * only appear once switched on — and the create/update round trips.
+ */
+import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@/components/ui/toast";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1" }),
+  useRouter: () => ({ push: mockPush, replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/projects/p1/datasets",
+}));
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+
+import { DatasetsView } from "./views/datasets-view";
+
+const DATASET = {
+  id: "ds1",
+  projectId: "p1",
+  name: "Billing routing",
+  description: "Routing tickets",
+  currentVersionId: "dv1",
+  createTime: "2026-07-16T00:00:00Z",
+  updateTime: "2026-07-17T00:00:00Z",
+  caseCount: 8,
+  versionCount: 3,
+};
+
+let requests: Array<{ url: string; method: string; body: unknown }> = [];
+/** Flipped by a test to make every write fail, exercising the error toasts. */
+let writesFail = false;
+
+function payloadFor(url: string): unknown {
+  if (url.includes("/evaluations")) {
+    return { data: [{ id: "eval1", name: "Billing routing", datasetId: "ds1" }] };
+  }
+  if (url.includes("/datasets")) {
+    return { data: [DATASET], meta: { page: 0, limit: 50, total: 1 } };
+  }
+  return {};
+}
+
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  window.HTMLElement.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+  Object.assign(navigator, { clipboard: { writeText: vi.fn(async () => {}) } });
+});
+
+beforeEach(() => {
+  requests = [];
+  writesFail = false;
+  mockPush.mockClear();
+  global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+    requests.push({
+      url: String(url),
+      method,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    if (writesFail && method !== "GET") {
+      return { ok: false, status: 500, json: async () => ({ error: "server exploded" }) };
+    }
+    return { ok: true, status: 200, json: async () => payloadFor(String(url)) };
+  }) as unknown as typeof fetch;
+});
+afterEach(() => cleanup());
+
+function mount() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ToastProvider>
+        <DatasetsView projectId="p1" />
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/** Opens the row's three-dot menu and picks an item. */
+async function rowAction(name: "Edit" | "Delete") {
+  fireEvent.click(await screen.findByLabelText("Row actions"));
+  fireEvent.click(await screen.findByText(name));
+}
+
+describe("New dataset panel", () => {
+  it("stays disabled until a name is typed, then POSTs name + description", async () => {
+    mount();
+    fireEvent.click(await screen.findByRole("button", { name: "New Dataset" }));
+
+    const create = screen.getByRole("button", { name: "Create dataset" });
+    expect(create.hasAttribute("disabled")).toBe(true);
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. Billing routing"), {
+      target: { value: "  Refund routing  " },
+    });
+    fireEvent.change(screen.getByPlaceholderText("What this collection of test cases is for"), {
+      target: { value: "Refund tickets" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create dataset" }));
+    expect(await screen.findByText("Dataset created")).toBeDefined();
+
+    const post = requests.find((r) => r.method === "POST");
+    expect(post?.url).toContain("/api/projects/p1/datasets");
+    expect(post?.body).toEqual({ name: "Refund routing", description: "Refund tickets" });
+    // Creating closes the panel.
+    await waitFor(() => expect(screen.queryByText("New dataset")).toBeNull());
+  });
+
+  it("an empty description persists as null, never as an empty string", async () => {
+    mount();
+    fireEvent.click(await screen.findByRole("button", { name: "New Dataset" }));
+    fireEvent.change(screen.getByPlaceholderText("e.g. Billing routing"), {
+      target: { value: "Refund routing" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create dataset" }));
+    await waitFor(() => expect(requests.some((r) => r.method === "POST")).toBe(true));
+    expect(requests.find((r) => r.method === "POST")?.body).toEqual({
+      name: "Refund routing",
+      description: null,
+    });
+  });
+
+  it("the schema cards reveal an editable JSON block only once switched on", async () => {
+    mount();
+    fireEvent.click(await screen.findByRole("button", { name: "New Dataset" }));
+
+    expect(screen.queryByLabelText("Input schema JSON")).toBeNull();
+    const [inputSwitch, expectedSwitch] = screen.getAllByRole("switch");
+
+    fireEvent.click(inputSwitch);
+    const inputSchema = (await screen.findByLabelText("Input schema JSON")) as HTMLTextAreaElement;
+    expect(inputSchema.value).toContain('"required": ["input"]');
+    fireEvent.change(inputSchema, { target: { value: '{"type":"string"}' } });
+    expect((screen.getByLabelText("Input schema JSON") as HTMLTextAreaElement).value).toContain(
+      '{"type":"string"}',
+    );
+
+    fireEvent.click(expectedSwitch);
+    expect(
+      ((await screen.findByLabelText("Expected output schema JSON")) as HTMLTextAreaElement).value,
+    ).toContain('"required": ["expected"]');
+
+    // Toggling back off hides the block again.
+    fireEvent.click(inputSwitch);
+    await waitFor(() => expect(screen.queryByLabelText("Input schema JSON")).toBeNull());
+  });
+
+  it("accepts free-form metadata", async () => {
+    mount();
+    fireEvent.click(await screen.findByRole("button", { name: "New Dataset" }));
+    const metadata = screen.getByLabelText("Metadata") as HTMLTextAreaElement;
+    fireEvent.change(metadata, { target: { value: '{"team":"support"}' } });
+    expect((screen.getByLabelText("Metadata") as HTMLTextAreaElement).value).toContain("support");
+  });
+
+  it("closes on Cancel, on the X, and on Escape", async () => {
+    mount();
+    const open = await screen.findByRole("button", { name: "New Dataset" });
+
+    fireEvent.click(open);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByText("New dataset")).toBeNull());
+
+    fireEvent.click(open);
+    fireEvent.click(await screen.findByLabelText("Close"));
+    await waitFor(() => expect(screen.queryByText("New dataset")).toBeNull());
+
+    fireEvent.click(open);
+    await screen.findByText("New dataset");
+    // The panel is a Radix drawer, which listens for Escape on the document via its
+    // dismissable layer — an event dispatched straight at `window` never reaches it.
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByText("New dataset")).toBeNull());
+  });
+
+  it("surfaces a create failure as a warning toast and keeps the panel open", async () => {
+    writesFail = true;
+    mount();
+    fireEvent.click(await screen.findByRole("button", { name: "New Dataset" }));
+    fireEvent.change(screen.getByPlaceholderText("e.g. Billing routing"), {
+      target: { value: "Refund routing" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create dataset" }));
+    expect(await screen.findByText("Could not create dataset")).toBeDefined();
+    expect(screen.getByText("New dataset")).toBeDefined();
+  });
+});
+
+describe("Edit dataset panel", () => {
+  it("opens seeded from the row and PATCHes the edited name", async () => {
+    mount();
+    await rowAction("Edit");
+
+    // Seeded from the dataset row.
+    const name = (await screen.findByPlaceholderText("e.g. Billing routing")) as HTMLInputElement;
+    expect(name.value).toBe("Billing routing");
+    expect(
+      (screen.getByPlaceholderText("What this collection of test cases is for") as HTMLInputElement)
+        .value,
+    ).toBe("Routing tickets");
+
+    fireEvent.change(name, { target: { value: "Billing routing v2" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(await screen.findByText("Dataset saved")).toBeDefined();
+
+    const patch = requests.find((r) => r.method === "PATCH");
+    expect(patch?.url).toContain("/api/projects/p1/datasets/ds1");
+    expect(patch?.body).toEqual({ name: "Billing routing v2", description: "Routing tickets" });
+  });
+
+  it("copies the dataset id from the header chip", async () => {
+    mount();
+    await rowAction("Edit");
+    fireEvent.click(await screen.findByTitle("Copy dataset ID"));
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ds1"));
+  });
+
+  it("surfaces a save failure and closes on Cancel", async () => {
+    writesFail = true;
+    mount();
+    await rowAction("Edit");
+    fireEvent.click(await screen.findByRole("button", { name: "Save" }));
+    expect(await screen.findByText("Could not save dataset")).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByText("Dataset")).toBeNull());
+  });
+
+  it("Delete removes the dataset through the real hook", async () => {
+    mount();
+    await rowAction("Delete");
+    // Deleting a dataset is irreversible, so the action opens a confirmation and
+    // only the dialog's own Delete performs it.
+    await screen.findByText("Delete dataset");
+    expect(requests.some((r) => r.method === "DELETE")).toBe(false);
+    // Confirmation is name-typed, not a bare "are you sure": the dialog spells out
+    // that every version's cases go with it.
+    const confirm = screen.getAllByRole("button", { name: "Delete" }).at(-1)!;
+    expect(confirm.hasAttribute("disabled")).toBe(true);
+    fireEvent.change(screen.getByPlaceholderText("Billing routing"), {
+      target: { value: "Billing routing" },
+    });
+    fireEvent.click(confirm);
+    expect(await screen.findByText("Deleted Billing routing")).toBeDefined();
+    expect(requests.some((r) => r.method === "DELETE" && r.url.endsWith("/datasets/ds1"))).toBe(
+      true,
+    );
+  });
+});

--- a/frontend/ui/src/features/evaluations/run-evaluation-drawer.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/run-evaluation-drawer.smoke.test.tsx
@@ -203,21 +203,24 @@ describe("TestCaseReviewDrawer (server-wired)", () => {
     expect(screen.getByText(/never blocks the case from an evaluation/)).toBeDefined();
   });
 
-  it("Mark ready submits without a correction and closes", async () => {
+  it("Mark ready submits without a correction and leaves closing to the caller", async () => {
     const onSubmit = vi.fn();
     const onOpenChange = vi.fn();
     mount(
       <TestCaseReviewDrawer target={TARGET} open onOpenChange={onOpenChange} onSubmit={onSubmit} />,
     );
     const boxes = await screen.findAllByRole("checkbox");
+    // "Mark ready" is gated on every verification check: a half-reviewed case must
+    // not be publishable as ready.
     fireEvent.click(boxes[0]);
-    fireEvent.click(boxes[4]);
-    // Ticking then un-ticking still leaves the checks purely advisory.
-    fireEvent.click(boxes[4]);
+    expect(screen.getByRole("button", { name: "Mark ready" }).hasAttribute("disabled")).toBe(true);
+    boxes.slice(1).forEach((b) => fireEvent.click(b));
 
     fireEvent.click(screen.getByRole("button", { name: "Mark ready" }));
     expect(onSubmit).toHaveBeenCalledWith({ review: "ready", correctedExpected: undefined });
-    expect(onOpenChange).toHaveBeenCalledWith(false);
+    // The drawer does not close itself: the save may still be in flight or fail, so
+    // the caller closes it only once it has actually persisted.
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it("a changed expected outcome rides along, trimmed", async () => {
@@ -239,6 +242,7 @@ describe("TestCaseReviewDrawer (server-wired)", () => {
     fireEvent.change(await screen.findByLabelText(/Correct the expected outcome/), {
       target: { value: "billing" },
     });
+    screen.getAllByRole("checkbox").forEach((b) => fireEvent.click(b));
     fireEvent.click(screen.getByRole("button", { name: "Mark ready" }));
     expect(onSubmit).toHaveBeenCalledWith({ review: "ready", correctedExpected: undefined });
   });

--- a/frontend/ui/src/features/evaluations/save-result-to-dataset-drawer.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-result-to-dataset-drawer.smoke.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+/**
+ * The result→dataset drawer: one RESULT saved back into a dataset three ways
+ * (update its source case / save a new case / duplicate as a variant). These mounts
+ * assert the two product invariants the UI must uphold alongside the backend:
+ *  - a candidate's output NEVER becomes the expected answer unless the reviewer
+ *    explicitly opts in (the toggle, off by default); and
+ *  - "update" derives its dataset from the result (no picker), while "save/duplicate"
+ *    require an explicit target dataset.
+ * It also surfaces the backend's actionable 409 (circular save) verbatim.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@/components/ui/toast";
+
+// Radix Select portals + is flaky in jsdom; mock to a native <select> (the pattern
+// used by save-test-case-drawer.smoke.test.tsx) so the dataset picker is drivable.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (v: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <select aria-label="Dataset" value={value} onChange={(e) => onValueChange(e.target.value)}>
+      <option value="" />
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+import {
+  SaveResultToDatasetDrawer,
+  type ResultDatasetAction,
+} from "./components/save-result-to-dataset-drawer";
+
+const RESULT = {
+  id: "res1",
+  input: "Produce a report about Q2 performance",
+  expectedOutput: null,
+  candidateOutput: "Q2 revenue grew 12% QoQ.",
+  testCaseId: "case-1",
+};
+
+function stubFetch(postResponse?: { ok: boolean; status: number; body: unknown }) {
+  const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+    if (init?.method === "POST") {
+      const r = postResponse ?? {
+        ok: true,
+        status: 201,
+        body: { dataset_id: "ds1", version_id: "v2", version_number: 2, test_case_id: "case-1" },
+      };
+      return { ok: r.ok, status: r.status, json: async () => r.body } as Response;
+    }
+    // useDatasets list.
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          { id: "ds1", name: "Billing routing", caseCount: 2, versionCount: 1 },
+          { id: "ds2", name: "Report quality", caseCount: 5, versionCount: 3 },
+        ],
+        meta: { page: 0, limit: 200, total: 2 },
+      }),
+    } as Response;
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function mount(action: ResultDatasetAction, onOpenChange = () => {}) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ToastProvider>
+        <SaveResultToDatasetDrawer
+          projectId="p1"
+          open
+          onOpenChange={onOpenChange}
+          action={action}
+          result={RESULT}
+          sourceDatasetId="ds1"
+          sourceDatasetName="Billing routing"
+        />
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+async function lastPost(fetchMock: ReturnType<typeof stubFetch>) {
+  const call = fetchMock.mock.calls.find(
+    (c) => (c[1] as RequestInit | undefined)?.method === "POST",
+  );
+  return {
+    url: call?.[0] as string,
+    body: JSON.parse((call?.[1] as RequestInit).body as string),
+  };
+}
+
+afterEach(() => cleanup());
+beforeEach(() => {
+  stubFetch();
+});
+
+describe("SaveResultToDatasetDrawer", () => {
+  it("update derives the dataset from the result — no dataset picker, source case shown", () => {
+    mount("update_existing_case");
+    expect(screen.getByText("Update source case")).toBeDefined();
+    // The source case is stated, and there is NO dataset chooser for update.
+    expect(screen.getByText("Billing routing")).toBeDefined();
+    expect(screen.getByText("case-1")).toBeDefined();
+    expect(screen.queryByLabelText("Dataset")).toBeNull();
+  });
+
+  it("save-new requires a target dataset picker", () => {
+    mount("save_new_case");
+    expect(screen.getByText("Save as a new case")).toBeDefined();
+    expect(screen.getByLabelText("Dataset")).toBeDefined();
+  });
+
+  it("never copies the candidate output into expected unless explicitly toggled on", async () => {
+    const fetchMock = stubFetch();
+    mount("update_existing_case");
+    // Type a real reference answer; the candidate output is a DIFFERENT string.
+    const expected = screen.getByLabelText("Expected answer") as HTMLTextAreaElement;
+    fireEvent.change(expected, { target: { value: "A concise Q2 summary." } });
+    fireEvent.click(screen.getByRole("button", { name: /Publish update/i }));
+
+    await waitFor(() => expect(fetchMock.mock.calls.some((c) => (c[1] as RequestInit)?.method === "POST")).toBe(true));
+    const { url, body } = await lastPost(fetchMock);
+    expect(url).toBe("/api/projects/p1/evaluations/results/res1/dataset-case");
+    expect(body.action).toBe("update_existing_case");
+    expect(body.use_candidate_as_expected).toBe(false);
+    expect(body.expected).toBe("A concise Q2 summary.");
+    // The candidate's own text must not leak into `expected`.
+    expect(body.expected).not.toBe(RESULT.candidateOutput);
+  });
+
+  it("promotes the candidate to expected ONLY through the explicit flag", async () => {
+    const fetchMock = stubFetch();
+    mount("update_existing_case");
+    // Flipping the toggle hides the free-text field and shows the candidate output.
+    fireEvent.click(screen.getByRole("switch"));
+    expect(screen.getByText(RESULT.candidateOutput)).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: /Publish update/i }));
+
+    await waitFor(() => expect(fetchMock.mock.calls.some((c) => (c[1] as RequestInit)?.method === "POST")).toBe(true));
+    const { body } = await lastPost(fetchMock);
+    expect(body.use_candidate_as_expected).toBe(true);
+    // `expected` is NOT sent — the server derives it from the candidate under the flag.
+    expect(body.expected).toBeUndefined();
+  });
+
+  it("surfaces the backend's actionable circular-save conflict verbatim", async () => {
+    const fetchMock = stubFetch({
+      ok: false,
+      status: 409,
+      body: { error: "This result already came from this case — use update instead." },
+    });
+    mount("save_new_case");
+    // ds1 is the source dataset (default); saving a new case that recreates the source
+    // is what the backend rejects.
+    fireEvent.click(screen.getByRole("button", { name: /Save new case/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toMatch(/use update instead/i),
+    );
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -61,7 +61,32 @@ import type {
   CompareResultRow,
   CompareRunsResponse,
   ResultRowComparison,
+  HumanScoreRow,
+  HumanReviewSummary,
 } from "../types";
+import { HUMAN_VERDICT_LABEL, type HumanReview, type HumanVerdict } from "@/features/offline-eval/types";
+
+/** The single canonical dimension reviewed in V1. */
+const REVIEW_DIMENSION = "overall";
+
+/**
+ * Map the read-model review row a result carries into the panel's `HumanReview`
+ * shape, so re-opening the review drawer pre-fills the saved verdict/quality/comment
+ * instead of a blank form (nulls → undefined; the review's `updateTime` is its `at`).
+ */
+function toExistingReview(humanScores: HumanScoreRow[]): HumanReview | undefined {
+  const saved =
+    humanScores.find((h) => h.dimension === REVIEW_DIMENSION) ?? humanScores[0];
+  return saved
+    ? {
+        verdict: saved.verdict as HumanVerdict,
+        quality: saved.quality ?? undefined,
+        comment: saved.comment ?? undefined,
+        reviewer: saved.reviewer,
+        at: saved.updateTime,
+      }
+    : undefined;
+}
 
 /** Case/run duration; "Unknown" when unmeasured (never 0s). */
 function fmtDurationMs(ms: number | null | undefined): string {
@@ -243,7 +268,10 @@ type ResultFilterId =
   | "failed"
   | "errors"
   | "unpaired"
-  | "not_scored";
+  | "not_scored"
+  | "needs_human_review"
+  | "human_reviewed"
+  | "judge_disagreement";
 
 const RESULT_FILTERS: Array<{ id: ResultFilterId; label: string }> = [
   { id: "all", label: "All" },
@@ -253,7 +281,67 @@ const RESULT_FILTERS: Array<{ id: ResultFilterId; label: string }> = [
   { id: "errors", label: "Errors" },
   { id: "unpaired", label: "Unpaired" },
   { id: "not_scored", label: "Not scored" },
+  { id: "needs_human_review", label: "Needs human review" },
+  { id: "human_reviewed", label: "Reviewed" },
+  { id: "judge_disagreement", label: "Judge disagreement" },
 ];
+
+/** The result's canonical human review (V1: the "overall" dimension), if any. */
+function resultReview(r: ResultRow): HumanScoreRow | undefined {
+  const reviews = r.humanScores ?? [];
+  return reviews.find((h) => h.dimension === REVIEW_DIMENSION) ?? reviews[0];
+}
+
+/**
+ * A human pass/fail verdict disagreeing with the automated pass/fail — both must be
+ * boolean, so "unsure" and a quality-only review never count (mirrors the backend
+ * `deriveHumanReviewSummary`). Read-only: this never alters the automated score.
+ */
+function isJudgeDisagreement(r: ResultRow): boolean {
+  const review = resultReview(r);
+  if (!review || (review.verdict !== "pass" && review.verdict !== "fail")) return false;
+  const automatedPass = r.status === "passed" ? true : r.status === "failed" ? false : null;
+  if (automatedPass === null) return false;
+  return (review.verdict === "pass") !== automatedPass;
+}
+
+/** Compact human-review chip for the result drawer — verdict/quality/reviewer, plus a
+ *  disagreement flag. Never renders the automated score; it sits beside it. */
+function ReviewTag({
+  review,
+  disagreement,
+}: {
+  review: HumanScoreRow | undefined;
+  disagreement: boolean;
+}) {
+  if (!review) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
+        <span className="text-muted-foreground">Human review:</span>
+        <span className="font-medium text-muted-foreground">Pending</span>
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs ${
+        disagreement
+          ? "border-amber-400/60 bg-amber-100/50 dark:border-amber-700/60 dark:bg-amber-950/30"
+          : "bg-muted/40"
+      }`}
+    >
+      <span className="text-muted-foreground">Human review:</span>
+      <span className="font-medium">{HUMAN_VERDICT_LABEL[review.verdict as HumanVerdict]}</span>
+      {review.quality != null && <span className="text-muted-foreground">· {review.quality}/5</span>}
+      <span className="text-muted-foreground">· {review.reviewer}</span>
+      {disagreement && (
+        <span className="font-medium text-amber-700 dark:text-amber-400">
+          · Disagrees with automated
+        </span>
+      )}
+    </span>
+  );
+}
 
 // Filters key on the DERIVED case verdict (comparison.caseChange), never the stored
 // change column. "Unpaired" folds in not_comparable (paired but un-trustable) cases.
@@ -266,6 +354,9 @@ const RESULT_FILTER_FN: Record<ResultFilterId, (r: ResultRow) => boolean> = {
   unpaired: (r) =>
     r.comparison?.caseChange === "unpaired" || r.comparison?.caseChange === "not_comparable",
   not_scored: (r) => r.status === "not_scored",
+  needs_human_review: (r) => !resultReview(r),
+  human_reviewed: (r) => !!resultReview(r),
+  judge_disagreement: isJudgeDisagreement,
 };
 
 /**
@@ -484,7 +575,7 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
                 className="h-7 text-[12px]"
                 onClick={() => setReviewOpen(true)}
               >
-                Review output
+                {resultReview(openResult) ? "Edit review" : "Review output"}
               </Button>
               <Link
                 href={`/projects/${projectId}/datasets/${run.datasetId}?case=${openResult.testCaseId}`}
@@ -530,6 +621,9 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
                   {run.datasetName} · {run.datasetVersionLabel}
                 </span>
               </span>
+              {/* Human review — shown ALONGSIDE the automated score/status (never
+                  replacing it); a disagreement between the two is labelled, not hidden. */}
+              <ReviewTag review={resultReview(openResult)} disagreement={isJudgeDisagreement(openResult)} />
             </>
           )}
           /* Baseline run's trace + a per-span matcher. Powers the viewer's Diff
@@ -569,7 +663,7 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
                   display: s.error ? "Scorer error" : scoreValue(s),
                   explanation: s.error ?? s.explanation ?? undefined,
                 })),
-                existing: undefined,
+                existing: toExistingReview(openResult.humanScores),
               } satisfies ReviewTarget)
             : null
         }
@@ -954,7 +1048,45 @@ function HeadlineMetrics({ run }: { run: RunDetail }) {
         )}
       </HeadlineStat>
       <HeadlineStat label="Duration">{fmtDurationMs(run.elapsedMs)}</HeadlineStat>
+      <HumanReviewHeadline hr={run.humanReview} />
     </div>
+  );
+}
+
+/**
+ * Run-level human-review summary. Sits alongside the automated headline stats and
+ * never replaces them — human review is a separate, co-equal signal.
+ */
+function HumanReviewHeadline({ hr }: { hr: HumanReviewSummary | undefined }) {
+  if (!hr || hr.dimensions.length === 0) {
+    return (
+      <HeadlineStat label="Human review">
+        <span className="text-muted-foreground">Not started</span>
+      </HeadlineStat>
+    );
+  }
+  const total = hr.reviewedCount + hr.pendingCount;
+  const judged = hr.passCount + hr.failCount;
+  return (
+    <>
+      <HeadlineStat label="Human review">
+        {hr.reviewedCount} / {total}
+      </HeadlineStat>
+      <HeadlineStat label="Human pass rate">
+        {judged === 0 ? (
+          <span className="text-muted-foreground">—</span>
+        ) : (
+          pctFraction(hr.passCount / judged)
+        )}
+      </HeadlineStat>
+      <HeadlineStat label="Disagreements">
+        {hr.disagreementCount === 0 ? (
+          <span className="text-muted-foreground">0</span>
+        ) : (
+          <span className="text-amber-600 dark:text-amber-500">{hr.disagreementCount}</span>
+        )}
+      </HeadlineStat>
+    </>
   );
 }
 

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -7,9 +7,10 @@ import {
   AlertTriangle,
   ArrowDown,
   ArrowUp,
+  Check,
   ChevronDown,
   Database,
-  Download,
+  GitCompare,
   Info,
   Loader2,
   Search,
@@ -24,7 +25,6 @@ import { ExpandableSection } from "@/components/ui/expandable-section";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
-import { useToast } from "@/components/ui/toast";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import {
   EvalPageHeader,
@@ -50,14 +50,29 @@ import {
   signedPoints,
   truncate,
 } from "@/features/offline-eval/utils";
-import { useEvaluationRun, useEvaluationRuns, useCreateHumanScore } from "../hooks";
-import { RunStatusBadge } from "./evaluations-view";
+import { useEvaluationRun, useEvaluationRuns, useCreateHumanScore, useCompareRuns } from "../hooks";
 import { PullCodeDrawer } from "../components/pull-code-drawer";
+import { PassRate } from "../components/pass-rate";
 import { SaveTestCaseDrawer } from "../components/trace-integration";
 import { reproduceRunCode, reproduceRunCodeTs } from "@/features/offline-eval/utils";
 import { attributeTraceUsage, type TraceUsage, type UsageSpan } from "@/lib/eval/trace-usage";
 import { matchSpans } from "@/lib/eval/span-match";
-import type { ResultRow, RunDetail, ScoreRow, Classification } from "../types";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  ResultRow,
+  RunDetail,
+  ScoreRow,
+  Classification,
+  CompareResultRow,
+  CompareRunsResponse,
+  ResultRowComparison,
+} from "../types";
 
 /** Case/run duration; "Unknown" when unmeasured (never 0s). */
 function fmtDurationMs(ms: number | null | undefined): string {
@@ -276,6 +291,10 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   // "Save as test case" drawer (only for real ingested traces): which span it targets.
   const [saveTestCaseOpen, setSaveTestCaseOpen] = React.useState(false);
   const [saveTestCaseSpanId, setSaveTestCaseSpanId] = React.useState<string | undefined>(undefined);
+  // "Compare with" — another run of the SAME evaluation, chosen inline. The current run
+  // is the candidate; the picked run is the baseline. Comparison is computed on demand
+  // by the backend engine (the SDK no longer declares baselines).
+  const [compareId, setCompareId] = React.useState<string | null>(null);
 
   const results = React.useMemo(() => data?.results ?? [], [data]);
   const run = data?.run;
@@ -299,7 +318,35 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
     [siblingRuns.data, run, projectId],
   );
 
+  // Other runs of this evaluation, to pick a comparison baseline from (never an
+  // arbitrary run from another evaluation). Newest first, current run excluded.
+  const compareOptions = React.useMemo(
+    () =>
+      run
+        ? (siblingRuns.data?.data ?? [])
+            .filter((s) => s.id !== run.id)
+            .sort((a, b) => b.runNumber - a.runNumber)
+            .map((s) => ({
+              id: s.id,
+              label: `#${s.runNumber} · ${s.candidateVersion}`,
+              score: s.mainScore,
+            }))
+        : [],
+    [siblingRuns.data, run],
+  );
+
+  // On-demand comparison of this run (candidate) vs the picked run (baseline), from the
+  // same backend engine + route the compare page uses — no second implementation.
+  const compare = useCompareRuns(projectId, runId, compareId);
+  const comparing = !!compareId && !!compare.data;
+  const compareByCase = React.useMemo(() => {
+    const m = new Map<string, CompareResultRow>();
+    for (const c of compare.data?.results ?? []) m.set(c.testCaseId, c);
+    return m;
+  }, [compare.data]);
+
   const openResult = openResultId ? (results.find((r) => r.id === openResultId) ?? null) : null;
+  const openCompareRow = openResult ? (compareByCase.get(openResult.testCaseId) ?? null) : null;
 
   // Prefer the result's REAL ingested trace. Probe it — this shares TraceViewerPanel's
   // ["trace", projectId, traceId] cache key, so opening the real panel does not refetch.
@@ -334,11 +381,11 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
 
   const openTraceSpans = useRealTrace ? realTrace.data?.spans : panelOverride?.spans;
 
-  // The baseline case's trace, fetched so the trace viewer's Diff toggle can diff each
-  // span (I/O, metadata, latency/token/cost) against its baseline counterpart. Span ids
-  // differ across runs, so we match structurally (kind + name + sibling index) once the
-  // baseline trace is loaded — the matcher resolves a span selection to its baseline span.
-  const baselineTraceId = openResult?.comparison?.baselineTraceId ?? null;
+  // The baseline case's trace (from the picked compare run), fetched so the trace
+  // viewer's Diff toggle can diff each span (I/O, metadata, latency/token/cost) against
+  // its baseline counterpart. Span ids differ across runs, so we match structurally
+  // (kind + name + sibling index) once the baseline trace is loaded.
+  const baselineTraceId = comparing ? (openCompareRow?.baselineTraceId ?? null) : null;
   const baselineTrace = useTrace(projectId, baselineTraceId ?? "", !!baselineTraceId);
   const baselineSpanMatch = React.useMemo(() => {
     const baseSpans = baselineTrace.data?.spans;
@@ -405,6 +452,12 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
             onFilterChange={setResultFilter}
             onOpenResult={setOpenResultId}
             openResultId={openResultId}
+            compareId={compareId}
+            onCompareChange={setCompareId}
+            compareOptions={compareOptions}
+            compareData={compare.data ?? null}
+            compareLoading={!!compareId && compare.isLoading}
+            compareByCase={comparing ? compareByCase : null}
           />
         )}
       </div>
@@ -441,6 +494,9 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
           headerIdentity={{ label: "Test case", value: openResult.testCaseId }}
           // The case's outcome, in the header's findings-alert slot.
           headerStatus={<EvalResultBadge status={openResult.status} />}
+          // With a compare run picked, open straight into diff mode against its matching
+          // case (the user chose to compare — don't make them toggle it on per trace).
+          defaultDiffOn={comparing}
           // While the "Save as test case" drawer is open, clicking a different span
           // retargets it to that span.
           onSelectionChange={(selection) => {
@@ -625,6 +681,12 @@ function RunBody({
   onFilterChange,
   onOpenResult,
   openResultId,
+  compareId,
+  onCompareChange,
+  compareOptions,
+  compareData,
+  compareLoading,
+  compareByCase,
 }: {
   projectId: string;
   run: RunDetail;
@@ -633,13 +695,21 @@ function RunBody({
   onFilterChange: (filter: ResultFilterId) => void;
   onOpenResult: (id: string) => void;
   openResultId: string | null;
+  compareId: string | null;
+  onCompareChange: (id: string | null) => void;
+  compareOptions: Array<{ id: string; label: string; score: number | null }>;
+  compareData: CompareRunsResponse | null;
+  compareLoading: boolean;
+  compareByCase: Map<string, CompareResultRow> | null;
 }) {
   const router = useRouter();
   const [detailsOpen, setDetailsOpen] = React.useState(false);
   const [reproduceOpen, setReproduceOpen] = React.useState(false);
-  const hasBaseline = run.baselineRunId !== null;
-  const incompatibleBaseline = run.comparison.available && !run.comparison.trustworthy;
-  const trustNote = comparisonReasonText(run.comparison.reasons, run.datasetVersionLabel);
+  const comparing = !!compareByCase;
+  // Trust note reflects the PICKED comparison (not a stored baseline).
+  const cmp = compareData?.comparison ?? null;
+  const incompatibleComparison = comparing && !!cmp && cmp.available && !cmp.trustworthy;
+  const trustNote = cmp ? comparisonReasonText(cmp.reasons, run.datasetVersionLabel) : "";
 
   return (
     <>
@@ -667,6 +737,40 @@ function RunBody({
         }
         action={
           <div className="flex items-center gap-2">
+            {/* Comparison is an inline action: this run is the candidate; pick another
+                run of the same evaluation as the baseline. The diff appears in place. */}
+            <div className="flex items-center gap-1.5">
+              <GitCompare className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+              <Select
+                value={compareId ?? NO_COMPARE}
+                onValueChange={(v) => onCompareChange(v === NO_COMPARE ? null : v)}
+              >
+                <SelectTrigger className="h-7 w-[190px] text-[12px]" aria-label="Compare with">
+                  <SelectValue placeholder="Compare with…" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NO_COMPARE} className="text-[12px]">
+                    Compare with…
+                  </SelectItem>
+                  {compareOptions.length === 0 ? (
+                    <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
+                      No other runs in this evaluation
+                    </div>
+                  ) : (
+                    compareOptions.map((o) => (
+                      <SelectItem key={o.id} value={o.id} className="text-[12px]">
+                        {o.label}
+                        {o.score !== null && (
+                          <span className="ml-1.5 tabular-nums text-muted-foreground">
+                            {pctFraction(o.score)}
+                          </span>
+                        )}
+                      </SelectItem>
+                    ))
+                  )}
+                </SelectContent>
+              </Select>
+            </div>
             <Button
               variant="outline"
               size="sm"
@@ -691,7 +795,41 @@ function RunBody({
 
       <div className="min-h-0 flex-1 overflow-auto">
         <div className="flex flex-col gap-3 p-4">
-          {incompatibleBaseline && (
+          {compareLoading && (
+            <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
+              Computing comparison…
+            </div>
+          )}
+
+          {comparing && cmp && (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border border-border bg-muted/30 px-3 py-2 text-[11px]">
+              <span className="flex items-center gap-1.5">
+                <GitCompare className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+                <span className="font-medium">
+                  Comparing vs #{compareData?.baseline.runNumber} ·{" "}
+                  <span className="font-mono">{compareData?.baseline.candidateVersion}</span>
+                </span>
+              </span>
+              <span className="text-muted-foreground">baseline → candidate (this run)</span>
+              <span className="h-3 w-px bg-border" aria-hidden />
+              <span className={cmp.caseCounts.regressed > 0 ? SENTIMENT_CLASS.bad : ""}>
+                {cmp.caseCounts.regressed} regressed
+              </span>
+              <span className={cmp.caseCounts.improved > 0 ? SENTIMENT_CLASS.good : ""}>
+                {cmp.caseCounts.improved} improved
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="ml-auto h-6 px-1.5 text-[11px] text-muted-foreground hover:text-foreground"
+                onClick={() => onCompareChange(null)}
+              >
+                Clear
+              </Button>
+            </div>
+          )}
+
+          {incompatibleComparison && (
             <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[11px] leading-relaxed text-amber-700 dark:text-amber-300">
               <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
               <span>
@@ -701,12 +839,11 @@ function RunBody({
             </div>
           )}
 
-          {/* Verdict first, as a one-line strip — then results are the hero. */}
-          <VerdictStrip run={run} onFilter={onFilterChange} />
-
           <ResultsSection
+            run={run}
             results={results}
-            hasBaseline={hasBaseline}
+            comparing={comparing}
+            compareByCase={compareByCase}
             filter={filter}
             onFilterChange={onFilterChange}
             onOpen={onOpenResult}
@@ -726,6 +863,7 @@ function RunBody({
         run={run}
         projectId={projectId}
         results={results}
+        compareData={compareData}
         open={detailsOpen}
         onOpenChange={setDetailsOpen}
       />
@@ -772,12 +910,14 @@ function RunDetailsDrawer({
   run,
   projectId,
   results,
+  compareData,
   open,
   onOpenChange,
 }: {
   run: RunDetail;
   projectId: string;
   results: ResultRow[];
+  compareData: CompareRunsResponse | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
@@ -816,7 +956,12 @@ function RunDetailsDrawer({
       <div className="min-h-0 flex-1 overflow-auto p-4 text-[12px]">
         {/* Mounted only while the drawer is open, so the per-case trace fetches for
             the token/cost aggregate happen lazily, not on every run-detail load. */}
-        <RunMetricsDiff run={run} projectId={projectId} results={results} />
+        <RunMetricsDiff
+          run={run}
+          projectId={projectId}
+          results={results}
+          compareData={compareData}
+        />
         <RunDetailsBody run={run} projectId={projectId} />
       </div>
     </div>
@@ -824,20 +969,25 @@ function RunDetailsDrawer({
 }
 
 /**
- * Run-level candidate-vs-baseline metrics. Duration is derived server-side (paired
- * case-duration mean). Tokens/cost are aggregated across the run's case traces vs the
- * baseline's — fetched lazily here (only while the drawer is open) and summed; while
- * any trace is still loading it shows a "computing" note, and traces without provider
- * usage simply contribute nothing.
+ * Run-level metrics. Duration is derived server-side (paired case-duration mean).
+ * Tokens/cost are aggregated across the run's case traces — fetched lazily here (only
+ * while the drawer is open) and summed; while any trace is still loading it shows a
+ * "computing" note, and traces without provider usage simply contribute nothing.
+ *
+ * The baseline column is driven by the page's "Compare with" selection (comparison is
+ * frontend-owned now that the SDK no longer sends a stored baseline): with a run picked,
+ * each metric shows its ± delta vs that run; with none picked, only the candidate value.
  */
 function RunMetricsDiff({
   run,
   projectId,
   results,
+  compareData,
 }: {
   run: RunDetail;
   projectId: string;
   results: ResultRow[];
+  compareData: CompareRunsResponse | null;
 }) {
   const { data: authSession } = useAuthSession();
   const user = authSession?.user
@@ -848,11 +998,18 @@ function RunMetricsDiff({
     () => [...new Set(results.map((r) => r.traceId).filter((x): x is string => !!x))],
     [results],
   );
+  // Baseline traces come from the picked compare run (per-case baselineTraceId), not a
+  // stored per-result baseline (which the SDK is dropping).
   const baselineIds = React.useMemo(
-    () => [
-      ...new Set(results.map((r) => r.comparison?.baselineTraceId).filter((x): x is string => !!x)),
-    ],
-    [results],
+    () =>
+      compareData
+        ? [
+            ...new Set(
+              compareData.results.map((r) => r.baselineTraceId).filter((x): x is string => !!x),
+            ),
+          ]
+        : [],
+    [compareData],
   );
   const allIds = React.useMemo(
     () => [...new Set([...candidateIds, ...baselineIds])],
@@ -892,7 +1049,9 @@ function RunMetricsDiff({
   };
   const cand = sum(candidateIds);
   const base = sum(baselineIds);
-  const dur = run.comparison.duration;
+  // Duration deltas come from the picked compare run when comparing; otherwise the
+  // candidate's own mean with no baseline.
+  const dur = compareData?.comparison.duration ?? run.comparison.duration;
 
   const fmtTok = (n: number) => `${Math.round(n).toLocaleString()}`;
   const fmtCost = (n: number) => (n > 0 ? `$${n.toFixed(4)}` : "$0");
@@ -901,11 +1060,15 @@ function RunMetricsDiff({
   return (
     <div className="mb-3 overflow-hidden rounded border border-border">
       <div className="border-b border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground">
-        Metrics vs baseline{" "}
-        {run.comparison.baseline ? (
-          <span className="text-foreground">({run.comparison.baseline.candidateVersion})</span>
+        {compareData ? (
+          <>
+            Metrics vs #{compareData.baseline.runNumber}{" "}
+            <span className="text-foreground">({compareData.baseline.candidateVersion})</span>
+          </>
         ) : (
-          <span>— no baseline</span>
+          <>
+            Run metrics <span>— pick a run in “Compare with” for deltas</span>
+          </>
         )}
       </div>
       <table className="w-full text-[11px]">
@@ -973,7 +1136,7 @@ function RunSwitcher({
           <ChevronDown className="h-3 w-3" aria-hidden />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="max-h-[360px] w-80 overflow-y-auto p-1">
+      <PopoverContent align="start" className="max-h-[360px] w-72 overflow-y-auto p-1">
         <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
           Run history
         </div>
@@ -985,31 +1148,22 @@ function RunSwitcher({
               onPick(sibling.id);
               setOpen(false);
             }}
-            className={cn(
-              "flex w-full flex-col gap-1 rounded px-2 py-1.5 text-left text-[12px] transition-colors",
-              sibling.id === run.id ? "bg-muted/70" : "hover:bg-muted/50",
-            )}
+            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] transition-colors hover:bg-muted/50"
           >
-            <div className="flex items-center justify-between gap-2">
-              <span className="flex items-center gap-1.5">
-                <span className="font-medium">Run #{sibling.runNumber}</span>
-                {sibling.id === run.id && (
-                  <span className="rounded bg-foreground/10 px-1 text-[10px] text-muted-foreground">
-                    current
-                  </span>
-                )}
-                <span className="font-mono text-[11px] text-muted-foreground">
-                  {sibling.candidateVersion}
-                </span>
-              </span>
-              <span className="tabular-nums text-muted-foreground">
-                {sibling.mainScore === null ? "—" : pctFraction(sibling.mainScore)}
-              </span>
-            </div>
-            <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
-              <RunStatusBadge status={sibling.status} />
-              <Timestamp iso={sibling.startedAt} />
-            </div>
+            <Check
+              className={cn(
+                "h-3.5 w-3.5 shrink-0",
+                sibling.id === run.id ? "opacity-100" : "opacity-0",
+              )}
+              aria-hidden
+            />
+            <span className="font-medium">Run #{sibling.runNumber}</span>
+            <span className="font-mono text-[11px] text-muted-foreground">
+              {sibling.candidateVersion}
+            </span>
+            <span className="ml-auto tabular-nums text-muted-foreground">
+              {sibling.mainScore === null ? "—" : pctFraction(sibling.mainScore)}
+            </span>
           </button>
         ))}
       </PopoverContent>
@@ -1017,161 +1171,30 @@ function RunSwitcher({
   );
 }
 
-/**
- * Compact verdict — the run's headline numbers on one strip, above the results.
- * Regressions and Errors are clickable: they filter the results table in place
- * rather than being separate sections the reader has to scroll past.
- */
-function VerdictStrip({
-  run,
-  onFilter,
-}: {
-  run: RunDetail;
-  onFilter: (filter: ResultFilterId) => void;
-}) {
-  const unscored = run.caseCount - run.scoredCount;
-  const cmp = run.comparison;
-  const cases = cmp.caseCounts;
-  const cells = cmp.scoreCellCounts;
-  // "Not cleanly compared" folds unpaired (one side only) + not_comparable (paired but
-  // un-trustable). A delta and regression counts are shown only when a comparison is
-  // available — otherwise "—" (unknown), never a delta beside a bare 0.
-  const unpaired = cases.unpaired + cases.not_comparable;
-  return (
-    <div className="rounded-md border border-border p-3">
-      <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
-        <RunStatusBadge status={run.status} />
-        <Metric
-          label={run.mainScoreName ?? "Main score"}
-          value={run.mainScore === null ? "—" : pctFraction(run.mainScore)}
-          hint={cmp.baseline ? `vs ${cmp.baseline.candidateVersion}` : undefined}
-          strong
-        />
-        <Metric
-          label="Change"
-          value={
-            !cmp.available || cmp.mainScore.delta === null ? (
-              <span className="text-muted-foreground">—</span>
-            ) : (
-              <span className={SENTIMENT_CLASS[changeSentiment(cmp.mainScore.delta)]}>
-                {signedPoints(cmp.mainScore.delta)} pp
-              </span>
-            )
-          }
-          hint={!cmp.available ? "No baseline" : !cmp.trustworthy ? "Not trusted" : undefined}
-        />
-        {/* Case-level (main scorer). Regressions/Improvements filter the table. */}
-        <FilterStat
-          label="Regressed"
-          count={cmp.available ? cases.regressed : null}
-          onClick={() => onFilter("regressions")}
-        />
-        <FilterStat
-          label="Improved"
-          count={cmp.available ? cases.improved : null}
-          onClick={() => onFilter("improvements")}
-        />
-        <Metric label="Unchanged" value={cmp.available ? cases.unchanged : "—"} />
-        <FilterStat
-          label="Unpaired"
-          count={cmp.available ? unpaired : null}
-          onClick={() => onFilter("unpaired")}
-        />
-        {/* Secondary, clearly labeled: regressed SCORE CELLS ≠ regressed cases. */}
-        <Metric
-          label="Regressed cells"
-          value={cmp.available ? cells.regressed : "—"}
-          hint="score cells"
-        />
-        <FilterStat label="Errors" count={run.errorCount} onClick={() => onFilter("errors")} />
-        <Metric label="Scored" value={`${run.scoredCount} / ${run.caseCount}`} />
-      </div>
-      {/* Completeness — the denominator is always explicit. */}
-      {unscored > 0 && (
-        <p className="mt-2 text-[11px] text-muted-foreground">
-          <span className="text-foreground">
-            {unscored} {unscored === 1 ? "case is" : "cases are"} not scored
-          </span>{" "}
-          — excluded from the average, not counted as zero.
-        </p>
-      )}
-    </div>
-  );
-}
-
-function Metric({
-  label,
-  value,
-  hint,
-  strong,
-}: {
-  label: string;
-  value: React.ReactNode;
-  hint?: string;
-  strong?: boolean;
-}) {
-  return (
-    <div>
-      <p className="text-[11px] text-muted-foreground">{label}</p>
-      <p className={cn("tabular-nums", strong ? "text-[18px] font-medium" : "text-[15px]")}>
-        {value}
-      </p>
-      {hint && <p className="text-[11px] text-muted-foreground">{hint}</p>}
-    </div>
-  );
-}
-
-/**
- * A count that filters the results table when non-zero. A null count means the
- * quantity is UNKNOWN (e.g. no baseline → regressions can't be counted) and renders
- * as "—", never a bare 0 that would read as "0 regressions" beside a delta.
- */
-function FilterStat({
-  label,
-  count,
-  onClick,
-}: {
-  label: string;
-  count: number | null;
-  onClick: () => void;
-}) {
-  if (count === null) {
-    return <Metric label={label} value={<span className="text-muted-foreground">—</span>} />;
-  }
-  if (count === 0) {
-    return <Metric label={label} value={<span className="text-muted-foreground">0</span>} />;
-  }
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="rounded text-left transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-      title={`Show ${label.toLowerCase()} in the results below`}
-    >
-      <span className="text-[11px] text-muted-foreground">{label}</span>
-      <span className="block text-[15px] font-medium tabular-nums">{count}</span>
-    </button>
-  );
-}
-
 const RESULT_COLUMN_COUNT = 6;
 
+/** Sentinel for the "Compare with" select's no-selection option (Radix needs a value). */
+const NO_COMPARE = "__none__";
+
 function ResultsSection({
+  run,
   results,
-  hasBaseline,
+  comparing,
+  compareByCase,
   filter,
   onFilterChange,
   onOpen,
   openResultId,
 }: {
+  run: RunDetail;
   results: ResultRow[];
-  hasBaseline: boolean;
+  comparing: boolean;
+  compareByCase: Map<string, CompareResultRow> | null;
   filter: ResultFilterId;
   onFilterChange: (filter: ResultFilterId) => void;
   onOpen: (id: string) => void;
   openResultId: string | null;
 }) {
-  const { toast } = useToast();
   const [keyword, setKeyword] = React.useState("");
   const [sortWorst, setSortWorst] = React.useState(false);
   const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
@@ -1179,6 +1202,12 @@ function ResultsSection({
   );
   const [customStart, setCustomStart] = React.useState<Date | null>(null);
   const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
+
+  // Per-result comparison vs the picked run (null when not comparing).
+  const cmpFor = React.useCallback(
+    (r: ResultRow) => (comparing ? (compareByCase?.get(r.testCaseId) ?? null) : null),
+    [comparing, compareByCase],
+  );
 
   const visible = React.useMemo(() => {
     const q = keyword.trim().toLowerCase();
@@ -1192,16 +1221,16 @@ function ResultsSection({
       );
     });
     if (!sortWorst) return filtered;
-    // Worst main-score regression first (most-negative delta); unknown deltas last.
+    // Worst main-score regression first (most-negative delta vs the picked run); unknown last.
     return [...filtered].sort((a, b) => {
-      const da = a.comparison?.mainScore.delta;
-      const db = b.comparison?.mainScore.delta;
+      const da = cmpFor(a)?.comparison?.mainScore.delta;
+      const db = cmpFor(b)?.comparison?.mainScore.delta;
       if (da == null && db == null) return 0;
       if (da == null) return 1;
       if (db == null) return -1;
       return da - db;
     });
-  }, [results, keyword, filter, sortWorst]);
+  }, [results, keyword, filter, sortWorst, cmpFor]);
 
   return (
     <div className="rounded-md border border-border">
@@ -1240,6 +1269,8 @@ function ResultsSection({
           ))}
         </div>
         <span className="flex-1" aria-hidden />
+        <PassRate counts={run} withLabel />
+        <span className="flex-1" aria-hidden />
         <Button
           variant={sortWorst ? "default" : "outline"}
           size="sm"
@@ -1250,15 +1281,6 @@ function ResultsSection({
           <ArrowDown className="h-3.5 w-3.5" aria-hidden />
           Worst regression
         </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-          onClick={() => toast({ title: "Export coming soon", tone: "success" })}
-        >
-          <Download className="h-3.5 w-3.5" aria-hidden />
-          Download
-        </Button>
       </SearchFilterBar>
 
       <Table>
@@ -1268,7 +1290,7 @@ function ResultsSection({
             <Th>Output</Th>
             <Th>Expected</Th>
             <Th className="w-[170px]">Main score</Th>
-            <Th className="w-[110px] text-right">Change</Th>
+            <Th className="w-[110px] text-right">{comparing ? "vs baseline" : "Change"}</Th>
             <Th className="w-[110px]">Status</Th>
           </TRHead>
         </THead>
@@ -1284,33 +1306,43 @@ function ResultsSection({
               </td>
             </tr>
           ) : (
-            visible.map((result) => (
-              <TR
-                key={result.id}
-                interactive
-                selected={result.id === openResultId}
-                onClick={() => onOpen(result.id)}
-              >
-                <Td>{truncate(result.input, 60)}</Td>
-                <Td>
-                  {result.candidateOutput ?? (
-                    <span className="text-muted-foreground">No output</span>
-                  )}
-                </Td>
-                <Td className="text-muted-foreground">{result.expectedOutput ?? "—"}</Td>
-                <Td>
-                  <MainScoreCell result={result} hasBaseline={hasBaseline} />
-                </Td>
-                <Td className="text-right">
-                  <ChangeCell
-                    change={hasBaseline ? (result.comparison?.caseChange ?? null) : null}
-                  />
-                </Td>
-                <Td>
-                  <EvalResultBadge status={result.status} />
-                </Td>
-              </TR>
-            ))
+            visible.map((result) => {
+              const row = cmpFor(result);
+              const rowCmp = row?.comparison ?? null;
+              return (
+                <TR
+                  key={result.id}
+                  interactive
+                  selected={result.id === openResultId}
+                  onClick={() => onOpen(result.id)}
+                >
+                  <Td>{truncate(result.input, 60)}</Td>
+                  <Td>
+                    {result.candidateOutput ?? (
+                      <span className="text-muted-foreground">No output</span>
+                    )}
+                    {row?.outputChanged === true && (
+                      <span
+                        className="ml-1.5 rounded bg-muted px-1 text-[10px] text-muted-foreground"
+                        title="Output differs from the baseline run"
+                      >
+                        ≠ baseline
+                      </span>
+                    )}
+                  </Td>
+                  <Td className="text-muted-foreground">{result.expectedOutput ?? "—"}</Td>
+                  <Td>
+                    <MainScoreCell result={result} comparison={rowCmp} />
+                  </Td>
+                  <Td className="text-right">
+                    <ChangeCell change={rowCmp?.caseChange ?? null} />
+                  </Td>
+                  <Td>
+                    <EvalResultBadge status={result.status} />
+                  </Td>
+                </TR>
+              );
+            })
           )}
         </TBody>
       </Table>
@@ -1319,16 +1351,21 @@ function ResultsSection({
 }
 
 /**
- * Per-result candidate main score, its baseline counterpart, and the delta — the
- * backend now derives the baseline per-case value, so we show a real magnitude, not
- * just a direction. Missing values render "—", never a fabricated 0.
+ * Per-result candidate main score, and — when comparing against a picked run — its
+ * baseline counterpart + delta (the backend engine derives the per-case baseline value,
+ * so we show a real magnitude). Missing values render "—", never a fabricated 0.
  */
-function MainScoreCell({ result, hasBaseline }: { result: ResultRow; hasBaseline: boolean }) {
-  const cmp = result.comparison;
-  const cand = cmp?.mainScore.candidate ?? result.mainScore;
+function MainScoreCell({
+  result,
+  comparison,
+}: {
+  result: ResultRow;
+  comparison: ResultRowComparison | null;
+}) {
+  const cand = comparison?.mainScore.candidate ?? result.mainScore;
   if (cand === null || cand === undefined) return <span className="text-muted-foreground">—</span>;
-  const base = hasBaseline ? (cmp?.mainScore.baseline ?? null) : null;
-  const delta = hasBaseline ? (cmp?.mainScore.delta ?? null) : null;
+  const base = comparison?.mainScore.baseline ?? null;
+  const delta = comparison?.mainScore.delta ?? null;
   return (
     <div className="flex flex-col gap-0.5 text-[12px] tabular-nums">
       <span>

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -26,6 +26,7 @@ import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { useToast } from "@/components/ui/toast";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import {
+  EditableValueBlock,
   EvalPageHeader,
   EvalResultBadge,
   ReviewPanel,
@@ -207,8 +208,9 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   const { data, isLoading, error } = useEvaluationRun(projectId, runId);
   const [openResultId, setOpenResultId] = React.useState<string | null>(null);
   const [resultFilter, setResultFilter] = React.useState<ResultFilterId>("all");
-  const [traceFullscreen, setTraceFullscreen] = React.useState(false);
   const [reviewOpen, setReviewOpen] = React.useState(false);
+  // The result's REAL ingested trace, opened as a side panel over the eval trace.
+  const [viewRealTraceId, setViewRealTraceId] = React.useState<string | null>(null);
 
   const { toast } = useToast();
   const results = React.useMemo(() => data?.results ?? [], [data]);
@@ -233,7 +235,7 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
 
   const closeResult = () => {
     setOpenResultId(null);
-    setTraceFullscreen(false);
+    setViewRealTraceId(null);
   };
 
   return (
@@ -270,12 +272,10 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
       {/* The real trace viewer on the eval-shaped trace — not a simplified tree. */}
       {openResult && openTrace && run && (
         <TraceViewerPanel
-          // Remount when fullscreen flips: initialFullscreen is read only at mount.
-          key={`${openTrace.trace_id}:${traceFullscreen ? "fs" : "panel"}`}
+          key={openTrace.trace_id}
           projectId={projectId}
           traceId={openTrace.trace_id}
           traceOverride={openTrace}
-          initialFullscreen={traceFullscreen}
           newTabPath={`/projects/${projectId}/evaluations/${runId}`}
           onClose={closeResult}
           onNavigate={() => {}}
@@ -286,8 +286,9 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
               projectId={projectId}
               run={run}
               result={openResult}
-              fullscreen={traceFullscreen}
-              onOpenFullTrace={() => setTraceFullscreen(true)}
+              onOpenFullTrace={
+                openResult.traceId ? () => setViewRealTraceId(openResult.traceId) : undefined
+              }
               onReview={() => setReviewOpen(true)}
               onSaveExpected={(value) =>
                 updateCase.mutate(
@@ -327,6 +328,21 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
               </span>
             </>
           )}
+        />
+      )}
+
+      {/* "Open full trace" opens the result's REAL ingested trace as a side panel
+          over the eval trace; closing it returns to the eval trace panel. */}
+      {viewRealTraceId && (
+        <TraceViewerPanel
+          key={`real:${viewRealTraceId}`}
+          projectId={projectId}
+          traceId={viewRealTraceId}
+          newTabPath={`/projects/${projectId}/evaluations/${runId}`}
+          onClose={() => setViewRealTraceId(null)}
+          onNavigate={() => {}}
+          canNavigateUp={false}
+          canNavigateDown={false}
         />
       )}
 
@@ -1001,14 +1017,15 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
 
 /**
  * The evaluation context for one result, shown as the trace viewer's span-actions
- * panel: input + candidate output, an editable expected outcome (saving publishes a
- * new dataset version), how the scorers judged it, what broke, and the human review.
+ * panel. The input/candidate output already render in the span detail below, so
+ * this adds only the eval-specific bits: the editable expected outcome (behind a
+ * button; saving publishes a new dataset version), the scores, what broke, the
+ * human review, and the actions.
  */
 function ResultContext({
   projectId,
   run,
   result,
-  fullscreen,
   onOpenFullTrace,
   onReview,
   onSaveExpected,
@@ -1016,56 +1033,91 @@ function ResultContext({
   projectId: string;
   run: RunDetail;
   result: ResultRow;
-  fullscreen: boolean;
-  onOpenFullTrace: () => void;
+  onOpenFullTrace?: () => void;
   onReview: () => void;
   onSaveExpected: (value: string) => void;
 }) {
   const expectedValue = result.expectedOutput ?? "";
+  const [editing, setEditing] = React.useState(false);
   const [expected, setExpected] = React.useState(expectedValue);
-  React.useEffect(() => setExpected(expectedValue), [expectedValue, result.id]);
+  React.useEffect(() => {
+    setExpected(expectedValue);
+    setEditing(false);
+  }, [expectedValue, result.id]);
   const expectedDirty = expected.trim() !== expectedValue.trim();
 
   return (
     <div className="w-full text-[12px]">
       <div className="mb-2 flex flex-wrap items-center gap-2">
-        <span className="text-[11px] font-medium text-muted-foreground">Evaluation result</span>
         <EvalResultBadge status={result.status} />
         <span className="font-mono text-[11px] text-muted-foreground">{result.testCaseId}</span>
       </div>
 
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        <MiniField label="Input">{result.input}</MiniField>
-        <MiniField label="Candidate output">
-          {result.candidateOutput ?? <span className="text-muted-foreground">No output</span>}
-        </MiniField>
-      </div>
-
-      {/* Expected outcome is edited inline. Saving edits the source test case. */}
-      <div className="mt-2">
-        <p className="mb-1 text-[11px] text-muted-foreground">Expected outcome</p>
-        <div className="flex items-center gap-2">
-          <Input
-            value={expected}
-            onChange={(e) => setExpected(e.target.value)}
-            placeholder="No expected outcome — a scorer judges the output directly."
-            className="h-7 text-[12px]"
+      {/* Expected outcome — a two-line editable field revealed by a button; saving
+          publishes a new dataset version (the input/output are in the span detail). */}
+      {editing ? (
+        <div>
+          <EditableValueBlock
+            label="Expected outcome"
+            text={expected}
+            onChange={setExpected}
+            boxed
+            autoDetectKind
+            copyable
+            minRows={2}
           />
-          <Button
-            size="sm"
-            className="h-7 shrink-0 text-[12px]"
-            disabled={!expectedDirty}
-            onClick={() => onSaveExpected(expected.trim())}
-          >
-            Save
-          </Button>
+          <div className="mt-1.5 flex items-center gap-2">
+            <Button
+              size="sm"
+              className="h-7 text-[12px]"
+              disabled={!expectedDirty}
+              onClick={() => {
+                onSaveExpected(expected.trim());
+                setEditing(false);
+              }}
+            >
+              Save
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-[12px]"
+              onClick={() => {
+                setExpected(expectedValue);
+                setEditing(false);
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Saving edits test case <span className="font-mono">{result.testCaseId}</span> in{" "}
+            <span className="font-medium">{run.datasetName}</span> — it changes what future runs are
+            compared against.
+          </p>
         </div>
-        <p className="mt-1 text-[11px] text-muted-foreground">
-          Saving edits test case <span className="font-mono">{result.testCaseId}</span> in{" "}
-          <span className="font-medium">{run.datasetName}</span> — it changes what future runs are
-          compared against.
-        </p>
-      </div>
+      ) : (
+        <div>
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <p className="text-[11px] text-muted-foreground">Expected outcome</p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-6 px-2 text-[11px]"
+              onClick={() => setEditing(true)}
+            >
+              Edit
+            </Button>
+          </div>
+          <div className="rounded border border-border bg-muted/20 px-2.5 py-2 leading-relaxed">
+            {expectedValue || (
+              <span className="text-muted-foreground">
+                No expected outcome — a scorer judges the output directly.
+              </span>
+            )}
+          </div>
+        </div>
+      )}
 
       {result.baselineOutput !== null && (
         <p className="mt-2 text-[11px] text-muted-foreground">
@@ -1134,7 +1186,7 @@ function ResultContext({
         <Button size="sm" className="h-7 text-[12px]" onClick={onReview}>
           Review output
         </Button>
-        {!fullscreen && (
+        {onOpenFullTrace && (
           <Button
             variant="outline"
             size="sm"
@@ -1146,7 +1198,7 @@ function ResultContext({
           </Button>
         )}
         <Link
-          href={`/projects/${projectId}/datasets/${run.datasetId}`}
+          href={`/projects/${projectId}/datasets/${run.datasetId}?case=${result.testCaseId}`}
           className="inline-flex h-7 items-center gap-1.5 rounded-md border border-input bg-background px-2.5 text-[12px] font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
           <Database className="h-3.5 w-3.5" aria-hidden />
@@ -1156,17 +1208,6 @@ function ResultContext({
           {result.durationMs !== null ? `${(result.durationMs / 1000).toFixed(1)}s` : "—"}
           {result.cost !== null ? ` · $${result.cost.toFixed(4)}` : ""}
         </span>
-      </div>
-    </div>
-  );
-}
-
-function MiniField({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div>
-      <p className="mb-1 text-[11px] text-muted-foreground">{label}</p>
-      <div className="rounded border border-border bg-muted/20 px-2.5 py-2 leading-relaxed">
-        {children}
       </div>
     </div>
   );

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -59,6 +59,13 @@ import { RunStatusBadge } from "./evaluations-view";
 import { attributeTraceUsage, type TraceUsage, type UsageSpan } from "@/lib/eval/trace-usage";
 import type { ResultRow, RunDetail, ScoreRow, Classification } from "../types";
 
+/** Verdict → badge tone, matching the design system's success/danger/warning. */
+const HUMAN_VERDICT_VARIANT: Record<string, "success" | "danger" | "warning"> = {
+  pass: "success",
+  fail: "danger",
+  unsure: "warning",
+};
+
 /** Case/run duration; "Unknown" when unmeasured (never 0s). */
 function fmtDurationMs(ms: number | null | undefined): string {
   if (ms === null || ms === undefined) return "Unknown";
@@ -1614,15 +1621,30 @@ function ResultContext({
       <UsageBreakdown usage={traceUsage} />
 
       {result.humanScores.length > 0 && (
-        <div className="mt-2 rounded border border-border bg-muted/20 px-2.5 py-1.5 text-[11px]">
-          <span className="text-muted-foreground">Human review: </span>
-          {result.humanScores.map((h, i) => (
-            <span key={h.id}>
-              {i > 0 ? "; " : ""}
-              <span className="font-medium capitalize">{h.verdict}</span>
-              {h.comment ? ` — ${h.comment}` : ""}
-            </span>
-          ))}
+        <div className="mt-2 overflow-hidden rounded border border-border">
+          <div className="border-b border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground">
+            Human review
+          </div>
+          <ul className="divide-y divide-border">
+            {result.humanScores.map((h) => (
+              <li key={h.id} className="flex flex-col gap-1 px-2.5 py-1.5 text-[11px]">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant={HUMAN_VERDICT_VARIANT[h.verdict] ?? "default"}>
+                    <span className="capitalize">{h.verdict}</span>
+                  </Badge>
+                  {h.quality != null && (
+                    <span className="tabular-nums text-muted-foreground">
+                      Quality {h.quality}/5
+                    </span>
+                  )}
+                  {h.reviewer && (
+                    <span className="ml-auto truncate text-muted-foreground">{h.reviewer}</span>
+                  )}
+                </div>
+                {h.comment && <p className="leading-relaxed text-muted-foreground">{h.comment}</p>}
+              </li>
+            ))}
+          </ul>
         </div>
       )}
 

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -4,105 +4,54 @@ import * as React from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
+  AlertTriangle,
   ArrowDown,
   ArrowUp,
-  Check,
   ChevronDown,
+  ChevronRight,
   Database,
-  GitCompare,
-  Loader2,
+  Download,
+  ExternalLink,
   Search,
-  X,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ExpandableSection } from "@/components/ui/expandable-section";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
+import { useToast } from "@/components/ui/toast";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import {
   EvalPageHeader,
   EvalResultBadge,
   ReviewPanel,
+  Timestamp,
   useSeedTraceIO,
   type ReviewTarget,
 } from "@/features/offline-eval/components";
 import { TraceViewerPanel } from "@/features/traces/components";
-import { useTrace } from "@/features/traces/hooks";
 import type { Span, TraceDetail } from "@/types/api";
 import type { SpanKind, SpanStatus } from "@traceroot/core";
 import { cn } from "@/lib/utils";
 import {
   changeSentiment,
-  pctFraction,
+  pct,
   SENTIMENT_CLASS,
-  signedPoints,
+  signed,
+  truncate,
 } from "@/features/offline-eval/utils";
-import { useEvaluationRun, useEvaluationRuns, useCreateHumanScore, useCompareRuns } from "../hooks";
-import { PullCodeDrawer } from "../components/pull-code-drawer";
-import { PassRate } from "../components/pass-rate";
-import { SaveTestCaseDrawer } from "../components/trace-integration";
-import { reproduceRunCode, reproduceRunCodeTs } from "@/features/offline-eval/utils";
-import { matchSpans } from "@/lib/eval/span-match";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import type {
-  ResultRow,
-  RunDetail,
-  ScoreRow,
-  Classification,
-  CompareResultRow,
-  CompareRunsResponse,
-  ResultRowComparison,
-} from "../types";
-
-/** Case/run duration; "Unknown" when unmeasured (never 0s). */
-function fmtDurationMs(ms: number | null | undefined): string {
-  if (ms === null || ms === undefined) return "Unknown";
-  if (ms < 1000) return `${Math.round(ms)}ms`;
-  return `${(ms / 1000).toFixed(1)}s`;
-}
-
-/** Signed candidate−baseline delta beside a duration/cost cell (lower is better:
- *  an increase is red, a decrease green). Rendered only when comparing. */
-function CellDelta({
-  delta,
-  format,
-}: {
-  delta: number | null;
-  format: (n: number) => string;
-}): React.ReactNode {
-  if (delta === null || delta === 0) return null;
-  return (
-    <span className={`ml-1 ${SENTIMENT_CLASS[changeSentiment(-delta)]}`}>
-      {delta > 0 ? "+" : "−"}
-      {format(Math.abs(delta))}
-    </span>
-  );
-}
-
-/**
- * Whether two authored values are the SAME value. A pure reformat (re-indenting
- * JSON, whether from the seed format or the format switcher) is not an edit —
- * without this, opening a case would offer to publish a new dataset version that
- * changes nothing but whitespace.
- */
-export function sameAuthoredValue(a: string, b: string): boolean {
-  if (a.trim() === b.trim()) return true;
-  try {
-    return JSON.stringify(JSON.parse(a)) === JSON.stringify(JSON.parse(b));
-  } catch {
-    return false; // one side isn't JSON — trust the text comparison above
-  }
-}
+  useEvaluationRun,
+  useEvaluationRuns,
+  useCreateHumanScore,
+  useUpdateTestCase,
+} from "../hooks";
+import { RunStatusBadge } from "./evaluations-view";
+import type { ResultRow, RunDetail, ScoreRow } from "../types";
 
 function scoreValue(s: ScoreRow): string {
   if (s.error) return "error";
@@ -140,28 +89,22 @@ function evalSpan(
 
 /**
  * The eval-shaped trace for one result, so the run detail opens into the real
- * trace viewer (span tree + span detail) — the shape the SDK reports:
+ * trace viewer (span tree + span detail) exactly like the mock — the shape the
+ * SDK reports:
  *
  *   evaluation item (root)
  *     ├─ task span      ← the candidate application's run
  *     ├─ scorer span    ← siblings of the task, one per scorer that ran
  *     └─ scorer span
  *
- * Built from the actual result + scores only (no fabricated sub-spans). This is a
- * clearly-LABELED fallback, used only when a result emitted no real trace; a result
- * with a real ingested trace opens that real trace directly instead.
+ * Built from the actual result + scores only (no fabricated sub-spans). When the
+ * result carries a real ingested trace, its full span tree is a click away via
+ * "Open full trace"; this synthetic trace is what always renders here.
  */
 function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
   const id = result.traceId || `eval-${result.id}`;
   const failed = Boolean(result.taskError);
   const rootStatus = (failed ? "ERROR" : "OK") as SpanStatus;
-
-  // Ordered fake timestamps so the reconstructed tree is deterministic and reads in
-  // the real order: task first, then scorers (which run after it). Without distinct
-  // starts, the stable sibling sort would tie and fall back to span_id.
-  const base = new Date(result.createTime).getTime();
-  const t0 = Number.isFinite(base) ? base : 0;
-  const iso = (ms: number) => new Date(ms).toISOString();
 
   const spans: Span[] = [
     evalSpan({
@@ -169,8 +112,6 @@ function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
       trace_id: id,
       name: `${run.evaluationName} · ${result.testCaseId}`,
       span_kind: "AGENT" as SpanKind,
-      span_start_time: iso(t0),
-      span_end_time: iso(t0 + result.scores.length + 2),
       input: result.input,
       output: result.candidateOutput,
       status: rootStatus,
@@ -188,8 +129,6 @@ function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
       parent_span_id: `${id}-root`,
       name: "task",
       span_kind: "SPAN" as SpanKind,
-      span_start_time: iso(t0),
-      span_end_time: iso(t0 + 1),
       input: result.input,
       output: result.candidateOutput,
       cost: result.cost,
@@ -199,8 +138,8 @@ function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
     }),
   ];
 
-  // Scorer spans — siblings of the task, one per scorer that ran, starting after it.
-  result.scores.forEach((s, i) => {
+  // Scorer spans — siblings of the task, one per scorer that ran.
+  for (const s of result.scores) {
     spans.push(
       evalSpan({
         span_id: `${id}-scorer-${s.id}`,
@@ -208,8 +147,6 @@ function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
         parent_span_id: `${id}-root`,
         name: s.scorerName,
         span_kind: "SPAN" as SpanKind,
-        span_start_time: iso(t0 + i + 2),
-        span_end_time: iso(t0 + i + 2),
         input: `output: ${result.candidateOutput ?? "—"}\nexpected: ${result.expectedOutput ?? "—"}`,
         output: s.error ?? scoreValue(s),
         status: (s.error ? "ERROR" : "OK") as SpanStatus,
@@ -217,7 +154,7 @@ function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
         metadata: JSON.stringify({ scorer: s.scorerName, version: s.scorerVersion }),
       }),
     );
-  });
+  }
 
   return {
     trace_id: id,
@@ -237,40 +174,26 @@ function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
   };
 }
 
-type ResultFilterId =
-  | "all"
-  | "regressions"
-  | "improvements"
-  | "failed"
-  | "errors"
-  | "unpaired"
-  | "not_scored";
+type ResultFilterId = "all" | "regressions" | "failed" | "errors" | "not_scored";
 
 const RESULT_FILTERS: Array<{ id: ResultFilterId; label: string }> = [
   { id: "all", label: "All" },
   { id: "regressions", label: "Regressions" },
-  { id: "improvements", label: "Improvements" },
-  { id: "failed", label: "Did not pass" },
+  { id: "failed", label: "Failed" },
   { id: "errors", label: "Errors" },
-  { id: "unpaired", label: "Unpaired" },
   { id: "not_scored", label: "Not scored" },
 ];
 
-// Filters key on the DERIVED case verdict (comparison.caseChange), never the stored
-// change column. "Unpaired" folds in not_comparable (paired but un-trustable) cases.
 const RESULT_FILTER_FN: Record<ResultFilterId, (r: ResultRow) => boolean> = {
   all: () => true,
-  regressions: (r) => r.comparison?.caseChange === "regressed",
-  improvements: (r) => r.comparison?.caseChange === "improved",
+  regressions: (r) => r.change === "regressed",
   failed: (r) => r.status === "failed",
   errors: (r) => r.status === "errored" || r.scores.some((s) => s.error),
-  unpaired: (r) =>
-    r.comparison?.caseChange === "unpaired" || r.comparison?.caseChange === "not_comparable",
   not_scored: (r) => r.status === "not_scored",
 };
 
 /**
- * Evaluation run detail — the run detail surface, wired to
+ * Evaluation run detail — faithful port of the prototype's run detail, wired to
  * the server. Ordered to answer, in sequence: did the candidate improve, what
  * regressed, what broke, and can the aggregate be trusted? Verdict strip first
  * (its Regressions/Errors counts filter the results table in place), then the
@@ -278,124 +201,44 @@ const RESULT_FILTER_FN: Record<ResultFilterId, (r: ResultRow) => boolean> = {
  *
  * Opening a result opens the REAL trace viewer (span tree + span detail) on an
  * eval-shaped trace built from the result, with the evaluation context, scores,
- * and human review as the span-actions panel.
+ * and human review as the span-actions panel — exactly like the mock.
  */
 export function RunDetailView({ projectId, runId }: { projectId: string; runId: string }) {
   const { data, isLoading, error } = useEvaluationRun(projectId, runId);
   const [openResultId, setOpenResultId] = React.useState<string | null>(null);
   const [resultFilter, setResultFilter] = React.useState<ResultFilterId>("all");
+  const [traceFullscreen, setTraceFullscreen] = React.useState(false);
   const [reviewOpen, setReviewOpen] = React.useState(false);
-  // "Save as test case" drawer (only for real ingested traces): which span it targets.
-  const [saveTestCaseOpen, setSaveTestCaseOpen] = React.useState(false);
-  const [saveTestCaseSpanId, setSaveTestCaseSpanId] = React.useState<string | undefined>(undefined);
-  // "Compare with" — another run of the SAME evaluation, chosen inline. The current run
-  // is the candidate; the picked run is the baseline. Comparison is computed on demand
-  // by the backend engine (the SDK no longer declares baselines).
-  const [compareId, setCompareId] = React.useState<string | null>(null);
 
+  const { toast } = useToast();
   const results = React.useMemo(() => data?.results ?? [], [data]);
   const run = data?.run;
 
-  // This evaluation's other runs — the compare-baseline picker below and the
-  // header RunSwitcher share this query key, so it's one fetch, not two.
-  const siblingRuns = useEvaluationRuns(projectId, {
-    evaluation_id: run?.evaluationId,
-    limit: 100,
-  });
-
-  // Other runs of this evaluation, to pick a comparison baseline from (never an
-  // arbitrary run from another evaluation). Newest first, current run excluded.
-  const compareOptions = React.useMemo(
-    () =>
-      run
-        ? (siblingRuns.data?.data ?? [])
-            .filter((s) => s.id !== run.id)
-            .sort((a, b) => b.runNumber - a.runNumber)
-            .map((s) => ({
-              id: s.id,
-              label: `#${s.runNumber} · ${s.candidateVersion}`,
-              score: s.mainScore,
-            }))
-        : [],
-    [siblingRuns.data, run],
-  );
-
-  // On-demand comparison of this run (candidate) vs the picked run (baseline), from the
-  // same backend engine + route the compare page uses — no second implementation.
-  const compare = useCompareRuns(projectId, runId, compareId);
-  const comparing = !!compareId && !!compare.data;
-  const compareByCase = React.useMemo(() => {
-    const m = new Map<string, CompareResultRow>();
-    for (const c of compare.data?.results ?? []) m.set(c.testCaseId, c);
-    return m;
-  }, [compare.data]);
-
-  const openResult = openResultId ? (results.find((r) => r.id === openResultId) ?? null) : null;
-  const openCompareRow = openResult ? (compareByCase.get(openResult.testCaseId) ?? null) : null;
-
-  // Prefer the result's REAL ingested trace. Probe it — this shares TraceViewerPanel's
-  // ["trace", projectId, traceId] cache key, so opening the real panel does not refetch.
-  // A result trace id means telemetry was emitted: show the real trace when it's
-  // available, and a pending state (retry) while it is still ingesting. When no trace
-  // id was emitted (fully-local run), fall back to a clearly-labeled reconstructed trace.
-  const realTraceId = openResult?.traceId ?? null;
-  const realTrace = useTrace(projectId, realTraceId ?? "", !!realTraceId);
-  // Only treat a reported trace as "pending" when its fetch genuinely fails (not yet
-  // ingested → 404). While it's merely loading, keep the trace panel mounted and let it
-  // show its own loading — so navigating between results updates in place instead of
-  // flickering through the pending panel and re-animating the slide-in.
-  const tracePending = !!realTraceId && realTrace.isError;
-  const useRealTrace = !!realTraceId && !realTrace.isError;
-
-  // Reconstructed eval-shaped trace — the labeled fallback, only for results that
-  // emitted no real trace. Seed span I/O just for those so the detail panel has it.
-  const fallbackTrace = React.useMemo(
-    () => (run && openResult && !realTraceId ? buildEvalTrace(openResult, run) : undefined),
-    [run, openResult, realTraceId],
-  );
-  const fallbackTraces = React.useMemo(
-    () => (run ? results.filter((r) => !r.traceId).map((r) => buildEvalTrace(r, run)) : []),
+  // One eval-shaped trace per result; seed their span I/O so the detail panel
+  // (which reads span input/output on demand) has it ready.
+  const resultTraces = React.useMemo(
+    () => (run ? results.map((r) => buildEvalTrace(r, run)) : []),
     [results, run],
   );
-  useSeedTraceIO(projectId, fallbackTraces);
+  useSeedTraceIO(projectId, resultTraces);
 
+  const openResult = openResultId ? (results.find((r) => r.id === openResultId) ?? null) : null;
+  const openTrace = React.useMemo(
+    () => (run && openResult ? buildEvalTrace(openResult, run) : undefined),
+    [run, openResult],
+  );
+
+  const updateCase = useUpdateTestCase(projectId, run?.datasetId ?? "");
   const humanScore = useCreateHumanScore(projectId, openResult?.id ?? "");
 
-  const panelTraceId = useRealTrace ? realTraceId : fallbackTrace?.trace_id;
-  const panelOverride = useRealTrace ? undefined : fallbackTrace;
-
-  const openTraceSpans = useRealTrace ? realTrace.data?.spans : panelOverride?.spans;
-
-  // The baseline case's trace (from the picked compare run), fetched so the trace
-  // viewer's Diff toggle can diff each span (I/O, metadata, latency/token/cost) against
-  // its baseline counterpart. Span ids differ across runs, so we match structurally
-  // (kind + name + sibling index) once the baseline trace is loaded.
-  const baselineTraceId = comparing ? (openCompareRow?.baselineTraceId ?? null) : null;
-  const baselineTrace = useTrace(projectId, baselineTraceId ?? "", !!baselineTraceId);
-  const baselineSpanMatch = React.useMemo(() => {
-    const baseSpans = baselineTrace.data?.spans;
-    if (!openTraceSpans?.length || !baseSpans?.length) return null;
-    return matchSpans(openTraceSpans, baseSpans);
-  }, [openTraceSpans, baselineTrace.data]);
-
-  const closeResult = () => setOpenResultId(null);
-
-  // The trace panel's up/down chevrons step between this run's results (in the same
-  // order + filter as the table), so you can walk case-by-case without closing it.
-  const visibleResults = React.useMemo(
-    () => results.filter(RESULT_FILTER_FN[resultFilter]),
-    [results, resultFilter],
-  );
-  const openIndex = openResult ? visibleResults.findIndex((r) => r.id === openResult.id) : -1;
-  const navigateResult = (dir: "up" | "down") => {
-    if (openIndex === -1) return;
-    const next = dir === "up" ? openIndex - 1 : openIndex + 1;
-    if (next >= 0 && next < visibleResults.length) setOpenResultId(visibleResults[next].id);
+  const closeResult = () => {
+    setOpenResultId(null);
+    setTraceFullscreen(false);
   };
 
   return (
     <>
-      <ProjectBreadcrumb projectId={projectId} />
+      <ProjectBreadcrumb projectId={projectId} current="Evaluations" />
       <div className="flex flex-1 flex-col overflow-hidden text-[12px]">
         {isLoading ? (
           <div className="flex h-64 items-center justify-center">
@@ -420,104 +263,51 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
             onFilterChange={setResultFilter}
             onOpenResult={setOpenResultId}
             openResultId={openResultId}
-            compareId={compareId}
-            onCompareChange={setCompareId}
-            compareOptions={compareOptions}
-            compareData={compare.data ?? null}
-            compareLoading={!!compareId && compare.isLoading}
-            compareByCase={comparing ? compareByCase : null}
           />
         )}
       </div>
 
-      {/* Telemetry for this result is still ingesting — pending state with retry. */}
-      {openResult && run && tracePending && (
-        <PendingTracePanel
-          traceId={realTraceId as string}
-          isFetching={realTrace.isFetching}
-          onRetry={() => realTrace.refetch()}
-          onClose={closeResult}
-        />
-      )}
-
-      {/* The result opens directly in the REAL trace viewer (span tree + span detail)
-          when its trace is available; otherwise a clearly-labeled reconstructed trace.
-          The evaluation context, scores, and human review are the span-actions panel. */}
-      {openResult && run && !tracePending && panelTraceId && (
+      {/* The real trace viewer on the eval-shaped trace — not a simplified tree. */}
+      {openResult && openTrace && run && (
         <TraceViewerPanel
-          // No key on panelTraceId: navigating results updates the panel in place
-          // (TraceViewerPanel resets its selection on traceId change), matching the
-          // trace-list navigation — a fresh key would replay the slide-in animation.
+          // Remount when fullscreen flips: initialFullscreen is read only at mount.
+          key={`${openTrace.trace_id}:${traceFullscreen ? "fs" : "panel"}`}
           projectId={projectId}
-          traceId={panelTraceId}
-          traceOverride={panelOverride}
+          traceId={openTrace.trace_id}
+          traceOverride={openTrace}
+          initialFullscreen={traceFullscreen}
           newTabPath={`/projects/${projectId}/evaluations/${runId}`}
           onClose={closeResult}
-          onNavigate={navigateResult}
-          canNavigateUp={openIndex > 0}
-          canNavigateDown={openIndex >= 0 && openIndex < visibleResults.length - 1}
-          // The test case is the identity that matters across runs (a trace id is
-          // per-execution, and synthetic when nothing was ingested), so the header
-          // leads with it instead of the trace id.
-          headerIdentity={{ label: "Test case", value: openResult.testCaseId }}
-          // The case's outcome, in the header's findings-alert slot.
-          headerStatus={<EvalResultBadge status={openResult.status} />}
-          // With a compare run picked, open straight into diff mode against its matching
-          // case (the user chose to compare — don't make them toggle it on per trace).
-          defaultDiffOn={comparing}
-          // While the "Save as test case" drawer is open, clicking a different span
-          // retargets it to that span.
-          onSelectionChange={(selection) => {
-            if (saveTestCaseOpen) {
-              setSaveTestCaseSpanId(selection.type === "span" ? selection.span.span_id : undefined);
-            }
-          }}
-          // The case actions live in the span panel's header-section bar, directly
-          // above the I/O — human review, the source test case, and (for a real
-          // ingested trace) saving the selected span as a new test case. Everything
-          // else that used to sit above the I/O has moved to the run detail table
-          // and the trace header.
-          spanActions={(selection) => (
-            <>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 text-[12px]"
-                onClick={() => setReviewOpen(true)}
-              >
-                Review output
-              </Button>
-              <Link
-                href={`/projects/${projectId}/datasets/${run.datasetId}?case=${openResult.testCaseId}`}
-                className="inline-flex h-7 items-center gap-1.5 rounded-md border border-input bg-background px-2.5 text-[12px] font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              >
-                <Database className="h-3.5 w-3.5" aria-hidden />
-                View source test case
-              </Link>
-              {useRealTrace && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-7 text-[12px]"
-                  onClick={() => {
-                    setSaveTestCaseSpanId(
-                      selection.type === "span" ? selection.span.span_id : undefined,
-                    );
-                    setSaveTestCaseOpen(true);
-                  }}
-                >
-                  Save as test case
-                </Button>
-              )}
-            </>
+          onNavigate={() => {}}
+          canNavigateUp={false}
+          canNavigateDown={false}
+          spanActions={() => (
+            <ResultContext
+              projectId={projectId}
+              run={run}
+              result={openResult}
+              fullscreen={traceFullscreen}
+              onOpenFullTrace={() => setTraceFullscreen(true)}
+              onReview={() => setReviewOpen(true)}
+              onSaveExpected={(value) =>
+                updateCase.mutate(
+                  {
+                    testCaseId: openResult.testCaseId,
+                    patch: { expected: value.trim() === "" ? null : value },
+                  },
+                  {
+                    onSuccess: () =>
+                      toast({
+                        title: "Expected outcome saved — new dataset version published",
+                        tone: "success",
+                      }),
+                  },
+                )
+              }
+            />
           )}
           spanExtraTags={() => (
             <>
-              {!useRealTrace && (
-                <span className="inline-flex items-center gap-1.5 rounded-md border border-amber-400/60 bg-amber-100/60 px-2.5 py-1 text-xs text-amber-800 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-300">
-                  Reconstructed — no telemetry was emitted for this result
-                </span>
-              )}
               <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
                 <span className="text-muted-foreground">Evaluation:</span>
                 <span className="font-medium">{run.evaluationName}</span>
@@ -531,23 +321,12 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
                   {run.datasetName} · {run.datasetVersionLabel}
                 </span>
               </span>
+              <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
+                <span className="text-muted-foreground">Test case:</span>
+                <span className="font-mono">{openResult.testCaseId}</span>
+              </span>
             </>
           )}
-          /* Baseline run's trace + a per-span matcher. Powers the viewer's Diff
-             toggle: latency/token/cost deltas + I/O line diffs vs the baseline, at
-             both the trace level and per span. Present (so the toggle appears) only
-             once the baseline trace has loaded. */
-          diffBaseline={
-            baselineTrace.data
-              ? {
-                  trace: baselineTrace.data,
-                  matchSpan: (selection) =>
-                    selection.type === "span"
-                      ? (baselineSpanMatch?.get(selection.span.span_id) ?? null)
-                      : null,
-                }
-              : undefined
-          }
         />
       )}
 
@@ -580,64 +359,7 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
           })
         }
       />
-
-      {/* Save a span (or the trace root) of the open result's real trace as a test case. */}
-      <SaveTestCaseDrawer
-        projectId={projectId}
-        traceId={useRealTrace ? realTraceId : null}
-        spanId={saveTestCaseSpanId}
-        open={saveTestCaseOpen}
-        onOpenChange={setSaveTestCaseOpen}
-      />
     </>
-  );
-}
-
-/** Slide-in panel shown while a result's real trace is still ingesting. */
-function PendingTracePanel({
-  traceId,
-  isFetching,
-  onRetry,
-  onClose,
-}: {
-  traceId: string;
-  isFetching: boolean;
-  onRetry: () => void;
-  onClose: () => void;
-}) {
-  return (
-    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[45%] min-w-[520px] max-w-[94vw] flex-col border-l border-border bg-background shadow-xl">
-      <div className="flex shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4 py-3">
-        <span className="text-sm font-medium">Evaluation trace</span>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 w-7 p-0"
-          onClick={onClose}
-          aria-label="Close"
-        >
-          <X className="h-4 w-4" />
-        </Button>
-      </div>
-      <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center text-[12px]">
-        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-hidden />
-        <p className="text-[13px] font-medium">Trace is still being ingested</p>
-        <p className="max-w-[360px] leading-relaxed text-muted-foreground">
-          This result reported a trace (<span className="font-mono">{traceId.slice(0, 12)}…</span>),
-          but its telemetry hasn&apos;t finished ingesting yet. It will appear here once it lands.
-        </p>
-        <Button
-          size="sm"
-          variant="outline"
-          className="h-7 gap-1.5 text-[12px]"
-          disabled={isFetching}
-          onClick={onRetry}
-        >
-          <Loader2 className={cn("h-3.5 w-3.5", isFetching && "animate-spin")} aria-hidden />
-          Retry
-        </Button>
-      </div>
-    </div>
   );
 }
 
@@ -649,12 +371,6 @@ function RunBody({
   onFilterChange,
   onOpenResult,
   openResultId,
-  compareId,
-  onCompareChange,
-  compareOptions,
-  compareData,
-  compareLoading,
-  compareByCase,
 }: {
   projectId: string;
   run: RunDetail;
@@ -663,22 +379,15 @@ function RunBody({
   onFilterChange: (filter: ResultFilterId) => void;
   onOpenResult: (id: string) => void;
   openResultId: string | null;
-  compareId: string | null;
-  onCompareChange: (id: string | null) => void;
-  compareOptions: Array<{ id: string; label: string; score: number | null }>;
-  compareData: CompareRunsResponse | null;
-  compareLoading: boolean;
-  compareByCase: Map<string, CompareResultRow> | null;
 }) {
   const router = useRouter();
-  const [reproduceOpen, setReproduceOpen] = React.useState(false);
-  const comparing = !!compareByCase;
-  const cmp = compareData?.comparison ?? null;
+  const hasBaseline = run.baselineRunId !== null;
+  const regressed = results.filter((r) => r.change === "regressed");
+  const incompatibleBaseline = run.baselineRunId !== null && !run.baselineComparable;
 
   return (
     <>
       <EvalPageHeader
-        parent={{ label: "Evaluations", href: `/projects/${projectId}/evaluations` }}
         title={
           <span className="flex flex-wrap items-center gap-2">
             <span>{run.evaluationName}</span>
@@ -700,144 +409,58 @@ function RunBody({
             />
           </span>
         }
-        action={
-          <div className="flex items-center gap-2">
-            {/* Comparison is an inline action: this run is the candidate; pick another
-                run of the same evaluation as the baseline. The diff appears in place. */}
-            <Select
-              value={compareId ?? ""}
-              onValueChange={(v) => onCompareChange(v === NO_COMPARE ? null : v)}
-            >
-              <SelectTrigger
-                className="h-7 w-fit max-w-[240px] gap-1.5 text-[12px]"
-                aria-label="Compare with"
-              >
-                <GitCompare className="h-3.5 w-3.5 shrink-0" aria-hidden />
-                <SelectValue placeholder="Compare with…" />
-              </SelectTrigger>
-              <SelectContent>
-                {/* Clear option — only meaningful once a run is picked. */}
-                {compareId && (
-                  <SelectItem value={NO_COMPARE} className="text-[12px] text-muted-foreground">
-                    None (stop comparing)
-                  </SelectItem>
-                )}
-                {compareOptions.length === 0 ? (
-                  <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
-                    No other runs in this evaluation
-                  </div>
-                ) : (
-                  compareOptions.map((o) => (
-                    <SelectItem key={o.id} value={o.id} className="text-[12px]">
-                      {o.label}
-                      {o.score !== null && (
-                        <span className="ml-1.5 tabular-nums text-muted-foreground">
-                          {pctFraction(o.score)}
-                        </span>
-                      )}
-                    </SelectItem>
-                  ))
-                )}
-              </SelectContent>
-            </Select>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 gap-1.5 text-[12px]"
-              onClick={() => setReproduceOpen(true)}
-            >
-              <Database className="h-3.5 w-3.5" aria-hidden />
-              Reproduce locally
-            </Button>
-          </div>
-        }
       />
 
       <div className="min-h-0 flex-1 overflow-auto">
         <div className="flex flex-col gap-3 p-4">
-          {compareLoading && (
-            <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
-              Computing comparison…
+          {incompatibleBaseline && (
+            <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[11px] leading-relaxed text-amber-700 dark:text-amber-300">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+              <span>
+                <span className="font-medium">Not directly comparable.</span> The selected baseline
+                measured a different dataset snapshot than this run (
+                <span className="font-mono">{run.datasetVersionLabel}</span>). The two runs covered
+                different test cases, so a single delta would be misleading. Pick a baseline on the
+                same snapshot to compare.
+              </span>
             </div>
           )}
 
-          {comparing && cmp && (
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border border-border bg-muted/30 px-3 py-2 text-[11px]">
-              <span className="flex items-center gap-1.5">
-                <GitCompare className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
-                <span className="font-medium">
-                  Comparing vs #{compareData?.baseline.runNumber} ·{" "}
-                  <span className="font-mono">{compareData?.baseline.candidateVersion}</span>
-                </span>
-              </span>
-              <span className="text-muted-foreground">baseline → candidate (this run)</span>
-              <span className="h-3 w-px bg-border" aria-hidden />
-              <span className={cmp.caseCounts.regressed > 0 ? SENTIMENT_CLASS.bad : ""}>
-                {cmp.caseCounts.regressed} regressed
-              </span>
-              <span className={cmp.caseCounts.improved > 0 ? SENTIMENT_CLASS.good : ""}>
-                {cmp.caseCounts.improved} improved
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="ml-auto h-6 px-1.5 text-[11px] text-muted-foreground hover:text-foreground"
-                onClick={() => onCompareChange(null)}
-              >
-                Clear
-              </Button>
-            </div>
-          )}
+          {/* Verdict first, as a one-line strip — then results are the hero. */}
+          <VerdictStrip
+            run={run}
+            regressionCount={regressed.length}
+            hasBaseline={hasBaseline}
+            onFilter={onFilterChange}
+          />
 
           <ResultsSection
-            run={run}
             results={results}
-            comparing={comparing}
-            compareByCase={compareByCase}
+            hasBaseline={hasBaseline}
             filter={filter}
             onFilterChange={onFilterChange}
             onOpen={onOpenResult}
             openResultId={openResultId}
           />
+
+          {/* Everything else folds below the results. */}
+          {hasBaseline && regressed.length > 0 && (
+            <ExpandableSection title={`Regressions (${regressed.length})`} defaultOpen={false}>
+              <RegressionsList regressed={regressed} onOpen={onOpenResult} />
+            </ExpandableSection>
+          )}
+
+          {run.errorCount > 0 && (
+            <ExpandableSection title={`Errors (${run.errorCount})`} defaultOpen={false}>
+              <ErrorsBody run={run} results={results} onOpen={onOpenResult} />
+            </ExpandableSection>
+          )}
+
+          <ExpandableSection title="Run details" defaultOpen={false}>
+            <RunDetailsBody run={run} projectId={projectId} />
+          </ExpandableSection>
         </div>
       </div>
-
-      {/* Reproduce this run locally = pull the EXACT dataset version it scored (not
-          the run/evaluation id, which pulls nothing). Shared pull-code drawer. */}
-      <PullCodeDrawer
-        title="Reproduce this run locally"
-        subtitle={
-          <>
-            Re-run a new candidate against the exact cases{" "}
-            <span className="font-medium text-foreground">
-              {run.evaluationName} #{run.runNumber}
-            </span>{" "}
-            scored — the same dataset snapshot, so the results line up against this run.
-          </>
-        }
-        options={[
-          {
-            id: "reproduce",
-            label: "Reproduce this run",
-            note: (
-              <>
-                Pins{" "}
-                <span className="font-medium text-foreground">
-                  {run.datasetName ?? "this dataset"}
-                </span>{" "}
-                at version <span className="font-mono">{run.datasetVersionLabel}</span> (snapshot{" "}
-                <span className="font-mono">{run.datasetVersionId}</span>), and passes this run
-                (candidate <span className="font-mono">{run.candidateVersion}</span>) as the
-                baseline to compare the new run against.
-              </>
-            ),
-            py: reproduceRunCode(run.datasetVersionId, run.evaluationName, run.id),
-            ts: reproduceRunCodeTs(run.datasetVersionId, run.evaluationName, run.id),
-          },
-        ]}
-        open={reproduceOpen}
-        onOpenChange={setReproduceOpen}
-      />
     </>
   );
 }
@@ -870,10 +493,7 @@ function RunSwitcher({
           <ChevronDown className="h-3 w-3" aria-hidden />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="max-h-[360px] w-72 overflow-y-auto p-1">
-        <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
-          Run history
-        </div>
+      <PopoverContent align="start" className="max-h-[320px] w-64 overflow-y-auto p-1">
         {runs.map((sibling) => (
           <button
             key={sibling.id}
@@ -882,21 +502,19 @@ function RunSwitcher({
               onPick(sibling.id);
               setOpen(false);
             }}
-            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] transition-colors hover:bg-muted/50"
+            className={cn(
+              "flex w-full items-center justify-between gap-2 rounded px-2 py-1 text-left text-[12px] transition-colors",
+              sibling.id === run.id ? "bg-muted/70" : "hover:bg-muted/50",
+            )}
           >
-            <Check
-              className={cn(
-                "h-3.5 w-3.5 shrink-0",
-                sibling.id === run.id ? "opacity-100" : "opacity-0",
-              )}
-              aria-hidden
-            />
-            <span className="font-medium">Run #{sibling.runNumber}</span>
-            <span className="font-mono text-[11px] text-muted-foreground">
-              {sibling.candidateVersion}
+            <span className="flex items-center gap-1.5">
+              <span>Run #{sibling.runNumber}</span>
+              <span className="font-mono text-[11px] text-muted-foreground">
+                {sibling.candidateVersion}
+              </span>
             </span>
-            <span className="ml-auto tabular-nums text-muted-foreground">
-              {sibling.mainScore === null ? "—" : pctFraction(sibling.mainScore)}
+            <span className="tabular-nums text-muted-foreground">
+              {sibling.mainScore === null ? "—" : pct(sibling.mainScore)}
             </span>
           </button>
         ))}
@@ -905,47 +523,144 @@ function RunSwitcher({
   );
 }
 
-const RESULT_COLUMN_COUNT = 8;
+/**
+ * Compact verdict — the run's headline numbers on one strip, above the results.
+ * Regressions and Errors are clickable: they filter the results table in place
+ * rather than being separate sections the reader has to scroll past.
+ */
+function VerdictStrip({
+  run,
+  regressionCount,
+  hasBaseline,
+  onFilter,
+}: {
+  run: RunDetail;
+  regressionCount: number;
+  hasBaseline: boolean;
+  onFilter: (filter: ResultFilterId) => void;
+}) {
+  const unscored = run.caseCount - run.scoredCount;
+  return (
+    <div className="rounded-md border border-border p-3">
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+        <RunStatusBadge status={run.status} />
+        <Metric
+          label={run.mainScoreName ?? "Main score"}
+          value={run.mainScore === null ? "—" : pct(run.mainScore)}
+          strong
+        />
+        <Metric
+          label="Change"
+          value={
+            run.changeFromBaseline === null ? (
+              <span className="text-muted-foreground">—</span>
+            ) : (
+              <span className={SENTIMENT_CLASS[changeSentiment(run.changeFromBaseline)]}>
+                {signed(run.changeFromBaseline)} pp
+              </span>
+            )
+          }
+          hint={hasBaseline ? undefined : "No baseline"}
+        />
+        <FilterStat
+          label="Regressions"
+          count={regressionCount}
+          onClick={() => onFilter("regressions")}
+        />
+        <FilterStat label="Errors" count={run.errorCount} onClick={() => onFilter("errors")} />
+        <Metric label="Scored" value={`${run.scoredCount} / ${run.caseCount}`} />
+      </div>
+      {/* Completeness — the denominator is always explicit. */}
+      {unscored > 0 && (
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          <span className="text-foreground">
+            {unscored} {unscored === 1 ? "case is" : "cases are"} not scored
+          </span>{" "}
+          — excluded from the average, not counted as zero.
+        </p>
+      )}
+    </div>
+  );
+}
 
-/** Sentinel for the "Compare with" select's no-selection option (Radix needs a value). */
-const NO_COMPARE = "__none__";
+function Metric({
+  label,
+  value,
+  hint,
+  strong,
+}: {
+  label: string;
+  value: React.ReactNode;
+  hint?: string;
+  strong?: boolean;
+}) {
+  return (
+    <div>
+      <p className="text-[11px] text-muted-foreground">{label}</p>
+      <p className={cn("tabular-nums", strong ? "text-[18px] font-medium" : "text-[15px]")}>
+        {value}
+      </p>
+      {hint && <p className="text-[11px] text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}
+
+/** A count that filters the results table when non-zero. */
+function FilterStat({
+  label,
+  count,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  onClick: () => void;
+}) {
+  if (count === 0) {
+    return <Metric label={label} value={<span className="text-muted-foreground">0</span>} />;
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded text-left transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      title={`Show ${label.toLowerCase()} in the results below`}
+    >
+      <span className="text-[11px] text-muted-foreground underline decoration-dotted underline-offset-2">
+        {label}
+      </span>
+      <span className="block text-[15px] font-medium tabular-nums">{count}</span>
+    </button>
+  );
+}
+
+const RESULT_COLUMN_COUNT = 6;
 
 function ResultsSection({
-  run,
   results,
-  comparing,
-  compareByCase,
+  hasBaseline,
   filter,
   onFilterChange,
   onOpen,
   openResultId,
 }: {
-  run: RunDetail;
   results: ResultRow[];
-  comparing: boolean;
-  compareByCase: Map<string, CompareResultRow> | null;
+  hasBaseline: boolean;
   filter: ResultFilterId;
   onFilterChange: (filter: ResultFilterId) => void;
   onOpen: (id: string) => void;
   openResultId: string | null;
 }) {
+  const { toast } = useToast();
   const [keyword, setKeyword] = React.useState("");
-  const [sortWorst, setSortWorst] = React.useState(false);
   const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
     DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0],
   );
   const [customStart, setCustomStart] = React.useState<Date | null>(null);
   const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
 
-  // Per-result comparison vs the picked run (null when not comparing).
-  const cmpFor = React.useCallback(
-    (r: ResultRow) => (comparing ? (compareByCase?.get(r.testCaseId) ?? null) : null),
-    [comparing, compareByCase],
-  );
-
   const visible = React.useMemo(() => {
     const q = keyword.trim().toLowerCase();
-    const filtered = results.filter((r) => {
+    return results.filter((r) => {
       if (!RESULT_FILTER_FN[filter](r)) return false;
       if (!q) return true;
       return (
@@ -954,17 +669,7 @@ function ResultsSection({
         (r.expectedOutput ?? "").toLowerCase().includes(q)
       );
     });
-    if (!sortWorst) return filtered;
-    // Worst main-score regression first (most-negative delta vs the picked run); unknown last.
-    return [...filtered].sort((a, b) => {
-      const da = cmpFor(a)?.comparison?.mainScore.delta;
-      const db = cmpFor(b)?.comparison?.mainScore.delta;
-      if (da == null && db == null) return 0;
-      if (da == null) return 1;
-      if (db == null) return -1;
-      return da - db;
-    });
-  }, [results, keyword, filter, sortWorst, cmpFor]);
+  }, [results, keyword, filter]);
 
   return (
     <div className="rounded-md border border-border">
@@ -1003,17 +708,14 @@ function ResultsSection({
           ))}
         </div>
         <span className="flex-1" aria-hidden />
-        <PassRate counts={run} withLabel />
-        <span className="flex-1" aria-hidden />
         <Button
-          variant={sortWorst ? "default" : "outline"}
+          variant="ghost"
           size="sm"
-          className="h-7 gap-1.5 px-2 text-[12px]"
-          onClick={() => setSortWorst((s) => !s)}
-          title="Sort by the worst main-score regression first"
+          className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+          onClick={() => toast({ title: "Export coming soon", tone: "success" })}
         >
-          <ArrowDown className="h-3.5 w-3.5" aria-hidden />
-          Worst regression
+          <Download className="h-3.5 w-3.5" aria-hidden />
+          Download
         </Button>
       </SearchFilterBar>
 
@@ -1023,18 +725,15 @@ function ResultsSection({
             <Th>Input</Th>
             <Th>Output</Th>
             <Th>Expected</Th>
-            <Th className="w-[170px]">Main score</Th>
-            {/* Change is only meaningful against a picked run; hidden otherwise. */}
-            {comparing && <Th className="w-[110px] text-right">vs baseline</Th>}
-            <Th className="w-[90px] text-right">Duration</Th>
-            <Th className="w-[90px] text-right">Cost</Th>
+            <Th className="w-[150px]">Scores</Th>
+            <Th className="w-[100px] text-right">Change</Th>
             <Th className="w-[110px]">Status</Th>
           </TRHead>
         </THead>
         <TBody>
           {visible.length === 0 ? (
             <tr>
-              <td colSpan={comparing ? RESULT_COLUMN_COUNT : RESULT_COLUMN_COUNT - 1}>
+              <td colSpan={RESULT_COLUMN_COUNT}>
                 <p className="px-4 py-12 text-center text-[12px] text-muted-foreground">
                   {results.length === 0
                     ? "No per-case results reported for this run yet."
@@ -1043,71 +742,31 @@ function ResultsSection({
               </td>
             </tr>
           ) : (
-            visible.map((result) => {
-              const row = cmpFor(result);
-              const rowCmp = row?.comparison ?? null;
-              return (
-                <TR
-                  key={result.id}
-                  interactive
-                  selected={result.id === openResultId}
-                  onClick={() => onOpen(result.id)}
-                >
-                  <Td className="max-w-[260px] truncate" title={result.input}>
-                    {result.input}
-                  </Td>
-                  <Td className="max-w-[260px]">
-                    <div className="flex min-w-0 items-center gap-1.5">
-                      <span className="truncate" title={result.candidateOutput ?? undefined}>
-                        {result.candidateOutput ?? (
-                          <span className="text-muted-foreground">No output</span>
-                        )}
-                      </span>
-                      {row?.outputChanged === true && (
-                        <span
-                          className="shrink-0 rounded bg-muted px-1 text-[10px] text-muted-foreground"
-                          title="Output differs from the baseline run"
-                        >
-                          ≠ baseline
-                        </span>
-                      )}
-                    </div>
-                  </Td>
-                  <Td
-                    className="max-w-[220px] truncate text-muted-foreground"
-                    title={result.expectedOutput ?? undefined}
-                  >
-                    {result.expectedOutput ?? "—"}
-                  </Td>
-                  <Td>
-                    <MainScoreCell result={result} comparison={rowCmp} />
-                  </Td>
-                  {comparing && (
-                    <Td className="text-right">
-                      <ChangeCell change={rowCmp?.caseChange ?? null} />
-                    </Td>
+            visible.map((result) => (
+              <TR
+                key={result.id}
+                interactive
+                selected={result.id === openResultId}
+                onClick={() => onOpen(result.id)}
+              >
+                <Td>{truncate(result.input, 60)}</Td>
+                <Td>
+                  {result.candidateOutput ?? (
+                    <span className="text-muted-foreground">No output</span>
                   )}
-                  <Td className="whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
-                    {fmtDurationMs(result.durationMs)}
-                    {comparing && (
-                      <CellDelta delta={rowCmp?.durationDeltaMs ?? null} format={fmtDurationMs} />
-                    )}
-                  </Td>
-                  <Td className="whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
-                    {result.cost === null ? "—" : `$${result.cost.toFixed(4)}`}
-                    {comparing && result.cost !== null && row?.baselineCost != null && (
-                      <CellDelta
-                        delta={result.cost - row.baselineCost}
-                        format={(n) => `$${n.toFixed(4)}`}
-                      />
-                    )}
-                  </Td>
-                  <Td>
-                    <EvalResultBadge status={result.status} />
-                  </Td>
-                </TR>
-              );
-            })
+                </Td>
+                <Td className="text-muted-foreground">{result.expectedOutput ?? "—"}</Td>
+                <Td>
+                  <ScoreCell result={result} />
+                </Td>
+                <Td className="text-right">
+                  <ChangeCell change={hasBaseline ? result.change : null} />
+                </Td>
+                <Td>
+                  <EvalResultBadge status={result.status} />
+                </Td>
+              </TR>
+            ))
           )}
         </TBody>
       </Table>
@@ -1116,36 +775,12 @@ function ResultsSection({
 }
 
 /**
- * Per-result candidate main score, and — when comparing against a picked run — its
- * baseline counterpart + delta (the backend engine derives the per-case baseline value,
- * so we show a real magnitude). Missing values render "—", never a fabricated 0.
+ * Per-result change direction. The prototype showed "+N pp" per case; the server
+ * reports only the direction (improved / regressed / unchanged) per result — no
+ * per-case baseline score to subtract — so we render the direction faithfully as
+ * a coloured arrow rather than a fabricated magnitude.
  */
-function MainScoreCell({
-  result,
-  comparison,
-}: {
-  result: ResultRow;
-  comparison: ResultRowComparison | null;
-}) {
-  const cand = comparison?.mainScore.candidate ?? result.mainScore;
-  if (cand === null || cand === undefined) return <span className="text-muted-foreground">—</span>;
-  const base = comparison?.mainScore.baseline ?? null;
-  const delta = comparison?.mainScore.delta ?? null;
-  return (
-    <div className="flex flex-col gap-0.5 text-[12px] tabular-nums">
-      <span>
-        {pctFraction(cand)}
-        {base !== null && <span className="text-muted-foreground"> vs {pctFraction(base)}</span>}
-      </span>
-      {delta !== null && (
-        <span className={SENTIMENT_CLASS[changeSentiment(delta)]}>{signedPoints(delta)} pp</span>
-      )}
-    </div>
-  );
-}
-
-/** Per-result case verdict (derived from the main scorer). */
-function ChangeCell({ change }: { change: Classification | null }) {
+function ChangeCell({ change }: { change: ResultRow["change"] }) {
   if (change === "improved") {
     return (
       <span
@@ -1168,18 +803,371 @@ function ChangeCell({ change }: { change: Classification | null }) {
       </span>
     );
   }
-  if (change === "changed") {
-    return <span title="Changed (categorical)">Changed</span>;
-  }
-  if (change === "unchanged") {
-    return <span className="text-muted-foreground">Unchanged</span>;
-  }
-  if (change === "unpaired" || change === "not_comparable") {
-    return (
-      <span className="text-muted-foreground" title="Not compared against a baseline value">
-        {change === "unpaired" ? "Unpaired" : "Not comparable"}
-      </span>
-    );
-  }
   return <span className="text-muted-foreground">—</span>;
+}
+
+/** Per-scorer values, with a failed scorer shown as an error rather than a 0. */
+function ScoreCell({ result }: { result: ResultRow }) {
+  if (result.scores.length === 0) return <span className="text-muted-foreground">—</span>;
+  return (
+    <span className="flex flex-col gap-0.5">
+      {result.scores.map((s) => (
+        <span key={s.id} className="flex items-center gap-1.5 text-[11px]">
+          <span className="truncate text-muted-foreground">{s.scorerName}</span>
+          <span className={cn("tabular-nums", s.error && "text-amber-600 dark:text-amber-400")}>
+            {scoreValue(s)}
+          </span>
+        </span>
+      ))}
+    </span>
+  );
+}
+
+/** The regressed cases, as a plain list; the caller wraps it in a section. */
+function RegressionsList({
+  regressed,
+  onOpen,
+}: {
+  regressed: ResultRow[];
+  onOpen: (id: string) => void;
+}) {
+  return (
+    <div className="-mx-2.5 -my-2 divide-y divide-border">
+      {regressed.map((r) => (
+        <button
+          key={r.id}
+          type="button"
+          onClick={() => onOpen(r.id)}
+          className="flex w-full items-start gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/40"
+        >
+          <span className="min-w-0 flex-1">
+            <span className="block truncate">{truncate(r.input, 90)}</span>
+            <span className="mt-0.5 block text-[11px] text-muted-foreground">
+              was <span className="text-foreground">{r.baselineOutput ?? "—"}</span> · now{" "}
+              <span className="text-foreground">{r.candidateOutput ?? "—"}</span> · expected{" "}
+              <span className="text-foreground">{r.expectedOutput ?? "—"}</span>
+            </span>
+          </span>
+          <ChevronRight className="mt-1 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Task errors and scorer errors are different failures and read differently. */
+function ErrorsBody({
+  run,
+  results,
+  onOpen,
+}: {
+  run: RunDetail;
+  results: ResultRow[];
+  onOpen: (id: string) => void;
+}) {
+  const taskErrors = results.filter((r) => r.taskError);
+  const scorerErrors = results.filter((r) => r.scores.some((s) => s.error));
+  return (
+    <div className="flex flex-col gap-3">
+      <ErrorGroup
+        title={`Application errors (${run.taskErrorCount})`}
+        blurb="The candidate application failed for these test cases, so there is no output to judge."
+        rows={taskErrors.map((r) => ({ id: r.id, input: r.input, detail: r.taskError ?? "" }))}
+        onOpen={onOpen}
+      />
+      <ErrorGroup
+        title={`Scorer errors (${run.scorerErrorCount})`}
+        blurb="The candidate produced an output, but a scorer failed to judge it. These cases are unscored."
+        rows={scorerErrors.map((r) => ({
+          id: r.id,
+          input: r.input,
+          detail: r.scores
+            .filter((s) => s.error)
+            .map((s) => `${s.scorerName}: ${s.error}`)
+            .join(" · "),
+        }))}
+        onOpen={onOpen}
+      />
+    </div>
+  );
+}
+
+function ErrorGroup({
+  title,
+  blurb,
+  rows,
+  onOpen,
+}: {
+  title: string;
+  blurb: string;
+  rows: Array<{ id: string; input: string; detail: string }>;
+  onOpen: (id: string) => void;
+}) {
+  return (
+    <div>
+      <p className="flex items-center gap-1.5 text-[12px] font-medium">
+        <AlertTriangle className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" aria-hidden />
+        {title}
+      </p>
+      <p className="mb-1.5 mt-0.5 text-[11px] leading-relaxed text-muted-foreground">{blurb}</p>
+      {rows.length === 0 ? (
+        <p className="text-[11px] text-muted-foreground">None.</p>
+      ) : (
+        <ul className="divide-y divide-border rounded border border-border">
+          {rows.map((row) => (
+            <li key={row.id}>
+              <button
+                type="button"
+                onClick={() => onOpen(row.id)}
+                className="flex w-full flex-col items-start px-2.5 py-1.5 text-left transition-colors hover:bg-muted/40"
+              >
+                <span className="truncate">{truncate(row.input, 80)}</span>
+                <span className="font-mono text-[11px] text-muted-foreground">{row.detail}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Run configuration + immutable identities; caller wraps in a section.
+ * The prototype also showed a baseline picker and duration/cost/token totals.
+ * The baseline is server-computed against a fixed baselineRunId (no endpoint to
+ * repoint it), so it is read-only here; the aggregate metrics are not persisted
+ * on a run, so those rows are omitted rather than fabricated.
+ */
+function RunDetailsBody({ run, projectId }: { run: RunDetail; projectId: string }) {
+  return (
+    <div>
+      <dl className="grid grid-cols-1 gap-x-6 gap-y-1.5 sm:grid-cols-2">
+        <Row label="Candidate version">
+          <span className="font-mono">{run.candidateVersion}</span>
+        </Row>
+        <Row label="Dataset">
+          <Link
+            href={`/projects/${projectId}/datasets/${run.datasetId}`}
+            className="inline-flex items-center gap-1 rounded hover:underline"
+          >
+            {run.datasetName ?? run.datasetId}
+            <span className="text-muted-foreground">· {run.datasetVersionLabel}</span>
+          </Link>
+        </Row>
+        <Row label="Environment">{run.environment}</Row>
+        <Row label="Started">
+          <Timestamp iso={run.startedAt} className="inline" />
+        </Row>
+        <Row label="Scorers">
+          {run.scorers && run.scorers.length > 0
+            ? run.scorers.map((s) => `${s.name} ${s.version}`).join(", ")
+            : "—"}
+        </Row>
+        <Row label="Baseline">
+          {run.baselineRunId ? (
+            <Link
+              href={`/projects/${projectId}/evaluations/${run.baselineRunId}`}
+              className="font-mono text-[11px] hover:underline"
+            >
+              {run.baselineRunId}
+            </Link>
+          ) : (
+            "No baseline"
+          )}
+        </Row>
+        <Row label="Evaluation ID">
+          <span className="font-mono text-[11px]">{run.evaluationId}</span>
+        </Row>
+        <Row label="Run ID">
+          <span className="font-mono text-[11px]">{run.id}</span>
+        </Row>
+        <Row label="Dataset snapshot ID">
+          <span className="font-mono text-[11px]">{run.datasetVersionId}</span>
+        </Row>
+      </dl>
+    </div>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-border/50 py-1 last:border-0">
+      <dt className="text-[11px] text-muted-foreground">{label}</dt>
+      <dd className="text-right text-[12px]">{children}</dd>
+    </div>
+  );
+}
+
+/**
+ * The evaluation context for one result, shown as the trace viewer's span-actions
+ * panel: input + candidate output, an editable expected outcome (saving publishes a
+ * new dataset version), how the scorers judged it, what broke, and the human review.
+ */
+function ResultContext({
+  projectId,
+  run,
+  result,
+  fullscreen,
+  onOpenFullTrace,
+  onReview,
+  onSaveExpected,
+}: {
+  projectId: string;
+  run: RunDetail;
+  result: ResultRow;
+  fullscreen: boolean;
+  onOpenFullTrace: () => void;
+  onReview: () => void;
+  onSaveExpected: (value: string) => void;
+}) {
+  const expectedValue = result.expectedOutput ?? "";
+  const [expected, setExpected] = React.useState(expectedValue);
+  React.useEffect(() => setExpected(expectedValue), [expectedValue, result.id]);
+  const expectedDirty = expected.trim() !== expectedValue.trim();
+
+  return (
+    <div className="w-full text-[12px]">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        <span className="text-[11px] font-medium text-muted-foreground">Evaluation result</span>
+        <EvalResultBadge status={result.status} />
+        <span className="font-mono text-[11px] text-muted-foreground">{result.testCaseId}</span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <MiniField label="Input">{result.input}</MiniField>
+        <MiniField label="Candidate output">
+          {result.candidateOutput ?? <span className="text-muted-foreground">No output</span>}
+        </MiniField>
+      </div>
+
+      {/* Expected outcome is edited inline. Saving edits the source test case. */}
+      <div className="mt-2">
+        <p className="mb-1 text-[11px] text-muted-foreground">Expected outcome</p>
+        <div className="flex items-center gap-2">
+          <Input
+            value={expected}
+            onChange={(e) => setExpected(e.target.value)}
+            placeholder="No expected outcome — a scorer judges the output directly."
+            className="h-7 text-[12px]"
+          />
+          <Button
+            size="sm"
+            className="h-7 shrink-0 text-[12px]"
+            disabled={!expectedDirty}
+            onClick={() => onSaveExpected(expected.trim())}
+          >
+            Save
+          </Button>
+        </div>
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          Saving edits test case <span className="font-mono">{result.testCaseId}</span> in{" "}
+          <span className="font-medium">{run.datasetName}</span> — it changes what future runs are
+          compared against.
+        </p>
+      </div>
+
+      {result.baselineOutput !== null && (
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          Baseline output: <span className="text-foreground">{result.baselineOutput}</span>
+        </p>
+      )}
+
+      {/* An application error means no scorer ever ran. */}
+      {result.taskError && (
+        <div className="mt-2 rounded border border-red-300 bg-red-50 px-2.5 py-1.5 dark:border-red-900 dark:bg-red-950/40">
+          <p className="text-[11px] font-medium text-red-700 dark:text-red-300">
+            Application error — the candidate failed, so no scorer ran
+          </p>
+          <p className="mt-0.5 font-mono text-[11px] text-red-700 dark:text-red-300">
+            {result.taskError}
+          </p>
+        </div>
+      )}
+
+      {result.scores.length > 0 && (
+        <ul className="mt-2 divide-y divide-border rounded border border-border">
+          {result.scores.map((s) => (
+            <li key={s.id} className="px-2.5 py-1.5">
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-medium">
+                  {s.scorerName}
+                  <span className="ml-1.5 font-normal text-muted-foreground">
+                    {s.scorerVersion}
+                  </span>
+                </span>
+                {s.error ? (
+                  <Badge variant="warning">Scorer error</Badge>
+                ) : (
+                  <span className="tabular-nums">{scoreValue(s)}</span>
+                )}
+              </div>
+              {s.explanation && (
+                <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+                  {s.explanation}
+                </p>
+              )}
+              {s.error && (
+                <p className="mt-0.5 font-mono text-[11px] text-amber-700 dark:text-amber-400">
+                  {s.error} — the candidate answered, only the judge failed.
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {result.humanScores.length > 0 && (
+        <div className="mt-2 rounded border border-border bg-muted/20 px-2.5 py-1.5 text-[11px]">
+          <span className="text-muted-foreground">Human review: </span>
+          {result.humanScores.map((h, i) => (
+            <span key={h.id}>
+              {i > 0 ? "; " : ""}
+              <span className="font-medium capitalize">{h.verdict}</span>
+              {h.comment ? ` — ${h.comment}` : ""}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <Button size="sm" className="h-7 text-[12px]" onClick={onReview}>
+          Review output
+        </Button>
+        {!fullscreen && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1.5 text-[12px]"
+            onClick={onOpenFullTrace}
+          >
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+            Open full trace
+          </Button>
+        )}
+        <Link
+          href={`/projects/${projectId}/datasets/${run.datasetId}`}
+          className="inline-flex h-7 items-center gap-1.5 rounded-md border border-input bg-background px-2.5 text-[12px] font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <Database className="h-3.5 w-3.5" aria-hidden />
+          View source test case
+        </Link>
+        <span className="ml-auto text-[11px] text-muted-foreground">
+          {result.durationMs !== null ? `${(result.durationMs / 1000).toFixed(1)}s` : "—"}
+          {result.cost !== null ? ` · $${result.cost.toFixed(4)}` : ""}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function MiniField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="mb-1 text-[11px] text-muted-foreground">{label}</p>
+      <div className="rounded border border-border bg-muted/20 px-2.5 py-2 leading-relaxed">
+        {children}
+      </div>
+    </div>
+  );
 }

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -19,6 +19,13 @@ import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { ProjectBreadcrumb } from "@/features/projects/components";
@@ -44,6 +51,10 @@ import { useEvaluationRun, useEvaluationRuns, useCreateHumanScore, useCompareRun
 import { PullCodeDrawer } from "../components/pull-code-drawer";
 import { PassRate } from "../components/pass-rate";
 import { SaveTestCaseDrawer } from "../components/trace-integration";
+import {
+  SaveResultToDatasetDrawer,
+  type ResultDatasetAction,
+} from "../components/save-result-to-dataset-drawer";
 import { reproduceRunCode, reproduceRunCodeTs } from "@/features/offline-eval/utils";
 import { matchSpans } from "@/lib/eval/span-match";
 import {
@@ -378,6 +389,10 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   // "Save as test case" drawer (only for real ingested traces): which span it targets.
   const [saveTestCaseOpen, setSaveTestCaseOpen] = React.useState(false);
   const [saveTestCaseSpanId, setSaveTestCaseSpanId] = React.useState<string | undefined>(undefined);
+  // Result→dataset drawer: which action the "Add to dataset" menu picked (null = closed).
+  const [resultDatasetAction, setResultDatasetAction] = React.useState<ResultDatasetAction | null>(
+    null,
+  );
   // "Compare with" — another run of the SAME evaluation, chosen inline. The current run
   // is the candidate; the picked run is the baseline. Comparison is computed on demand
   // by the backend engine (the SDK no longer declares baselines).
@@ -584,21 +599,66 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
                 <Database className="h-3.5 w-3.5" aria-hidden />
                 View source test case
               </Link>
-              {useRealTrace && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-7 text-[12px]"
-                  onClick={() => {
-                    setSaveTestCaseSpanId(
-                      selection.type === "span" ? selection.span.span_id : undefined,
-                    );
-                    setSaveTestCaseOpen(true);
-                  }}
-                >
-                  Save as test case
-                </Button>
-              )}
+              {/* Result → dataset: the three case-level actions live under one menu.
+                  Saving/duplicating/updating operates on the RESULT (its whole
+                  candidate output for this case), publishing a new immutable dataset
+                  version; the finer "save a specific span" capture stays available
+                  below for real ingested traces. */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="sm" className="h-7 gap-1 text-[12px]">
+                    <Database className="h-3.5 w-3.5" aria-hidden />
+                    Add to dataset
+                    <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-64">
+                  <DropdownMenuItem onSelect={() => setResultDatasetAction("update_existing_case")}>
+                    <div>
+                      <div className="text-[12px] font-medium">Update source case</div>
+                      <div className="text-[11px] text-muted-foreground">
+                        Publish a new version of this case
+                      </div>
+                    </div>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => setResultDatasetAction("save_new_case")}>
+                    <div>
+                      <div className="text-[12px] font-medium">Save as a new case</div>
+                      <div className="text-[11px] text-muted-foreground">
+                        Add a new case to a dataset
+                      </div>
+                    </div>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => setResultDatasetAction("duplicate_as_variant")}>
+                    <div>
+                      <div className="text-[12px] font-medium">Duplicate as a variant</div>
+                      <div className="text-[11px] text-muted-foreground">
+                        Branch this case without touching the original
+                      </div>
+                    </div>
+                  </DropdownMenuItem>
+                  {useRealTrace && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onSelect={() => {
+                          setSaveTestCaseSpanId(
+                            selection.type === "span" ? selection.span.span_id : undefined,
+                          );
+                          setSaveTestCaseOpen(true);
+                        }}
+                      >
+                        <div>
+                          <div className="text-[12px] font-medium">Save a span as a case…</div>
+                          <div className="text-[11px] text-muted-foreground">
+                            Capture the selected span&rsquo;s input/output
+                          </div>
+                        </div>
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
             </>
           )}
           spanExtraTags={() => (
@@ -695,6 +755,28 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
         open={saveTestCaseOpen}
         onOpenChange={setSaveTestCaseOpen}
       />
+
+      {/* Result → dataset: update the source case, save a new one, or duplicate as a
+          variant. Publishes a new immutable dataset version; never a scoring action. */}
+      {openResult && run && (
+        <SaveResultToDatasetDrawer
+          projectId={projectId}
+          open={resultDatasetAction !== null}
+          onOpenChange={(o) => {
+            if (!o) setResultDatasetAction(null);
+          }}
+          action={resultDatasetAction ?? "update_existing_case"}
+          result={{
+            id: openResult.id,
+            input: openResult.input,
+            expectedOutput: openResult.expectedOutput,
+            candidateOutput: openResult.candidateOutput,
+            testCaseId: openResult.testCaseId,
+          }}
+          sourceDatasetId={run.datasetId}
+          sourceDatasetName={run.datasetName ?? "this run's dataset"}
+        />
+      )}
     </>
   );
 }

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -81,6 +81,24 @@ function fmtDurationMs(ms: number | null | undefined): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
+/** Signed candidate−baseline delta beside a duration/cost cell (lower is better:
+ *  an increase is red, a decrease green). Rendered only when comparing. */
+function CellDelta({
+  delta,
+  format,
+}: {
+  delta: number | null;
+  format: (n: number) => string;
+}): React.ReactNode {
+  if (delta === null || delta === 0) return null;
+  return (
+    <span className={`ml-1 ${SENTIMENT_CLASS[changeSentiment(-delta)]}`}>
+      {delta > 0 ? "+" : "−"}
+      {format(Math.abs(delta))}
+    </span>
+  );
+}
+
 /**
  * Whether two authored values are the SAME value. A pure reformat (re-indenting
  * JSON, whether from the seed format or the format switcher) is not an edit —
@@ -149,12 +167,21 @@ function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
   const failed = Boolean(result.taskError);
   const rootStatus = (failed ? "ERROR" : "OK") as SpanStatus;
 
+  // Ordered fake timestamps so the reconstructed tree is deterministic and reads in
+  // the real order: task first, then scorers (which run after it). Without distinct
+  // starts, the stable sibling sort would tie and fall back to span_id.
+  const base = new Date(result.createTime).getTime();
+  const t0 = Number.isFinite(base) ? base : 0;
+  const iso = (ms: number) => new Date(ms).toISOString();
+
   const spans: Span[] = [
     evalSpan({
       span_id: `${id}-root`,
       trace_id: id,
       name: `${run.evaluationName} · ${result.testCaseId}`,
       span_kind: "AGENT" as SpanKind,
+      span_start_time: iso(t0),
+      span_end_time: iso(t0 + result.scores.length + 2),
       input: result.input,
       output: result.candidateOutput,
       status: rootStatus,
@@ -172,6 +199,8 @@ function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
       parent_span_id: `${id}-root`,
       name: "task",
       span_kind: "SPAN" as SpanKind,
+      span_start_time: iso(t0),
+      span_end_time: iso(t0 + 1),
       input: result.input,
       output: result.candidateOutput,
       cost: result.cost,
@@ -181,8 +210,8 @@ function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
     }),
   ];
 
-  // Scorer spans — siblings of the task, one per scorer that ran.
-  for (const s of result.scores) {
+  // Scorer spans — siblings of the task, one per scorer that ran, starting after it.
+  result.scores.forEach((s, i) => {
     spans.push(
       evalSpan({
         span_id: `${id}-scorer-${s.id}`,
@@ -190,6 +219,8 @@ function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
         parent_span_id: `${id}-root`,
         name: s.scorerName,
         span_kind: "SPAN" as SpanKind,
+        span_start_time: iso(t0 + i + 2),
+        span_end_time: iso(t0 + i + 2),
         input: `output: ${result.candidateOutput ?? "—"}\nexpected: ${result.expectedOutput ?? "—"}`,
         output: s.error ?? scoreValue(s),
         status: (s.error ? "ERROR" : "OK") as SpanStatus,
@@ -197,7 +228,7 @@ function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
         metadata: JSON.stringify({ scorer: s.scorerName, version: s.scorerVersion }),
       }),
     );
-  }
+  });
 
   return {
     trace_id: id,
@@ -1175,7 +1206,7 @@ function RunSwitcher({
   );
 }
 
-const RESULT_COLUMN_COUNT = 6;
+const RESULT_COLUMN_COUNT = 8;
 
 /** Sentinel for the "Compare with" select's no-selection option (Radix needs a value). */
 const NO_COMPARE = "__none__";
@@ -1294,14 +1325,17 @@ function ResultsSection({
             <Th>Output</Th>
             <Th>Expected</Th>
             <Th className="w-[170px]">Main score</Th>
-            <Th className="w-[110px] text-right">{comparing ? "vs baseline" : "Change"}</Th>
+            {/* Change is only meaningful against a picked run; hidden otherwise. */}
+            {comparing && <Th className="w-[110px] text-right">vs baseline</Th>}
+            <Th className="w-[90px] text-right">Duration</Th>
+            <Th className="w-[90px] text-right">Cost</Th>
             <Th className="w-[110px]">Status</Th>
           </TRHead>
         </THead>
         <TBody>
           {visible.length === 0 ? (
             <tr>
-              <td colSpan={RESULT_COLUMN_COUNT}>
+              <td colSpan={comparing ? RESULT_COLUMN_COUNT : RESULT_COLUMN_COUNT - 1}>
                 <p className="px-4 py-12 text-center text-[12px] text-muted-foreground">
                   {results.length === 0
                     ? "No per-case results reported for this run yet."
@@ -1349,8 +1383,25 @@ function ResultsSection({
                   <Td>
                     <MainScoreCell result={result} comparison={rowCmp} />
                   </Td>
-                  <Td className="text-right">
-                    <ChangeCell change={rowCmp?.caseChange ?? null} />
+                  {comparing && (
+                    <Td className="text-right">
+                      <ChangeCell change={rowCmp?.caseChange ?? null} />
+                    </Td>
+                  )}
+                  <Td className="whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
+                    {fmtDurationMs(result.durationMs)}
+                    {comparing && (
+                      <CellDelta delta={rowCmp?.durationDeltaMs ?? null} format={fmtDurationMs} />
+                    )}
+                  </Td>
+                  <Td className="whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
+                    {result.cost === null ? "—" : `$${result.cost.toFixed(4)}`}
+                    {comparing && result.cost !== null && row?.baselineCost != null && (
+                      <CellDelta
+                        delta={result.cost - row.baselineCost}
+                        format={(n) => `$${n.toFixed(4)}`}
+                      />
+                    )}
                   </Td>
                   <Td>
                     <EvalResultBadge status={result.status} />

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -140,8 +140,7 @@ function evalSpan(
 
 /**
  * The eval-shaped trace for one result, so the run detail opens into the real
- * trace viewer (span tree + span detail) exactly like the mock — the shape the
- * SDK reports:
+ * trace viewer (span tree + span detail) — the shape the SDK reports:
  *
  *   evaluation item (root)
  *     ├─ task span      ← the candidate application's run
@@ -271,7 +270,7 @@ const RESULT_FILTER_FN: Record<ResultFilterId, (r: ResultRow) => boolean> = {
 };
 
 /**
- * Evaluation run detail — faithful port of the prototype's run detail, wired to
+ * Evaluation run detail — the run detail surface, wired to
  * the server. Ordered to answer, in sequence: did the candidate improve, what
  * regressed, what broke, and can the aggregate be trusted? Verdict strip first
  * (its Regressions/Errors counts filter the results table in place), then the
@@ -279,7 +278,7 @@ const RESULT_FILTER_FN: Record<ResultFilterId, (r: ResultRow) => boolean> = {
  *
  * Opening a result opens the REAL trace viewer (span tree + span detail) on an
  * eval-shaped trace built from the result, with the evaluation context, scores,
- * and human review as the span-actions panel — exactly like the mock.
+ * and human review as the span-actions panel.
  */
 export function RunDetailView({ projectId, runId }: { projectId: string; runId: string }) {
   const { data, isLoading, error } = useEvaluationRun(projectId, runId);
@@ -297,24 +296,12 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   const results = React.useMemo(() => data?.results ?? [], [data]);
   const run = data?.run;
 
-  // This evaluation's other runs, for the breadcrumb's run switcher. Shares the
-  // RunSwitcher's query key, so it's the same fetch, not a second one.
+  // This evaluation's other runs — the compare-baseline picker below and the
+  // header RunSwitcher share this query key, so it's one fetch, not two.
   const siblingRuns = useEvaluationRuns(projectId, {
     evaluation_id: run?.evaluationId,
     limit: 100,
   });
-  const runOptions = React.useMemo(
-    () =>
-      run
-        ? (siblingRuns.data?.data ?? []).map((r) => ({
-            id: r.id,
-            label: `#${r.runNumber} · ${r.candidateVersion}`,
-            href: `/projects/${projectId}/evaluations/${r.id}`,
-            isCurrent: r.id === run.id,
-          }))
-        : [],
-    [siblingRuns.data, run, projectId],
-  );
 
   // Other runs of this evaluation, to pick a comparison baseline from (never an
   // arbitrary run from another evaluation). Newest first, current run excluded.
@@ -408,24 +395,7 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
 
   return (
     <>
-      <ProjectBreadcrumb
-        projectId={projectId}
-        trail={
-          run
-            ? [
-                {
-                  // Just the run segment (no separate "Evaluations" crumb) — a dropdown
-                  // of this evaluation's runs. Its menu header still links to the
-                  // Evaluations list, so that page stays one click away.
-                  label: `${run.evaluationName} #${run.runNumber}`,
-                  menuHeader: { label: "Evaluations", href: `/projects/${projectId}/evaluations` },
-                  options: runOptions,
-                },
-              ]
-            : undefined
-        }
-        current={run ? undefined : "Evaluations"}
-      />
+      <ProjectBreadcrumb projectId={projectId} />
       <div className="flex flex-1 flex-col overflow-hidden text-[12px]">
         {isLoading ? (
           <div className="flex h-64 items-center justify-center">
@@ -708,6 +678,7 @@ function RunBody({
   return (
     <>
       <EvalPageHeader
+        parent={{ label: "Evaluations", href: `/projects/${projectId}/evaluations` }}
         title={
           <span className="flex flex-wrap items-center gap-2">
             <span>{run.evaluationName}</span>
@@ -782,16 +753,16 @@ function RunBody({
         }
       />
 
-      <div className="min-h-0 flex-1 overflow-auto">
-        <div className="flex flex-col gap-3 p-4">
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col">
           {compareLoading && (
-            <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
+            <div className="border-b border-border bg-muted/30 px-3 py-1.5 text-[11px] text-muted-foreground">
               Computing comparison…
             </div>
           )}
 
           {comparing && cmp && (
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border border-border bg-muted/30 px-3 py-2 text-[11px]">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-border bg-muted/30 px-3 py-2 text-[11px]">
               <span className="flex items-center gap-1.5">
                 <GitCompare className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
                 <span className="font-medium">
@@ -996,7 +967,7 @@ function ResultsSection({
   }, [results, keyword, filter, sortWorst, cmpFor]);
 
   return (
-    <div className="rounded-md border border-border">
+    <div className="flex min-h-0 flex-1 flex-col">
       <SearchFilterBar
         searchInput={
           <div className="relative min-w-[10rem] max-w-md flex-1">
@@ -1046,100 +1017,102 @@ function ResultsSection({
         </Button>
       </SearchFilterBar>
 
-      <Table>
-        <THead>
-          <TRHead>
-            <Th>Input</Th>
-            <Th>Output</Th>
-            <Th>Expected</Th>
-            <Th className="w-[170px]">Main score</Th>
-            {/* Change is only meaningful against a picked run; hidden otherwise. */}
-            {comparing && <Th className="w-[110px] text-right">vs baseline</Th>}
-            <Th className="w-[90px] text-right">Duration</Th>
-            <Th className="w-[90px] text-right">Cost</Th>
-            <Th className="w-[110px]">Status</Th>
-          </TRHead>
-        </THead>
-        <TBody>
-          {visible.length === 0 ? (
-            <tr>
-              <td colSpan={comparing ? RESULT_COLUMN_COUNT : RESULT_COLUMN_COUNT - 1}>
-                <p className="px-4 py-12 text-center text-[12px] text-muted-foreground">
-                  {results.length === 0
-                    ? "No per-case results reported for this run yet."
-                    : "No results match this filter."}
-                </p>
-              </td>
-            </tr>
-          ) : (
-            visible.map((result) => {
-              const row = cmpFor(result);
-              const rowCmp = row?.comparison ?? null;
-              return (
-                <TR
-                  key={result.id}
-                  interactive
-                  selected={result.id === openResultId}
-                  onClick={() => onOpen(result.id)}
-                >
-                  <Td className="max-w-[260px] truncate" title={result.input}>
-                    {result.input}
-                  </Td>
-                  <Td className="max-w-[260px]">
-                    <div className="flex min-w-0 items-center gap-1.5">
-                      <span className="truncate" title={result.candidateOutput ?? undefined}>
-                        {result.candidateOutput ?? (
-                          <span className="text-muted-foreground">No output</span>
-                        )}
-                      </span>
-                      {row?.outputChanged === true && (
-                        <span
-                          className="shrink-0 rounded bg-muted px-1 text-[10px] text-muted-foreground"
-                          title="Output differs from the baseline run"
-                        >
-                          ≠ baseline
-                        </span>
-                      )}
-                    </div>
-                  </Td>
-                  <Td
-                    className="max-w-[220px] truncate text-muted-foreground"
-                    title={result.expectedOutput ?? undefined}
+      <div className="min-h-0 flex-1 overflow-auto">
+        <Table>
+          <THead>
+            <TRHead>
+              <Th>Input</Th>
+              <Th>Output</Th>
+              <Th>Expected</Th>
+              <Th className="w-[170px]">Main score</Th>
+              {/* Change is only meaningful against a picked run; hidden otherwise. */}
+              {comparing && <Th className="w-[110px] text-right">vs baseline</Th>}
+              <Th className="w-[90px] text-right">Duration</Th>
+              <Th className="w-[90px] text-right">Cost</Th>
+              <Th className="w-[110px]">Status</Th>
+            </TRHead>
+          </THead>
+          <TBody>
+            {visible.length === 0 ? (
+              <tr>
+                <td colSpan={comparing ? RESULT_COLUMN_COUNT : RESULT_COLUMN_COUNT - 1}>
+                  <p className="px-4 py-12 text-center text-[12px] text-muted-foreground">
+                    {results.length === 0
+                      ? "No per-case results reported for this run yet."
+                      : "No results match this filter."}
+                  </p>
+                </td>
+              </tr>
+            ) : (
+              visible.map((result) => {
+                const row = cmpFor(result);
+                const rowCmp = row?.comparison ?? null;
+                return (
+                  <TR
+                    key={result.id}
+                    interactive
+                    selected={result.id === openResultId}
+                    onClick={() => onOpen(result.id)}
                   >
-                    {result.expectedOutput ?? "—"}
-                  </Td>
-                  <Td>
-                    <MainScoreCell result={result} comparison={rowCmp} />
-                  </Td>
-                  {comparing && (
-                    <Td className="text-right">
-                      <ChangeCell change={rowCmp?.caseChange ?? null} />
+                    <Td className="max-w-[260px] truncate" title={result.input}>
+                      {result.input}
                     </Td>
-                  )}
-                  <Td className="whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
-                    {fmtDurationMs(result.durationMs)}
+                    <Td className="max-w-[260px]">
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <span className="truncate" title={result.candidateOutput ?? undefined}>
+                          {result.candidateOutput ?? (
+                            <span className="text-muted-foreground">No output</span>
+                          )}
+                        </span>
+                        {row?.outputChanged === true && (
+                          <span
+                            className="shrink-0 rounded bg-muted px-1 text-[10px] text-muted-foreground"
+                            title="Output differs from the baseline run"
+                          >
+                            ≠ baseline
+                          </span>
+                        )}
+                      </div>
+                    </Td>
+                    <Td
+                      className="max-w-[220px] truncate text-muted-foreground"
+                      title={result.expectedOutput ?? undefined}
+                    >
+                      {result.expectedOutput ?? "—"}
+                    </Td>
+                    <Td>
+                      <MainScoreCell result={result} comparison={rowCmp} />
+                    </Td>
                     {comparing && (
-                      <CellDelta delta={rowCmp?.durationDeltaMs ?? null} format={fmtDurationMs} />
+                      <Td className="text-right">
+                        <ChangeCell change={rowCmp?.caseChange ?? null} />
+                      </Td>
                     )}
-                  </Td>
-                  <Td className="whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
-                    {result.cost === null ? "—" : `$${result.cost.toFixed(4)}`}
-                    {comparing && result.cost !== null && row?.baselineCost != null && (
-                      <CellDelta
-                        delta={result.cost - row.baselineCost}
-                        format={(n) => `$${n.toFixed(4)}`}
-                      />
-                    )}
-                  </Td>
-                  <Td>
-                    <EvalResultBadge status={result.status} />
-                  </Td>
-                </TR>
-              );
-            })
-          )}
-        </TBody>
-      </Table>
+                    <Td className="whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
+                      {fmtDurationMs(result.durationMs)}
+                      {comparing && (
+                        <CellDelta delta={rowCmp?.durationDeltaMs ?? null} format={fmtDurationMs} />
+                      )}
+                    </Td>
+                    <Td className="whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
+                      {result.cost === null ? "—" : `$${result.cost.toFixed(4)}`}
+                      {comparing && result.cost !== null && row?.baselineCost != null && (
+                        <CellDelta
+                          delta={result.cost - row.baselineCost}
+                          format={(n) => `$${n.toFixed(4)}`}
+                        />
+                      )}
+                    </Td>
+                    <Td>
+                      <EvalResultBadge status={result.status} />
+                    </Td>
+                  </TR>
+                );
+              })
+            )}
+          </TBody>
+        </Table>
+      </div>
     </div>
   );
 }
@@ -1173,7 +1146,7 @@ function MainScoreCell({
   );
 }
 
-/** Per-result case verdict (derived from the main scorer), faithfully rendered. */
+/** Per-result case verdict (derived from the main scorer). */
 function ChangeCell({ change }: { change: Classification | null }) {
   if (change === "improved") {
     return (

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -280,29 +280,6 @@ const RESULT_FILTER_FN: Record<ResultFilterId, (r: ResultRow) => boolean> = {
   not_scored: (r) => r.status === "not_scored",
 };
 
-/** Human-readable explanation of why a comparison is untrustworthy, from its reasons. */
-function comparisonReasonText(reasons: string[], datasetVersionLabel: string): string {
-  const parts: string[] = [];
-  if (reasons.includes("different_dataset_version")) {
-    parts.push(
-      `the baseline measured a different dataset snapshot than this run (${datasetVersionLabel}), so the two runs covered different test cases`,
-    );
-  }
-  if (reasons.includes("different_evaluation")) {
-    parts.push("the baseline belongs to a different evaluation");
-  }
-  if (reasons.includes("baseline_not_terminal")) {
-    parts.push("the baseline run has not finished, so its scores may still change");
-  }
-  if (reasons.includes("main_scorer_incompatible")) {
-    parts.push(
-      "the main scorer could not be compared on any shared case (missing or version-mismatched)",
-    );
-  }
-  if (parts.length === 0) return "The selected baseline is not directly comparable.";
-  return parts.map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join("; ") + ".";
-}
-
 /**
  * Evaluation run detail — faithful port of the prototype's run detail, wired to
  * the server. Ordered to answer, in sequence: did the candidate improve, what
@@ -737,10 +714,7 @@ function RunBody({
   const [detailsOpen, setDetailsOpen] = React.useState(false);
   const [reproduceOpen, setReproduceOpen] = React.useState(false);
   const comparing = !!compareByCase;
-  // Trust note reflects the PICKED comparison (not a stored baseline).
   const cmp = compareData?.comparison ?? null;
-  const incompatibleComparison = comparing && !!cmp && cmp.available && !cmp.trustworthy;
-  const trustNote = cmp ? comparisonReasonText(cmp.reasons, run.datasetVersionLabel) : "";
 
   return (
     <>
@@ -775,7 +749,7 @@ function RunBody({
               onValueChange={(v) => onCompareChange(v === NO_COMPARE ? null : v)}
             >
               <SelectTrigger
-                className="h-7 w-[200px] gap-1.5 text-[12px]"
+                className="h-7 w-fit max-w-[240px] gap-1.5 text-[12px]"
                 aria-label="Compare with"
               >
                 <GitCompare className="h-3.5 w-3.5 shrink-0" aria-hidden />
@@ -861,16 +835,6 @@ function RunBody({
               >
                 Clear
               </Button>
-            </div>
-          )}
-
-          {incompatibleComparison && (
-            <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[11px] leading-relaxed text-amber-700 dark:text-amber-300">
-              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
-              <span>
-                <span className="font-medium">Comparison not fully trustworthy.</span> {trustNote}{" "}
-                The change is shown for context but should not be read as a clean verdict.
-              </span>
             </div>
           )}
 

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -1316,21 +1316,32 @@ function ResultsSection({
                   selected={result.id === openResultId}
                   onClick={() => onOpen(result.id)}
                 >
-                  <Td>{truncate(result.input, 60)}</Td>
-                  <Td>
-                    {result.candidateOutput ?? (
-                      <span className="text-muted-foreground">No output</span>
-                    )}
-                    {row?.outputChanged === true && (
-                      <span
-                        className="ml-1.5 rounded bg-muted px-1 text-[10px] text-muted-foreground"
-                        title="Output differs from the baseline run"
-                      >
-                        ≠ baseline
-                      </span>
-                    )}
+                  <Td className="max-w-[260px] truncate" title={result.input}>
+                    {result.input}
                   </Td>
-                  <Td className="text-muted-foreground">{result.expectedOutput ?? "—"}</Td>
+                  <Td className="max-w-[260px]">
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <span className="truncate" title={result.candidateOutput ?? undefined}>
+                        {result.candidateOutput ?? (
+                          <span className="text-muted-foreground">No output</span>
+                        )}
+                      </span>
+                      {row?.outputChanged === true && (
+                        <span
+                          className="shrink-0 rounded bg-muted px-1 text-[10px] text-muted-foreground"
+                          title="Output differs from the baseline run"
+                        >
+                          ≠ baseline
+                        </span>
+                      )}
+                    </div>
+                  </Td>
+                  <Td
+                    className="max-w-[220px] truncate text-muted-foreground"
+                    title={result.expectedOutput ?? undefined}
+                  >
+                    {result.expectedOutput ?? "—"}
+                  </Td>
                   <Td>
                     <MainScoreCell result={result} comparison={rowCmp} />
                   </Td>

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -54,7 +54,15 @@ import {
   useUpdateTestCase,
 } from "../hooks";
 import { RunStatusBadge } from "./evaluations-view";
-import type { ResultRow, RunDetail, ScoreRow } from "../types";
+import { attributeTraceUsage, type TraceUsage, type UsageSpan } from "@/lib/eval/trace-usage";
+import type { ResultRow, RunDetail, ScoreRow, Classification } from "../types";
+
+/** Case/run duration; "Unknown" when unmeasured (never 0s). */
+function fmtDurationMs(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined) return "Unknown";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
 
 function scoreValue(s: ScoreRow): string {
   if (s.error) return "error";
@@ -177,23 +185,60 @@ function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
   };
 }
 
-type ResultFilterId = "all" | "regressions" | "failed" | "errors" | "not_scored";
+type ResultFilterId =
+  | "all"
+  | "regressions"
+  | "improvements"
+  | "failed"
+  | "errors"
+  | "unpaired"
+  | "not_scored";
 
 const RESULT_FILTERS: Array<{ id: ResultFilterId; label: string }> = [
   { id: "all", label: "All" },
   { id: "regressions", label: "Regressions" },
+  { id: "improvements", label: "Improvements" },
   { id: "failed", label: "Failed" },
   { id: "errors", label: "Errors" },
+  { id: "unpaired", label: "Unpaired" },
   { id: "not_scored", label: "Not scored" },
 ];
 
+// Filters key on the DERIVED case verdict (comparison.caseChange), never the stored
+// change column. "Unpaired" folds in not_comparable (paired but un-trustable) cases.
 const RESULT_FILTER_FN: Record<ResultFilterId, (r: ResultRow) => boolean> = {
   all: () => true,
-  regressions: (r) => r.change === "regressed",
+  regressions: (r) => r.comparison?.caseChange === "regressed",
+  improvements: (r) => r.comparison?.caseChange === "improved",
   failed: (r) => r.status === "failed",
   errors: (r) => r.status === "errored" || r.scores.some((s) => s.error),
+  unpaired: (r) =>
+    r.comparison?.caseChange === "unpaired" || r.comparison?.caseChange === "not_comparable",
   not_scored: (r) => r.status === "not_scored",
 };
+
+/** Human-readable explanation of why a comparison is untrustworthy, from its reasons. */
+function comparisonReasonText(reasons: string[], datasetVersionLabel: string): string {
+  const parts: string[] = [];
+  if (reasons.includes("different_dataset_version")) {
+    parts.push(
+      `the baseline measured a different dataset snapshot than this run (${datasetVersionLabel}), so the two runs covered different test cases`,
+    );
+  }
+  if (reasons.includes("different_evaluation")) {
+    parts.push("the baseline belongs to a different evaluation");
+  }
+  if (reasons.includes("baseline_not_terminal")) {
+    parts.push("the baseline run has not finished, so its scores may still change");
+  }
+  if (reasons.includes("main_scorer_incompatible")) {
+    parts.push(
+      "the main scorer could not be compared on any shared case (missing or version-mismatched)",
+    );
+  }
+  if (parts.length === 0) return "The selected baseline is not directly comparable.";
+  return parts.map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join("; ") + ".";
+}
 
 /**
  * Evaluation run detail — faithful port of the prototype's run detail, wired to
@@ -225,8 +270,12 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   // id was emitted (fully-local run), fall back to a clearly-labeled reconstructed trace.
   const realTraceId = openResult?.traceId ?? null;
   const realTrace = useTrace(projectId, realTraceId ?? "", !!realTraceId);
-  const hasRealTrace = !!realTraceId && !!realTrace.data;
-  const tracePending = !!realTraceId && !realTrace.data; // loading or still ingesting
+  // Only treat a reported trace as "pending" when its fetch genuinely fails (not yet
+  // ingested → 404). While it's merely loading, keep the trace panel mounted and let it
+  // show its own loading — so navigating between results updates in place instead of
+  // flickering through the pending panel and re-animating the slide-in.
+  const tracePending = !!realTraceId && realTrace.isError;
+  const useRealTrace = !!realTraceId && !realTrace.isError;
 
   // Reconstructed eval-shaped trace — the labeled fallback, only for results that
   // emitted no real trace. Seed span I/O just for those so the detail panel has it.
@@ -243,8 +292,20 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   const updateCase = useUpdateTestCase(projectId, run?.datasetId ?? "");
   const humanScore = useCreateHumanScore(projectId, openResult?.id ?? "");
 
-  const panelTraceId = hasRealTrace ? realTraceId : fallbackTrace?.trace_id;
-  const panelOverride = hasRealTrace ? undefined : fallbackTrace;
+  const panelTraceId = useRealTrace ? realTraceId : fallbackTrace?.trace_id;
+  const panelOverride = useRealTrace ? undefined : fallbackTrace;
+
+  // Token/cost derived from the OPEN result's real trace (already fetched — bounded, no
+  // extra query). Pending while the reported trace ingests; the reconstructed fallback
+  // has no LLM leaves so it reports "unknown", never a fabricated 0.
+  const openTraceSpans = useRealTrace ? realTrace.data?.spans : panelOverride?.spans;
+  const traceUsage = React.useMemo<TraceUsage>(
+    () =>
+      tracePending
+        ? attributeTraceUsage(null)
+        : attributeTraceUsage(openTraceSpans as UsageSpan[] | undefined),
+    [tracePending, openTraceSpans],
+  );
 
   const closeResult = () => setOpenResultId(null);
 
@@ -323,6 +384,7 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
               projectId={projectId}
               run={run}
               result={openResult}
+              traceUsage={traceUsage}
               onReview={() => setReviewOpen(true)}
               onSaveExpected={(value) =>
                 updateCase.mutate(
@@ -343,7 +405,7 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
           )}
           spanExtraTags={() => (
             <>
-              {!hasRealTrace && (
+              {!useRealTrace && (
                 <span className="inline-flex items-center gap-1.5 rounded-md border border-amber-400/60 bg-amber-100/60 px-2.5 py-1 text-xs text-amber-800 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-300">
                   Reconstructed — no telemetry was emitted for this result
                 </span>
@@ -470,8 +532,10 @@ function RunBody({
 }) {
   const router = useRouter();
   const hasBaseline = run.baselineRunId !== null;
-  const regressed = results.filter((r) => r.change === "regressed");
-  const incompatibleBaseline = run.baselineRunId !== null && !run.baselineComparable;
+  // Derived verdict — never the stored `change` column.
+  const regressed = results.filter((r) => r.comparison?.caseChange === "regressed");
+  const incompatibleBaseline = run.comparison.available && !run.comparison.trustworthy;
+  const trustNote = comparisonReasonText(run.comparison.reasons, run.datasetVersionLabel);
 
   return (
     <>
@@ -505,22 +569,14 @@ function RunBody({
             <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[11px] leading-relaxed text-amber-700 dark:text-amber-300">
               <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
               <span>
-                <span className="font-medium">Not directly comparable.</span> The selected baseline
-                measured a different dataset snapshot than this run (
-                <span className="font-mono">{run.datasetVersionLabel}</span>). The two runs covered
-                different test cases, so a single delta would be misleading. Pick a baseline on the
-                same snapshot to compare.
+                <span className="font-medium">Comparison not fully trustworthy.</span> {trustNote}{" "}
+                The change is shown for context but should not be read as a clean verdict.
               </span>
             </div>
           )}
 
           {/* Verdict first, as a one-line strip — then results are the hero. */}
-          <VerdictStrip
-            run={run}
-            regressionCount={regressed.length}
-            hasBaseline={hasBaseline}
-            onFilter={onFilterChange}
-          />
+          <VerdictStrip run={run} onFilter={onFilterChange} />
 
           <ResultsSection
             results={results}
@@ -618,16 +674,19 @@ function RunSwitcher({
  */
 function VerdictStrip({
   run,
-  regressionCount,
-  hasBaseline,
   onFilter,
 }: {
   run: RunDetail;
-  regressionCount: number;
-  hasBaseline: boolean;
   onFilter: (filter: ResultFilterId) => void;
 }) {
   const unscored = run.caseCount - run.scoredCount;
+  const cmp = run.comparison;
+  const cases = cmp.caseCounts;
+  const cells = cmp.scoreCellCounts;
+  // "Not cleanly compared" folds unpaired (one side only) + not_comparable (paired but
+  // un-trustable). A delta and regression counts are shown only when a comparison is
+  // available — otherwise "—" (unknown), never a delta beside a bare 0.
+  const unpaired = cases.unpaired + cases.not_comparable;
   return (
     <div className="rounded-md border border-border p-3">
       <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
@@ -635,25 +694,44 @@ function VerdictStrip({
         <Metric
           label={run.mainScoreName ?? "Main score"}
           value={run.mainScore === null ? "—" : pct(run.mainScore)}
+          hint={cmp.baseline ? `vs ${cmp.baseline.candidateVersion}` : undefined}
           strong
         />
         <Metric
           label="Change"
           value={
-            run.changeFromBaseline === null ? (
+            !cmp.available || cmp.mainScore.delta === null ? (
               <span className="text-muted-foreground">—</span>
             ) : (
-              <span className={SENTIMENT_CLASS[changeSentiment(run.changeFromBaseline)]}>
-                {signed(run.changeFromBaseline)} pp
+              <span className={SENTIMENT_CLASS[changeSentiment(cmp.mainScore.delta)]}>
+                {signed(cmp.mainScore.delta)} pp
               </span>
             )
           }
-          hint={hasBaseline ? undefined : "No baseline"}
+          hint={!cmp.available ? "No baseline" : !cmp.trustworthy ? "Not trusted" : undefined}
+        />
+        {/* Case-level (main scorer). Regressions/Improvements filter the table. */}
+        <FilterStat
+          label="Regressed"
+          count={cmp.available ? cases.regressed : null}
+          onClick={() => onFilter("regressions")}
         />
         <FilterStat
-          label="Regressions"
-          count={regressionCount}
-          onClick={() => onFilter("regressions")}
+          label="Improved"
+          count={cmp.available ? cases.improved : null}
+          onClick={() => onFilter("improvements")}
+        />
+        <Metric label="Unchanged" value={cmp.available ? cases.unchanged : "—"} />
+        <FilterStat
+          label="Unpaired"
+          count={cmp.available ? unpaired : null}
+          onClick={() => onFilter("unpaired")}
+        />
+        {/* Secondary, clearly labeled: regressed SCORE CELLS ≠ regressed cases. */}
+        <Metric
+          label="Regressed cells"
+          value={cmp.available ? cells.regressed : "—"}
+          hint="score cells"
         />
         <FilterStat label="Errors" count={run.errorCount} onClick={() => onFilter("errors")} />
         <Metric label="Scored" value={`${run.scoredCount} / ${run.caseCount}`} />
@@ -693,16 +771,23 @@ function Metric({
   );
 }
 
-/** A count that filters the results table when non-zero. */
+/**
+ * A count that filters the results table when non-zero. A null count means the
+ * quantity is UNKNOWN (e.g. no baseline → regressions can't be counted) and renders
+ * as "—", never a bare 0 that would read as "0 regressions" beside a delta.
+ */
 function FilterStat({
   label,
   count,
   onClick,
 }: {
   label: string;
-  count: number;
+  count: number | null;
   onClick: () => void;
 }) {
+  if (count === null) {
+    return <Metric label={label} value={<span className="text-muted-foreground">—</span>} />;
+  }
   if (count === 0) {
     return <Metric label={label} value={<span className="text-muted-foreground">0</span>} />;
   }
@@ -740,6 +825,7 @@ function ResultsSection({
 }) {
   const { toast } = useToast();
   const [keyword, setKeyword] = React.useState("");
+  const [sortWorst, setSortWorst] = React.useState(false);
   const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
     DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0],
   );
@@ -748,7 +834,7 @@ function ResultsSection({
 
   const visible = React.useMemo(() => {
     const q = keyword.trim().toLowerCase();
-    return results.filter((r) => {
+    const filtered = results.filter((r) => {
       if (!RESULT_FILTER_FN[filter](r)) return false;
       if (!q) return true;
       return (
@@ -757,7 +843,17 @@ function ResultsSection({
         (r.expectedOutput ?? "").toLowerCase().includes(q)
       );
     });
-  }, [results, keyword, filter]);
+    if (!sortWorst) return filtered;
+    // Worst main-score regression first (most-negative delta); unknown deltas last.
+    return [...filtered].sort((a, b) => {
+      const da = a.comparison?.mainScore.delta;
+      const db = b.comparison?.mainScore.delta;
+      if (da == null && db == null) return 0;
+      if (da == null) return 1;
+      if (db == null) return -1;
+      return da - db;
+    });
+  }, [results, keyword, filter, sortWorst]);
 
   return (
     <div className="rounded-md border border-border">
@@ -797,6 +893,16 @@ function ResultsSection({
         </div>
         <span className="flex-1" aria-hidden />
         <Button
+          variant={sortWorst ? "default" : "outline"}
+          size="sm"
+          className="h-7 gap-1.5 px-2 text-[12px]"
+          onClick={() => setSortWorst((s) => !s)}
+          title="Sort by the worst main-score regression first"
+        >
+          <ArrowDown className="h-3.5 w-3.5" aria-hidden />
+          Worst regression
+        </Button>
+        <Button
           variant="ghost"
           size="sm"
           className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
@@ -813,8 +919,8 @@ function ResultsSection({
             <Th>Input</Th>
             <Th>Output</Th>
             <Th>Expected</Th>
-            <Th className="w-[150px]">Scores</Th>
-            <Th className="w-[100px] text-right">Change</Th>
+            <Th className="w-[170px]">Main score</Th>
+            <Th className="w-[110px] text-right">Change</Th>
             <Th className="w-[110px]">Status</Th>
           </TRHead>
         </THead>
@@ -845,10 +951,12 @@ function ResultsSection({
                 </Td>
                 <Td className="text-muted-foreground">{result.expectedOutput ?? "—"}</Td>
                 <Td>
-                  <ScoreCell result={result} />
+                  <MainScoreCell result={result} hasBaseline={hasBaseline} />
                 </Td>
                 <Td className="text-right">
-                  <ChangeCell change={hasBaseline ? result.change : null} />
+                  <ChangeCell
+                    change={hasBaseline ? (result.comparison?.caseChange ?? null) : null}
+                  />
                 </Td>
                 <Td>
                   <EvalResultBadge status={result.status} />
@@ -863,12 +971,31 @@ function ResultsSection({
 }
 
 /**
- * Per-result change direction. The prototype showed "+N pp" per case; the server
- * reports only the direction (improved / regressed / unchanged) per result — no
- * per-case baseline score to subtract — so we render the direction faithfully as
- * a coloured arrow rather than a fabricated magnitude.
+ * Per-result candidate main score, its baseline counterpart, and the delta — the
+ * backend now derives the baseline per-case value, so we show a real magnitude, not
+ * just a direction. Missing values render "—", never a fabricated 0.
  */
-function ChangeCell({ change }: { change: ResultRow["change"] }) {
+function MainScoreCell({ result, hasBaseline }: { result: ResultRow; hasBaseline: boolean }) {
+  const cmp = result.comparison;
+  const cand = cmp?.mainScore.candidate ?? result.mainScore;
+  if (cand === null || cand === undefined) return <span className="text-muted-foreground">—</span>;
+  const base = hasBaseline ? (cmp?.mainScore.baseline ?? null) : null;
+  const delta = hasBaseline ? (cmp?.mainScore.delta ?? null) : null;
+  return (
+    <div className="flex flex-col gap-0.5 text-[12px] tabular-nums">
+      <span>
+        {pct(cand)}
+        {base !== null && <span className="text-muted-foreground"> vs {pct(base)}</span>}
+      </span>
+      {delta !== null && (
+        <span className={SENTIMENT_CLASS[changeSentiment(delta)]}>{signed(delta)} pp</span>
+      )}
+    </div>
+  );
+}
+
+/** Per-result case verdict (derived from the main scorer), faithfully rendered. */
+function ChangeCell({ change }: { change: Classification | null }) {
   if (change === "improved") {
     return (
       <span
@@ -891,23 +1018,185 @@ function ChangeCell({ change }: { change: ResultRow["change"] }) {
       </span>
     );
   }
+  if (change === "changed") {
+    return <span title="Changed (categorical)">Changed</span>;
+  }
+  if (change === "unchanged") {
+    return <span className="text-muted-foreground">Unchanged</span>;
+  }
+  if (change === "unpaired" || change === "not_comparable") {
+    return (
+      <span className="text-muted-foreground" title="Not compared against a baseline value">
+        {change === "unpaired" ? "Unpaired" : "Not comparable"}
+      </span>
+    );
+  }
   return <span className="text-muted-foreground">—</span>;
 }
 
-/** Per-scorer values, with a failed scorer shown as an error rather than a 0. */
-function ScoreCell({ result }: { result: ResultRow }) {
-  if (result.scores.length === 0) return <span className="text-muted-foreground">—</span>;
+function cellValueDisplay(v: number | boolean | string | null): string {
+  if (v === null || v === undefined) return "—";
+  if (typeof v === "boolean") return v ? "true" : "false";
+  if (typeof v === "number") return Number.isInteger(v) ? String(v) : v.toFixed(3);
+  return v;
+}
+
+const CELL_CLASS_STYLE: Record<Classification, { label: string; className: string }> = {
+  improved: { label: "Improved", className: SENTIMENT_CLASS.good },
+  regressed: { label: "Regressed", className: SENTIMENT_CLASS.bad },
+  unchanged: { label: "Unchanged", className: "text-muted-foreground" },
+  changed: { label: "Changed", className: "text-foreground" },
+  unpaired: { label: "Unpaired", className: "text-muted-foreground" },
+  not_comparable: { label: "Not comparable", className: "text-amber-600 dark:text-amber-400" },
+};
+
+/**
+ * The candidate-vs-baseline breakdown per scorer cell, shown beside the trace. Uses
+ * the derived comparison (candidate value, baseline value, delta or transition, and the
+ * cell classification + reason); falls back to candidate-only scores when there is no
+ * comparison (no baseline). A failed scorer is an error, never a 0.
+ */
+function ScorerBreakdown({ result }: { result: ResultRow }) {
+  const cells = result.comparison?.scorerCells ?? [];
+  const byName = new Map(result.scores.map((s) => [s.scorerName, s]));
+
+  if (cells.length === 0) {
+    if (result.scores.length === 0) return null;
+    return (
+      <ul className="mt-2 divide-y divide-border rounded border border-border">
+        {result.scores.map((s) => (
+          <li key={s.id} className="px-2.5 py-1.5">
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-medium">
+                {s.scorerName}
+                <span className="ml-1.5 font-normal text-muted-foreground">{s.scorerVersion}</span>
+              </span>
+              {s.error ? (
+                <Badge variant="warning">Scorer error</Badge>
+              ) : (
+                <span className="tabular-nums">{scoreValue(s)}</span>
+              )}
+            </div>
+            {s.explanation && (
+              <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+                {s.explanation}
+              </p>
+            )}
+            {s.error && (
+              <p className="mt-0.5 font-mono text-[11px] text-amber-700 dark:text-amber-400">
+                {s.error} — the candidate answered, only the judge failed.
+              </p>
+            )}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
   return (
-    <span className="flex flex-col gap-0.5">
-      {result.scores.map((s) => (
-        <span key={s.id} className="flex items-center gap-1.5 text-[11px]">
-          <span className="truncate text-muted-foreground">{s.scorerName}</span>
-          <span className={cn("tabular-nums", s.error && "text-amber-600 dark:text-amber-400")}>
-            {scoreValue(s)}
+    <ul className="mt-2 divide-y divide-border rounded border border-border">
+      {cells.map((c) => {
+        const s = byName.get(c.scorerName);
+        const style = CELL_CLASS_STYLE[c.classification];
+        return (
+          <li key={c.scorerName} className="px-2.5 py-1.5">
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-medium">
+                {c.scorerName}
+                <span className="ml-1.5 font-normal text-muted-foreground">{c.scorerVersion}</span>
+              </span>
+              <span className={cn("text-[11px] font-medium", style.className)}>{style.label}</span>
+            </div>
+            <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] tabular-nums text-muted-foreground">
+              <span>
+                candidate{" "}
+                <span className="text-foreground">{cellValueDisplay(c.candidateValue)}</span>
+              </span>
+              <span>
+                baseline{" "}
+                <span className="text-foreground">{cellValueDisplay(c.baselineValue)}</span>
+              </span>
+              {c.delta !== null && (
+                <span className={SENTIMENT_CLASS[changeSentiment(c.delta)]}>{signed(c.delta)}</span>
+              )}
+              {c.transition && (
+                <span className="text-foreground">
+                  {c.transition.from} → {c.transition.to}
+                </span>
+              )}
+              {c.reason && (
+                <span className="text-amber-600 dark:text-amber-400">
+                  {c.reason.replace(/_/g, " ")}
+                </span>
+              )}
+            </div>
+            {s?.explanation && (
+              <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+                {s.explanation}
+              </p>
+            )}
+            {s?.error && (
+              <p className="mt-0.5 font-mono text-[11px] text-amber-700 dark:text-amber-400">
+                {s.error} — the candidate answered, only the judge failed.
+              </p>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/**
+ * Trace-derived token/cost for the open case, split by application (task) vs
+ * evaluation-judge (scorers). `pending` while the trace ingests, `unknown` when the
+ * trace carries no provider usage — a real 0 only when the trace proves it.
+ */
+function UsageBreakdown({ usage }: { usage: TraceUsage }) {
+  if (usage.state === "pending") {
+    return (
+      <p className="mt-2 text-[11px] text-muted-foreground">
+        Tokens &amp; cost: <span className="text-foreground">pending</span> — the case trace is
+        still ingesting.
+      </p>
+    );
+  }
+  if (usage.state === "unknown") {
+    return (
+      <p className="mt-2 text-[11px] text-muted-foreground">
+        Tokens &amp; cost: <span className="text-foreground">unknown</span> — the trace reported no
+        provider usage.
+      </p>
+    );
+  }
+  const fmtCost = (c: number) => (c > 0 ? `$${c.toFixed(4)}` : "$0");
+  const rows = [
+    { label: "Application (task)", b: usage.task },
+    { label: "Evaluation judge (scorers)", b: usage.scorer },
+    { label: "Other", b: usage.other },
+  ].filter((r) => r.b.spanCount > 0);
+  return (
+    <div className="mt-2 overflow-hidden rounded border border-border">
+      <div className="border-b border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground">
+        Tokens &amp; cost (from the trace)
+      </div>
+      <ul className="divide-y divide-border">
+        {rows.map((r) => (
+          <li key={r.label} className="flex items-center justify-between px-2.5 py-1 text-[11px]">
+            <span className="text-muted-foreground">{r.label}</span>
+            <span className="tabular-nums">
+              {r.b.totalTokens.toLocaleString()} tok · {fmtCost(r.b.cost)}
+            </span>
+          </li>
+        ))}
+        <li className="flex items-center justify-between bg-muted/20 px-2.5 py-1 text-[11px] font-medium">
+          <span>Combined</span>
+          <span className="tabular-nums">
+            {usage.combined.totalTokens.toLocaleString()} tok · {fmtCost(usage.combined.cost)}
           </span>
-        </span>
-      ))}
-    </span>
+        </li>
+      </ul>
+    </div>
   );
 }
 
@@ -1047,6 +1336,31 @@ function RunDetailsBody({ run, projectId }: { run: RunDetail; projectId: string 
         <Row label="Started">
           <Timestamp iso={run.startedAt} className="inline" />
         </Row>
+        {/* Run wall-clock (completedAt − startedAt), NOT the sum of case durations. */}
+        <Row label="Run elapsed">{fmtDurationMs(run.elapsedMs)}</Row>
+        {run.comparison.duration.pairedCount > 0 && (
+          <Row label="Avg case duration">
+            <span title="Mean per-case wall-clock (task + scorers), not run elapsed">
+              {fmtDurationMs(run.comparison.duration.candidateMeanMs)}
+              {run.comparison.duration.baselineMeanMs !== null && (
+                <span className="text-muted-foreground">
+                  {" "}
+                  vs {fmtDurationMs(run.comparison.duration.baselineMeanMs)}
+                </span>
+              )}
+              {run.comparison.duration.deltaMs !== null && (
+                <span
+                  className={cn(
+                    "ml-1",
+                    SENTIMENT_CLASS[changeSentiment(-run.comparison.duration.deltaMs)],
+                  )}
+                >
+                  ({signed(run.comparison.duration.deltaMs / 1000)}s)
+                </span>
+              )}
+            </span>
+          </Row>
+        )}
         <Row label="Scorers">
           {run.scorers && run.scorers.length > 0
             ? run.scorers.map((s) => `${s.name} ${s.version}`).join(", ")
@@ -1073,7 +1387,60 @@ function RunDetailsBody({ run, projectId }: { run: RunDetail; projectId: string 
         <Row label="Dataset snapshot ID">
           <span className="font-mono text-[11px]">{run.datasetVersionId}</span>
         </Row>
+        {run.model && (
+          <Row label="Model">
+            <span className="font-mono text-[11px]">{run.model}</span>
+          </Row>
+        )}
       </dl>
+      <ProvenanceBlock metadata={run.metadata} />
+    </div>
+  );
+}
+
+// Keys that may carry secrets/env — never rendered (informational safety, per spec).
+const SECRET_KEY_RE = /secret|token|password|api[_-]?key|credential|\benv\b|authorization/i;
+
+/**
+ * Structured run provenance (model, prompt, config, git) as SECONDARY detail. Free-form
+ * and optional: when absent it's an informational "not recorded" line, never an error.
+ * The candidate label stays the primary identity (shown in the header). Env vars and
+ * secret-looking keys are redacted; git repo/ref/commit are surfaced when present.
+ */
+function ProvenanceBlock({ metadata }: { metadata: Record<string, unknown> | null }) {
+  const entries = metadata ? Object.entries(metadata).filter(([k]) => !SECRET_KEY_RE.test(k)) : [];
+  const git =
+    metadata && typeof metadata.git === "object" && metadata.git !== null
+      ? (metadata.git as Record<string, unknown>)
+      : null;
+
+  return (
+    <div className="mt-3 border-t border-border/50 pt-2">
+      <p className="mb-1 text-[11px] font-medium text-muted-foreground">Provenance</p>
+      {entries.length === 0 && !git ? (
+        <p className="text-[11px] text-muted-foreground">
+          No provenance recorded for this run — informational only, not an error.
+        </p>
+      ) : (
+        <dl className="grid grid-cols-1 gap-x-6 gap-y-1 sm:grid-cols-2">
+          {git && (
+            <Row label="Git">
+              <span className="font-mono text-[11px]">
+                {[git.repo, git.ref ?? git.commit].filter(Boolean).join(" @ ") || "—"}
+              </span>
+            </Row>
+          )}
+          {entries
+            .filter(([k]) => k !== "git")
+            .map(([k, v]) => (
+              <Row key={k} label={k}>
+                <span className="font-mono text-[11px]">
+                  {typeof v === "object" ? JSON.stringify(v) : String(v)}
+                </span>
+              </Row>
+            ))}
+        </dl>
+      )}
     </div>
   );
 }
@@ -1098,12 +1465,14 @@ function ResultContext({
   projectId,
   run,
   result,
+  traceUsage,
   onReview,
   onSaveExpected,
 }: {
   projectId: string;
   run: RunDetail;
   result: ResultRow;
+  traceUsage: TraceUsage;
   onReview: () => void;
   onSaveExpected: (value: string) => void;
 }) {
@@ -1176,37 +1545,9 @@ function ResultContext({
         </div>
       )}
 
-      {result.scores.length > 0 && (
-        <ul className="mt-2 divide-y divide-border rounded border border-border">
-          {result.scores.map((s) => (
-            <li key={s.id} className="px-2.5 py-1.5">
-              <div className="flex items-center justify-between gap-2">
-                <span className="font-medium">
-                  {s.scorerName}
-                  <span className="ml-1.5 font-normal text-muted-foreground">
-                    {s.scorerVersion}
-                  </span>
-                </span>
-                {s.error ? (
-                  <Badge variant="warning">Scorer error</Badge>
-                ) : (
-                  <span className="tabular-nums">{scoreValue(s)}</span>
-                )}
-              </div>
-              {s.explanation && (
-                <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
-                  {s.explanation}
-                </p>
-              )}
-              {s.error && (
-                <p className="mt-0.5 font-mono text-[11px] text-amber-700 dark:text-amber-400">
-                  {s.error} — the candidate answered, only the judge failed.
-                </p>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
+      <ScorerBreakdown result={result} />
+
+      <UsageBreakdown usage={traceUsage} />
 
       {result.humanScores.length > 0 && (
         <div className="mt-2 rounded border border-border bg-muted/20 px-2.5 py-1.5 text-[11px]">
@@ -1232,9 +1573,18 @@ function ResultContext({
           <Database className="h-3.5 w-3.5" aria-hidden />
           View source test case
         </Link>
-        <span className="ml-auto text-[11px] text-muted-foreground">
-          {result.durationMs !== null ? `${(result.durationMs / 1000).toFixed(1)}s` : "—"}
-          {result.cost !== null ? ` · $${result.cost.toFixed(4)}` : ""}
+        <span className="ml-auto flex items-center gap-1 text-[11px] text-muted-foreground">
+          {/* Candidate case duration vs baseline; "Unknown" when unmeasured, never 0. */}
+          <span title="Case duration (task + scorers)">{fmtDurationMs(result.durationMs)}</span>
+          {result.comparison?.baselineDurationMs != null && (
+            <span>vs {fmtDurationMs(result.comparison.baselineDurationMs)}</span>
+          )}
+          {result.comparison?.durationDeltaMs != null && (
+            <span className={SENTIMENT_CLASS[changeSentiment(-result.comparison.durationDeltaMs)]}>
+              ({signed(result.comparison.durationDeltaMs / 1000)}s)
+            </span>
+          )}
+          {result.cost !== null ? <span>· ${result.cost.toFixed(4)}</span> : ""}
         </span>
       </div>
     </div>

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -307,7 +307,9 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
           The evaluation context, scores, and human review are the span-actions panel. */}
       {openResult && run && !tracePending && panelTraceId && (
         <TraceViewerPanel
-          key={panelTraceId}
+          // No key on panelTraceId: navigating results updates the panel in place
+          // (TraceViewerPanel resets its selection on traceId change), matching the
+          // trace-list navigation — a fresh key would replay the slide-in animation.
           projectId={projectId}
           traceId={panelTraceId}
           traceOverride={panelOverride}

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -721,10 +721,11 @@ function RunBody({
               onValueChange={(v) => onCompareChange(v === NO_COMPARE ? null : v)}
             >
               <SelectTrigger
-                // The trigger is justify-between by default, which pushes the value
-                // away from the icon whenever the box is wider than its text. Keep the
-                // pair together on the left and let the chevron take the slack.
-                className="h-7 w-fit max-w-[240px] justify-start gap-1.5 text-[12px] [&>span]:mr-auto"
+                // The trigger is justify-between by default, so any width beyond the
+                // text is dealt out BETWEEN the icon and the value — measured at 44px
+                // on a 240px trigger. Letting the value grow absorbs that space
+                // instead, which holds even if the width utilities don't apply.
+                className="h-7 w-fit max-w-[240px] justify-start gap-1.5 text-[12px] [&>span]:min-w-0 [&>span]:flex-1"
                 aria-label="Compare with"
               >
                 <GitCompare className="h-3.5 w-3.5 shrink-0" aria-hidden />

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -973,7 +973,10 @@ function RunSwitcher({
           <ChevronDown className="h-3 w-3" aria-hidden />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="max-h-[320px] w-64 overflow-y-auto p-1">
+      <PopoverContent align="start" className="max-h-[360px] w-80 overflow-y-auto p-1">
+        <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+          Run history
+        </div>
         {runs.map((sibling) => (
           <button
             key={sibling.id}
@@ -983,19 +986,30 @@ function RunSwitcher({
               setOpen(false);
             }}
             className={cn(
-              "flex w-full items-center justify-between gap-2 rounded px-2 py-1 text-left text-[12px] transition-colors",
+              "flex w-full flex-col gap-1 rounded px-2 py-1.5 text-left text-[12px] transition-colors",
               sibling.id === run.id ? "bg-muted/70" : "hover:bg-muted/50",
             )}
           >
-            <span className="flex items-center gap-1.5">
-              <span>Run #{sibling.runNumber}</span>
-              <span className="font-mono text-[11px] text-muted-foreground">
-                {sibling.candidateVersion}
+            <div className="flex items-center justify-between gap-2">
+              <span className="flex items-center gap-1.5">
+                <span className="font-medium">Run #{sibling.runNumber}</span>
+                {sibling.id === run.id && (
+                  <span className="rounded bg-foreground/10 px-1 text-[10px] text-muted-foreground">
+                    current
+                  </span>
+                )}
+                <span className="font-mono text-[11px] text-muted-foreground">
+                  {sibling.candidateVersion}
+                </span>
               </span>
-            </span>
-            <span className="tabular-nums text-muted-foreground">
-              {sibling.mainScore === null ? "—" : pctFraction(sibling.mainScore)}
-            </span>
+              <span className="tabular-nums text-muted-foreground">
+                {sibling.mainScore === null ? "—" : pctFraction(sibling.mainScore)}
+              </span>
+            </div>
+            <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+              <RunStatusBadge status={sibling.status} />
+              <Timestamp iso={sibling.startedAt} />
+            </div>
           </button>
         ))}
       </PopoverContent>

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -60,8 +60,10 @@ import {
 } from "../hooks";
 import { RunStatusBadge } from "./evaluations-view";
 import { PullCodeDrawer } from "../components/pull-code-drawer";
+import { SaveTestCaseDrawer } from "../components/trace-integration";
 import { reproduceRunCode, reproduceRunCodeTs } from "@/features/offline-eval/utils";
 import { attributeTraceUsage, type TraceUsage, type UsageSpan } from "@/lib/eval/trace-usage";
+import { matchSpans } from "@/lib/eval/span-match";
 import type { ResultRow, RunDetail, ScoreRow, Classification } from "../types";
 
 /** Verdict → badge tone, matching the design system's success/danger/warning. */
@@ -285,6 +287,9 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   const [openResultId, setOpenResultId] = React.useState<string | null>(null);
   const [resultFilter, setResultFilter] = React.useState<ResultFilterId>("all");
   const [reviewOpen, setReviewOpen] = React.useState(false);
+  // "Save as test case" drawer (only for real ingested traces): which span it targets.
+  const [saveTestCaseOpen, setSaveTestCaseOpen] = React.useState(false);
+  const [saveTestCaseSpanId, setSaveTestCaseSpanId] = React.useState<string | undefined>(undefined);
 
   const { toast } = useToast();
   const results = React.useMemo(() => data?.results ?? [], [data]);
@@ -343,26 +348,19 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   const panelTraceId = useRealTrace ? realTraceId : fallbackTrace?.trace_id;
   const panelOverride = useRealTrace ? undefined : fallbackTrace;
 
-  // Token/cost derived from the OPEN result's real trace (already fetched — bounded, no
-  // extra query). Pending while the reported trace ingests; the reconstructed fallback
-  // has no LLM leaves so it reports "unknown", never a fabricated 0.
   const openTraceSpans = useRealTrace ? realTrace.data?.spans : panelOverride?.spans;
-  const traceUsage = React.useMemo<TraceUsage>(
-    () =>
-      tracePending
-        ? attributeTraceUsage(null)
-        : attributeTraceUsage(openTraceSpans as UsageSpan[] | undefined),
-    [tracePending, openTraceSpans],
-  );
 
-  // The baseline case's trace, fetched so the result panel can diff tokens/cost
-  // against the candidate (its duration is already derived server-side).
+  // The baseline case's trace, fetched so the trace viewer's Diff toggle can diff each
+  // span (I/O, metadata, latency/token/cost) against its baseline counterpart. Span ids
+  // differ across runs, so we match structurally (kind + name + sibling index) once the
+  // baseline trace is loaded — the matcher resolves a span selection to its baseline span.
   const baselineTraceId = openResult?.comparison?.baselineTraceId ?? null;
   const baselineTrace = useTrace(projectId, baselineTraceId ?? "", !!baselineTraceId);
-  const baselineUsage = React.useMemo<TraceUsage>(
-    () => attributeTraceUsage(baselineTrace.data?.spans as UsageSpan[] | undefined),
-    [baselineTrace.data],
-  );
+  const baselineSpanMatch = React.useMemo(() => {
+    const baseSpans = baselineTrace.data?.spans;
+    if (!openTraceSpans?.length || !baseSpans?.length) return null;
+    return matchSpans(openTraceSpans, baseSpans);
+  }, [openTraceSpans, baselineTrace.data]);
 
   const closeResult = () => setOpenResultId(null);
 
@@ -453,6 +451,34 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
           onNavigate={navigateResult}
           canNavigateUp={openIndex > 0}
           canNavigateDown={openIndex >= 0 && openIndex < visibleResults.length - 1}
+          // Save any span (or the trace root) of a real eval trace as a dataset test
+          // case. Only offered for real ingested traces — a reconstructed fallback has
+          // no telemetry for the drawer to read.
+          spanHeaderAction={
+            useRealTrace
+              ? (selection) => (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 shrink-0 text-[12px]"
+                    onClick={() => {
+                      setSaveTestCaseSpanId(
+                        selection.type === "span" ? selection.span.span_id : undefined,
+                      );
+                      setSaveTestCaseOpen(true);
+                    }}
+                  >
+                    Save as test case
+                  </Button>
+                )
+              : undefined
+          }
+          // While the drawer is open, clicking a different span retargets it.
+          onSelectionChange={(selection) => {
+            if (saveTestCaseOpen) {
+              setSaveTestCaseSpanId(selection.type === "span" ? selection.span.span_id : undefined);
+            }
+          }}
           spanActions={() => (
             <ResultContext
               projectId={projectId}
@@ -500,16 +526,23 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
                 <span className="text-muted-foreground">Test case:</span>
                 <span className="font-mono">{openResult.testCaseId}</span>
               </span>
-              {/* The case's trace metrics as chips — duration, tokens, cost — each with a
-                  ± delta vs the baseline case (lower is better). */}
-              <CaseMetricChips
-                candidate={traceUsage}
-                baseline={baselineUsage}
-                durationMs={openResult.durationMs}
-                baselineDurationMs={openResult.comparison?.baselineDurationMs ?? null}
-              />
             </>
           )}
+          /* Baseline run's trace + a per-span matcher. Powers the viewer's Diff
+             toggle: latency/token/cost deltas + I/O line diffs vs the baseline, at
+             both the trace level and per span. Present (so the toggle appears) only
+             once the baseline trace has loaded. */
+          diffBaseline={
+            baselineTrace.data
+              ? {
+                  trace: baselineTrace.data,
+                  matchSpan: (selection) =>
+                    selection.type === "span"
+                      ? (baselineSpanMatch?.get(selection.span.span_id) ?? null)
+                      : null,
+                }
+              : undefined
+          }
         />
       )}
 
@@ -541,6 +574,15 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
             reviewer: review.reviewer,
           })
         }
+      />
+
+      {/* Save a span (or the trace root) of the open result's real trace as a test case. */}
+      <SaveTestCaseDrawer
+        projectId={projectId}
+        traceId={useRealTrace ? realTraceId : null}
+        spanId={saveTestCaseSpanId}
+        open={saveTestCaseOpen}
+        onOpenChange={setSaveTestCaseOpen}
       />
     </>
   );
@@ -889,9 +931,7 @@ function RunMetricsDiff({
         <thead>
           <tr className="text-[10px] text-muted-foreground">
             <th className="py-1 pl-2.5 text-left font-normal"></th>
-            <th className="py-1 text-right font-normal">Candidate</th>
-            <th className="py-1 text-right font-normal">Baseline</th>
-            <th className="py-1 pr-2.5 text-right font-normal">Δ</th>
+            <th className="py-1 pr-2.5 text-right font-normal">Candidate</th>
           </tr>
         </thead>
         <tbody className="[&_td:first-child]:pl-2.5 [&_td:last-child]:pr-2.5">
@@ -1478,100 +1518,31 @@ function MetricRow({
   return (
     <tr>
       <td className="py-1 pr-2 text-muted-foreground">{label}</td>
+      {/* Candidate value with its ± delta vs baseline beside it (lower is better). */}
       <td className="py-1 text-right tabular-nums">
-        {candidate === null ? "—" : format(candidate)}
-      </td>
-      <td className="py-1 text-right tabular-nums text-muted-foreground">
-        {baseline === null ? "—" : format(baseline)}
-      </td>
-      <td className="py-1 pl-2 text-right tabular-nums">
-        {delta === null || delta === 0 ? (
-          <span className="text-muted-foreground">{delta === 0 ? format(0) : "—"}</span>
+        {candidate === null ? (
+          "—"
         ) : (
-          <span className={SENTIMENT_CLASS[changeSentiment(lowerIsBetter ? -delta : delta)]}>
-            {delta > 0 ? "+" : "−"}
-            {format(Math.abs(delta))}
-          </span>
+          <>
+            {format(candidate)}
+            {delta !== null &&
+              (delta === 0 ? (
+                <span className="ml-1.5 text-muted-foreground">±0</span>
+              ) : (
+                <span
+                  className={cn(
+                    "ml-1.5",
+                    SENTIMENT_CLASS[changeSentiment(lowerIsBetter ? -delta : delta)],
+                  )}
+                >
+                  {delta > 0 ? "+" : "−"}
+                  {format(Math.abs(delta))}
+                </span>
+              ))}
+          </>
         )}
       </td>
     </tr>
-  );
-}
-
-/** One metric as a span-tag-style chip: "Label: value ±delta" (lower is better). */
-function MetricChip({
-  label,
-  candidate,
-  baseline,
-  format,
-}: {
-  label: string;
-  candidate: number | null;
-  baseline: number | null;
-  format: (n: number) => string;
-}) {
-  if (candidate === null) return null;
-  const delta = baseline !== null ? candidate - baseline : null;
-  return (
-    <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
-      <span className="text-muted-foreground">{label}:</span>
-      <span className="font-medium tabular-nums">{format(candidate)}</span>
-      {delta !== null &&
-        (delta === 0 ? (
-          <span className="text-muted-foreground">±0</span>
-        ) : (
-          <span className={SENTIMENT_CLASS[changeSentiment(-delta)]}>
-            {delta > 0 ? "+" : "−"}
-            {format(Math.abs(delta))}
-          </span>
-        ))}
-    </span>
-  );
-}
-
-/**
- * The open case's trace metrics as span-tag chips, shown on the trace panel's tag
- * row beside the eval-context chips — duration, tokens, cost, each with a ± delta
- * vs the baseline case (lower is better → green when smaller). Tokens/cost only
- * appear once the case trace reports provider usage.
- */
-function CaseMetricChips({
-  candidate,
-  baseline,
-  durationMs,
-  baselineDurationMs,
-}: {
-  candidate: TraceUsage;
-  baseline: TraceUsage;
-  durationMs: number | null;
-  baselineDurationMs: number | null;
-}) {
-  const fmtMs = (n: number) => (n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`);
-  const fmtTok = (n: number) => `${Math.round(n).toLocaleString()} tok`;
-  const fmtCost = (n: number) => (n > 0 ? `$${n.toFixed(4)}` : "$0");
-  const tok = (u: TraceUsage) => (u.state === "present" ? u.combined.totalTokens : null);
-  const cost = (u: TraceUsage) => (u.state === "present" ? u.combined.cost : null);
-  return (
-    <>
-      <MetricChip
-        label="Duration"
-        candidate={durationMs}
-        baseline={baselineDurationMs}
-        format={fmtMs}
-      />
-      <MetricChip
-        label="Tokens"
-        candidate={tok(candidate)}
-        baseline={tok(baseline)}
-        format={fmtTok}
-      />
-      <MetricChip
-        label="Cost"
-        candidate={cost(candidate)}
-        baseline={cost(baseline)}
-        format={fmtCost}
-      />
-    </>
   );
 }
 
@@ -1922,11 +1893,9 @@ function ResultContext({
         </p>
       </div>
 
-      {result.baselineOutput !== null && (
-        <p className="mt-2 text-[11px] text-muted-foreground">
-          Baseline output: <span className="text-foreground">{result.baselineOutput}</span>
-        </p>
-      )}
+      {/* Per-span candidate-vs-baseline output diffs now live in the trace viewer's
+          Diff toggle (each span's Input/Output/Metadata), so no case-level output
+          diff is rendered here. */}
 
       {/* An application error means no scorer ever ran. */}
       {result.taskError && (

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -36,8 +36,11 @@ import {
   useSeedTraceIO,
   type ReviewTarget,
 } from "@/features/offline-eval/components";
+import { useQueries } from "@tanstack/react-query";
 import { TraceViewerPanel } from "@/features/traces/components";
 import { useTrace } from "@/features/traces/hooks";
+import { getTrace } from "@/lib/api";
+import { useSession as useAuthSession } from "@/lib/auth-client";
 import type { Span, TraceDetail } from "@/types/api";
 import type { SpanKind, SpanStatus } from "@traceroot/core";
 import { cn } from "@/lib/utils";
@@ -350,6 +353,15 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
     [tracePending, openTraceSpans],
   );
 
+  // The baseline case's trace, fetched so the result panel can diff tokens/cost
+  // against the candidate (its duration is already derived server-side).
+  const baselineTraceId = openResult?.comparison?.baselineTraceId ?? null;
+  const baselineTrace = useTrace(projectId, baselineTraceId ?? "", !!baselineTraceId);
+  const baselineUsage = React.useMemo<TraceUsage>(
+    () => attributeTraceUsage(baselineTrace.data?.spans as UsageSpan[] | undefined),
+    [baselineTrace.data],
+  );
+
   const closeResult = () => setOpenResultId(null);
 
   // The trace panel's up/down chevrons step between this run's results (in the same
@@ -445,6 +457,7 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
               run={run}
               result={openResult}
               traceUsage={traceUsage}
+              baselineUsage={baselineUsage}
               onReview={() => setReviewOpen(true)}
               onSaveExpected={(value) =>
                 updateCase.mutate(
@@ -669,6 +682,7 @@ function RunBody({
       <RunDetailsDrawer
         run={run}
         projectId={projectId}
+        results={results}
         open={detailsOpen}
         onOpenChange={setDetailsOpen}
       />
@@ -681,11 +695,13 @@ function RunBody({
 function RunDetailsDrawer({
   run,
   projectId,
+  results,
   open,
   onOpenChange,
 }: {
   run: RunDetail;
   projectId: string;
+  results: ResultRow[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
@@ -722,8 +738,135 @@ function RunDetailsDrawer({
         </button>
       </div>
       <div className="min-h-0 flex-1 overflow-auto p-4 text-[12px]">
+        {/* Mounted only while the drawer is open, so the per-case trace fetches for
+            the token/cost aggregate happen lazily, not on every run-detail load. */}
+        <RunMetricsDiff run={run} projectId={projectId} results={results} />
         <RunDetailsBody run={run} projectId={projectId} />
       </div>
+    </div>
+  );
+}
+
+/**
+ * Run-level candidate-vs-baseline metrics. Duration is derived server-side (paired
+ * case-duration mean). Tokens/cost are aggregated across the run's case traces vs the
+ * baseline's — fetched lazily here (only while the drawer is open) and summed; while
+ * any trace is still loading it shows a "computing" note, and traces without provider
+ * usage simply contribute nothing.
+ */
+function RunMetricsDiff({
+  run,
+  projectId,
+  results,
+}: {
+  run: RunDetail;
+  projectId: string;
+  results: ResultRow[];
+}) {
+  const { data: authSession } = useAuthSession();
+  const user = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
+
+  const candidateIds = React.useMemo(
+    () => [...new Set(results.map((r) => r.traceId).filter((x): x is string => !!x))],
+    [results],
+  );
+  const baselineIds = React.useMemo(
+    () => [
+      ...new Set(results.map((r) => r.comparison?.baselineTraceId).filter((x): x is string => !!x)),
+    ],
+    [results],
+  );
+  const allIds = React.useMemo(
+    () => [...new Set([...candidateIds, ...baselineIds])],
+    [candidateIds, baselineIds],
+  );
+
+  // Share useTrace's cache key so any already-opened trace is reused, not refetched.
+  const queries = useQueries({
+    queries: allIds.map((id) => ({
+      queryKey: ["trace", projectId, id],
+      queryFn: () => getTrace(projectId, id, "", user),
+      enabled: !!user,
+    })),
+  });
+
+  const usageById = new Map<string, TraceUsage>();
+  let loading = false;
+  allIds.forEach((id, i) => {
+    const q = queries[i];
+    if (q.isLoading || q.isFetching) loading = true;
+    usageById.set(id, attributeTraceUsage(q.data?.spans as UsageSpan[] | undefined));
+  });
+
+  const sum = (ids: string[]) => {
+    let tokens = 0;
+    let cost = 0;
+    let any = false;
+    for (const id of ids) {
+      const u = usageById.get(id);
+      if (u && u.state === "present") {
+        tokens += u.combined.totalTokens;
+        cost += u.combined.cost;
+        any = true;
+      }
+    }
+    return any ? { tokens, cost } : null;
+  };
+  const cand = sum(candidateIds);
+  const base = sum(baselineIds);
+  const dur = run.comparison.duration;
+
+  const fmtTok = (n: number) => `${Math.round(n).toLocaleString()}`;
+  const fmtCost = (n: number) => (n > 0 ? `$${n.toFixed(4)}` : "$0");
+  const fmtMs = (n: number) => (n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`);
+
+  return (
+    <div className="mb-3 overflow-hidden rounded border border-border">
+      <div className="border-b border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground">
+        Metrics vs baseline{" "}
+        {run.comparison.baseline ? (
+          <span className="text-foreground">({run.comparison.baseline.candidateVersion})</span>
+        ) : (
+          <span>— no baseline</span>
+        )}
+      </div>
+      <table className="w-full text-[11px]">
+        <thead>
+          <tr className="text-[10px] text-muted-foreground">
+            <th className="py-1 pl-2.5 text-left font-normal"></th>
+            <th className="py-1 text-right font-normal">Candidate</th>
+            <th className="py-1 text-right font-normal">Baseline</th>
+            <th className="py-1 pr-2.5 text-right font-normal">Δ</th>
+          </tr>
+        </thead>
+        <tbody className="[&_td:first-child]:pl-2.5 [&_td:last-child]:pr-2.5">
+          <MetricRow
+            label="Avg case duration"
+            candidate={dur.candidateMeanMs}
+            baseline={dur.baselineMeanMs}
+            format={fmtMs}
+          />
+          <MetricRow
+            label="Total tokens"
+            candidate={cand ? cand.tokens : null}
+            baseline={base ? base.tokens : null}
+            format={fmtTok}
+          />
+          <MetricRow
+            label="Total cost"
+            candidate={cand ? cand.cost : null}
+            baseline={base ? base.cost : null}
+            format={fmtCost}
+          />
+        </tbody>
+      </table>
+      {loading && (
+        <p className="border-t border-border px-2.5 py-1 text-[10px] text-muted-foreground">
+          Summing token/cost across {allIds.length} case traces…
+        </p>
+      )}
     </div>
   );
 }
@@ -1264,6 +1407,110 @@ function ScorerBreakdown({ result }: { result: ResultRow }) {
   );
 }
 
+/** One metric row: candidate vs baseline vs delta. Missing values show "—". */
+function MetricRow({
+  label,
+  candidate,
+  baseline,
+  format,
+  lowerIsBetter = true,
+}: {
+  label: string;
+  candidate: number | null;
+  baseline: number | null;
+  format: (n: number) => string;
+  lowerIsBetter?: boolean;
+}) {
+  const delta = candidate !== null && baseline !== null ? candidate - baseline : null;
+  return (
+    <tr>
+      <td className="py-1 pr-2 text-muted-foreground">{label}</td>
+      <td className="py-1 text-right tabular-nums">
+        {candidate === null ? "—" : format(candidate)}
+      </td>
+      <td className="py-1 text-right tabular-nums text-muted-foreground">
+        {baseline === null ? "—" : format(baseline)}
+      </td>
+      <td className="py-1 pl-2 text-right tabular-nums">
+        {delta === null || delta === 0 ? (
+          <span className="text-muted-foreground">{delta === 0 ? format(0) : "—"}</span>
+        ) : (
+          <span className={SENTIMENT_CLASS[changeSentiment(lowerIsBetter ? -delta : delta)]}>
+            {delta > 0 ? "+" : "−"}
+            {format(Math.abs(delta))}
+          </span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * Candidate-vs-baseline metrics for the open case — duration, tokens, and cost side
+ * by side with deltas. Duration is derived server-side; tokens/cost come from each
+ * side's trace (pending/unknown when a trace lacks provider usage). Lower is better
+ * for all three, so a smaller candidate reads green.
+ */
+function MetricsDiff({
+  candidate,
+  baseline,
+  candidateDurationMs,
+  baselineDurationMs,
+}: {
+  candidate: TraceUsage;
+  baseline: TraceUsage;
+  candidateDurationMs: number | null;
+  baselineDurationMs: number | null;
+}) {
+  const tok = (u: TraceUsage) => (u.state === "present" ? u.combined.totalTokens : null);
+  const cost = (u: TraceUsage) => (u.state === "present" ? u.combined.cost : null);
+  const fmtTok = (n: number) => `${Math.round(n).toLocaleString()}`;
+  const fmtCost = (n: number) => (n > 0 ? `$${n.toFixed(4)}` : "$0");
+  const fmtMs = (n: number) => (n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`);
+  return (
+    <div className="mt-2 overflow-hidden rounded border border-border">
+      <div className="border-b border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground">
+        Metrics vs baseline
+      </div>
+      <table className="w-full px-2.5 text-[11px]">
+        <thead>
+          <tr className="text-[10px] text-muted-foreground">
+            <th className="py-1 pl-2.5 text-left font-normal"></th>
+            <th className="py-1 text-right font-normal">Candidate</th>
+            <th className="py-1 text-right font-normal">Baseline</th>
+            <th className="py-1 pr-2.5 text-right font-normal">Δ</th>
+          </tr>
+        </thead>
+        <tbody className="[&_td:first-child]:pl-2.5 [&_td:last-child]:pr-2.5">
+          <MetricRow
+            label="Duration"
+            candidate={candidateDurationMs}
+            baseline={baselineDurationMs}
+            format={fmtMs}
+          />
+          <MetricRow
+            label="Tokens"
+            candidate={tok(candidate)}
+            baseline={tok(baseline)}
+            format={fmtTok}
+          />
+          <MetricRow
+            label="Cost"
+            candidate={cost(candidate)}
+            baseline={cost(baseline)}
+            format={fmtCost}
+          />
+        </tbody>
+      </table>
+      {(candidate.state === "pending" || baseline.state === "pending") && (
+        <p className="border-t border-border px-2.5 py-1 text-[10px] text-muted-foreground">
+          A trace is still ingesting — token/cost values will fill in.
+        </p>
+      )}
+    </div>
+  );
+}
+
 /**
  * Trace-derived token/cost for the open case, split by application (task) vs
  * evaluation-judge (scorers). `pending` while the trace ingests, `unknown` when the
@@ -1555,6 +1802,7 @@ function ResultContext({
   run,
   result,
   traceUsage,
+  baselineUsage,
   onReview,
   onSaveExpected,
 }: {
@@ -1562,6 +1810,7 @@ function ResultContext({
   run: RunDetail;
   result: ResultRow;
   traceUsage: TraceUsage;
+  baselineUsage: TraceUsage;
   onReview: () => void;
   onSaveExpected: (value: string) => void;
 }) {
@@ -1690,7 +1939,16 @@ function ResultContext({
 
       <ScorerBreakdown result={result} />
 
-      <UsageBreakdown usage={traceUsage} />
+      {result.comparison?.baselineTraceId ? (
+        <MetricsDiff
+          candidate={traceUsage}
+          baseline={baselineUsage}
+          candidateDurationMs={result.durationMs}
+          baselineDurationMs={result.comparison.baselineDurationMs}
+        />
+      ) : (
+        <UsageBreakdown usage={traceUsage} />
+      )}
 
       {result.humanScores.length > 0 && (
         <div className="mt-2 overflow-hidden rounded border border-border">

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -4,14 +4,12 @@ import * as React from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
-  AlertTriangle,
   ArrowDown,
   ArrowUp,
   Check,
   ChevronDown,
   Database,
   GitCompare,
-  Info,
   Loader2,
   Search,
   X,
@@ -21,7 +19,6 @@ import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { ExpandableSection } from "@/components/ui/expandable-section";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
@@ -30,15 +27,11 @@ import {
   EvalPageHeader,
   EvalResultBadge,
   ReviewPanel,
-  Timestamp,
   useSeedTraceIO,
   type ReviewTarget,
 } from "@/features/offline-eval/components";
-import { useQueries } from "@tanstack/react-query";
 import { TraceViewerPanel } from "@/features/traces/components";
 import { useTrace } from "@/features/traces/hooks";
-import { getTrace } from "@/lib/api";
-import { useSession as useAuthSession } from "@/lib/auth-client";
 import type { Span, TraceDetail } from "@/types/api";
 import type { SpanKind, SpanStatus } from "@traceroot/core";
 import { cn } from "@/lib/utils";
@@ -46,16 +39,13 @@ import {
   changeSentiment,
   pctFraction,
   SENTIMENT_CLASS,
-  signed,
   signedPoints,
-  truncate,
 } from "@/features/offline-eval/utils";
 import { useEvaluationRun, useEvaluationRuns, useCreateHumanScore, useCompareRuns } from "../hooks";
 import { PullCodeDrawer } from "../components/pull-code-drawer";
 import { PassRate } from "../components/pass-rate";
 import { SaveTestCaseDrawer } from "../components/trace-integration";
 import { reproduceRunCode, reproduceRunCodeTs } from "@/features/offline-eval/utils";
-import { attributeTraceUsage, type TraceUsage, type UsageSpan } from "@/lib/eval/trace-usage";
 import { matchSpans } from "@/lib/eval/span-match";
 import {
   Select,
@@ -711,7 +701,6 @@ function RunBody({
   compareByCase: Map<string, CompareResultRow> | null;
 }) {
   const router = useRouter();
-  const [detailsOpen, setDetailsOpen] = React.useState(false);
   const [reproduceOpen, setReproduceOpen] = React.useState(false);
   const comparing = !!compareByCase;
   const cmp = compareData?.comparison ?? null;
@@ -789,15 +778,6 @@ function RunBody({
               <Database className="h-3.5 w-3.5" aria-hidden />
               Reproduce locally
             </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 gap-1.5 text-[12px]"
-              onClick={() => setDetailsOpen(true)}
-            >
-              <Info className="h-3.5 w-3.5" aria-hidden />
-              Run details
-            </Button>
           </div>
         }
       />
@@ -848,24 +828,8 @@ function RunBody({
             onOpen={onOpenResult}
             openResultId={openResultId}
           />
-
-          {/* Errors fold below the results; run details open in a side panel. */}
-          {run.errorCount > 0 && (
-            <ExpandableSection title={`Errors (${run.errorCount})`} defaultOpen={false}>
-              <ErrorsBody run={run} results={results} onOpen={onOpenResult} />
-            </ExpandableSection>
-          )}
         </div>
       </div>
-
-      <RunDetailsDrawer
-        run={run}
-        projectId={projectId}
-        results={results}
-        compareData={compareData}
-        open={detailsOpen}
-        onOpenChange={setDetailsOpen}
-      />
 
       {/* Reproduce this run locally = pull the EXACT dataset version it scored (not
           the run/evaluation id, which pulls nothing). Shared pull-code drawer. */}
@@ -873,11 +837,11 @@ function RunBody({
         title="Reproduce this run locally"
         subtitle={
           <>
-            Pulls the exact cases{" "}
+            Re-run a new candidate against the exact cases{" "}
             <span className="font-medium text-foreground">
               {run.evaluationName} #{run.runNumber}
             </span>{" "}
-            scored, so a new candidate is measured on the same data and is comparable to this run.
+            scored — the same dataset snapshot, so the results line up against this run.
           </>
         }
         options={[
@@ -886,10 +850,14 @@ function RunBody({
             label: "Reproduce this run",
             note: (
               <>
-                Pins dataset version <span className="font-mono">{run.datasetVersionId}</span>. The
-                run id (<span className="font-mono">{run.id}</span>) is only used as the{" "}
-                <span className="font-mono">baseline</span> to compare against — it isn&apos;t
-                pullable.
+                Pins{" "}
+                <span className="font-medium text-foreground">
+                  {run.datasetName ?? "this dataset"}
+                </span>{" "}
+                at version <span className="font-mono">{run.datasetVersionLabel}</span> (snapshot{" "}
+                <span className="font-mono">{run.datasetVersionId}</span>), and passes this run
+                (candidate <span className="font-mono">{run.candidateVersion}</span>) as the
+                baseline to compare the new run against.
               </>
             ),
             py: reproduceRunCode(run.datasetVersionId, run.evaluationName, run.id),
@@ -900,210 +868,6 @@ function RunBody({
         onOpenChange={setReproduceOpen}
       />
     </>
-  );
-}
-
-/** Run details (identity, dataset, scorers, provenance) as a right-side slide-out,
- *  opened from the header — matching the starter-code / pull-code drawers. */
-function RunDetailsDrawer({
-  run,
-  projectId,
-  results,
-  compareData,
-  open,
-  onOpenChange,
-}: {
-  run: RunDetail;
-  projectId: string;
-  results: ResultRow[];
-  compareData: CompareRunsResponse | null;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) {
-  React.useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.stopPropagation();
-        onOpenChange(false);
-      }
-    };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [open, onOpenChange]);
-
-  if (!open) return null;
-
-  return (
-    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
-      <div className="flex shrink-0 items-start justify-between gap-2 border-b border-border px-4 py-3">
-        <div>
-          <h2 className="text-[13px] font-semibold">Run details</h2>
-          <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
-            {run.evaluationName} #{run.runNumber} · {run.candidateVersion}
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={() => onOpenChange(false)}
-          aria-label="Close"
-          className="mt-0.5 rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
-        >
-          <X className="h-4 w-4" />
-        </button>
-      </div>
-      <div className="min-h-0 flex-1 overflow-auto p-4 text-[12px]">
-        {/* Mounted only while the drawer is open, so the per-case trace fetches for
-            the token/cost aggregate happen lazily, not on every run-detail load. */}
-        <RunMetricsDiff
-          run={run}
-          projectId={projectId}
-          results={results}
-          compareData={compareData}
-        />
-        <RunDetailsBody run={run} projectId={projectId} />
-      </div>
-    </div>
-  );
-}
-
-/**
- * Run-level metrics. Duration is derived server-side (paired case-duration mean).
- * Tokens/cost are aggregated across the run's case traces — fetched lazily here (only
- * while the drawer is open) and summed; while any trace is still loading it shows a
- * "computing" note, and traces without provider usage simply contribute nothing.
- *
- * The baseline column is driven by the page's "Compare with" selection (comparison is
- * frontend-owned now that the SDK no longer sends a stored baseline): with a run picked,
- * each metric shows its ± delta vs that run; with none picked, only the candidate value.
- */
-function RunMetricsDiff({
-  run,
-  projectId,
-  results,
-  compareData,
-}: {
-  run: RunDetail;
-  projectId: string;
-  results: ResultRow[];
-  compareData: CompareRunsResponse | null;
-}) {
-  const { data: authSession } = useAuthSession();
-  const user = authSession?.user
-    ? { id: authSession.user.id, email: authSession.user.email }
-    : undefined;
-
-  const candidateIds = React.useMemo(
-    () => [...new Set(results.map((r) => r.traceId).filter((x): x is string => !!x))],
-    [results],
-  );
-  // Baseline traces come from the picked compare run (per-case baselineTraceId), not a
-  // stored per-result baseline (which the SDK is dropping).
-  const baselineIds = React.useMemo(
-    () =>
-      compareData
-        ? [
-            ...new Set(
-              compareData.results.map((r) => r.baselineTraceId).filter((x): x is string => !!x),
-            ),
-          ]
-        : [],
-    [compareData],
-  );
-  const allIds = React.useMemo(
-    () => [...new Set([...candidateIds, ...baselineIds])],
-    [candidateIds, baselineIds],
-  );
-
-  // Share useTrace's cache key so any already-opened trace is reused, not refetched.
-  const queries = useQueries({
-    queries: allIds.map((id) => ({
-      queryKey: ["trace", projectId, id],
-      queryFn: () => getTrace(projectId, id, "", user),
-      enabled: !!user,
-    })),
-  });
-
-  const usageById = new Map<string, TraceUsage>();
-  let loading = false;
-  allIds.forEach((id, i) => {
-    const q = queries[i];
-    if (q.isLoading || q.isFetching) loading = true;
-    usageById.set(id, attributeTraceUsage(q.data?.spans as UsageSpan[] | undefined));
-  });
-
-  const sum = (ids: string[]) => {
-    let tokens = 0;
-    let cost = 0;
-    let any = false;
-    for (const id of ids) {
-      const u = usageById.get(id);
-      if (u && u.state === "present") {
-        tokens += u.combined.totalTokens;
-        cost += u.combined.cost;
-        any = true;
-      }
-    }
-    return any ? { tokens, cost } : null;
-  };
-  const cand = sum(candidateIds);
-  const base = sum(baselineIds);
-  // Duration deltas come from the picked compare run when comparing; otherwise the
-  // candidate's own mean with no baseline.
-  const dur = compareData?.comparison.duration ?? run.comparison.duration;
-
-  const fmtTok = (n: number) => `${Math.round(n).toLocaleString()}`;
-  const fmtCost = (n: number) => (n > 0 ? `$${n.toFixed(4)}` : "$0");
-  const fmtMs = (n: number) => (n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`);
-
-  return (
-    <div className="mb-3 overflow-hidden rounded border border-border">
-      <div className="border-b border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground">
-        {compareData ? (
-          <>
-            Metrics vs #{compareData.baseline.runNumber}{" "}
-            <span className="text-foreground">({compareData.baseline.candidateVersion})</span>
-          </>
-        ) : (
-          <>
-            Run metrics <span>— pick a run in “Compare with” for deltas</span>
-          </>
-        )}
-      </div>
-      <table className="w-full text-[11px]">
-        <thead>
-          <tr className="text-[10px] text-muted-foreground">
-            <th className="py-1 pl-2.5 text-left font-normal"></th>
-            <th className="py-1 pr-2.5 text-right font-normal">Candidate</th>
-          </tr>
-        </thead>
-        <tbody className="[&_td:first-child]:pl-2.5 [&_td:last-child]:pr-2.5">
-          <MetricRow
-            label="Avg case duration"
-            candidate={dur.candidateMeanMs}
-            baseline={dur.baselineMeanMs}
-            format={fmtMs}
-          />
-          <MetricRow
-            label="Total tokens"
-            candidate={cand ? cand.tokens : null}
-            baseline={base ? base.tokens : null}
-            format={fmtTok}
-          />
-          <MetricRow
-            label="Total cost"
-            candidate={cand ? cand.cost : null}
-            baseline={base ? base.cost : null}
-            format={fmtCost}
-          />
-        </tbody>
-      </table>
-      {loading && (
-        <p className="border-t border-border px-2.5 py-1 text-[10px] text-muted-foreground">
-          Summing token/cost across {allIds.length} case traces…
-        </p>
-      )}
-    </div>
   );
 }
 
@@ -1447,272 +1211,4 @@ function ChangeCell({ change }: { change: Classification | null }) {
     );
   }
   return <span className="text-muted-foreground">—</span>;
-}
-
-/** One metric row: candidate value with its ± delta beside it (lower is better). */
-function MetricRow({
-  label,
-  candidate,
-  baseline,
-  format,
-  lowerIsBetter = true,
-}: {
-  label: string;
-  candidate: number | null;
-  baseline: number | null;
-  format: (n: number) => string;
-  lowerIsBetter?: boolean;
-}) {
-  const delta = candidate !== null && baseline !== null ? candidate - baseline : null;
-  return (
-    <tr>
-      <td className="py-1 pr-2 text-muted-foreground">{label}</td>
-      {/* Candidate value with its ± delta vs baseline beside it (lower is better). */}
-      <td className="py-1 text-right tabular-nums">
-        {candidate === null ? (
-          "—"
-        ) : (
-          <>
-            {format(candidate)}
-            {delta !== null &&
-              (delta === 0 ? (
-                <span className="ml-1.5 text-muted-foreground">±0</span>
-              ) : (
-                <span
-                  className={cn(
-                    "ml-1.5",
-                    SENTIMENT_CLASS[changeSentiment(lowerIsBetter ? -delta : delta)],
-                  )}
-                >
-                  {delta > 0 ? "+" : "−"}
-                  {format(Math.abs(delta))}
-                </span>
-              ))}
-          </>
-        )}
-      </td>
-    </tr>
-  );
-}
-
-/** Task errors and scorer errors are different failures and read differently. */
-function ErrorsBody({
-  run,
-  results,
-  onOpen,
-}: {
-  run: RunDetail;
-  results: ResultRow[];
-  onOpen: (id: string) => void;
-}) {
-  const taskErrors = results.filter((r) => r.taskError);
-  const scorerErrors = results.filter((r) => r.scores.some((s) => s.error));
-  return (
-    <div className="flex flex-col gap-3">
-      <ErrorGroup
-        title={`Application errors (${run.taskErrorCount})`}
-        blurb="The candidate application failed for these test cases, so there is no output to judge."
-        rows={taskErrors.map((r) => ({ id: r.id, input: r.input, detail: r.taskError ?? "" }))}
-        onOpen={onOpen}
-      />
-      <ErrorGroup
-        title={`Scorer errors (${run.scorerErrorCount})`}
-        blurb="The candidate produced an output, but a scorer failed to judge it. These cases are unscored."
-        rows={scorerErrors.map((r) => ({
-          id: r.id,
-          input: r.input,
-          detail: r.scores
-            .filter((s) => s.error)
-            .map((s) => `${s.scorerName}: ${s.error}`)
-            .join(" · "),
-        }))}
-        onOpen={onOpen}
-      />
-    </div>
-  );
-}
-
-function ErrorGroup({
-  title,
-  blurb,
-  rows,
-  onOpen,
-}: {
-  title: string;
-  blurb: string;
-  rows: Array<{ id: string; input: string; detail: string }>;
-  onOpen: (id: string) => void;
-}) {
-  return (
-    <div>
-      <p className="flex items-center gap-1.5 text-[12px] font-medium">
-        <AlertTriangle className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" aria-hidden />
-        {title}
-      </p>
-      <p className="mb-1.5 mt-0.5 text-[11px] leading-relaxed text-muted-foreground">{blurb}</p>
-      {rows.length === 0 ? (
-        <p className="text-[11px] text-muted-foreground">None.</p>
-      ) : (
-        <ul className="divide-y divide-border rounded border border-border">
-          {rows.map((row) => (
-            <li key={row.id}>
-              <button
-                type="button"
-                onClick={() => onOpen(row.id)}
-                className="flex w-full flex-col items-start px-2.5 py-1.5 text-left transition-colors hover:bg-muted/40"
-              >
-                <span className="truncate">{truncate(row.input, 80)}</span>
-                <span className="font-mono text-[11px] text-muted-foreground">{row.detail}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-}
-
-/**
- * Run configuration + immutable identities; caller wraps in a section.
- * The prototype also showed a baseline picker and duration/cost/token totals.
- * The baseline is server-computed against a fixed baselineRunId (no endpoint to
- * repoint it), so it is read-only here; the aggregate metrics are not persisted
- * on a run, so those rows are omitted rather than fabricated.
- */
-function RunDetailsBody({ run, projectId }: { run: RunDetail; projectId: string }) {
-  return (
-    <div>
-      <dl className="grid grid-cols-1 gap-x-6 gap-y-1.5 sm:grid-cols-2">
-        <Row label="Candidate version">
-          <span className="font-mono">{run.candidateVersion}</span>
-        </Row>
-        <Row label="Dataset">
-          <Link
-            href={`/projects/${projectId}/datasets/${run.datasetId}`}
-            className="inline-flex items-center gap-1 rounded hover:underline"
-          >
-            {run.datasetName ?? run.datasetId}
-            <span className="text-muted-foreground">· {run.datasetVersionLabel}</span>
-          </Link>
-        </Row>
-        <Row label="Environment">{run.environment}</Row>
-        <Row label="Started">
-          <Timestamp iso={run.startedAt} className="inline" />
-        </Row>
-        {/* Run wall-clock (completedAt − startedAt), NOT the sum of case durations. */}
-        <Row label="Run elapsed">{fmtDurationMs(run.elapsedMs)}</Row>
-        {run.comparison.duration.pairedCount > 0 && (
-          <Row label="Avg case duration">
-            <span title="Mean per-case wall-clock (task + scorers), not run elapsed">
-              {fmtDurationMs(run.comparison.duration.candidateMeanMs)}
-              {run.comparison.duration.baselineMeanMs !== null && (
-                <span className="text-muted-foreground">
-                  {" "}
-                  vs {fmtDurationMs(run.comparison.duration.baselineMeanMs)}
-                </span>
-              )}
-              {run.comparison.duration.deltaMs !== null && (
-                <span
-                  className={cn(
-                    "ml-1",
-                    SENTIMENT_CLASS[changeSentiment(-run.comparison.duration.deltaMs)],
-                  )}
-                >
-                  ({signed(run.comparison.duration.deltaMs / 1000)}s)
-                </span>
-              )}
-            </span>
-          </Row>
-        )}
-        <Row label="Scorers">
-          {run.scorers && run.scorers.length > 0
-            ? run.scorers.map((s) => `${s.name} ${s.version}`).join(", ")
-            : "—"}
-        </Row>
-        <Row label="Baseline">
-          {run.baselineRunId ? (
-            <Link
-              href={`/projects/${projectId}/evaluations/${run.baselineRunId}`}
-              className="font-mono text-[11px] hover:underline"
-            >
-              {run.baselineRunId}
-            </Link>
-          ) : (
-            "No baseline"
-          )}
-        </Row>
-        <Row label="Evaluation ID">
-          <span className="font-mono text-[11px]">{run.evaluationId}</span>
-        </Row>
-        <Row label="Run ID">
-          <span className="font-mono text-[11px]">{run.id}</span>
-        </Row>
-        <Row label="Dataset snapshot ID">
-          <span className="font-mono text-[11px]">{run.datasetVersionId}</span>
-        </Row>
-        {run.model && (
-          <Row label="Model">
-            <span className="font-mono text-[11px]">{run.model}</span>
-          </Row>
-        )}
-      </dl>
-      <ProvenanceBlock metadata={run.metadata} />
-    </div>
-  );
-}
-
-// Keys that may carry secrets/env — never rendered (informational safety, per spec).
-const SECRET_KEY_RE = /secret|token|password|api[_-]?key|credential|\benv\b|authorization/i;
-
-/**
- * Structured run provenance (model, prompt, config, git) as SECONDARY detail. Free-form
- * and optional: when absent it's an informational "not recorded" line, never an error.
- * The candidate label stays the primary identity (shown in the header). Env vars and
- * secret-looking keys are redacted; git repo/ref/commit are surfaced when present.
- */
-function ProvenanceBlock({ metadata }: { metadata: Record<string, unknown> | null }) {
-  const entries = metadata ? Object.entries(metadata).filter(([k]) => !SECRET_KEY_RE.test(k)) : [];
-  const git =
-    metadata && typeof metadata.git === "object" && metadata.git !== null
-      ? (metadata.git as Record<string, unknown>)
-      : null;
-
-  return (
-    <div className="mt-3 border-t border-border/50 pt-2">
-      <p className="mb-1 text-[11px] font-medium text-muted-foreground">Provenance</p>
-      {entries.length === 0 && !git ? (
-        <p className="text-[11px] text-muted-foreground">
-          No provenance recorded for this run — informational only, not an error.
-        </p>
-      ) : (
-        <dl className="grid grid-cols-1 gap-x-6 gap-y-1 sm:grid-cols-2">
-          {git && (
-            <Row label="Git">
-              <span className="font-mono text-[11px]">
-                {[git.repo, git.ref ?? git.commit].filter(Boolean).join(" @ ") || "—"}
-              </span>
-            </Row>
-          )}
-          {entries
-            .filter(([k]) => k !== "git")
-            .map(([k, v]) => (
-              <Row key={k} label={k}>
-                <span className="font-mono text-[11px]">
-                  {typeof v === "object" ? JSON.stringify(v) : String(v)}
-                </span>
-              </Row>
-            ))}
-        </dl>
-      )}
-    </div>
-  );
-}
-
-function Row({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="flex items-center justify-between gap-3 border-b border-border/50 py-1 last:border-0">
-      <dt className="text-[11px] text-muted-foreground">{label}</dt>
-      <dd className="text-right text-[12px]">{children}</dd>
-    </div>
-  );
 }

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -20,7 +20,6 @@ import { CopyButton } from "@/components/ui/copy-button";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { SearchFilterBar } from "@/components/search-filter-bar";
-import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import {
@@ -556,6 +555,11 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
         target={
           openResult
             ? ({
+                // The result id, not the object literal below (which is rebuilt on
+                // every render) — ReviewPanel keys its form-reset effect on this so
+                // an unrelated re-render (e.g. a background refetch) can't wipe an
+                // in-progress review.
+                targetKey: openResult.id,
                 contextLabel: `${openResult.testCaseId} · ${run?.evaluationName} ${run?.candidateVersion}`,
                 input: openResult.input,
                 output: openResult.candidateOutput ?? "No output — the task errored.",
@@ -572,11 +576,19 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
         open={reviewOpen}
         onOpenChange={setReviewOpen}
         onSave={(review) =>
-          humanScore.mutate({
-            verdict: review.verdict,
-            quality: review.quality ?? null,
-            comment: review.comment ?? null,
-            reviewer: review.reviewer,
+          // A promise ReviewPanel awaits: it only toasts "Review saved" and closes
+          // the drawer once this resolves, and surfaces a failure (rejecting here)
+          // instead of silently discarding the review.
+          new Promise<void>((resolve, reject) => {
+            humanScore.mutate(
+              {
+                verdict: review.verdict,
+                quality: review.quality ?? null,
+                comment: review.comment ?? null,
+                reviewer: review.reviewer,
+              },
+              { onSuccess: () => resolve(), onError: (e) => reject(e) },
+            );
           })
         }
       />
@@ -910,6 +922,49 @@ const RESULT_COLUMN_COUNT = 8;
 /** Sentinel for the "Compare with" select's no-selection option (Radix needs a value). */
 const NO_COMPARE = "__none__";
 
+/**
+ * Run-level headline metrics — main score, pass rate, cost, duration — above the
+ * filter bar. Sourced from `run` (never derived from `results`), so an empty or
+ * fully-failing run still renders these instead of a blank strip. `null`/`undefined`
+ * render "—", never a fabricated 0 — the run may simply not have reported a cost,
+ * or may still be running (no `elapsedMs` yet).
+ */
+function HeadlineMetrics({ run }: { run: RunDetail }) {
+  return (
+    <div className="flex flex-wrap items-center gap-6 border-b border-border px-3 py-2">
+      <HeadlineStat label={run.mainScoreName ?? "Main score"}>
+        {run.mainScore === null ? (
+          <span className="text-muted-foreground">—</span>
+        ) : (
+          pctFraction(run.mainScore)
+        )}
+      </HeadlineStat>
+      <HeadlineStat label="Pass rate">
+        <PassRate counts={run} />
+      </HeadlineStat>
+      <HeadlineStat label="Cost">
+        {run.cost === null || run.cost === undefined ? (
+          <span className="text-muted-foreground">—</span>
+        ) : (
+          `$${run.cost.toFixed(4)}`
+        )}
+      </HeadlineStat>
+      <HeadlineStat label="Duration">{fmtDurationMs(run.elapsedMs)}</HeadlineStat>
+    </div>
+  );
+}
+
+function HeadlineStat({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</span>
+      <div className="text-[13px] font-medium tabular-nums">{children}</div>
+    </div>
+  );
+}
+
+const RESULT_COLUMN_COUNT = 7;
+
 function ResultsSection({
   run,
   results,
@@ -931,11 +986,6 @@ function ResultsSection({
 }) {
   const [keyword, setKeyword] = React.useState("");
   const [sortWorst, setSortWorst] = React.useState(false);
-  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
-    DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0],
-  );
-  const [customStart, setCustomStart] = React.useState<Date | null>(null);
-  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
 
   // Per-result comparison vs the picked run (null when not comparing).
   const cmpFor = React.useCallback(
@@ -968,6 +1018,13 @@ function ResultsSection({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
+      {/* Headline metrics for the run — rendered from the run itself, never from
+          `results`, so they still show for an empty or fully-failing run (no
+          per-case rows) rather than leaving this a blank strip above the table. */}
+      <HeadlineMetrics run={run} />
+      {/* No date-range control here: every result in this table belongs to one run,
+          so there is no time range to narrow — a date filter would render but
+          filter nothing. */}
       <SearchFilterBar
         searchInput={
           <div className="relative min-w-[10rem] max-w-md flex-1">
@@ -980,14 +1037,6 @@ function ResultsSection({
             />
           </div>
         }
-        dateFilter={dateFilter}
-        customStartDate={customStart}
-        customEndDate={customEnd}
-        onDateFilterChange={setDateFilter}
-        onCustomRangeChange={(s, e) => {
-          setCustomStart(s);
-          setCustomEnd(e);
-        }}
       >
         <div className="flex items-center gap-1">
           {RESULT_FILTERS.map((option) => (
@@ -1003,6 +1052,9 @@ function ResultsSection({
           ))}
         </div>
         <span className="flex-1" aria-hidden />
+        {/* This is the run's overall pass rate — it does not change with the status
+            filter above, so it reads as the run's rate, not a count of the
+            currently-visible rows. */}
         <PassRate counts={run} withLabel />
         <span className="flex-1" aria-hidden />
         <Button

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -365,18 +365,18 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
         trail={
           run
             ? [
-                { label: "Evaluations", href: `/projects/${projectId}/evaluations` },
                 {
-                  // The run segment is a dropdown of this evaluation's runs, like the
-                  // dataset switcher — jump to another run without leaving the page.
+                  // Just the run segment (no separate "Evaluations" crumb) — a dropdown
+                  // of this evaluation's runs. Its menu header still links to the
+                  // Evaluations list, so that page stays one click away.
                   label: `${run.evaluationName} #${run.runNumber}`,
                   menuHeader: { label: "Evaluations", href: `/projects/${projectId}/evaluations` },
                   options: runOptions,
                 },
               ]
-            : [{ label: "Evaluations", href: `/projects/${projectId}/evaluations` }]
+            : undefined
         }
-        current={run ? undefined : "Run"}
+        current={run ? undefined : "Evaluations"}
       />
       <div className="flex flex-1 flex-col overflow-hidden text-[12px]">
         {isLoading ? (

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -1445,78 +1445,35 @@ function MetricRow({
   );
 }
 
-/**
- * Candidate-vs-baseline metrics for the open case — duration, tokens, and cost side
- * by side with deltas. Duration is derived server-side; tokens/cost come from each
- * side's trace (pending/unknown when a trace lacks provider usage). Lower is better
- * for all three, so a smaller candidate reads green.
- */
-function MetricsDiff({
+/** Signed, coloured delta beside a metric (lower is better → green when negative). */
+function InlineDelta({
   candidate,
   baseline,
-  candidateDurationMs,
-  baselineDurationMs,
+  format,
 }: {
-  candidate: TraceUsage;
-  baseline: TraceUsage;
-  candidateDurationMs: number | null;
-  baselineDurationMs: number | null;
+  candidate: number;
+  baseline: number | null;
+  format: (n: number) => string;
 }) {
-  const tok = (u: TraceUsage) => (u.state === "present" ? u.combined.totalTokens : null);
-  const cost = (u: TraceUsage) => (u.state === "present" ? u.combined.cost : null);
-  const fmtTok = (n: number) => `${Math.round(n).toLocaleString()}`;
-  const fmtCost = (n: number) => (n > 0 ? `$${n.toFixed(4)}` : "$0");
-  const fmtMs = (n: number) => (n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`);
+  if (baseline === null) return null;
+  const delta = candidate - baseline;
+  if (delta === 0) return <span className="text-muted-foreground"> ±0</span>;
   return (
-    <div className="mt-2 overflow-hidden rounded border border-border">
-      <div className="border-b border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground">
-        Metrics vs baseline
-      </div>
-      <table className="w-full px-2.5 text-[11px]">
-        <thead>
-          <tr className="text-[10px] text-muted-foreground">
-            <th className="py-1 pl-2.5 text-left font-normal"></th>
-            <th className="py-1 text-right font-normal">Candidate</th>
-            <th className="py-1 text-right font-normal">Baseline</th>
-            <th className="py-1 pr-2.5 text-right font-normal">Δ</th>
-          </tr>
-        </thead>
-        <tbody className="[&_td:first-child]:pl-2.5 [&_td:last-child]:pr-2.5">
-          <MetricRow
-            label="Duration"
-            candidate={candidateDurationMs}
-            baseline={baselineDurationMs}
-            format={fmtMs}
-          />
-          <MetricRow
-            label="Tokens"
-            candidate={tok(candidate)}
-            baseline={tok(baseline)}
-            format={fmtTok}
-          />
-          <MetricRow
-            label="Cost"
-            candidate={cost(candidate)}
-            baseline={cost(baseline)}
-            format={fmtCost}
-          />
-        </tbody>
-      </table>
-      {(candidate.state === "pending" || baseline.state === "pending") && (
-        <p className="border-t border-border px-2.5 py-1 text-[10px] text-muted-foreground">
-          A trace is still ingesting — token/cost values will fill in.
-        </p>
-      )}
-    </div>
+    <span className={SENTIMENT_CLASS[changeSentiment(-delta)]}>
+      {" "}
+      {delta > 0 ? "+" : "−"}
+      {format(Math.abs(delta))}
+    </span>
   );
 }
 
 /**
  * Trace-derived token/cost for the open case, split by application (task) vs
  * evaluation-judge (scorers). `pending` while the trace ingests, `unknown` when the
- * trace carries no provider usage — a real 0 only when the trace proves it.
+ * trace carries no provider usage — a real 0 only when the trace proves it. When a
+ * baseline usage is supplied, each value carries an inline ± delta against it.
  */
-function UsageBreakdown({ usage }: { usage: TraceUsage }) {
+function UsageBreakdown({ usage, baseline }: { usage: TraceUsage; baseline?: TraceUsage }) {
   if (usage.state === "pending") {
     return (
       <p className="mt-2 text-[11px] text-muted-foreground">
@@ -1534,32 +1491,66 @@ function UsageBreakdown({ usage }: { usage: TraceUsage }) {
     );
   }
   const fmtCost = (c: number) => (c > 0 ? `$${c.toFixed(4)}` : "$0");
+  const fmtTok = (n: number) => Math.round(n).toLocaleString();
+  // Only diff against a baseline bucket that actually has usage (spanCount > 0), so
+  // we never show a delta "vs 0" for a bucket the baseline case didn't have.
+  const bl = baseline && baseline.state === "present" ? baseline : null;
+  const bt = (b: { spanCount: number; totalTokens: number }) =>
+    bl && b.spanCount > 0 ? b.totalTokens : null;
+  const bc = (b: { spanCount: number; cost: number }) => (bl && b.spanCount > 0 ? b.cost : null);
   const rows = [
-    { label: "Application (task)", b: usage.task },
-    { label: "Evaluation judge (scorers)", b: usage.scorer },
-    { label: "Other", b: usage.other },
+    { label: "Application (task)", b: usage.task, base: bl?.task },
+    { label: "Evaluation judge (scorers)", b: usage.scorer, base: bl?.scorer },
+    { label: "Other", b: usage.other, base: bl?.other },
   ].filter((r) => r.b.spanCount > 0);
   return (
     <div className="mt-2 overflow-hidden rounded border border-border">
       <div className="border-b border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground">
-        Tokens &amp; cost (from the trace)
+        Tokens &amp; cost (from the trace){bl ? " · vs baseline" : ""}
       </div>
       <ul className="divide-y divide-border">
         {rows.map((r) => (
-          <li key={r.label} className="flex items-center justify-between px-2.5 py-1 text-[11px]">
+          <li
+            key={r.label}
+            className="flex items-center justify-between gap-2 px-2.5 py-1 text-[11px]"
+          >
             <span className="text-muted-foreground">{r.label}</span>
             <span className="tabular-nums">
-              {r.b.totalTokens.toLocaleString()} tok · {fmtCost(r.b.cost)}
+              {fmtTok(r.b.totalTokens)} tok
+              {r.base && (
+                <InlineDelta candidate={r.b.totalTokens} baseline={bt(r.base)} format={fmtTok} />
+              )}
+              {" · "}
+              {fmtCost(r.b.cost)}
+              {r.base && (
+                <InlineDelta candidate={r.b.cost} baseline={bc(r.base)} format={fmtCost} />
+              )}
             </span>
           </li>
         ))}
         {/* Only worth a Combined total when the cost is split across buckets (e.g. an
             LLM judge). With a single bucket it just repeats the row above. */}
         {rows.length > 1 && (
-          <li className="flex items-center justify-between bg-muted/20 px-2.5 py-1 text-[11px] font-medium">
+          <li className="flex items-center justify-between gap-2 bg-muted/20 px-2.5 py-1 text-[11px] font-medium">
             <span>Combined</span>
             <span className="tabular-nums">
-              {usage.combined.totalTokens.toLocaleString()} tok · {fmtCost(usage.combined.cost)}
+              {fmtTok(usage.combined.totalTokens)} tok
+              {bl && (
+                <InlineDelta
+                  candidate={usage.combined.totalTokens}
+                  baseline={bt(bl.combined)}
+                  format={fmtTok}
+                />
+              )}
+              {" · "}
+              {fmtCost(usage.combined.cost)}
+              {bl && (
+                <InlineDelta
+                  candidate={usage.combined.cost}
+                  baseline={bc(bl.combined)}
+                  format={fmtCost}
+                />
+              )}
             </span>
           </li>
         )}
@@ -1939,16 +1930,10 @@ function ResultContext({
 
       <ScorerBreakdown result={result} />
 
-      {result.comparison?.baselineTraceId ? (
-        <MetricsDiff
-          candidate={traceUsage}
-          baseline={baselineUsage}
-          candidateDurationMs={result.durationMs}
-          baselineDurationMs={result.comparison.baselineDurationMs}
-        />
-      ) : (
-        <UsageBreakdown usage={traceUsage} />
-      )}
+      <UsageBreakdown
+        usage={traceUsage}
+        baseline={result.comparison?.baselineTraceId ? baselineUsage : undefined}
+      />
 
       {result.humanScores.length > 0 && (
         <div className="mt-2 overflow-hidden rounded border border-border">

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -1306,18 +1306,21 @@ function UsageBreakdown({ usage }: { usage: TraceUsage }) {
             </span>
           </li>
         ))}
-        <li className="flex items-center justify-between bg-muted/20 px-2.5 py-1 text-[11px] font-medium">
-          <span>Combined</span>
-          <span className="tabular-nums">
-            {usage.combined.totalTokens.toLocaleString()} tok · {fmtCost(usage.combined.cost)}
-          </span>
-        </li>
+        {/* Only worth a Combined total when the cost is split across buckets (e.g. an
+            LLM judge). With a single bucket it just repeats the row above. */}
+        {rows.length > 1 && (
+          <li className="flex items-center justify-between bg-muted/20 px-2.5 py-1 text-[11px] font-medium">
+            <span>Combined</span>
+            <span className="tabular-nums">
+              {usage.combined.totalTokens.toLocaleString()} tok · {fmtCost(usage.combined.cost)}
+            </span>
+          </li>
+        )}
       </ul>
     </div>
   );
 }
 
-/** The regressed cases, as a plain list; the caller wraps it in a section. */
 /** Task errors and scorer errors are different failures and read differently. */
 function ErrorsBody({
   run,

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -721,7 +721,10 @@ function RunBody({
               onValueChange={(v) => onCompareChange(v === NO_COMPARE ? null : v)}
             >
               <SelectTrigger
-                className="h-7 w-fit max-w-[240px] gap-1.5 text-[12px]"
+                // The trigger is justify-between by default, which pushes the value
+                // away from the icon whenever the box is wider than its text. Keep the
+                // pair together on the left and let the chevron take the slack.
+                className="h-7 w-fit max-w-[240px] justify-start gap-1.5 text-[12px] [&>span]:mr-auto"
                 aria-label="Compare with"
               >
                 <GitCompare className="h-3.5 w-3.5 shrink-0" aria-hidden />

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -8,9 +8,9 @@ import {
   ArrowDown,
   ArrowUp,
   ChevronDown,
-  ChevronRight,
   Database,
   Download,
+  Info,
   Loader2,
   Search,
   X,
@@ -222,7 +222,7 @@ const RESULT_FILTERS: Array<{ id: ResultFilterId; label: string }> = [
   { id: "all", label: "All" },
   { id: "regressions", label: "Regressions" },
   { id: "improvements", label: "Improvements" },
-  { id: "failed", label: "Failed" },
+  { id: "failed", label: "Did not pass" },
   { id: "errors", label: "Errors" },
   { id: "unpaired", label: "Unpaired" },
   { id: "not_scored", label: "Not scored" },
@@ -591,9 +591,8 @@ function RunBody({
   openResultId: string | null;
 }) {
   const router = useRouter();
+  const [detailsOpen, setDetailsOpen] = React.useState(false);
   const hasBaseline = run.baselineRunId !== null;
-  // Derived verdict — never the stored `change` column.
-  const regressed = results.filter((r) => r.comparison?.caseChange === "regressed");
   const incompatibleBaseline = run.comparison.available && !run.comparison.trustworthy;
   const trustNote = comparisonReasonText(run.comparison.reasons, run.datasetVersionLabel);
 
@@ -621,6 +620,17 @@ function RunBody({
             />
           </span>
         }
+        action={
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1.5 text-[12px]"
+            onClick={() => setDetailsOpen(true)}
+          >
+            <Info className="h-3.5 w-3.5" aria-hidden />
+            Run details
+          </Button>
+        }
       />
 
       <div className="min-h-0 flex-1 overflow-auto">
@@ -647,25 +657,74 @@ function RunBody({
             openResultId={openResultId}
           />
 
-          {/* Everything else folds below the results. */}
-          {hasBaseline && regressed.length > 0 && (
-            <ExpandableSection title={`Regressions (${regressed.length})`} defaultOpen={false}>
-              <RegressionsList regressed={regressed} onOpen={onOpenResult} />
-            </ExpandableSection>
-          )}
-
+          {/* Errors fold below the results; run details open in a side panel. */}
           {run.errorCount > 0 && (
             <ExpandableSection title={`Errors (${run.errorCount})`} defaultOpen={false}>
               <ErrorsBody run={run} results={results} onOpen={onOpenResult} />
             </ExpandableSection>
           )}
-
-          <ExpandableSection title="Run details" defaultOpen={false}>
-            <RunDetailsBody run={run} projectId={projectId} />
-          </ExpandableSection>
         </div>
       </div>
+
+      <RunDetailsDrawer
+        run={run}
+        projectId={projectId}
+        open={detailsOpen}
+        onOpenChange={setDetailsOpen}
+      />
     </>
+  );
+}
+
+/** Run details (identity, dataset, scorers, provenance) as a right-side slide-out,
+ *  opened from the header — matching the starter-code / pull-code drawers. */
+function RunDetailsDrawer({
+  run,
+  projectId,
+  open,
+  onOpenChange,
+}: {
+  run: RunDetail;
+  projectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onOpenChange(false);
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+
+  return (
+    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
+      <div className="flex shrink-0 items-start justify-between gap-2 border-b border-border px-4 py-3">
+        <div>
+          <h2 className="text-[13px] font-semibold">Run details</h2>
+          <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
+            {run.evaluationName} #{run.runNumber} · {run.candidateVersion}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onOpenChange(false)}
+          aria-label="Close"
+          className="mt-0.5 rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-4 text-[12px]">
+        <RunDetailsBody run={run} projectId={projectId} />
+      </div>
+    </div>
   );
 }
 
@@ -858,9 +917,7 @@ function FilterStat({
       className="rounded text-left transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       title={`Show ${label.toLowerCase()} in the results below`}
     >
-      <span className="text-[11px] text-muted-foreground underline decoration-dotted underline-offset-2">
-        {label}
-      </span>
+      <span className="text-[11px] text-muted-foreground">{label}</span>
       <span className="block text-[15px] font-medium tabular-nums">{count}</span>
     </button>
   );
@@ -1261,37 +1318,6 @@ function UsageBreakdown({ usage }: { usage: TraceUsage }) {
 }
 
 /** The regressed cases, as a plain list; the caller wraps it in a section. */
-function RegressionsList({
-  regressed,
-  onOpen,
-}: {
-  regressed: ResultRow[];
-  onOpen: (id: string) => void;
-}) {
-  return (
-    <div className="-mx-2.5 -my-2 divide-y divide-border">
-      {regressed.map((r) => (
-        <button
-          key={r.id}
-          type="button"
-          onClick={() => onOpen(r.id)}
-          className="flex w-full items-start gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/40"
-        >
-          <span className="min-w-0 flex-1">
-            <span className="block truncate">{truncate(r.input, 90)}</span>
-            <span className="mt-0.5 block text-[11px] text-muted-foreground">
-              was <span className="text-foreground">{r.baselineOutput ?? "—"}</span> · now{" "}
-              <span className="text-foreground">{r.candidateOutput ?? "—"}</span> · expected{" "}
-              <span className="text-foreground">{r.expectedOutput ?? "—"}</span>
-            </span>
-          </span>
-          <ChevronRight className="mt-1 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
-        </button>
-      ))}
-    </div>
-  );
-}
-
 /** Task errors and scorer errors are different failures and read differently. */
 function ErrorsBody({
   run,
@@ -1556,6 +1582,49 @@ function ResultContext({
         <EvalResultBadge status={result.status} />
         <span className="font-mono text-[11px] text-muted-foreground">{result.testCaseId}</span>
       </div>
+
+      {/* Candidate vs baseline for THIS case, beside the trace — mirrors the run-level
+          "vs baseline" up top. Only when a baseline comparison is available. */}
+      {run.comparison.available && result.comparison && (
+        <div className="mb-3 rounded border border-border bg-muted/20 px-2.5 py-2 text-[11px]">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="font-medium">
+              Candidate vs baseline
+              {run.comparison.baseline && (
+                <span className="ml-1 font-normal text-muted-foreground">
+                  ({run.comparison.baseline.candidateVersion})
+                </span>
+              )}
+            </span>
+            <span
+              className={cn(
+                "font-medium",
+                CELL_CLASS_STYLE[result.comparison.caseChange].className,
+              )}
+            >
+              {CELL_CLASS_STYLE[result.comparison.caseChange].label}
+            </span>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 tabular-nums text-muted-foreground">
+            <span>
+              {run.mainScoreName ?? "Main score"}:{" "}
+              <span className="text-foreground">
+                {result.comparison.mainScore.candidate === null
+                  ? "—"
+                  : pctFraction(result.comparison.mainScore.candidate)}
+              </span>
+              {result.comparison.mainScore.baseline !== null && (
+                <span> vs {pctFraction(result.comparison.mainScore.baseline)}</span>
+              )}
+            </span>
+            {result.comparison.mainScore.delta !== null && (
+              <span className={SENTIMENT_CLASS[changeSentiment(result.comparison.mainScore.delta)]}>
+                {signedPoints(result.comparison.mainScore.delta)} pp
+              </span>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Expected outcome — the same editable, format-aware value block used on the
           dataset case panel; Save (shown when edited) publishes a new dataset version. */}

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -27,11 +27,9 @@ import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { useToast } from "@/components/ui/toast";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import {
-  EditableValueBlock,
   EvalPageHeader,
   EvalResultBadge,
   ReviewPanel,
-  seedFormat,
   Timestamp,
   useSeedTraceIO,
   type ReviewTarget,
@@ -52,12 +50,7 @@ import {
   signedPoints,
   truncate,
 } from "@/features/offline-eval/utils";
-import {
-  useEvaluationRun,
-  useEvaluationRuns,
-  useCreateHumanScore,
-  useUpdateTestCase,
-} from "../hooks";
+import { useEvaluationRun, useEvaluationRuns, useCreateHumanScore } from "../hooks";
 import { RunStatusBadge } from "./evaluations-view";
 import { PullCodeDrawer } from "../components/pull-code-drawer";
 import { SaveTestCaseDrawer } from "../components/trace-integration";
@@ -65,13 +58,6 @@ import { reproduceRunCode, reproduceRunCodeTs } from "@/features/offline-eval/ut
 import { attributeTraceUsage, type TraceUsage, type UsageSpan } from "@/lib/eval/trace-usage";
 import { matchSpans } from "@/lib/eval/span-match";
 import type { ResultRow, RunDetail, ScoreRow, Classification } from "../types";
-
-/** Verdict → badge tone, matching the design system's success/danger/warning. */
-const HUMAN_VERDICT_VARIANT: Record<string, "success" | "danger" | "warning"> = {
-  pass: "success",
-  fail: "danger",
-  unsure: "warning",
-};
 
 /** Case/run duration; "Unknown" when unmeasured (never 0s). */
 function fmtDurationMs(ms: number | null | undefined): string {
@@ -291,7 +277,6 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   const [saveTestCaseOpen, setSaveTestCaseOpen] = React.useState(false);
   const [saveTestCaseSpanId, setSaveTestCaseSpanId] = React.useState<string | undefined>(undefined);
 
-  const { toast } = useToast();
   const results = React.useMemo(() => data?.results ?? [], [data]);
   const run = data?.run;
 
@@ -342,7 +327,6 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   );
   useSeedTraceIO(projectId, fallbackTraces);
 
-  const updateCase = useUpdateTestCase(projectId, run?.datasetId ?? "");
   const humanScore = useCreateHumanScore(projectId, openResult?.id ?? "");
 
   const panelTraceId = useRealTrace ? realTraceId : fallbackTrace?.trace_id;
@@ -451,56 +435,57 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
           onNavigate={navigateResult}
           canNavigateUp={openIndex > 0}
           canNavigateDown={openIndex >= 0 && openIndex < visibleResults.length - 1}
-          // Save any span (or the trace root) of a real eval trace as a dataset test
-          // case. Only offered for real ingested traces — a reconstructed fallback has
-          // no telemetry for the drawer to read.
-          spanHeaderAction={
-            useRealTrace
-              ? (selection) => (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 shrink-0 text-[12px]"
-                    onClick={() => {
-                      setSaveTestCaseSpanId(
-                        selection.type === "span" ? selection.span.span_id : undefined,
-                      );
-                      setSaveTestCaseOpen(true);
-                    }}
-                  >
-                    Save as test case
-                  </Button>
-                )
-              : undefined
-          }
-          // While the drawer is open, clicking a different span retargets it.
+          // The test case is the identity that matters across runs (a trace id is
+          // per-execution, and synthetic when nothing was ingested), so the header
+          // leads with it instead of the trace id.
+          headerIdentity={{ label: "Test case", value: openResult.testCaseId }}
+          // The case's outcome, in the header's findings-alert slot.
+          headerStatus={<EvalResultBadge status={openResult.status} />}
+          // While the "Save as test case" drawer is open, clicking a different span
+          // retargets it to that span.
           onSelectionChange={(selection) => {
             if (saveTestCaseOpen) {
               setSaveTestCaseSpanId(selection.type === "span" ? selection.span.span_id : undefined);
             }
           }}
-          spanActions={() => (
-            <ResultContext
-              projectId={projectId}
-              run={run}
-              result={openResult}
-              onReview={() => setReviewOpen(true)}
-              onSaveExpected={(value) =>
-                updateCase.mutate(
-                  {
-                    testCaseId: openResult.testCaseId,
-                    patch: { expected: value.trim() === "" ? null : value },
-                  },
-                  {
-                    onSuccess: () =>
-                      toast({
-                        title: "Expected outcome saved — new dataset version published",
-                        tone: "success",
-                      }),
-                  },
-                )
-              }
-            />
+          // The case actions live in the span panel's header-section bar, directly
+          // above the I/O — human review, the source test case, and (for a real
+          // ingested trace) saving the selected span as a new test case. Everything
+          // else that used to sit above the I/O has moved to the run detail table
+          // and the trace header.
+          spanActions={(selection) => (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-[12px]"
+                onClick={() => setReviewOpen(true)}
+              >
+                Review output
+              </Button>
+              <Link
+                href={`/projects/${projectId}/datasets/${run.datasetId}?case=${openResult.testCaseId}`}
+                className="inline-flex h-7 items-center gap-1.5 rounded-md border border-input bg-background px-2.5 text-[12px] font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <Database className="h-3.5 w-3.5" aria-hidden />
+                View source test case
+              </Link>
+              {useRealTrace && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-[12px]"
+                  onClick={() => {
+                    setSaveTestCaseSpanId(
+                      selection.type === "span" ? selection.span.span_id : undefined,
+                    );
+                    setSaveTestCaseOpen(true);
+                  }}
+                >
+                  Save as test case
+                </Button>
+              )}
+            </>
           )}
           spanExtraTags={() => (
             <>
@@ -521,10 +506,6 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
                 <span className="font-medium">
                   {run.datasetName} · {run.datasetVersionLabel}
                 </span>
-              </span>
-              <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
-                <span className="text-muted-foreground">Test case:</span>
-                <span className="font-mono">{openResult.testCaseId}</span>
               </span>
             </>
           )}
@@ -1387,120 +1368,7 @@ function ChangeCell({ change }: { change: Classification | null }) {
   return <span className="text-muted-foreground">—</span>;
 }
 
-function cellValueDisplay(v: number | boolean | string | null): string {
-  if (v === null || v === undefined) return "—";
-  if (typeof v === "boolean") return v ? "true" : "false";
-  if (typeof v === "number") return Number.isInteger(v) ? String(v) : v.toFixed(3);
-  return v;
-}
-
-const CELL_CLASS_STYLE: Record<Classification, { label: string; className: string }> = {
-  improved: { label: "Improved", className: SENTIMENT_CLASS.good },
-  regressed: { label: "Regressed", className: SENTIMENT_CLASS.bad },
-  unchanged: { label: "Unchanged", className: "text-muted-foreground" },
-  changed: { label: "Changed", className: "text-foreground" },
-  unpaired: { label: "Unpaired", className: "text-muted-foreground" },
-  not_comparable: { label: "Not comparable", className: "text-amber-600 dark:text-amber-400" },
-};
-
-/**
- * The candidate-vs-baseline breakdown per scorer cell, shown beside the trace. Uses
- * the derived comparison (candidate value, baseline value, delta or transition, and the
- * cell classification + reason); falls back to candidate-only scores when there is no
- * comparison (no baseline). A failed scorer is an error, never a 0.
- */
-function ScorerBreakdown({ result }: { result: ResultRow }) {
-  const cells = result.comparison?.scorerCells ?? [];
-  const byName = new Map(result.scores.map((s) => [s.scorerName, s]));
-
-  if (cells.length === 0) {
-    if (result.scores.length === 0) return null;
-    return (
-      <ul className="mt-2 divide-y divide-border rounded border border-border">
-        {result.scores.map((s) => (
-          <li key={s.id} className="px-2.5 py-1.5">
-            <div className="flex items-center justify-between gap-2">
-              <span className="font-medium">
-                {s.scorerName}
-                <span className="ml-1.5 font-normal text-muted-foreground">{s.scorerVersion}</span>
-              </span>
-              {s.error ? (
-                <Badge variant="warning">Scorer error</Badge>
-              ) : (
-                <span className="tabular-nums">{scoreValue(s)}</span>
-              )}
-            </div>
-            {s.explanation && (
-              <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
-                {s.explanation}
-              </p>
-            )}
-            {s.error && (
-              <p className="mt-0.5 font-mono text-[11px] text-amber-700 dark:text-amber-400">
-                {s.error} — the candidate answered, only the judge failed.
-              </p>
-            )}
-          </li>
-        ))}
-      </ul>
-    );
-  }
-
-  return (
-    <ul className="mt-2 divide-y divide-border rounded border border-border">
-      {cells.map((c) => {
-        const s = byName.get(c.scorerName);
-        const style = CELL_CLASS_STYLE[c.classification];
-        return (
-          <li key={c.scorerName} className="px-2.5 py-1.5">
-            <div className="flex items-center justify-between gap-2">
-              <span className="font-medium">
-                {c.scorerName}
-                <span className="ml-1.5 font-normal text-muted-foreground">{c.scorerVersion}</span>
-              </span>
-              <span className={cn("text-[11px] font-medium", style.className)}>{style.label}</span>
-            </div>
-            <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] tabular-nums text-muted-foreground">
-              <span>
-                candidate{" "}
-                <span className="text-foreground">{cellValueDisplay(c.candidateValue)}</span>
-              </span>
-              <span>
-                baseline{" "}
-                <span className="text-foreground">{cellValueDisplay(c.baselineValue)}</span>
-              </span>
-              {c.delta !== null && (
-                <span className={SENTIMENT_CLASS[changeSentiment(c.delta)]}>{signed(c.delta)}</span>
-              )}
-              {c.transition && (
-                <span className="text-foreground">
-                  {c.transition.from} → {c.transition.to}
-                </span>
-              )}
-              {c.reason && (
-                <span className="text-amber-600 dark:text-amber-400">
-                  {c.reason.replace(/_/g, " ")}
-                </span>
-              )}
-            </div>
-            {s?.explanation && (
-              <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
-                {s.explanation}
-              </p>
-            )}
-            {s?.error && (
-              <p className="mt-0.5 font-mono text-[11px] text-amber-700 dark:text-amber-400">
-                {s.error} — the candidate answered, only the judge failed.
-              </p>
-            )}
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
-
-/** One metric row: candidate vs baseline vs delta. Missing values show "—". */
+/** One metric row: candidate value with its ± delta beside it (lower is better). */
 function MetricRow({
   label,
   candidate,
@@ -1764,209 +1632,6 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
     <div className="flex items-center justify-between gap-3 border-b border-border/50 py-1 last:border-0">
       <dt className="text-[11px] text-muted-foreground">{label}</dt>
       <dd className="text-right text-[12px]">{children}</dd>
-    </div>
-  );
-}
-
-/**
- * The evaluation context for one result, shown as the trace viewer's span-actions
- * panel. The input/candidate output already render in the span detail below, so
- * this adds only the eval-specific bits: the editable expected outcome (behind a
- * button; saving publishes a new dataset version), the scores, what broke, the
- * human review, and the actions.
- */
-function ResultContext({
-  projectId,
-  run,
-  result,
-  onReview,
-  onSaveExpected,
-}: {
-  projectId: string;
-  run: RunDetail;
-  result: ResultRow;
-  onReview: () => void;
-  onSaveExpected: (value: string) => void;
-}) {
-  // Seed the canonical (expanded) form here rather than letting the field
-  // normalise it: this component re-seeds `expected` from the prop whenever the
-  // open result changes, which would otherwise clobber the field's own fix-up.
-  const expectedValue = result.expectedOutput ?? "";
-  const seededExpected = React.useMemo(
-    () => seedFormat(expectedValue, "expanded").text,
-    [expectedValue],
-  );
-  const [expected, setExpected] = React.useState(seededExpected);
-  React.useEffect(() => setExpected(seededExpected), [seededExpected, result.id]);
-  // Saving publishes a NEW dataset version, so only a real change counts as dirty:
-  // re-indenting a value (by the seed format, or the format switcher) is not an edit.
-  const expectedDirty = !sameAuthoredValue(expected, expectedValue);
-
-  return (
-    <div className="w-full text-[12px]">
-      <div className="mb-2 flex flex-wrap items-center gap-2">
-        <EvalResultBadge status={result.status} />
-        <span className="font-mono text-[11px] text-muted-foreground">{result.testCaseId}</span>
-      </div>
-
-      {/* Candidate vs baseline for THIS case, beside the trace — mirrors the run-level
-          "vs baseline" up top. Only when a baseline comparison is available. */}
-      {run.comparison.available && result.comparison && (
-        <div className="mb-3 rounded border border-border bg-muted/20 px-2.5 py-2 text-[11px]">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <span className="font-medium">
-              Candidate vs baseline
-              {run.comparison.baseline && (
-                <span className="ml-1 font-normal text-muted-foreground">
-                  ({run.comparison.baseline.candidateVersion})
-                </span>
-              )}
-            </span>
-            <span
-              className={cn(
-                "font-medium",
-                CELL_CLASS_STYLE[result.comparison.caseChange].className,
-              )}
-            >
-              {CELL_CLASS_STYLE[result.comparison.caseChange].label}
-            </span>
-          </div>
-          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 tabular-nums text-muted-foreground">
-            <span>
-              {run.mainScoreName ?? "Main score"}:{" "}
-              <span className="text-foreground">
-                {result.comparison.mainScore.candidate === null
-                  ? "—"
-                  : pctFraction(result.comparison.mainScore.candidate)}
-              </span>
-              {result.comparison.mainScore.baseline !== null && (
-                <span> vs {pctFraction(result.comparison.mainScore.baseline)}</span>
-              )}
-            </span>
-            {result.comparison.mainScore.delta !== null && (
-              <span className={SENTIMENT_CLASS[changeSentiment(result.comparison.mainScore.delta)]}>
-                {signedPoints(result.comparison.mainScore.delta)} pp
-              </span>
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* Expected outcome — the same editable, format-aware value block used on the
-          dataset case panel; Save (shown when edited) publishes a new dataset version. */}
-      <div>
-        <EditableValueBlock
-          key={result.id}
-          label="Expected outcome"
-          text={expected}
-          onChange={setExpected}
-          boxed
-          // The value candidate output is graded against, read closely and edited
-          // here → expand it, like Input/Recorded output in Save as test case.
-          seedJson="expanded"
-          copyable
-          minRows={2}
-        />
-        {expectedDirty && (
-          <div className="mt-1.5 flex items-center gap-2">
-            <Button
-              size="sm"
-              className="h-7 text-[12px]"
-              onClick={() => onSaveExpected(expected.trim())}
-            >
-              Save
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 text-[12px]"
-              onClick={() => setExpected(expectedValue)}
-            >
-              Cancel
-            </Button>
-          </div>
-        )}
-        <p className="mt-1 text-[11px] text-muted-foreground">
-          Saving edits test case <span className="font-mono">{result.testCaseId}</span> in{" "}
-          <span className="font-medium">{run.datasetName}</span> — it changes what future runs are
-          compared against.
-        </p>
-      </div>
-
-      {/* Per-span candidate-vs-baseline output diffs now live in the trace viewer's
-          Diff toggle (each span's Input/Output/Metadata), so no case-level output
-          diff is rendered here. */}
-
-      {/* An application error means no scorer ever ran. */}
-      {result.taskError && (
-        <div className="mt-2 rounded border border-red-300 bg-red-50 px-2.5 py-1.5 dark:border-red-900 dark:bg-red-950/40">
-          <p className="text-[11px] font-medium text-red-700 dark:text-red-300">
-            Application error — the candidate failed, so no scorer ran
-          </p>
-          <p className="mt-0.5 font-mono text-[11px] text-red-700 dark:text-red-300">
-            {result.taskError}
-          </p>
-        </div>
-      )}
-
-      <ScorerBreakdown result={result} />
-
-      {/* Token/cost/duration now live as chips on the trace tag row (spanExtraTags),
-          not a table here. */}
-
-      {result.humanScores.length > 0 && (
-        <div className="mt-2 overflow-hidden rounded border border-border">
-          <div className="border-b border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground">
-            Human review
-          </div>
-          <ul className="divide-y divide-border">
-            {result.humanScores.map((h) => (
-              <li key={h.id} className="flex flex-col gap-1 px-2.5 py-1.5 text-[11px]">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Badge variant={HUMAN_VERDICT_VARIANT[h.verdict] ?? "default"}>
-                    <span className="capitalize">{h.verdict}</span>
-                  </Badge>
-                  {h.quality != null && (
-                    <span className="tabular-nums text-muted-foreground">
-                      Quality {h.quality}/5
-                    </span>
-                  )}
-                  {h.reviewer && (
-                    <span className="ml-auto truncate text-muted-foreground">{h.reviewer}</span>
-                  )}
-                </div>
-                {h.comment && <p className="leading-relaxed text-muted-foreground">{h.comment}</p>}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      <div className="mt-2 flex flex-wrap items-center gap-2">
-        <Button size="sm" className="h-7 text-[12px]" onClick={onReview}>
-          Review output
-        </Button>
-        <Link
-          href={`/projects/${projectId}/datasets/${run.datasetId}?case=${result.testCaseId}`}
-          className="inline-flex h-7 items-center gap-1.5 rounded-md border border-input bg-background px-2.5 text-[12px] font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-        >
-          <Database className="h-3.5 w-3.5" aria-hidden />
-          View source test case
-        </Link>
-        <span className="ml-auto flex items-center gap-1 text-[11px] text-muted-foreground">
-          {/* Candidate case duration vs baseline; "Unknown" when unmeasured, never 0. */}
-          <span title="Case duration (task + scorers)">{fmtDurationMs(result.durationMs)}</span>
-          {result.comparison?.baselineDurationMs != null && (
-            <span>vs {fmtDurationMs(result.comparison.baselineDurationMs)}</span>
-          )}
-          {result.comparison?.durationDeltaMs != null && (
-            <span className={SENTIMENT_CLASS[changeSentiment(-result.comparison.durationDeltaMs)]}>
-              ({signed(result.comparison.durationDeltaMs / 1000)}s)
-            </span>
-          )}
-          {result.cost !== null ? <span>· ${result.cost.toFixed(4)}</span> : ""}
-        </span>
-      </div>
     </div>
   );
 }

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -739,38 +739,42 @@ function RunBody({
           <div className="flex items-center gap-2">
             {/* Comparison is an inline action: this run is the candidate; pick another
                 run of the same evaluation as the baseline. The diff appears in place. */}
-            <div className="flex items-center gap-1.5">
-              <GitCompare className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
-              <Select
-                value={compareId ?? NO_COMPARE}
-                onValueChange={(v) => onCompareChange(v === NO_COMPARE ? null : v)}
+            <Select
+              value={compareId ?? ""}
+              onValueChange={(v) => onCompareChange(v === NO_COMPARE ? null : v)}
+            >
+              <SelectTrigger
+                className="h-7 w-[200px] gap-1.5 text-[12px]"
+                aria-label="Compare with"
               >
-                <SelectTrigger className="h-7 w-[190px] text-[12px]" aria-label="Compare with">
-                  <SelectValue placeholder="Compare with…" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={NO_COMPARE} className="text-[12px]">
-                    Compare with…
+                <GitCompare className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                <SelectValue placeholder="Compare with…" />
+              </SelectTrigger>
+              <SelectContent>
+                {/* Clear option — only meaningful once a run is picked. */}
+                {compareId && (
+                  <SelectItem value={NO_COMPARE} className="text-[12px] text-muted-foreground">
+                    None (stop comparing)
                   </SelectItem>
-                  {compareOptions.length === 0 ? (
-                    <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
-                      No other runs in this evaluation
-                    </div>
-                  ) : (
-                    compareOptions.map((o) => (
-                      <SelectItem key={o.id} value={o.id} className="text-[12px]">
-                        {o.label}
-                        {o.score !== null && (
-                          <span className="ml-1.5 tabular-nums text-muted-foreground">
-                            {pctFraction(o.score)}
-                          </span>
-                        )}
-                      </SelectItem>
-                    ))
-                  )}
-                </SelectContent>
-              </Select>
-            </div>
+                )}
+                {compareOptions.length === 0 ? (
+                  <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
+                    No other runs in this evaluation
+                  </div>
+                ) : (
+                  compareOptions.map((o) => (
+                    <SelectItem key={o.id} value={o.id} className="text-[12px]">
+                      {o.label}
+                      {o.score !== null && (
+                        <span className="ml-1.5 tabular-nums text-muted-foreground">
+                          {pctFraction(o.score)}
+                        </span>
+                      )}
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
             <Button
               variant="outline"
               size="sm"

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -11,8 +11,9 @@ import {
   ChevronRight,
   Database,
   Download,
-  ExternalLink,
+  Loader2,
   Search,
+  X,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -35,6 +36,7 @@ import {
   type ReviewTarget,
 } from "@/features/offline-eval/components";
 import { TraceViewerPanel } from "@/features/traces/components";
+import { useTrace } from "@/features/traces/hooks";
 import type { Span, TraceDetail } from "@/types/api";
 import type { SpanKind, SpanStatus } from "@traceroot/core";
 import { cn } from "@/lib/utils";
@@ -98,9 +100,9 @@ function evalSpan(
  *     ├─ scorer span    ← siblings of the task, one per scorer that ran
  *     └─ scorer span
  *
- * Built from the actual result + scores only (no fabricated sub-spans). When the
- * result carries a real ingested trace, its full span tree is a click away via
- * "Open full trace"; this synthetic trace is what always renders here.
+ * Built from the actual result + scores only (no fabricated sub-spans). This is a
+ * clearly-LABELED fallback, used only when a result emitted no real trace; a result
+ * with a real ingested trace opens that real trace directly instead.
  */
 function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
   const id = result.traceId || `eval-${result.id}`;
@@ -209,33 +211,54 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   const [openResultId, setOpenResultId] = React.useState<string | null>(null);
   const [resultFilter, setResultFilter] = React.useState<ResultFilterId>("all");
   const [reviewOpen, setReviewOpen] = React.useState(false);
-  // The result's REAL ingested trace, opened as a side panel over the eval trace.
-  const [viewRealTraceId, setViewRealTraceId] = React.useState<string | null>(null);
 
   const { toast } = useToast();
   const results = React.useMemo(() => data?.results ?? [], [data]);
   const run = data?.run;
 
-  // One eval-shaped trace per result; seed their span I/O so the detail panel
-  // (which reads span input/output on demand) has it ready.
-  const resultTraces = React.useMemo(
-    () => (run ? results.map((r) => buildEvalTrace(r, run)) : []),
+  const openResult = openResultId ? (results.find((r) => r.id === openResultId) ?? null) : null;
+
+  // Prefer the result's REAL ingested trace. Probe it — this shares TraceViewerPanel's
+  // ["trace", projectId, traceId] cache key, so opening the real panel does not refetch.
+  // A result trace id means telemetry was emitted: show the real trace when it's
+  // available, and a pending state (retry) while it is still ingesting. When no trace
+  // id was emitted (fully-local run), fall back to a clearly-labeled reconstructed trace.
+  const realTraceId = openResult?.traceId ?? null;
+  const realTrace = useTrace(projectId, realTraceId ?? "", !!realTraceId);
+  const hasRealTrace = !!realTraceId && !!realTrace.data;
+  const tracePending = !!realTraceId && !realTrace.data; // loading or still ingesting
+
+  // Reconstructed eval-shaped trace — the labeled fallback, only for results that
+  // emitted no real trace. Seed span I/O just for those so the detail panel has it.
+  const fallbackTrace = React.useMemo(
+    () => (run && openResult && !realTraceId ? buildEvalTrace(openResult, run) : undefined),
+    [run, openResult, realTraceId],
+  );
+  const fallbackTraces = React.useMemo(
+    () => (run ? results.filter((r) => !r.traceId).map((r) => buildEvalTrace(r, run)) : []),
     [results, run],
   );
-  useSeedTraceIO(projectId, resultTraces);
-
-  const openResult = openResultId ? (results.find((r) => r.id === openResultId) ?? null) : null;
-  const openTrace = React.useMemo(
-    () => (run && openResult ? buildEvalTrace(openResult, run) : undefined),
-    [run, openResult],
-  );
+  useSeedTraceIO(projectId, fallbackTraces);
 
   const updateCase = useUpdateTestCase(projectId, run?.datasetId ?? "");
   const humanScore = useCreateHumanScore(projectId, openResult?.id ?? "");
 
-  const closeResult = () => {
-    setOpenResultId(null);
-    setViewRealTraceId(null);
+  const panelTraceId = hasRealTrace ? realTraceId : fallbackTrace?.trace_id;
+  const panelOverride = hasRealTrace ? undefined : fallbackTrace;
+
+  const closeResult = () => setOpenResultId(null);
+
+  // The trace panel's up/down chevrons step between this run's results (in the same
+  // order + filter as the table), so you can walk case-by-case without closing it.
+  const visibleResults = React.useMemo(
+    () => results.filter(RESULT_FILTER_FN[resultFilter]),
+    [results, resultFilter],
+  );
+  const openIndex = openResult ? visibleResults.findIndex((r) => r.id === openResult.id) : -1;
+  const navigateResult = (dir: "up" | "down") => {
+    if (openIndex === -1) return;
+    const next = dir === "up" ? openIndex - 1 : openIndex + 1;
+    if (next >= 0 && next < visibleResults.length) setOpenResultId(visibleResults[next].id);
   };
 
   return (
@@ -269,26 +292,35 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
         )}
       </div>
 
-      {/* The real trace viewer on the eval-shaped trace — not a simplified tree. */}
-      {openResult && openTrace && run && (
+      {/* Telemetry for this result is still ingesting — pending state with retry. */}
+      {openResult && run && tracePending && (
+        <PendingTracePanel
+          traceId={realTraceId as string}
+          isFetching={realTrace.isFetching}
+          onRetry={() => realTrace.refetch()}
+          onClose={closeResult}
+        />
+      )}
+
+      {/* The result opens directly in the REAL trace viewer (span tree + span detail)
+          when its trace is available; otherwise a clearly-labeled reconstructed trace.
+          The evaluation context, scores, and human review are the span-actions panel. */}
+      {openResult && run && !tracePending && panelTraceId && (
         <TraceViewerPanel
-          key={openTrace.trace_id}
+          key={panelTraceId}
           projectId={projectId}
-          traceId={openTrace.trace_id}
-          traceOverride={openTrace}
+          traceId={panelTraceId}
+          traceOverride={panelOverride}
           newTabPath={`/projects/${projectId}/evaluations/${runId}`}
           onClose={closeResult}
-          onNavigate={() => {}}
-          canNavigateUp={false}
-          canNavigateDown={false}
+          onNavigate={navigateResult}
+          canNavigateUp={openIndex > 0}
+          canNavigateDown={openIndex >= 0 && openIndex < visibleResults.length - 1}
           spanActions={() => (
             <ResultContext
               projectId={projectId}
               run={run}
               result={openResult}
-              onOpenFullTrace={
-                openResult.traceId ? () => setViewRealTraceId(openResult.traceId) : undefined
-              }
               onReview={() => setReviewOpen(true)}
               onSaveExpected={(value) =>
                 updateCase.mutate(
@@ -309,6 +341,11 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
           )}
           spanExtraTags={() => (
             <>
+              {!hasRealTrace && (
+                <span className="inline-flex items-center gap-1.5 rounded-md border border-amber-400/60 bg-amber-100/60 px-2.5 py-1 text-xs text-amber-800 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-300">
+                  Reconstructed — no telemetry was emitted for this result
+                </span>
+              )}
               <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
                 <span className="text-muted-foreground">Evaluation:</span>
                 <span className="font-medium">{run.evaluationName}</span>
@@ -328,21 +365,6 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
               </span>
             </>
           )}
-        />
-      )}
-
-      {/* "Open full trace" opens the result's REAL ingested trace as a side panel
-          over the eval trace; closing it returns to the eval trace panel. */}
-      {viewRealTraceId && (
-        <TraceViewerPanel
-          key={`real:${viewRealTraceId}`}
-          projectId={projectId}
-          traceId={viewRealTraceId}
-          newTabPath={`/projects/${projectId}/evaluations/${runId}`}
-          onClose={() => setViewRealTraceId(null)}
-          onNavigate={() => {}}
-          canNavigateUp={false}
-          canNavigateDown={false}
         />
       )}
 
@@ -376,6 +398,54 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
         }
       />
     </>
+  );
+}
+
+/** Slide-in panel shown while a result's real trace is still ingesting. */
+function PendingTracePanel({
+  traceId,
+  isFetching,
+  onRetry,
+  onClose,
+}: {
+  traceId: string;
+  isFetching: boolean;
+  onRetry: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[45%] min-w-[520px] max-w-[94vw] flex-col border-l border-border bg-background shadow-xl">
+      <div className="flex shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4 py-3">
+        <span className="text-sm font-medium">Evaluation trace</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center text-[12px]">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-hidden />
+        <p className="text-[13px] font-medium">Trace is still being ingested</p>
+        <p className="max-w-[360px] leading-relaxed text-muted-foreground">
+          This result reported a trace (<span className="font-mono">{traceId.slice(0, 12)}…</span>),
+          but its telemetry hasn&apos;t finished ingesting yet. It will appear here once it lands.
+        </p>
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-7 gap-1.5 text-[12px]"
+          disabled={isFetching}
+          onClick={onRetry}
+        >
+          <Loader2 className={cn("h-3.5 w-3.5", isFetching && "animate-spin")} aria-hidden />
+          Retry
+        </Button>
+      </div>
+    </div>
   );
 }
 
@@ -1026,24 +1096,18 @@ function ResultContext({
   projectId,
   run,
   result,
-  onOpenFullTrace,
   onReview,
   onSaveExpected,
 }: {
   projectId: string;
   run: RunDetail;
   result: ResultRow;
-  onOpenFullTrace?: () => void;
   onReview: () => void;
   onSaveExpected: (value: string) => void;
 }) {
   const expectedValue = result.expectedOutput ?? "";
-  const [editing, setEditing] = React.useState(false);
   const [expected, setExpected] = React.useState(expectedValue);
-  React.useEffect(() => {
-    setExpected(expectedValue);
-    setEditing(false);
-  }, [expectedValue, result.id]);
+  React.useEffect(() => setExpected(expectedValue), [expectedValue, result.id]);
   const expectedDirty = expected.trim() !== expectedValue.trim();
 
   return (
@@ -1053,28 +1117,25 @@ function ResultContext({
         <span className="font-mono text-[11px] text-muted-foreground">{result.testCaseId}</span>
       </div>
 
-      {/* Expected outcome — a two-line editable field revealed by a button; saving
-          publishes a new dataset version (the input/output are in the span detail). */}
-      {editing ? (
-        <div>
-          <EditableValueBlock
-            label="Expected outcome"
-            text={expected}
-            onChange={setExpected}
-            boxed
-            autoDetectKind
-            copyable
-            minRows={2}
-          />
+      {/* Expected outcome — the same editable, format-aware value block used on the
+          dataset case panel; Save (shown when edited) publishes a new dataset version. */}
+      <div>
+        <EditableValueBlock
+          key={result.id}
+          label="Expected outcome"
+          text={expected}
+          onChange={setExpected}
+          boxed
+          autoDetectKind
+          copyable
+          minRows={2}
+        />
+        {expectedDirty && (
           <div className="mt-1.5 flex items-center gap-2">
             <Button
               size="sm"
               className="h-7 text-[12px]"
-              disabled={!expectedDirty}
-              onClick={() => {
-                onSaveExpected(expected.trim());
-                setEditing(false);
-              }}
+              onClick={() => onSaveExpected(expected.trim())}
             >
               Save
             </Button>
@@ -1082,42 +1143,18 @@ function ResultContext({
               variant="ghost"
               size="sm"
               className="h-7 text-[12px]"
-              onClick={() => {
-                setExpected(expectedValue);
-                setEditing(false);
-              }}
+              onClick={() => setExpected(expectedValue)}
             >
               Cancel
             </Button>
           </div>
-          <p className="mt-1 text-[11px] text-muted-foreground">
-            Saving edits test case <span className="font-mono">{result.testCaseId}</span> in{" "}
-            <span className="font-medium">{run.datasetName}</span> — it changes what future runs are
-            compared against.
-          </p>
-        </div>
-      ) : (
-        <div>
-          <div className="mb-1 flex items-center justify-between gap-2">
-            <p className="text-[11px] text-muted-foreground">Expected outcome</p>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-6 px-2 text-[11px]"
-              onClick={() => setEditing(true)}
-            >
-              Edit
-            </Button>
-          </div>
-          <div className="rounded border border-border bg-muted/20 px-2.5 py-2 leading-relaxed">
-            {expectedValue || (
-              <span className="text-muted-foreground">
-                No expected outcome — a scorer judges the output directly.
-              </span>
-            )}
-          </div>
-        </div>
-      )}
+        )}
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          Saving edits test case <span className="font-mono">{result.testCaseId}</span> in{" "}
+          <span className="font-medium">{run.datasetName}</span> — it changes what future runs are
+          compared against.
+        </p>
+      </div>
 
       {result.baselineOutput !== null && (
         <p className="mt-2 text-[11px] text-muted-foreground">
@@ -1186,17 +1223,6 @@ function ResultContext({
         <Button size="sm" className="h-7 text-[12px]" onClick={onReview}>
           Review output
         </Button>
-        {onOpenFullTrace && (
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 gap-1.5 text-[12px]"
-            onClick={onOpenFullTrace}
-          >
-            <ExternalLink className="h-3.5 w-3.5" aria-hidden />
-            Open full trace
-          </Button>
-        )}
         <Link
           href={`/projects/${projectId}/datasets/${run.datasetId}?case=${result.testCaseId}`}
           className="inline-flex h-7 items-center gap-1.5 rounded-md border border-input bg-background px-2.5 text-[12px] font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -59,6 +59,8 @@ import {
   useUpdateTestCase,
 } from "../hooks";
 import { RunStatusBadge } from "./evaluations-view";
+import { PullCodeDrawer } from "../components/pull-code-drawer";
+import { reproduceRunCode, reproduceRunCodeTs } from "@/features/offline-eval/utils";
 import { attributeTraceUsage, type TraceUsage, type UsageSpan } from "@/lib/eval/trace-usage";
 import type { ResultRow, RunDetail, ScoreRow, Classification } from "../types";
 
@@ -456,8 +458,6 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
               projectId={projectId}
               run={run}
               result={openResult}
-              traceUsage={traceUsage}
-              baselineUsage={baselineUsage}
               onReview={() => setReviewOpen(true)}
               onSaveExpected={(value) =>
                 updateCase.mutate(
@@ -500,6 +500,14 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
                 <span className="text-muted-foreground">Test case:</span>
                 <span className="font-mono">{openResult.testCaseId}</span>
               </span>
+              {/* The case's trace metrics as chips — duration, tokens, cost — each with a
+                  ± delta vs the baseline case (lower is better). */}
+              <CaseMetricChips
+                candidate={traceUsage}
+                baseline={baselineUsage}
+                durationMs={openResult.durationMs}
+                baselineDurationMs={openResult.comparison?.baselineDurationMs ?? null}
+              />
             </>
           )}
         />
@@ -605,6 +613,7 @@ function RunBody({
 }) {
   const router = useRouter();
   const [detailsOpen, setDetailsOpen] = React.useState(false);
+  const [reproduceOpen, setReproduceOpen] = React.useState(false);
   const hasBaseline = run.baselineRunId !== null;
   const incompatibleBaseline = run.comparison.available && !run.comparison.trustworthy;
   const trustNote = comparisonReasonText(run.comparison.reasons, run.datasetVersionLabel);
@@ -634,15 +643,26 @@ function RunBody({
           </span>
         }
         action={
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 gap-1.5 text-[12px]"
-            onClick={() => setDetailsOpen(true)}
-          >
-            <Info className="h-3.5 w-3.5" aria-hidden />
-            Run details
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1.5 text-[12px]"
+              onClick={() => setReproduceOpen(true)}
+            >
+              <Database className="h-3.5 w-3.5" aria-hidden />
+              Reproduce locally
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1.5 text-[12px]"
+              onClick={() => setDetailsOpen(true)}
+            >
+              <Info className="h-3.5 w-3.5" aria-hidden />
+              Run details
+            </Button>
+          </div>
         }
       />
 
@@ -685,6 +705,39 @@ function RunBody({
         results={results}
         open={detailsOpen}
         onOpenChange={setDetailsOpen}
+      />
+
+      {/* Reproduce this run locally = pull the EXACT dataset version it scored (not
+          the run/evaluation id, which pulls nothing). Shared pull-code drawer. */}
+      <PullCodeDrawer
+        title="Reproduce this run locally"
+        subtitle={
+          <>
+            Pulls the exact cases{" "}
+            <span className="font-medium text-foreground">
+              {run.evaluationName} #{run.runNumber}
+            </span>{" "}
+            scored, so a new candidate is measured on the same data and is comparable to this run.
+          </>
+        }
+        options={[
+          {
+            id: "reproduce",
+            label: "Reproduce this run",
+            note: (
+              <>
+                Pins dataset version <span className="font-mono">{run.datasetVersionId}</span>. The
+                run id (<span className="font-mono">{run.id}</span>) is only used as the{" "}
+                <span className="font-mono">baseline</span> to compare against — it isn&apos;t
+                pullable.
+              </>
+            ),
+            py: reproduceRunCode(run.datasetVersionId, run.evaluationName, run.id),
+            ts: reproduceRunCodeTs(run.datasetVersionId, run.evaluationName, run.id),
+          },
+        ]}
+        open={reproduceOpen}
+        onOpenChange={setReproduceOpen}
       />
     </>
   );
@@ -1445,117 +1498,80 @@ function MetricRow({
   );
 }
 
-/** Signed, coloured delta beside a metric (lower is better → green when negative). */
-function InlineDelta({
+/** One metric as a span-tag-style chip: "Label: value ±delta" (lower is better). */
+function MetricChip({
+  label,
   candidate,
   baseline,
   format,
 }: {
-  candidate: number;
+  label: string;
+  candidate: number | null;
   baseline: number | null;
   format: (n: number) => string;
 }) {
-  if (baseline === null) return null;
-  const delta = candidate - baseline;
-  if (delta === 0) return <span className="text-muted-foreground"> ±0</span>;
+  if (candidate === null) return null;
+  const delta = baseline !== null ? candidate - baseline : null;
   return (
-    <span className={SENTIMENT_CLASS[changeSentiment(-delta)]}>
-      {" "}
-      {delta > 0 ? "+" : "−"}
-      {format(Math.abs(delta))}
+    <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
+      <span className="text-muted-foreground">{label}:</span>
+      <span className="font-medium tabular-nums">{format(candidate)}</span>
+      {delta !== null &&
+        (delta === 0 ? (
+          <span className="text-muted-foreground">±0</span>
+        ) : (
+          <span className={SENTIMENT_CLASS[changeSentiment(-delta)]}>
+            {delta > 0 ? "+" : "−"}
+            {format(Math.abs(delta))}
+          </span>
+        ))}
     </span>
   );
 }
 
 /**
- * Trace-derived token/cost for the open case, split by application (task) vs
- * evaluation-judge (scorers). `pending` while the trace ingests, `unknown` when the
- * trace carries no provider usage — a real 0 only when the trace proves it. When a
- * baseline usage is supplied, each value carries an inline ± delta against it.
+ * The open case's trace metrics as span-tag chips, shown on the trace panel's tag
+ * row beside the eval-context chips — duration, tokens, cost, each with a ± delta
+ * vs the baseline case (lower is better → green when smaller). Tokens/cost only
+ * appear once the case trace reports provider usage.
  */
-function UsageBreakdown({ usage, baseline }: { usage: TraceUsage; baseline?: TraceUsage }) {
-  if (usage.state === "pending") {
-    return (
-      <p className="mt-2 text-[11px] text-muted-foreground">
-        Tokens &amp; cost: <span className="text-foreground">pending</span> — the case trace is
-        still ingesting.
-      </p>
-    );
-  }
-  if (usage.state === "unknown") {
-    return (
-      <p className="mt-2 text-[11px] text-muted-foreground">
-        Tokens &amp; cost: <span className="text-foreground">unknown</span> — the trace reported no
-        provider usage.
-      </p>
-    );
-  }
-  const fmtCost = (c: number) => (c > 0 ? `$${c.toFixed(4)}` : "$0");
-  const fmtTok = (n: number) => Math.round(n).toLocaleString();
-  // Only diff against a baseline bucket that actually has usage (spanCount > 0), so
-  // we never show a delta "vs 0" for a bucket the baseline case didn't have.
-  const bl = baseline && baseline.state === "present" ? baseline : null;
-  const bt = (b: { spanCount: number; totalTokens: number }) =>
-    bl && b.spanCount > 0 ? b.totalTokens : null;
-  const bc = (b: { spanCount: number; cost: number }) => (bl && b.spanCount > 0 ? b.cost : null);
-  const rows = [
-    { label: "Application (task)", b: usage.task, base: bl?.task },
-    { label: "Evaluation judge (scorers)", b: usage.scorer, base: bl?.scorer },
-    { label: "Other", b: usage.other, base: bl?.other },
-  ].filter((r) => r.b.spanCount > 0);
+function CaseMetricChips({
+  candidate,
+  baseline,
+  durationMs,
+  baselineDurationMs,
+}: {
+  candidate: TraceUsage;
+  baseline: TraceUsage;
+  durationMs: number | null;
+  baselineDurationMs: number | null;
+}) {
+  const fmtMs = (n: number) => (n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`);
+  const fmtTok = (n: number) => `${Math.round(n).toLocaleString()} tok`;
+  const fmtCost = (n: number) => (n > 0 ? `$${n.toFixed(4)}` : "$0");
+  const tok = (u: TraceUsage) => (u.state === "present" ? u.combined.totalTokens : null);
+  const cost = (u: TraceUsage) => (u.state === "present" ? u.combined.cost : null);
   return (
-    <div className="mt-2 overflow-hidden rounded border border-border">
-      <div className="border-b border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground">
-        Tokens &amp; cost (from the trace){bl ? " · vs baseline" : ""}
-      </div>
-      <ul className="divide-y divide-border">
-        {rows.map((r) => (
-          <li
-            key={r.label}
-            className="flex items-center justify-between gap-2 px-2.5 py-1 text-[11px]"
-          >
-            <span className="text-muted-foreground">{r.label}</span>
-            <span className="tabular-nums">
-              {fmtTok(r.b.totalTokens)} tok
-              {r.base && (
-                <InlineDelta candidate={r.b.totalTokens} baseline={bt(r.base)} format={fmtTok} />
-              )}
-              {" · "}
-              {fmtCost(r.b.cost)}
-              {r.base && (
-                <InlineDelta candidate={r.b.cost} baseline={bc(r.base)} format={fmtCost} />
-              )}
-            </span>
-          </li>
-        ))}
-        {/* Only worth a Combined total when the cost is split across buckets (e.g. an
-            LLM judge). With a single bucket it just repeats the row above. */}
-        {rows.length > 1 && (
-          <li className="flex items-center justify-between gap-2 bg-muted/20 px-2.5 py-1 text-[11px] font-medium">
-            <span>Combined</span>
-            <span className="tabular-nums">
-              {fmtTok(usage.combined.totalTokens)} tok
-              {bl && (
-                <InlineDelta
-                  candidate={usage.combined.totalTokens}
-                  baseline={bt(bl.combined)}
-                  format={fmtTok}
-                />
-              )}
-              {" · "}
-              {fmtCost(usage.combined.cost)}
-              {bl && (
-                <InlineDelta
-                  candidate={usage.combined.cost}
-                  baseline={bc(bl.combined)}
-                  format={fmtCost}
-                />
-              )}
-            </span>
-          </li>
-        )}
-      </ul>
-    </div>
+    <>
+      <MetricChip
+        label="Duration"
+        candidate={durationMs}
+        baseline={baselineDurationMs}
+        format={fmtMs}
+      />
+      <MetricChip
+        label="Tokens"
+        candidate={tok(candidate)}
+        baseline={tok(baseline)}
+        format={fmtTok}
+      />
+      <MetricChip
+        label="Cost"
+        candidate={cost(candidate)}
+        baseline={cost(baseline)}
+        format={fmtCost}
+      />
+    </>
   );
 }
 
@@ -1792,16 +1808,12 @@ function ResultContext({
   projectId,
   run,
   result,
-  traceUsage,
-  baselineUsage,
   onReview,
   onSaveExpected,
 }: {
   projectId: string;
   run: RunDetail;
   result: ResultRow;
-  traceUsage: TraceUsage;
-  baselineUsage: TraceUsage;
   onReview: () => void;
   onSaveExpected: (value: string) => void;
 }) {
@@ -1930,10 +1942,8 @@ function ResultContext({
 
       <ScorerBreakdown result={result} />
 
-      <UsageBreakdown
-        usage={traceUsage}
-        baseline={result.comparison?.baselineTraceId ? baselineUsage : undefined}
-      />
+      {/* Token/cost/duration now live as chips on the trace tag row (spanExtraTags),
+          not a table here. */}
 
       {result.humanScores.length > 0 && (
         <div className="mt-2 overflow-hidden rounded border border-border">

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -31,6 +31,7 @@ import {
   EvalPageHeader,
   EvalResultBadge,
   ReviewPanel,
+  seedFormat,
   Timestamp,
   useSeedTraceIO,
   type ReviewTarget,
@@ -42,9 +43,10 @@ import type { SpanKind, SpanStatus } from "@traceroot/core";
 import { cn } from "@/lib/utils";
 import {
   changeSentiment,
-  pct,
+  pctFraction,
   SENTIMENT_CLASS,
   signed,
+  signedPoints,
   truncate,
 } from "@/features/offline-eval/utils";
 import {
@@ -62,6 +64,21 @@ function fmtDurationMs(ms: number | null | undefined): string {
   if (ms === null || ms === undefined) return "Unknown";
   if (ms < 1000) return `${Math.round(ms)}ms`;
   return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * Whether two authored values are the SAME value. A pure reformat (re-indenting
+ * JSON, whether from the seed format or the format switcher) is not an edit —
+ * without this, opening a case would offer to publish a new dataset version that
+ * changes nothing but whitespace.
+ */
+export function sameAuthoredValue(a: string, b: string): boolean {
+  if (a.trim() === b.trim()) return true;
+  try {
+    return JSON.stringify(JSON.parse(a)) === JSON.stringify(JSON.parse(b));
+  } catch {
+    return false; // one side isn't JSON — trust the text comparison above
+  }
 }
 
 function scoreValue(s: ScoreRow): string {
@@ -261,6 +278,25 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   const results = React.useMemo(() => data?.results ?? [], [data]);
   const run = data?.run;
 
+  // This evaluation's other runs, for the breadcrumb's run switcher. Shares the
+  // RunSwitcher's query key, so it's the same fetch, not a second one.
+  const siblingRuns = useEvaluationRuns(projectId, {
+    evaluation_id: run?.evaluationId,
+    limit: 100,
+  });
+  const runOptions = React.useMemo(
+    () =>
+      run
+        ? (siblingRuns.data?.data ?? []).map((r) => ({
+            id: r.id,
+            label: `#${r.runNumber} · ${r.candidateVersion}`,
+            href: `/projects/${projectId}/evaluations/${r.id}`,
+            isCurrent: r.id === run.id,
+          }))
+        : [],
+    [siblingRuns.data, run, projectId],
+  );
+
   const openResult = openResultId ? (results.find((r) => r.id === openResultId) ?? null) : null;
 
   // Prefer the result's REAL ingested trace. Probe it — this shares TraceViewerPanel's
@@ -324,7 +360,24 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
 
   return (
     <>
-      <ProjectBreadcrumb projectId={projectId} current="Evaluations" />
+      <ProjectBreadcrumb
+        projectId={projectId}
+        trail={
+          run
+            ? [
+                { label: "Evaluations", href: `/projects/${projectId}/evaluations` },
+                {
+                  // The run segment is a dropdown of this evaluation's runs, like the
+                  // dataset switcher — jump to another run without leaving the page.
+                  label: `${run.evaluationName} #${run.runNumber}`,
+                  menuHeader: { label: "Evaluations", href: `/projects/${projectId}/evaluations` },
+                  options: runOptions,
+                },
+              ]
+            : [{ label: "Evaluations", href: `/projects/${projectId}/evaluations` }]
+        }
+        current={run ? undefined : "Run"}
+      />
       <div className="flex flex-1 flex-col overflow-hidden text-[12px]">
         {isLoading ? (
           <div className="flex h-64 items-center justify-center">
@@ -658,7 +711,7 @@ function RunSwitcher({
               </span>
             </span>
             <span className="tabular-nums text-muted-foreground">
-              {sibling.mainScore === null ? "—" : pct(sibling.mainScore)}
+              {sibling.mainScore === null ? "—" : pctFraction(sibling.mainScore)}
             </span>
           </button>
         ))}
@@ -693,7 +746,7 @@ function VerdictStrip({
         <RunStatusBadge status={run.status} />
         <Metric
           label={run.mainScoreName ?? "Main score"}
-          value={run.mainScore === null ? "—" : pct(run.mainScore)}
+          value={run.mainScore === null ? "—" : pctFraction(run.mainScore)}
           hint={cmp.baseline ? `vs ${cmp.baseline.candidateVersion}` : undefined}
           strong
         />
@@ -704,7 +757,7 @@ function VerdictStrip({
               <span className="text-muted-foreground">—</span>
             ) : (
               <span className={SENTIMENT_CLASS[changeSentiment(cmp.mainScore.delta)]}>
-                {signed(cmp.mainScore.delta)} pp
+                {signedPoints(cmp.mainScore.delta)} pp
               </span>
             )
           }
@@ -984,11 +1037,11 @@ function MainScoreCell({ result, hasBaseline }: { result: ResultRow; hasBaseline
   return (
     <div className="flex flex-col gap-0.5 text-[12px] tabular-nums">
       <span>
-        {pct(cand)}
-        {base !== null && <span className="text-muted-foreground"> vs {pct(base)}</span>}
+        {pctFraction(cand)}
+        {base !== null && <span className="text-muted-foreground"> vs {pctFraction(base)}</span>}
       </span>
       {delta !== null && (
-        <span className={SENTIMENT_CLASS[changeSentiment(delta)]}>{signed(delta)} pp</span>
+        <span className={SENTIMENT_CLASS[changeSentiment(delta)]}>{signedPoints(delta)} pp</span>
       )}
     </div>
   );
@@ -1476,10 +1529,19 @@ function ResultContext({
   onReview: () => void;
   onSaveExpected: (value: string) => void;
 }) {
+  // Seed the canonical (expanded) form here rather than letting the field
+  // normalise it: this component re-seeds `expected` from the prop whenever the
+  // open result changes, which would otherwise clobber the field's own fix-up.
   const expectedValue = result.expectedOutput ?? "";
-  const [expected, setExpected] = React.useState(expectedValue);
-  React.useEffect(() => setExpected(expectedValue), [expectedValue, result.id]);
-  const expectedDirty = expected.trim() !== expectedValue.trim();
+  const seededExpected = React.useMemo(
+    () => seedFormat(expectedValue, "expanded").text,
+    [expectedValue],
+  );
+  const [expected, setExpected] = React.useState(seededExpected);
+  React.useEffect(() => setExpected(seededExpected), [seededExpected, result.id]);
+  // Saving publishes a NEW dataset version, so only a real change counts as dirty:
+  // re-indenting a value (by the seed format, or the format switcher) is not an edit.
+  const expectedDirty = !sameAuthoredValue(expected, expectedValue);
 
   return (
     <div className="w-full text-[12px]">
@@ -1497,7 +1559,9 @@ function ResultContext({
           text={expected}
           onChange={setExpected}
           boxed
-          autoDetectKind
+          // The value candidate output is graded against, read closely and edited
+          // here → expand it, like Input/Recorded output in Save as test case.
+          seedJson="expanded"
           copyable
           minRows={2}
         />

--- a/frontend/ui/src/features/offline-eval/components/review-panel.review.test.tsx
+++ b/frontend/ui/src/features/offline-eval/components/review-panel.review.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { ReviewPanel, type ReviewTarget } from "./review-panel";
+import { ToastProvider } from "@/components/ui/toast";
+
+afterEach(() => cleanup());
+
+function baseTarget(overrides: Partial<ReviewTarget> = {}): ReviewTarget {
+  return {
+    targetKey: "result-1",
+    contextLabel: "case-1 · eval v1",
+    input: "input",
+    output: "output",
+    expected: null,
+    autoScores: [],
+    existing: undefined,
+    ...overrides,
+  };
+}
+
+describe("ReviewPanel", () => {
+  it("does not reset the form when the parent re-renders with a new target object of the same identity", () => {
+    const onSave = vi.fn();
+    const { rerender } = render(
+      <ToastProvider>
+        <ReviewPanel target={baseTarget()} open onOpenChange={vi.fn()} onSave={onSave} />
+      </ToastProvider>,
+    );
+
+    const comment = screen.getByLabelText(/comment/i) as HTMLInputElement;
+    fireEvent.change(comment, { target: { value: "in progress notes" } });
+    expect(comment.value).toBe("in progress notes");
+
+    // Same targetKey, but a brand-new object literal — simulates the parent
+    // re-rendering (e.g. a background refetch) and rebuilding `target` inline.
+    rerender(
+      <ToastProvider>
+        <ReviewPanel target={baseTarget()} open onOpenChange={vi.fn()} onSave={onSave} />
+      </ToastProvider>,
+    );
+
+    const commentAfter = screen.getByLabelText(/comment/i) as HTMLInputElement;
+    expect(commentAfter.value).toBe("in progress notes");
+  });
+
+  it("resets the form when the target actually changes (different targetKey)", () => {
+    const onSave = vi.fn();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <ToastProvider>
+        <ReviewPanel
+          target={baseTarget({ targetKey: "result-1" })}
+          open
+          onOpenChange={onOpenChange}
+          onSave={onSave}
+        />
+      </ToastProvider>,
+    );
+
+    const comment = screen.getByLabelText(/comment/i) as HTMLInputElement;
+    fireEvent.change(comment, { target: { value: "notes for result 1" } });
+
+    rerender(
+      <ToastProvider>
+        <ReviewPanel
+          target={baseTarget({ targetKey: "result-2" })}
+          open
+          onOpenChange={onOpenChange}
+          onSave={onSave}
+        />
+      </ToastProvider>,
+    );
+
+    const commentAfter = screen.getByLabelText(/comment/i) as HTMLInputElement;
+    expect(commentAfter.value).toBe("");
+  });
+
+  it("keeps the drawer open and does not toast success when onSave rejects", async () => {
+    const onOpenChange = vi.fn();
+    const onSave = vi.fn().mockRejectedValue(new Error("network error"));
+    render(
+      <ToastProvider>
+        <ReviewPanel target={baseTarget()} open onOpenChange={onOpenChange} onSave={onSave} />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save review" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText(/could not save/i)).toBeDefined());
+    expect(screen.queryByText("Review saved")).toBeNull();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("toasts success and closes the drawer when onSave resolves", async () => {
+    const onOpenChange = vi.fn();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ToastProvider>
+        <ReviewPanel target={baseTarget()} open onOpenChange={onOpenChange} onSave={onSave} />
+      </ToastProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save review" }));
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(screen.getByText("Review saved")).toBeDefined();
+  });
+});

--- a/frontend/ui/src/features/offline-eval/components/review-panel.review.test.tsx
+++ b/frontend/ui/src/features/offline-eval/components/review-panel.review.test.tsx
@@ -76,6 +76,32 @@ describe("ReviewPanel", () => {
     expect(commentAfter.value).toBe("");
   });
 
+  it("pre-fills the form from an existing saved review (the reload path)", () => {
+    render(
+      <ToastProvider>
+        <ReviewPanel
+          target={baseTarget({
+            existing: {
+              verdict: "fail",
+              quality: 2,
+              comment: "missing the conclusion",
+              reviewer: "hao@example.com",
+              at: "2026-08-01T00:00:00Z",
+            },
+          })}
+          open
+          onOpenChange={vi.fn()}
+          onSave={vi.fn()}
+        />
+      </ToastProvider>,
+    );
+    // Re-opening a reviewed result seeds the saved comment instead of a blank form —
+    // the downstream of the run-detail-view reload fix (existing was hard-coded undefined).
+    expect((screen.getByLabelText(/comment/i) as HTMLInputElement).value).toBe(
+      "missing the conclusion",
+    );
+  });
+
   it("keeps the drawer open and does not toast success when onSave rejects", async () => {
     const onOpenChange = vi.fn();
     const onSave = vi.fn().mockRejectedValue(new Error("network error"));

--- a/frontend/ui/src/features/offline-eval/components/review-panel.test.tsx
+++ b/frontend/ui/src/features/offline-eval/components/review-panel.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+/**
+ * Coverage for the human review drawer — the one thing a person authors in the
+ * offline-eval UI. Exercises seeding from an existing review, the verdict /
+ * quality / comment controls, the optional evidence toggle and saving.
+ */
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import * as React from "react";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ToastProvider } from "@/components/ui/toast";
+import { ReviewPanel, type ReviewTarget } from "./review-panel";
+
+beforeAll(() => {
+  if (!globalThis.ResizeObserver) {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+    Element.prototype.setPointerCapture = () => {};
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => cleanup());
+
+const TARGET: ReviewTarget = {
+  targetKey: "run-27:case-1",
+  contextLabel: "Run 27 · case-1",
+  input: "I was charged twice for my July invoice",
+  output: "billing",
+  expected: "billing",
+  autoScores: [
+    { name: "routing-accuracy", display: "Pass", explanation: "Reached billing" },
+    { name: "tone", display: "0.8" },
+  ],
+};
+
+type PanelProps = Omit<
+  Partial<React.ComponentProps<typeof ReviewPanel>>,
+  "onSave" | "onOpenChange"
+>;
+
+function renderPanel(props: PanelProps = {}) {
+  const onSave = vi.fn();
+  const onOpenChange = vi.fn();
+  const result = render(
+    <ToastProvider>
+      <ReviewPanel target={TARGET} open onOpenChange={onOpenChange} onSave={onSave} {...props} />
+    </ToastProvider>,
+  );
+  return { ...result, onSave, onOpenChange };
+}
+
+describe("ReviewPanel", () => {
+  it("renders nothing without a target", () => {
+    const { container } = render(
+      <ToastProvider>
+        <ReviewPanel target={null} open onOpenChange={vi.fn()} onSave={vi.fn()} />
+      </ToastProvider>,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders the target context, values and automatic scores", () => {
+    renderPanel();
+    expect(screen.getByText("Review")).toBeTruthy();
+    expect(screen.getByText("Run 27 · case-1")).toBeTruthy();
+    expect(screen.getByText("I was charged twice for my July invoice")).toBeTruthy();
+    expect(screen.getByText("routing-accuracy:")).toBeTruthy();
+    expect(screen.getByText("Reached billing")).toBeTruthy();
+    // A score with no explanation renders just its display value.
+    expect(screen.getByText("0.8")).toBeTruthy();
+  });
+
+  it("explains an absent expected output instead of leaving it blank", () => {
+    renderPanel({ target: { ...TARGET, expected: null } });
+    expect(screen.getByText(/Not required — a scorer judges the output directly/)).toBeTruthy();
+  });
+
+  it("omits the automatic-scores block when there are none", () => {
+    renderPanel({ target: { ...TARGET, autoScores: [] } });
+    expect(screen.queryByText("Automatic scores")).toBeNull();
+  });
+
+  it("defaults to Pass with no quality and an empty comment", () => {
+    renderPanel();
+    expect(screen.getByRole("radio", { name: "Pass" }).getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByRole("radio", { name: "3" }).getAttribute("aria-checked")).toBe("false");
+    expect((screen.getByLabelText(/Comment/) as HTMLInputElement).value).toBe("");
+  });
+
+  it("seeds from an existing review", () => {
+    renderPanel({
+      target: {
+        ...TARGET,
+        existing: {
+          verdict: "fail",
+          quality: 2,
+          comment: "wrong queue",
+          reviewer: "Ada",
+          at: "2026-07-17T10:30:00Z",
+        },
+      },
+    });
+    expect(screen.getByRole("radio", { name: "Fail" }).getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByRole("radio", { name: "2" }).getAttribute("aria-checked")).toBe("true");
+    expect((screen.getByLabelText(/Comment/) as HTMLInputElement).value).toBe("wrong queue");
+  });
+
+  it("changes the verdict", () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole("radio", { name: "Unsure" }));
+    expect(screen.getByRole("radio", { name: "Unsure" }).getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("toggles a quality score off when it is picked twice", () => {
+    renderPanel();
+    const four = screen.getByRole("radio", { name: "4" });
+    fireEvent.click(four);
+    expect(four.getAttribute("aria-checked")).toBe("true");
+    fireEvent.click(four);
+    expect(four.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("shows and hides the optional trace evidence", () => {
+    renderPanel({ target: { ...TARGET, evidence: <div>trace evidence</div> } });
+    expect(screen.queryByText("trace evidence")).toBeNull();
+    fireEvent.click(screen.getByText("Show the trace"));
+    expect(screen.getByText("trace evidence")).toBeTruthy();
+    fireEvent.click(screen.getByText("Hide the trace"));
+    expect(screen.queryByText("trace evidence")).toBeNull();
+  });
+
+  it("saves the review and closes", async () => {
+    const { onSave, onOpenChange } = renderPanel({ savedDescription: "Recorded on run 27." });
+    fireEvent.click(screen.getByRole("radio", { name: "Fail" }));
+    fireEvent.click(screen.getByRole("radio", { name: "5" }));
+    fireEvent.change(screen.getByLabelText(/Comment/), { target: { value: "  wrong  " } });
+    fireEvent.click(screen.getByText("Save review"));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const review = onSave.mock.calls[0][0];
+    expect(review.verdict).toBe("fail");
+    expect(review.quality).toBe(5);
+    expect(review.comment).toBe("wrong");
+    expect(review.reviewer).toBe("You");
+    expect(typeof review.at).toBe("string");
+    // The drawer only closes once the save has actually persisted — a failure
+    // keeps it open with the reviewer's input intact.
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(screen.getByText("Review saved")).toBeTruthy();
+  });
+
+  it("drops a whitespace-only comment", () => {
+    const { onSave } = renderPanel();
+    fireEvent.change(screen.getByLabelText(/Comment/), { target: { value: "   " } });
+    fireEvent.click(screen.getByText("Save review"));
+    expect(onSave.mock.calls[0][0].comment).toBeUndefined();
+  });
+
+  it("closes without saving from Cancel", () => {
+    const { onSave, onOpenChange } = renderPanel();
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("renders the default footer note and an override", () => {
+    const { unmount } = renderPanel();
+    expect(screen.getByText("Recorded on this run.")).toBeTruthy();
+    unmount();
+    renderPanel({ footerNote: "Saved in this page only." });
+    expect(screen.getByText("Saved in this page only.")).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/features/offline-eval/components/review-panel.tsx
+++ b/frontend/ui/src/features/offline-eval/components/review-panel.tsx
@@ -52,7 +52,7 @@ export function ReviewPanel({
   onSave: (review: HumanReview) => void;
   /** Toast description shown after saving; omit for none. */
   savedDescription?: string;
-  /** Small note in the footer (e.g. "Saved in this page only."). */
+  /** Small note in the footer (e.g. the prototype's "Saved in this page only."). */
   footerNote?: string;
 }) {
   const { toast } = useToast();

--- a/frontend/ui/src/features/offline-eval/components/review-panel.tsx
+++ b/frontend/ui/src/features/offline-eval/components/review-panel.tsx
@@ -26,6 +26,15 @@ import { HUMAN_VERDICT_LABEL, type HumanReview, type HumanVerdict } from "../typ
  */
 
 export interface ReviewTarget {
+  /**
+   * Stable identity for this target (e.g. the result/span id), independent of
+   * object identity. Callers build `target` as a fresh object literal on every
+   * render, so the form-seeding effect below keys on this instead of on `target`
+   * itself — otherwise any parent re-render (a background refetch, a mutation
+   * settling) would look like "the user opened a new target" and wipe an
+   * in-progress, unsaved review.
+   */
+  targetKey: string;
   /** Where the review was opened from. */
   contextLabel: string;
   input: string;
@@ -49,10 +58,16 @@ export function ReviewPanel({
   target: ReviewTarget | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSave: (review: HumanReview) => void;
+  /**
+   * May reject/throw to report a save failure. Awaited by `handleSave`, which
+   * only toasts success and closes the drawer once this resolves — a failure
+   * keeps the drawer open with the reviewer's input intact and toasts an error
+   * instead, since a false "saved" here is silent data loss.
+   */
+  onSave: (review: HumanReview) => void | Promise<unknown>;
   /** Toast description shown after saving; omit for none. */
   savedDescription?: string;
-  /** Small note in the footer (e.g. the prototype's "Saved in this page only."). */
+  /** Small note in the footer (e.g. "Saved in this page only."). */
   footerNote?: string;
 }) {
   const { toast } = useToast();
@@ -61,6 +76,7 @@ export function ReviewPanel({
   const [quality, setQuality] = React.useState<number | undefined>(undefined);
   const [comment, setComment] = React.useState("");
   const [showEvidence, setShowEvidence] = React.useState(false);
+  const [saving, setSaving] = React.useState(false);
 
   React.useEffect(() => {
     if (!open || !target) return;
@@ -69,24 +85,37 @@ export function ReviewPanel({
     setQuality(existing?.quality);
     setComment(existing?.comment ?? "");
     setShowEvidence(false);
-  }, [open, target]);
+    // Keyed on the stable targetKey, not on `target` itself — callers pass a fresh
+    // object literal every render, and depending on that identity would reset the
+    // form (discarding an unsaved review) on any unrelated parent re-render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, target?.targetKey]);
 
   if (!target) return null;
 
-  const handleSave = () => {
-    onSave({
-      verdict,
-      quality,
-      comment: comment.trim() || undefined,
-      reviewer: "You",
-      at: new Date().toISOString(),
-    });
-    toast({
-      title: "Review saved",
-      ...(savedDescription ? { description: savedDescription } : {}),
-      tone: "success",
-    });
-    onOpenChange(false);
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await onSave({
+        verdict,
+        quality,
+        comment: comment.trim() || undefined,
+        reviewer: "You",
+        at: new Date().toISOString(),
+      });
+      toast({
+        title: "Review saved",
+        ...(savedDescription ? { description: savedDescription } : {}),
+        tone: "success",
+      });
+      onOpenChange(false);
+    } catch (e) {
+      // Keep the drawer open with the reviewer's input intact — closing here
+      // (or toasting success) would discard a review that was never persisted.
+      toast({ title: "Could not save the review", description: String(e), tone: "warning" });
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -216,12 +245,13 @@ export function ReviewPanel({
               variant="outline"
               size="sm"
               className="h-7 text-[12px]"
+              disabled={saving}
               onClick={() => onOpenChange(false)}
             >
               Cancel
             </Button>
-            <Button size="sm" className="h-7 text-[12px]" onClick={handleSave}>
-              Save review
+            <Button size="sm" className="h-7 text-[12px]" disabled={saving} onClick={handleSave}>
+              {saving ? "Saving..." : "Save review"}
             </Button>
           </span>
         </DrawerFooter>


### PR DESCRIPTION
## Summary

Fixes: #1663

Adds the run-detail page: a results table with one row per test case, single-line and ellipsis-truncated like the traces list, that opens the real trace on click, plus per-case Duration and Cost columns. A status filter bar narrows the table to a status — did-not-pass, errors, not-scored — while surfacing the run's pass rate, so a user can jump straight to the failures. "Reproduce locally" pulls the exact pinned dataset version this run scored and names this run as the baseline, so a new candidate is comparable to it. All headline values come straight from the run-detail read model.

## How it works

The header carries the evaluation name, a run switcher to this evaluation's other runs, the candidate version, and the run id with a copy button. The filter bar holds the status filters, the "N/M passed · X%" pass-rate readout, and a "Worst regression" sort; switching a filter updates both the visible rows and which cases are counted. Each result row truncates Input / Output / Expected with title tooltips and opens the result's trace on click. "Reproduce locally" opens the shared pull-code drawer with a single snippet pinning the dataset at the exact version id the run scored and passing this run as the comparison baseline.

## What's included

### Routes
- `app/projects/[projectId]/evaluations/[runId]/page.tsx` — the run-detail route, keyed on `runId` so switching runs fully remounts the view with fresh data and reset panel/filter state.

### UI
- `features/evaluations/views/run-detail-view.tsx` — `RunDetailView` / `RunBody` / `ResultsSection`: the header (run switcher, candidate version, copyable run id), the status filter bar with the pass-rate readout and worst-regression sort, the single-line truncated results table with per-case Duration and Cost, opening a result's trace on row click, and the "Reproduce locally" drawer. Loading, not-found, and empty/fully-failing states still render the header and an explanatory table state.
- `features/offline-eval/components/review-panel.tsx` — provides `ReviewTarget`, `ReviewPanel`.

### Shared components

### Hooks / data

### Tests
- `components/search-filter-bar.test.tsx` — covers `search-filter-bar`.
- `features/offline-eval/components/review-panel.test.tsx` — covers `review-panel`.
- `features/evaluations/dataset-panels.smoke.test.tsx` — covers `dataset-panels.smoke`.
- `features/evaluations/run-evaluation-drawer.smoke.test.tsx` — covers `run-evaluation-drawer.smoke`.
- `features/offline-eval/components/review-panel.review.test.tsx` — covers `review-panel.review`.

## Test plan

- [ ] Result rows are single-line / truncated with tooltips and open the trace on click.
- [ ] Per-case Duration and Cost render; the filter bar shows the pass rate and narrows the table to the selected status.
- [ ] Switching the status filter updates both the visible rows and the pass-rate readout.
- [ ] "Reproduce locally" names the pinned dataset and version and pins the exact version id this run scored, with this run as the baseline.
- [ ] Headline metrics and per-case values come straight from the read model.
- [ ] An empty or fully-failing run still renders the header and an explanatory table state, not a blank page.
