### PR TITLE
feat(traces): open a result's eval-shaped trace with stepping

### DIFF
--- a/frontend/ui/src/features/evaluations/compare-derive.test.ts
+++ b/frontend/ui/src/features/evaluations/compare-derive.test.ts
@@ -8,6 +8,7 @@ import {
   type CaseFilterId,
 } from "./compare-derive";
 import type { CompareResultRow, RunComparison } from "./types";
+import { deriveComparisonState } from "@/lib/eval/comparison";
 
 function counts(p: Partial<RunComparison["caseCounts"]> = {}) {
   return {
@@ -21,7 +22,7 @@ function counts(p: Partial<RunComparison["caseCounts"]> = {}) {
   };
 }
 function comparison(p: Partial<RunComparison> = {}): RunComparison {
-  return {
+  const merged = {
     available: true,
     trustworthy: true,
     reasons: [],
@@ -32,6 +33,12 @@ function comparison(p: Partial<RunComparison> = {}): RunComparison {
     scorers: [],
     duration: { candidateMeanMs: null, baselineMeanMs: null, deltaMs: null, pairedCount: 0 },
     ...p,
+  } satisfies Omit<RunComparison, "state"> & Partial<Pick<RunComparison, "state">>;
+  // Keep `state` consistent with whatever available/trustworthy/reasons the test set,
+  // unless the test pinned it explicitly.
+  return {
+    ...merged,
+    state: p.state ?? deriveComparisonState(merged.available, merged.trustworthy, merged.reasons),
   };
 }
 

--- a/frontend/ui/src/features/evaluations/compare-runs.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/compare-runs.smoke.test.tsx
@@ -194,6 +194,7 @@ const labData = {
   comparison: {
     available: true,
     trustworthy: true,
+    state: "trustworthy",
     reasons: [],
     baseline: { runId: "opus", runNumber: 41, candidateVersion: "opus" },
     mainScore: { candidate: 6 / 7, baseline: 1, delta: 6 / 7 - 1 },

--- a/frontend/ui/src/features/evaluations/components/comparability-banner.test.tsx
+++ b/frontend/ui/src/features/evaluations/components/comparability-banner.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { ComparabilityBanner } from "./comparability-banner";
+
+afterEach(() => cleanup());
+
+describe("ComparabilityBanner", () => {
+  it("renders nothing for a trustworthy comparison (the view shows its own verdict)", () => {
+    const { container } = render(<ComparabilityBanner state="trustworthy" reasons={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("is a strong alert for an exploratory (cross-evaluation) comparison, with the concrete reason", () => {
+    render(<ComparabilityBanner state="exploratory" reasons={["different_evaluation"]} />);
+    // role=alert → assistive tech announces it; the deltas are explicitly NOT a verdict.
+    expect(screen.getByRole("alert")).toBeDefined();
+    expect(screen.getByText(/not directly comparable/i)).toBeDefined();
+    expect(screen.getByText(/ship \/ no-ship/i)).toBeDefined();
+    expect(screen.getByText(/different evaluations/i)).toBeDefined();
+  });
+
+  it("lists every concrete reason for an exploratory comparison", () => {
+    render(
+      <ComparabilityBanner
+        state="exploratory"
+        reasons={["different_dataset_version", "main_scorer_incompatible"]}
+      />,
+    );
+    expect(screen.getByText(/different dataset snapshots/i)).toBeDefined();
+    expect(screen.getByText(/main scorer isn’t comparable/i)).toBeDefined();
+  });
+
+  it("is informational (not an alert) while a run is still pending", () => {
+    render(<ComparabilityBanner state="pending" reasons={["candidate_not_terminal"]} />);
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByText(/comparison pending/i)).toBeDefined();
+    expect(screen.getByText(/still going/i)).toBeDefined();
+  });
+
+  it("is muted with a way out when there is no baseline", () => {
+    render(
+      <ComparabilityBanner
+        state="unavailable"
+        reasons={["no_baseline"]}
+        action={<button>Clear</button>}
+      />,
+    );
+    expect(screen.getByText(/no comparison/i)).toBeDefined();
+    expect(screen.getByText(/no baseline was picked/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: "Clear" })).toBeDefined();
+  });
+});

--- a/frontend/ui/src/features/evaluations/components/comparability-banner.tsx
+++ b/frontend/ui/src/features/evaluations/components/comparability-banner.tsx
@@ -1,0 +1,110 @@
+/**
+ * The single place the UI turns the comparison engine's `state` + `reasons` into
+ * prose. Both the run-detail comparison strip and the compare page render THIS —
+ * neither re-derives comparison semantics from `trustworthy`/`reasons` themselves
+ * (see `deriveComparisonState` in `lib/eval/comparison.ts`, which owns that logic).
+ *
+ * A `trustworthy` comparison renders nothing here (the views show their authoritative
+ * verdict). Every other state gets a banner: `exploratory` is a STRONG "not directly
+ * comparable" warning so an exploratory delta is never mistaken for a ship / no-ship
+ * result; `pending` is informational; `unavailable` is muted.
+ */
+import * as React from "react";
+import { AlertTriangle, GitCompare, Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ComparisonState, RunComparabilityReason } from "@/lib/eval/comparison";
+
+/** Canonical reason → human text. Kept complete over every `RunComparabilityReason`
+ *  so the banner never falls back to a raw enum token. */
+export const COMPARABILITY_REASON_TEXT: Record<RunComparabilityReason, string> = {
+  no_baseline: "No baseline was picked.",
+  baseline_missing: "The baseline run couldn’t be found.",
+  different_evaluation:
+    "The runs are from different evaluations — no baseline relationship is saved.",
+  different_dataset_version:
+    "The runs used different dataset snapshots, so their cases don’t line up.",
+  baseline_not_terminal: "The baseline run is still running.",
+  candidate_not_terminal: "This run is still going.",
+  case_set_mismatch: "The two runs covered different sets of cases.",
+  main_scorer_incompatible: "The main scorer isn’t comparable between these runs.",
+};
+
+type Tone = "warn" | "info" | "muted";
+
+const STATE_META: Record<
+  Exclude<ComparisonState, "trustworthy">,
+  { title: string; blurb: string; tone: Tone; Icon: typeof Info }
+> = {
+  exploratory: {
+    title: "Exploratory comparison — not directly comparable",
+    blurb: "Shown for exploration only. Don’t read these deltas as a ship / no-ship result.",
+    tone: "warn",
+    Icon: AlertTriangle,
+  },
+  pending: {
+    title: "Comparison pending",
+    blurb: "A run hasn’t finished, so the comparison isn’t final yet.",
+    tone: "info",
+    Icon: Info,
+  },
+  unavailable: {
+    title: "No comparison",
+    blurb: "There’s no baseline to compare this run against.",
+    tone: "muted",
+    Icon: GitCompare,
+  },
+};
+
+const TONE_CLASS: Record<Tone, string> = {
+  warn: "border-amber-400/60 bg-amber-100/50 text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-200",
+  info: "border-border bg-muted/40 text-foreground",
+  muted: "border-border bg-muted/30 text-muted-foreground",
+};
+
+/**
+ * Renders the comparability state; `null` for a trustworthy comparison. `action`
+ * (e.g. a "Clear" button) is placed at the trailing edge.
+ */
+export function ComparabilityBanner({
+  state,
+  reasons,
+  className,
+  action,
+}: {
+  state: ComparisonState;
+  reasons: readonly RunComparabilityReason[];
+  className?: string;
+  action?: React.ReactNode;
+}): React.ReactElement | null {
+  if (state === "trustworthy") return null;
+  const meta = STATE_META[state];
+  // Defensive: an unrecognized/absent discriminant degrades to nothing rather than
+  // crashing the run-detail surface. The backend always sends one of the four states.
+  if (!meta) return null;
+  const { Icon } = meta;
+  const lines = reasons.map((r) => COMPARABILITY_REASON_TEXT[r] ?? r);
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 rounded border px-3 py-2 text-[11px]",
+        TONE_CLASS[meta.tone],
+        className,
+      )}
+      role={meta.tone === "warn" ? "alert" : undefined}
+    >
+      <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <div className="font-semibold">{meta.title}</div>
+        <div className="mt-0.5 opacity-90">{meta.blurb}</div>
+        {lines.length > 0 && (
+          <ul className="mt-1 list-disc space-y-0.5 pl-4">
+            {lines.map((l, i) => (
+              <li key={i}>{l}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}

--- a/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
@@ -41,7 +41,7 @@ const RUN = {
   taskErrorCount: 1,
   scorerErrorCount: 1,
   scorers: [{ name: "routing-accuracy", version: "v3" }],
-  model: null,
+  provenance: null,
   startedAt: "2026-07-17T10:24:00Z",
   completedAt: "2026-07-17T10:30:00Z",
   evaluationName: "Billing routing",
@@ -54,6 +54,7 @@ const RUN = {
   comparison: {
     available: true,
     trustworthy: true,
+    state: "trustworthy",
     reasons: [],
     baseline: { runId: "run0", runNumber: 26, candidateVersion: "git:0000000" },
     mainScore: { candidate: 0.938, baseline: 0.714, delta: 0.224 },
@@ -87,7 +88,16 @@ const RUN = {
     ],
     duration: { candidateMeanMs: 1500, baselineMeanMs: 1400, deltaMs: 100, pairedCount: 22 },
   },
-};
+  humanReview: {
+    dimensions: [],
+    reviewedCount: 0,
+    pendingCount: 0,
+    passCount: 0,
+    failCount: 0,
+    disagreementCount: 0,
+  },
+  metadata: null,
+} satisfies RunDetail;
 
 const RESULT = {
   id: "res1",

--- a/frontend/ui/src/features/evaluations/run-detail-compare.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/run-detail-compare.smoke.test.tsx
@@ -1,0 +1,302 @@
+// @vitest-environment jsdom
+/**
+ * Compare-with on the run-detail page (task #4). Picking another run of the same
+ * evaluation from the dropdown should: compute the comparison via the shared engine
+ * (useCompareRuns → /evaluations/compare), show the comparison banner, drive the
+ * results table's diff cells (vs-baseline delta + "≠ baseline" output marker), and
+ * open the trace viewer straight into diff mode (defaultDiffOn) against the picked
+ * run's matching case trace.
+ *
+ * Radix Select is mocked to a native <select> (portal/pointer events don't work in
+ * jsdom); TraceViewerPanel is a prop recorder.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, screen, fireEvent, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@/components/ui/toast";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1", runId: "run1" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/projects/p1/evaluations",
+}));
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+
+const traceState = {
+  data: { trace_id: "tr", spans: [] },
+  isFetching: false,
+  isError: false,
+  refetch: vi.fn(),
+};
+vi.mock("@/features/traces/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/traces/hooks")>();
+  return { ...actual, useTrace: () => traceState };
+});
+
+let lastPanel: { traceId?: string; defaultDiffOn?: boolean; hasDiffBaseline?: boolean } = {};
+vi.mock("@/features/traces/components", () => ({
+  TraceViewerPanel: (props: {
+    traceId: string;
+    defaultDiffOn?: boolean;
+    diffBaseline?: unknown;
+  }) => {
+    lastPanel = {
+      traceId: props.traceId,
+      defaultDiffOn: props.defaultDiffOn,
+      hasDiffBaseline: !!props.diffBaseline,
+    };
+    return <div data-testid="trace-panel" />;
+  },
+}));
+
+// Native-select stand-in for the Radix Select (jsdom can't drive the real one).
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (v: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <select
+      data-testid="compare-select"
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { RunDetailView } from "./views/run-detail-view";
+
+const runRow = (id: string, runNumber: number, version: string, mainScore: number) => ({
+  id,
+  evaluationId: "eval1",
+  datasetId: "ds1",
+  datasetVersionId: "dv1",
+  runNumber,
+  candidateVersion: version,
+  environment: "evaluation",
+  status: "completed",
+  baselineRunId: null,
+  mainScore,
+  mainScoreName: "accuracy",
+  caseCount: 1,
+  scoredCount: 1,
+  taskErrorCount: 0,
+  scorerErrorCount: 0,
+  passedCount: 1,
+  failedCount: 0,
+  erroredCount: 0,
+  notScoredCount: 0,
+  scorers: [{ name: "accuracy", version: "v1" }],
+  model: null,
+  startedAt: "2026-07-17T10:24:00Z",
+  completedAt: "2026-07-17T10:30:00Z",
+  evaluationName: "Billing routing",
+  datasetName: "Billing routing",
+  datasetVersionLabel: "v12",
+  changeFromBaseline: null,
+  errorCount: 0,
+  baselineComparable: false,
+  elapsedMs: 360000,
+  cost: 0.01,
+});
+
+const emptyComparison = {
+  available: false,
+  trustworthy: false,
+  reasons: ["no_baseline"],
+  baseline: null,
+  mainScore: { candidate: 1, baseline: null, delta: null },
+  caseCounts: {
+    improved: 0,
+    regressed: 0,
+    unchanged: 0,
+    changed: 0,
+    unpaired: 1,
+    not_comparable: 0,
+  },
+  scoreCellCounts: {
+    improved: 0,
+    regressed: 0,
+    unchanged: 0,
+    changed: 0,
+    unpaired: 0,
+    not_comparable: 0,
+  },
+  scorers: [],
+  duration: { candidateMeanMs: null, baselineMeanMs: null, deltaMs: null, pairedCount: 0 },
+};
+
+const RUN1 = { ...runRow("run1", 27, "v2", 1), comparison: emptyComparison };
+
+const RESULT = {
+  id: "res1",
+  runId: "run1",
+  evaluationId: "eval1",
+  testCaseId: "case-1",
+  traceId: "tr_cand",
+  input: "I was charged twice for my July invoice",
+  expectedOutput: "billing",
+  candidateOutput: "billing",
+  baselineOutput: null,
+  status: "passed",
+  mainScore: 1,
+  change: null,
+  taskError: null,
+  durationMs: 2400,
+  cost: 0.012,
+  createTime: "2026-07-17T10:24:00Z",
+  scores: [],
+  humanScores: [],
+  comparison: null,
+};
+
+// The compare response: this run (candidate, score 1) vs run #26 (baseline, score 0).
+const COMPARE = {
+  candidate: runRow("run1", 27, "v2", 1),
+  baseline: runRow("run2", 26, "v1", 0),
+  comparison: {
+    available: true,
+    trustworthy: true,
+    reasons: [],
+    baseline: { runId: "run2", runNumber: 26, candidateVersion: "v1" },
+    mainScore: { candidate: 1, baseline: 0, delta: 1 },
+    caseCounts: {
+      improved: 1,
+      regressed: 0,
+      unchanged: 0,
+      changed: 0,
+      unpaired: 0,
+      not_comparable: 0,
+    },
+    scoreCellCounts: {
+      improved: 1,
+      regressed: 0,
+      unchanged: 0,
+      changed: 0,
+      unpaired: 0,
+      not_comparable: 0,
+    },
+    scorers: [],
+    duration: { candidateMeanMs: 2400, baselineMeanMs: 2100, deltaMs: 300, pairedCount: 1 },
+  },
+  results: [
+    {
+      testCaseId: "case-1",
+      input: "I was charged twice for my July invoice",
+      expectedOutput: "billing",
+      metadata: null,
+      provenance: null,
+      inputMatchesDataset: true,
+      candidateStatus: "passed",
+      baselineStatus: "failed",
+      candidateOutput: "billing",
+      baselineOutput: "account_management",
+      candidateTraceId: "tr_cand",
+      baselineTraceId: "tr_base",
+      candidateCost: 0.012,
+      baselineCost: 0.011,
+      candidateTaskError: null,
+      baselineTaskError: null,
+      candidateScores: [],
+      baselineScores: [],
+      outputChanged: true,
+      change: "improved",
+      comparison: {
+        caseChange: "improved",
+        pairing: "paired",
+        mainScore: { candidate: 1, baseline: 0, delta: 1 },
+        baselineOutput: "account_management",
+        durationMs: 2400,
+        baselineDurationMs: 2100,
+        durationDeltaMs: 300,
+        baselineTraceId: "tr_base",
+        scorerCells: [],
+        regressedCellCount: 0,
+        comparableCellCount: 1,
+      },
+    },
+  ],
+};
+
+beforeEach(() => {
+  lastPanel = {};
+  global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+    const u = String(url);
+    let body: unknown = { data: [], meta: { page: 0, limit: 50, total: 0 } };
+    if (u.includes("/evaluations/runs/run1")) body = { run: RUN1, results: [RESULT] };
+    else if (u.includes("/evaluations/compare")) body = COMPARE;
+    else if (u.includes("/evaluations/runs")) {
+      // sibling runs for the compare dropdown: this run + an earlier one.
+      body = { data: [RUN1, runRow("run2", 26, "v1", 0)], meta: { page: 0, limit: 100, total: 2 } };
+    }
+    return { ok: true, status: 200, json: async () => body } as Response;
+  }) as unknown as typeof fetch;
+});
+afterEach(() => cleanup());
+
+function mount() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ToastProvider>
+        <RunDetailView projectId="p1" runId="run1" />
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const pickCompare = async () => {
+  const select = (await screen.findByTestId("compare-select")) as HTMLSelectElement;
+  // The earlier run (#26) is offered as a baseline option.
+  expect(within(select).getByText(/#26/)).toBeDefined();
+  fireEvent.change(select, { target: { value: "run2" } });
+};
+
+describe("run detail — compare with", () => {
+  it("lists sibling runs and, on pick, shows the comparison banner", async () => {
+    mount();
+    await pickCompare();
+    expect(await screen.findByText(/Comparing vs #26/)).toBeDefined();
+    expect(screen.getByText(/1 improved/)).toBeDefined();
+  });
+
+  it("drives the results table diff cells vs the picked run", async () => {
+    mount();
+    await pickCompare();
+    // Header switches to the diff label, the main-score cell shows the +100 pp delta,
+    // and the output is flagged as differing from the baseline.
+    expect(await screen.findByText("vs baseline")).toBeDefined();
+    expect(screen.getByText(/\+100\.0 pp/)).toBeDefined();
+    expect(screen.getByText("≠ baseline")).toBeDefined();
+  });
+
+  it("opens the case trace straight into diff mode against the picked run", async () => {
+    mount();
+    await pickCompare();
+    await screen.findByText(/Comparing vs #26/);
+    fireEvent.click(await screen.findByText(/charged twice/));
+    expect(await screen.findByTestId("trace-panel")).toBeDefined();
+    expect(lastPanel.defaultDiffOn).toBe(true);
+    expect(lastPanel.hasDiffBaseline).toBe(true);
+  });
+
+  it("shows no diff column until a run is picked", async () => {
+    mount();
+    await screen.findByText(/charged twice/);
+    expect(screen.queryByText("vs baseline")).toBeNull();
+    expect(screen.getByText("Change")).toBeDefined();
+  });
+});

--- a/frontend/ui/src/features/evaluations/run-detail-compare.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/run-detail-compare.smoke.test.tsx
@@ -116,6 +116,7 @@ const runRow = (id: string, runNumber: number, version: string, mainScore: numbe
 const emptyComparison = {
   available: false,
   trustworthy: false,
+  state: "unavailable",
   reasons: ["no_baseline"],
   baseline: null,
   mainScore: { candidate: 1, baseline: null, delta: null },
@@ -170,6 +171,7 @@ const COMPARE = {
   comparison: {
     available: true,
     trustworthy: true,
+    state: "trustworthy",
     reasons: [],
     baseline: { runId: "run2", runNumber: 26, candidateVersion: "v1" },
     mainScore: { candidate: 1, baseline: 0, delta: 1 },

--- a/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useQueries } from "@tanstack/react-query";
-import { ArrowLeftRight, ArrowRight, ChevronDown, ChevronRight, Info } from "lucide-react";
+import { ArrowLeftRight, ArrowRight, ChevronDown, ChevronRight } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -30,11 +30,10 @@ import type {
 } from "../types";
 import { RunStatusBadge } from "./evaluations-view";
 import { CompareCaseDrawer } from "./compare-case-drawer";
+import { ComparabilityBanner } from "@/features/evaluations/components/comparability-banner";
 import {
   deriveVerdict,
   VERDICT_META,
-  BLOCKING_REASONS,
-  REASON_LABEL,
   CASE_FILTERS,
   CASE_SORTS,
   matchesFilter,
@@ -630,7 +629,6 @@ export function CompareRunsView({
   const [traceView, setTraceView] = React.useState<{ traceId: string; label: string } | null>(null);
 
   const crossEval = !!data && data.candidate.evaluationId !== data.baseline.evaluationId;
-  const blocking = (data?.comparison.reasons ?? []).filter((r) => BLOCKING_REASONS.has(r));
 
   const rows = React.useMemo(() => data?.results ?? [], [data]);
   const durationWorsened = (data?.comparison.duration.deltaMs ?? 0) > 0;
@@ -705,19 +703,18 @@ export function CompareRunsView({
               <RunHeaderCard run={data.candidate} role="Candidate" crossEval={crossEval} />
             </div>
 
-            {crossEval && (
-              <div className="flex items-start gap-1.5 rounded border border-border bg-muted/30 px-2.5 py-1.5 text-[11px]">
-                <Info className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" aria-hidden />
-                <span>
-                  <span className="font-medium">Cross-evaluation comparison</span> —{" "}
-                  {data.baseline.evaluationName} → {data.candidate.evaluationName}. No baseline
-                  relationship is saved.
-                </span>
-              </div>
-            )}
+            {/* Comparability first, straight from the backend discriminant. A
+                non-trustworthy comparison (cross-evaluation, mismatched snapshot,
+                a still-running run) gets the strong banner and NO colored verdict —
+                its deltas still render below as neutral metrics, never as a
+                ship / no-ship result. */}
+            <ComparabilityBanner
+              state={data.comparison.state}
+              reasons={data.comparison.reasons}
+            />
 
-            {/* Layer 2 — verdict */}
-            {verdict && (
+            {/* Layer 2 — verdict (only when the comparison is authoritative) */}
+            {verdict && data.comparison.state === "trustworthy" && (
               <div
                 className={cn(
                   "rounded border px-3 py-2",
@@ -731,9 +728,6 @@ export function CompareRunsView({
                   {verdict.reasons.map((line, i) => (
                     <div key={i}>{line}</div>
                   ))}
-                  {verdict.verdict === "not_comparable" &&
-                    blocking.length === 0 &&
-                    data.comparison.reasons.map((r) => <div key={r}>{REASON_LABEL[r] ?? r}</div>)}
                 </div>
               </div>
             )}

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -57,6 +57,7 @@ import {
 } from "../components/save-result-to-dataset-drawer";
 import { reproduceRunCode, reproduceRunCodeTs } from "@/features/offline-eval/utils";
 import { matchSpans } from "@/lib/eval/span-match";
+import { ComparabilityBanner } from "@/features/evaluations/components/comparability-banner";
 import {
   Select,
   SelectContent,
@@ -953,32 +954,62 @@ function RunBody({
             </div>
           )}
 
-          {comparing && cmp && (
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-border bg-muted/30 px-3 py-2 text-[11px]">
-              <span className="flex items-center gap-1.5">
-                <GitCompare className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
-                <span className="font-medium">
-                  Comparing vs #{compareData?.baseline.runNumber} ·{" "}
-                  <span className="font-mono">{compareData?.baseline.candidateVersion}</span>
-                </span>
-              </span>
-              <span className="text-muted-foreground">baseline → candidate (this run)</span>
-              <span className="h-3 w-px bg-border" aria-hidden />
-              <span className={cmp.caseCounts.regressed > 0 ? SENTIMENT_CLASS.bad : ""}>
-                {cmp.caseCounts.regressed} regressed
-              </span>
-              <span className={cmp.caseCounts.improved > 0 ? SENTIMENT_CLASS.good : ""}>
-                {cmp.caseCounts.improved} improved
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="ml-auto h-6 px-1.5 text-[11px] text-muted-foreground hover:text-foreground"
-                onClick={() => onCompareChange(null)}
-              >
-                Clear
-              </Button>
+          {/* Comparability is a single backend-owned discriminant (`cmp.state`). An
+              `unavailable` comparison is only the banner + a way out; every other
+              state keeps the counts strip, and a non-trustworthy state rides the
+              banner ABOVE it so the counts are never read as an authoritative verdict. */}
+          {comparing && cmp && cmp.state === "unavailable" && (
+            <div className="border-b border-border px-3 py-2">
+              <ComparabilityBanner
+                state={cmp.state}
+                reasons={cmp.reasons}
+                action={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-1.5 text-[11px] text-muted-foreground hover:text-foreground"
+                    onClick={() => onCompareChange(null)}
+                  >
+                    Clear
+                  </Button>
+                }
+              />
             </div>
+          )}
+
+          {comparing && cmp && cmp.state !== "unavailable" && (
+            <>
+              {cmp.state !== "trustworthy" && (
+                <div className="border-b border-border px-3 py-2">
+                  <ComparabilityBanner state={cmp.state} reasons={cmp.reasons} />
+                </div>
+              )}
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-border bg-muted/30 px-3 py-2 text-[11px]">
+                <span className="flex items-center gap-1.5">
+                  <GitCompare className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+                  <span className="font-medium">
+                    Comparing vs #{compareData?.baseline.runNumber} ·{" "}
+                    <span className="font-mono">{compareData?.baseline.candidateVersion}</span>
+                  </span>
+                </span>
+                <span className="text-muted-foreground">baseline → candidate (this run)</span>
+                <span className="h-3 w-px bg-border" aria-hidden />
+                <span className={cmp.caseCounts.regressed > 0 ? SENTIMENT_CLASS.bad : ""}>
+                  {cmp.caseCounts.regressed} regressed
+                </span>
+                <span className={cmp.caseCounts.improved > 0 ? SENTIMENT_CLASS.good : ""}>
+                  {cmp.caseCounts.improved} improved
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="ml-auto h-6 px-1.5 text-[11px] text-muted-foreground hover:text-foreground"
+                  onClick={() => onCompareChange(null)}
+                >
+                  Clear
+                </Button>
+              </div>
+            </>
           )}
 
           <ResultsSection

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.review.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.review.test.tsx
@@ -1,0 +1,354 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import React from "react";
+import { SpanStatus } from "@traceroot/core";
+import { SpanInfoPanel } from "./SpanInfoPanel";
+import type { TraceDetail } from "@/types/api";
+import type { TraceSelection } from "../types";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+const mockUseSpanIO = vi.fn(() => ({ data: null as unknown, isLoading: false }));
+vi.mock("../hooks", () => ({
+  useSpanIO: () => mockUseSpanIO(),
+}));
+
+vi.mock("@/components/ui/copy-button", () => ({
+  CopyButton: () => <button data-testid="copy-button" />,
+}));
+
+vi.mock("@/components/ui/expandable-section", () => ({
+  ExpandableSection: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <div data-testid={`expandable-${title.toLowerCase()}`}>{children}</div>
+  ),
+}));
+
+vi.mock("./ContentRenderer", () => ({
+  ContentRenderer: ({ content }: { content: string | null }) => (
+    <div data-testid="content-renderer">{content}</div>
+  ),
+}));
+
+vi.mock("./SpanKindIcon", () => ({
+  SpanKindIcon: () => <div data-testid="span-kind-icon" />,
+}));
+
+afterEach(() => {
+  cleanup();
+  mockUseSpanIO.mockReset().mockReturnValue({ data: null, isLoading: false });
+});
+
+describe("SpanInfoPanel - Error box source location badges", () => {
+  const mockTrace: TraceDetail = {
+    trace_id: "trace-123",
+    project_id: "proj-123",
+    name: "test-trace",
+    trace_start_time: "2026-07-12T12:00:00Z",
+    user_id: null,
+    session_id: null,
+    git_ref: "a1b2c3d4e5f6g7h8i9j0",
+    git_repo: "github.com/org-name/a-very-long-monorepo-name-example",
+    environment: "production",
+    release: null,
+    input: null,
+    output: null,
+    metadata: null,
+    spans: [],
+  };
+
+  const mockSelection: TraceSelection = {
+    type: "span",
+    span: {
+      span_id: "span-456",
+      trace_id: "trace-123",
+      parent_span_id: null,
+      name: "test-span",
+      span_kind: "LLM",
+      span_start_time: "2026-07-12T12:00:00Z",
+      span_end_time: "2026-07-12T12:00:01Z",
+      status: SpanStatus.ERROR,
+      status_message: "Traceback (most recent call last): ...",
+      model_name: "gpt-4o",
+      cost: 0.005,
+      input_tokens: 150,
+      output_tokens: 250,
+      total_tokens: 400,
+      git_source_file:
+        "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/lib/python3.14/asyncio/events.py",
+      git_source_line: 123,
+      git_source_function: "run",
+    },
+  };
+
+  it("renders Error box with git_repo, git_source_file, and git_ref badges", () => {
+    render(<SpanInfoPanel projectId="proj-123" trace={mockTrace} selection={mockSelection} />);
+
+    // 1. Verify git_repo badge wrapping styles
+    const repoSpan = screen.getByText("github.com/org-name/a-very-long-monorepo-name-example");
+    expect(repoSpan).toBeTruthy();
+    expect(repoSpan.className).toContain("min-w-0");
+    expect(repoSpan.className).toContain("break-all");
+
+    const repoParentDiv = repoSpan.parentElement;
+    expect(repoParentDiv).toBeTruthy();
+    expect(repoParentDiv?.className).toContain("inline-flex");
+    expect(repoParentDiv?.className).toContain("min-w-0");
+
+    const repoIcon = repoParentDiv?.querySelector("svg");
+    expect(repoIcon).toBeTruthy();
+    expect(repoIcon?.getAttribute("class")).toContain("shrink-0");
+
+    // 2. Verify git_source_file badge wrapping styles
+    const expectedFilePath =
+      "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/lib/python3.14/asyncio/events.py:123";
+    const fileSpan = screen.getByText((content, element) => {
+      const text = element?.textContent || "";
+      return (
+        text.replace(/\s+/g, "") === expectedFilePath.replace(/\s+/g, "") &&
+        element?.tagName.toLowerCase() === "span"
+      );
+    });
+    expect(fileSpan).toBeTruthy();
+    expect(fileSpan.className).toContain("min-w-0");
+    expect(fileSpan.className).toContain("break-all");
+
+    const fileParentDiv = fileSpan.parentElement;
+    expect(fileParentDiv).toBeTruthy();
+    expect(fileParentDiv?.className).toContain("inline-flex");
+    expect(fileParentDiv?.className).toContain("min-w-0");
+
+    const fileIcon = fileParentDiv?.querySelector("svg");
+    expect(fileIcon).toBeTruthy();
+    expect(fileIcon?.getAttribute("class")).toContain("shrink-0");
+
+    // 3. Verify git_ref badge is NOT affected (no min-w-0, no break-all on span or parent)
+    const refSpan = screen.getByText("a1b2c3d");
+    expect(refSpan).toBeTruthy();
+    expect(refSpan.className).not.toContain("min-w-0");
+    expect(refSpan.className).not.toContain("break-all");
+
+    const refParentDiv = refSpan.parentElement;
+    expect(refParentDiv).toBeTruthy();
+    expect(refParentDiv?.className).toContain("inline-flex");
+    expect(refParentDiv?.className).not.toContain("min-w-0");
+
+    const refIcon = refParentDiv?.querySelector("svg");
+    expect(refIcon).toBeTruthy();
+    expect(refIcon?.getAttribute("class")).toContain("shrink-0");
+
+    // 4. Verify the sibling error message text is rendered
+    const errorMessage = screen.getByText("Traceback (most recent call last): ...");
+    expect(errorMessage).toBeTruthy();
+    expect(errorMessage.className).toContain("whitespace-pre-wrap");
+    expect(errorMessage.className).toContain("break-all");
+  });
+
+  it("renders the model_name pill with its icon", () => {
+    render(<SpanInfoPanel projectId="proj-123" trace={mockTrace} selection={mockSelection} />);
+
+    const modelPill = screen.getByText("gpt-4o");
+    expect(modelPill).toBeTruthy();
+
+    const modelIcon = modelPill.querySelector("svg");
+    expect(modelIcon).toBeTruthy();
+  });
+
+  it("renders Trace header with git_repo and git_ref badges with correct wrapping styles", () => {
+    const mockTraceSelection: TraceSelection = {
+      type: "trace",
+    };
+
+    render(<SpanInfoPanel projectId="proj-123" trace={mockTrace} selection={mockTraceSelection} />);
+
+    // Verify header git_repo badge wrapping styles
+    const repoSpan = screen.getByText("github.com/org-name/a-very-long-monorepo-name-example");
+    expect(repoSpan).toBeTruthy();
+    expect(repoSpan.className).toContain("min-w-0");
+    expect(repoSpan.className).toContain("break-all");
+
+    const repoParentLink = repoSpan.parentElement;
+    expect(repoParentLink).toBeTruthy();
+    expect(repoParentLink?.tagName.toLowerCase()).toBe("a");
+    expect(repoParentLink?.className).toContain("inline-flex");
+    expect(repoParentLink?.className).toContain("min-w-0");
+
+    const headerRepoIcon = repoParentLink?.querySelector("svg");
+    expect(headerRepoIcon).toBeTruthy();
+    expect(headerRepoIcon?.getAttribute("class")).toContain("shrink-0");
+
+    const headerRepoLabel = screen.getByText("Repo:");
+    expect(headerRepoLabel).toBeTruthy();
+    expect(headerRepoLabel.className).toContain("shrink-0");
+
+    // Verify header git_ref badge is NOT affected (no min-w-0, no break-all on span or parent)
+    const refSpan = screen.getByText("a1b2c3d");
+    expect(refSpan).toBeTruthy();
+    expect(refSpan.className).not.toContain("min-w-0");
+    expect(refSpan.className).not.toContain("break-all");
+
+    const refParentLink = refSpan.parentElement;
+    expect(refParentLink).toBeTruthy();
+    expect(refParentLink?.tagName.toLowerCase()).toBe("a");
+    expect(refParentLink?.className).toContain("inline-flex");
+    expect(refParentLink?.className).not.toContain("min-w-0");
+
+    const headerRefIcon = refParentLink?.querySelector("svg");
+    expect(headerRefIcon).toBeTruthy();
+    expect(headerRefIcon?.getAttribute("class")).toContain("shrink-0");
+
+    const headerRefLabel = screen.getByText("Ref:");
+    expect(headerRefLabel).toBeTruthy();
+    expect(headerRefLabel.className).toContain("shrink-0");
+  });
+
+  it("renders User and Session link badges when the trace has both ids", () => {
+    const traceWithIds: TraceDetail = { ...mockTrace, user_id: "user-42", session_id: "session-7" };
+    const mockTraceSelection: TraceSelection = { type: "trace" };
+
+    render(
+      <SpanInfoPanel projectId="proj-123" trace={traceWithIds} selection={mockTraceSelection} />,
+    );
+
+    expect(screen.getByText("User:")).toBeTruthy();
+    expect(screen.getByText("user-42")).toBeTruthy();
+    expect(screen.getByText("Session:")).toBeTruthy();
+    expect(screen.getByText("session-7")).toBeTruthy();
+  });
+});
+
+describe("SpanInfoPanel - eval-shaped reconstructed trace", () => {
+  const mockTrace: TraceDetail = {
+    trace_id: "eval-result-1",
+    project_id: "eval-1",
+    name: "eval trace",
+    trace_start_time: "2026-07-12T12:00:00Z",
+    user_id: null,
+    session_id: null,
+    git_ref: null,
+    git_repo: null,
+    environment: "evaluation",
+    release: null,
+    input: null,
+    output: null,
+    metadata: null,
+    spans: [],
+  };
+
+  const evalSpanSelection: TraceSelection = {
+    type: "span",
+    span: {
+      span_id: "eval-result-1-task",
+      trace_id: "eval-result-1",
+      parent_span_id: "eval-result-1-root",
+      name: "task",
+      span_kind: "SPAN",
+      span_start_time: "1970-01-01T00:00:00.000Z",
+      span_end_time: "1970-01-01T00:00:00.001Z",
+      status: SpanStatus.OK,
+      status_message: null,
+      model_name: null,
+      // Non-null cost/tokens so the token/cost chips would render if they weren't
+      // gated on isEvalShaped (they'd otherwise also self-gate on these being null,
+      // which wouldn't prove the gating itself works).
+      cost: 0.0025,
+      input_tokens: 10,
+      output_tokens: 20,
+      total_tokens: 30,
+      input: "the seeded input",
+      output: "the seeded output",
+      metadata: JSON.stringify({ step: "task" }),
+      git_source_file: null,
+      git_source_line: null,
+      git_source_function: null,
+    },
+  };
+
+  it("falls back to the span's own input/output/metadata when the span-IO fetch is empty", () => {
+    // The lazy /span-io fetch has resolved with nothing (as for a synthetic span
+    // id with no ClickHouse row), so the panel must fall back to the span object.
+    mockUseSpanIO.mockReturnValue({ data: null, isLoading: false });
+
+    render(<SpanInfoPanel projectId="eval-1" trace={mockTrace} selection={evalSpanSelection} />);
+
+    expect(screen.getByText("the seeded input")).toBeTruthy();
+    expect(screen.getByText("the seeded output")).toBeTruthy();
+    expect(screen.getByText(JSON.stringify({ step: "task" }))).toBeTruthy();
+  });
+
+  it("hides the span-level duration/token/cost badges and shows I/O only when isEvalShaped", () => {
+    render(
+      <SpanInfoPanel
+        projectId="eval-1"
+        trace={mockTrace}
+        selection={evalSpanSelection}
+        isEvalShaped
+      />,
+    );
+
+    expect(screen.queryByText("Latency:")).toBeNull();
+    // Token/cost are non-null on this span (so they'd render if not gated —
+    // otherwise this would pass even without the isEvalShaped fix).
+    expect(screen.queryByText("10 → 20 (30)")).toBeNull();
+    expect(screen.queryByText("0.002500")).toBeNull();
+    expect(screen.getByTestId("expandable-input")).toBeTruthy();
+    expect(screen.getByTestId("expandable-output")).toBeTruthy();
+    expect(screen.getByTestId("expandable-metadata")).toBeTruthy();
+  });
+
+  it("hides the trace-level duration/token/cost/git badges when isEvalShaped", () => {
+    const traceWithMetrics: TraceDetail = {
+      ...mockTrace,
+      git_ref: "a1b2c3d4e5f6",
+      git_repo: "github.com/org/eval-repo",
+      spans: [
+        {
+          span_id: "eval-result-1-task",
+          trace_id: "eval-result-1",
+          parent_span_id: null,
+          name: "task",
+          span_kind: "SPAN",
+          span_start_time: "1970-01-01T00:00:00.000Z",
+          span_end_time: "1970-01-01T00:00:00.001Z",
+          status: SpanStatus.OK,
+          status_message: null,
+          model_name: null,
+          cost: 0.0025,
+          input_tokens: 10,
+          output_tokens: 20,
+          total_tokens: 30,
+          input: null,
+          output: null,
+          metadata: null,
+          git_source_file: null,
+          git_source_line: null,
+          git_source_function: null,
+        },
+      ],
+    };
+
+    render(
+      <SpanInfoPanel
+        projectId="eval-1"
+        trace={traceWithMetrics}
+        selection={{ type: "trace" }}
+        isEvalShaped
+      />,
+    );
+
+    expect(screen.queryByText("Latency:")).toBeNull();
+    expect(screen.queryByText("10 → 20 (30)")).toBeNull();
+    expect(screen.queryByText("0.002500")).toBeNull();
+    expect(screen.queryByText("Repo:")).toBeNull();
+    expect(screen.queryByText("Ref:")).toBeNull();
+  });
+
+  it("still shows the latency badge when isEvalShaped is not set (real trace)", () => {
+    const realTrace: TraceDetail = { ...mockTrace, environment: "production" };
+    render(<SpanInfoPanel projectId="eval-1" trace={realTrace} selection={evalSpanSelection} />);
+
+    expect(screen.getByText("Latency:")).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -43,6 +43,13 @@ interface SpanInfoPanelProps {
   customStartDate?: Date | null;
   customEndDate?: Date | null;
   /**
+   * True for the offline-eval reconstructed trace (built from a result's I/O +
+   * scores, not real telemetry — see `buildEvalTrace`). Its duration/token/cost
+   * fields are fabricated placeholders, not measurements, so those badges are
+   * hidden and the panel shows I/O only. Unset in production.
+   */
+  isEvalShaped?: boolean;
+  /**
    * Optional action bar rendered between the header and the content, e.g. the
    * offline-eval "Save as test case" / "Review" buttons. Unset in production, so
    * the standard trace viewer is unaffected.
@@ -96,6 +103,7 @@ export function SpanInfoPanel({
   dateFilter,
   customStartDate,
   customEndDate,
+  isEvalShaped,
   spanActions,
   headerAction,
   extraTags,
@@ -204,6 +212,32 @@ export function SpanInfoPanel({
   const fmtTokens = (n: number) => Math.round(n).toLocaleString();
   const fmtCost = (n: number) => `$${n.toFixed(6)}`;
 
+  // Baseline token/cost detail for the hover breakdowns' per-row ± deltas (diff mode):
+  // the trace aggregates for the trace selection, the matched span's counts otherwise.
+  const baselineTokenCounts = !diffActive
+    ? undefined
+    : isTrace
+      ? baselineTrace
+        ? (getTraceTokenUsage(baselineTrace) ?? undefined)
+        : undefined
+      : baselineSpan
+        ? {
+            inputTokens: baselineSpan.input_tokens,
+            outputTokens: baselineSpan.output_tokens,
+            totalTokens: baselineSpan.total_tokens,
+            cacheReadTokens: baselineSpan.usage_details?.cache_read_tokens,
+            cacheWriteTokens: baselineSpan.usage_details?.cache_write_tokens,
+            reasoningTokens: baselineSpan.usage_details?.reasoning_tokens,
+          }
+        : undefined;
+  const baselineCostDetails = !diffActive
+    ? undefined
+    : isTrace
+      ? baselineTrace
+        ? getTraceCostBreakdown(baselineTrace)
+        : undefined
+      : baselineSpan?.cost_details;
+
   // Error status
   const hasError = isTrace ? false : selection.span.status === SpanStatus.ERROR;
   const statusMessage = !isTrace ? selection.span.status_message : null;
@@ -243,12 +277,17 @@ export function SpanInfoPanel({
             <span className="font-medium">{kind.toLowerCase()}</span>
           </div>
           {extraTags}
-          <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
-            <DOMAIN_ICONS.latency className="h-3 w-3 text-muted-foreground" />
-            <span className="text-muted-foreground">Latency:</span>
-            <span className="font-medium">{formatDuration(duration)}</span>
-            <MetricDelta delta={durationDelta} format={formatDuration} />
-          </div>
+          {/* Duration is fabricated on the offline-eval reconstructed trace (fixed
+              placeholder offsets, not a measurement), so it's hidden there. The
+              token/cost/git badges below gate on !isEvalShaped for the same reason. */}
+          {!isEvalShaped && (
+            <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
+              <DOMAIN_ICONS.latency className="h-3 w-3 text-muted-foreground" />
+              <span className="text-muted-foreground">Latency:</span>
+              <span className="font-medium">{formatDuration(duration)}</span>
+              <MetricDelta delta={durationDelta} format={formatDuration} />
+            </div>
+          )}
           {hasError && (
             <div className="inline-flex items-center gap-1.5 rounded-md bg-red-100 px-2.5 py-1 text-xs font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
               <DOMAIN_ICONS.error className="h-3 w-3" />
@@ -261,7 +300,10 @@ export function SpanInfoPanel({
               <span className="font-medium">{trace.environment}</span>
             </div>
           )}
-          {isTrace && traceTokenUsage && (
+          {/* Token/cost aggregates are meaningless on the offline-eval reconstructed
+              trace (its spans carry no real usage/cost telemetry), so they're hidden
+              there — the trace and span variants below all gate on !isEvalShaped. */}
+          {!isEvalShaped && isTrace && traceTokenUsage && (
             <TokenChip
               inputTokens={traceTokenUsage.inputTokens}
               outputTokens={traceTokenUsage.outputTokens}
@@ -270,13 +312,15 @@ export function SpanInfoPanel({
               cacheWriteTokens={traceTokenUsage.cacheWriteTokens}
               reasoningTokens={traceTokenUsage.reasoningTokens}
               delta={<MetricDelta delta={tokenDelta} format={fmtTokens} />}
+              baseline={baselineTokenCounts}
             />
           )}
-          {isTrace && traceTotalCost != null && (
+          {!isEvalShaped && isTrace && traceTotalCost != null && (
             <CostChip
               cost={traceTotalCost}
               costDetails={traceCostDetails}
               delta={<MetricDelta delta={costDelta} format={fmtCost} />}
+              baselineDetails={baselineCostDetails}
             />
           )}
           {!isTrace && selection.span.model_name && (
@@ -285,7 +329,7 @@ export function SpanInfoPanel({
               {selection.span.model_name}
             </div>
           )}
-          {!isTrace && selection.span.total_tokens != null && (
+          {!isEvalShaped && !isTrace && selection.span.total_tokens != null && (
             <TokenChip
               inputTokens={selection.span.input_tokens}
               outputTokens={selection.span.output_tokens}
@@ -294,19 +338,23 @@ export function SpanInfoPanel({
               cacheWriteTokens={selection.span.usage_details?.cache_write_tokens}
               reasoningTokens={selection.span.usage_details?.reasoning_tokens}
               delta={<MetricDelta delta={tokenDelta} format={fmtTokens} />}
+              baseline={baselineTokenCounts}
             />
           )}
-          {!isTrace && (
+          {!isEvalShaped && !isTrace && (
             <CostChip
               cost={selection.span.cost}
               costDetails={selection.span.cost_details}
               delta={<MetricDelta delta={costDelta} format={fmtCost} />}
+              baselineDetails={baselineCostDetails}
             />
           )}
         </div>
 
-        {/* Row 2: Git related badges */}
-        {isTrace && (trace.git_ref || trace.git_repo) && (
+        {/* Row 2: Git related badges. Always absent on the offline-eval reconstructed
+            trace (its spans carry no git_ref/git_repo), but gated explicitly rather
+            than relying on that, since "eval-shaped spans show I/O only". */}
+        {!isEvalShaped && isTrace && (trace.git_ref || trace.git_repo) && (
           <div className="mt-2 flex flex-wrap items-center gap-2">
             {trace.git_repo && (
               <a

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -69,6 +69,19 @@ interface SpanInfoPanelProps {
   diffMode?: boolean;
   baselineSpan?: Span | null;
   baselineTrace?: TraceDetail | null;
+  /**
+   * Replaces the TRACE-level identity (offline-eval): the leading kind chip, the
+   * header title, and what the copy button copies — so an evaluation trace leads
+   * with its test case rather than a raw trace id. Unset in production, where the
+   * trace selection keeps its trace name, trace id and "Span Kind: trace".
+   */
+  traceIdentity?: { kindLabel: string; title: string; copyValue: string };
+  /**
+   * Badge rendered where a span's ERROR badge sits. A trace-level selection has no
+   * status of its own, so this is how an eval case's outcome (Passed / Did not
+   * pass / Errored) surfaces there. Unset in production.
+   */
+  traceStatusBadge?: ReactNode;
 }
 
 /** Drop internal `traceroot.span.*` keys so the Metadata panel shows only user metadata. */
@@ -102,6 +115,8 @@ export function SpanInfoPanel({
   diffMode = false,
   baselineSpan,
   baselineTrace,
+  traceIdentity,
+  traceStatusBadge,
 }: SpanInfoPanelProps) {
   const router = useRouter();
 
@@ -113,7 +128,11 @@ export function SpanInfoPanel({
   // per-value "expand" state resets when you switch spans/traces (and persists
   // within the same selection, e.g. across live updates).
   const selectionId = isTrace ? trace.trace_id : selection.span.span_id;
-  const name = isTrace ? trace.name : selection.span.name;
+  // An eval trace overrides the trace-level identity so it leads with its test
+  // case; every other trace (and every span) keeps the standard identity.
+  const identity = isTrace ? traceIdentity : undefined;
+  const name = identity?.title ?? (isTrace ? trace.name : selection.span.name);
+  const copyId = identity?.copyValue ?? (isTrace ? trace.trace_id : selection.span.span_id);
   const kind = isTrace ? "trace" : selection.span.span_kind;
   const duration = isTrace ? getTraceDuration(trace) : getSpanDuration(selection.span);
   const timestamp = isTrace ? trace.trace_start_time : selection.span.span_start_time;
@@ -227,7 +246,7 @@ export function SpanInfoPanel({
               <SpanKindIcon kind={kind} size="md" selected />
               <h3 className="text-sm font-medium">{name}</h3>
               <CopyButton
-                value={isTrace ? trace.trace_id : selection.span.span_id}
+                value={copyId}
                 className="h-6 w-6 text-muted-foreground hover:text-foreground"
                 title="Copy ID"
               />
@@ -239,8 +258,14 @@ export function SpanInfoPanel({
         {/* Row 1: LLM related badges */}
         <div className="flex flex-wrap items-center gap-2">
           <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
-            <span className="text-muted-foreground">Span Kind:</span>
-            <span className="font-medium">{kind.toLowerCase()}</span>
+            {identity ? (
+              <span className="font-medium">{identity.kindLabel}</span>
+            ) : (
+              <>
+                <span className="text-muted-foreground">Span Kind:</span>
+                <span className="font-medium">{kind.toLowerCase()}</span>
+              </>
+            )}
           </div>
           {extraTags}
           <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
@@ -255,6 +280,9 @@ export function SpanInfoPanel({
               ERROR
             </div>
           )}
+          {/* A trace-level selection has no status of its own; offline-eval puts the
+              case's outcome here, where a span's ERROR badge would be. */}
+          {isTrace && traceStatusBadge}
           {isTrace && trace.environment && (
             <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
               <span className="text-muted-foreground">Env:</span>

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -69,19 +69,6 @@ interface SpanInfoPanelProps {
   diffMode?: boolean;
   baselineSpan?: Span | null;
   baselineTrace?: TraceDetail | null;
-  /**
-   * Replaces the TRACE-level identity (offline-eval): the leading kind chip, the
-   * header title, and what the copy button copies — so an evaluation trace leads
-   * with its test case rather than a raw trace id. Unset in production, where the
-   * trace selection keeps its trace name, trace id and "Span Kind: trace".
-   */
-  traceIdentity?: { kindLabel: string; title: string; copyValue: string };
-  /**
-   * Badge rendered where a span's ERROR badge sits. A trace-level selection has no
-   * status of its own, so this is how an eval case's outcome (Passed / Did not
-   * pass / Errored) surfaces there. Unset in production.
-   */
-  traceStatusBadge?: ReactNode;
 }
 
 /** Drop internal `traceroot.span.*` keys so the Metadata panel shows only user metadata. */
@@ -115,8 +102,6 @@ export function SpanInfoPanel({
   diffMode = false,
   baselineSpan,
   baselineTrace,
-  traceIdentity,
-  traceStatusBadge,
 }: SpanInfoPanelProps) {
   const router = useRouter();
 
@@ -128,11 +113,7 @@ export function SpanInfoPanel({
   // per-value "expand" state resets when you switch spans/traces (and persists
   // within the same selection, e.g. across live updates).
   const selectionId = isTrace ? trace.trace_id : selection.span.span_id;
-  // An eval trace overrides the trace-level identity so it leads with its test
-  // case; every other trace (and every span) keeps the standard identity.
-  const identity = isTrace ? traceIdentity : undefined;
-  const name = identity?.title ?? (isTrace ? trace.name : selection.span.name);
-  const copyId = identity?.copyValue ?? (isTrace ? trace.trace_id : selection.span.span_id);
+  const name = isTrace ? trace.name : selection.span.name;
   const kind = isTrace ? "trace" : selection.span.span_kind;
   const duration = isTrace ? getTraceDuration(trace) : getSpanDuration(selection.span);
   const timestamp = isTrace ? trace.trace_start_time : selection.span.span_start_time;
@@ -246,7 +227,7 @@ export function SpanInfoPanel({
               <SpanKindIcon kind={kind} size="md" selected />
               <h3 className="text-sm font-medium">{name}</h3>
               <CopyButton
-                value={copyId}
+                value={isTrace ? trace.trace_id : selection.span.span_id}
                 className="h-6 w-6 text-muted-foreground hover:text-foreground"
                 title="Copy ID"
               />
@@ -258,14 +239,8 @@ export function SpanInfoPanel({
         {/* Row 1: LLM related badges */}
         <div className="flex flex-wrap items-center gap-2">
           <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
-            {identity ? (
-              <span className="font-medium">{identity.kindLabel}</span>
-            ) : (
-              <>
-                <span className="text-muted-foreground">Span Kind:</span>
-                <span className="font-medium">{kind.toLowerCase()}</span>
-              </>
-            )}
+            <span className="text-muted-foreground">Span Kind:</span>
+            <span className="font-medium">{kind.toLowerCase()}</span>
           </div>
           {extraTags}
           <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
@@ -280,9 +255,6 @@ export function SpanInfoPanel({
               ERROR
             </div>
           )}
-          {/* A trace-level selection has no status of its own; offline-eval puts the
-              case's outcome here, where a span's ERROR badge would be. */}
-          {isTrace && traceStatusBadge}
           {isTrace && trace.environment && (
             <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
               <span className="text-muted-foreground">Env:</span>

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -2,16 +2,6 @@
 
 import type { ReactNode } from "react";
 import { useRouter } from "next/navigation";
-import {
-  Clock,
-  Users,
-  Layers,
-  ChevronRight,
-  AlertCircle,
-  GitBranch,
-  GitCommitHorizontal,
-  FileCode,
-} from "lucide-react";
 import { ChevronRight, GitBranch, GitCommitHorizontal, FileCode, Loader2 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
@@ -29,7 +19,8 @@ import {
   getTraceCostBreakdown,
 } from "../utils";
 import { SpanKindIcon } from "./SpanKindIcon";
-import { TraceIOSection } from "./TraceIOValue";
+import { ContentRenderer } from "./ContentRenderer";
+import { ExpandableSection } from "@/components/ui/expandable-section";
 import { useSpanIO } from "../hooks";
 
 interface SpanInfoPanelProps {
@@ -128,8 +119,15 @@ export function SpanInfoPanel({
 
   // Show a spinner while a selected span's I/O is in flight; trace-level I/O is
   // already loaded so it never spins.
-  // A selected span's I/O is fetched on demand; trace-level I/O is already loaded.
-  const ioLoading = !isTrace && isLoadingIO;
+  const renderIOContent = (content: string | null) =>
+    !isTrace && isLoadingIO ? (
+      <div className="flex items-center gap-2 py-3 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Loading…
+      </div>
+    ) : (
+      <ContentRenderer key={selectionId} content={content} />
+    );
 
   return (
     <div className="h-full overflow-y-auto">
@@ -156,7 +154,6 @@ export function SpanInfoPanel({
             <span className="text-muted-foreground">Span Kind:</span>
             <span className="font-medium">{kind.toLowerCase()}</span>
           </div>
-          {extraTags}
           <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
             <DOMAIN_ICONS.latency className="h-3 w-3 text-muted-foreground" />
             <span className="text-muted-foreground">Latency:</span>
@@ -206,6 +203,7 @@ export function SpanInfoPanel({
           {!isTrace && (
             <CostChip cost={selection.span.cost} costDetails={selection.span.cost_details} />
           )}
+          {extraTags}
         </div>
 
         {/* Row 2: Git related badges */}
@@ -344,29 +342,32 @@ export function SpanInfoPanel({
           </div>
         )}
 
-        {/* Input / Output / Metadata — each with a header format switcher. The key
-            resets the chosen format when a different span/trace is selected. */}
-        <TraceIOSection
-          key={`${selectionId}:input`}
+        {/* Input */}
+        <ExpandableSection
           title="Input"
-          content={input}
-          loading={ioLoading}
+          defaultOpen={true}
           onCopy={input ? () => copyToClipboard(input) : undefined}
-        />
-        <TraceIOSection
-          key={`${selectionId}:output`}
+        >
+          {renderIOContent(input)}
+        </ExpandableSection>
+
+        {/* Output */}
+        <ExpandableSection
           title="Output"
-          content={output}
-          loading={ioLoading}
+          defaultOpen={true}
           onCopy={output ? () => copyToClipboard(output) : undefined}
-        />
-        <TraceIOSection
-          key={`${selectionId}:metadata`}
+        >
+          {renderIOContent(output)}
+        </ExpandableSection>
+
+        {/* Metadata */}
+        <ExpandableSection
           title="Metadata"
-          content={metadata}
-          loading={ioLoading}
+          defaultOpen={true}
           onCopy={metadata ? () => copyToClipboard(metadata) : undefined}
-        />
+        >
+          {renderIOContent(metadata)}
+        </ExpandableSection>
       </div>
     </div>
   );

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -2,14 +2,26 @@
 
 import type { ReactNode } from "react";
 import { useRouter } from "next/navigation";
+import {
+  Clock,
+  Users,
+  Layers,
+  ChevronRight,
+  AlertCircle,
+  GitBranch,
+  GitCommitHorizontal,
+  FileCode,
+} from "lucide-react";
 import { ChevronRight, GitBranch, GitCommitHorizontal, FileCode, Loader2 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { formatDuration, formatDate, buildUrlWithFilters } from "@/lib/utils";
 import { TokenChip } from "./TokenChip";
 import { CostChip } from "./CostChip";
+import { MetricDelta } from "./MetricDelta";
+import { TraceIODiffSection } from "./TraceIODiff";
 import { SpanStatus } from "@traceroot/core";
-import type { TraceDetail } from "@/types/api";
+import type { Span, TraceDetail } from "@/types/api";
 import type { TraceSelection } from "../types";
 import {
   getSpanDuration,
@@ -19,8 +31,7 @@ import {
   getTraceCostBreakdown,
 } from "../utils";
 import { SpanKindIcon } from "./SpanKindIcon";
-import { ContentRenderer } from "./ContentRenderer";
-import { ExpandableSection } from "@/components/ui/expandable-section";
+import { TraceIOSection } from "./TraceIOValue";
 import { useSpanIO } from "../hooks";
 
 interface SpanInfoPanelProps {
@@ -48,6 +59,30 @@ interface SpanInfoPanelProps {
    * offline-eval's "Dataset:" chip). Unset in production.
    */
   extraTags?: ReactNode;
+  /**
+   * Diff mode (offline-eval only): when on, the latency/token/cost tags show ±
+   * deltas and Input/Output/Metadata render as git-style line diffs vs the baseline
+   * run — for the trace-level selection (using `baselineTrace`) as well as a span
+   * selection (using the matched `baselineSpan`). Unset in production, so the
+   * standard viewer is unaffected.
+   */
+  diffMode?: boolean;
+  baselineSpan?: Span | null;
+  baselineTrace?: TraceDetail | null;
+}
+
+/** Drop internal `traceroot.span.*` keys so the Metadata panel shows only user metadata. */
+function stripInternalMetadata(raw: string | null | undefined): string | null {
+  if (!raw) return raw ?? null;
+  try {
+    const parsed = JSON.parse(raw);
+    const filtered = Object.fromEntries(
+      Object.entries(parsed).filter(([k]) => !k.startsWith("traceroot.span.")),
+    );
+    return JSON.stringify(filtered);
+  } catch {
+    return raw;
+  }
 }
 
 /**
@@ -64,6 +99,9 @@ export function SpanInfoPanel({
   spanActions,
   headerAction,
   extraTags,
+  diffMode = false,
+  baselineSpan,
+  baselineTrace,
 }: SpanInfoPanelProps) {
   const router = useRouter();
 
@@ -88,26 +126,83 @@ export function SpanInfoPanel({
     selectedSpanId,
   );
 
-  const input = isTrace ? trace.input : (spanIO?.input ?? null);
-  const output = isTrace ? trace.output : (spanIO?.output ?? null);
-  const rawMetadata = isTrace ? trace.metadata : (spanIO?.metadata ?? null);
-  const metadata = (() => {
-    if (!rawMetadata) return rawMetadata;
-    try {
-      const parsed = JSON.parse(rawMetadata);
-      const filtered = Object.fromEntries(
-        Object.entries(parsed).filter(([k]) => !k.startsWith("traceroot.span.")),
-      );
-      return JSON.stringify(filtered);
-    } catch {
-      return rawMetadata;
-    }
-  })();
+  // Per-span I/O comes from the lazy fetch, but fall back to whatever the span
+  // object itself carries — a provided trace (e.g. an evaluation's reconstructed
+  // trace) ships I/O on the span, and the `/io` fetch returns nothing for those
+  // synthetic span ids. Production skeleton spans have null here, so normal traces
+  // are unchanged (the fetch stays the source).
+  const input = isTrace ? trace.input : (spanIO?.input ?? selection.span.input ?? null);
+  const output = isTrace ? trace.output : (spanIO?.output ?? selection.span.output ?? null);
+  const rawMetadata = isTrace
+    ? trace.metadata
+    : (spanIO?.metadata ?? selection.span.metadata ?? null);
+  const metadata = stripInternalMetadata(rawMetadata);
 
-  // Trace-level aggregates
+  // Trace-level aggregates (also the diff baseline source for the trace selection).
   const traceTotalCost = isTrace ? getTraceTotalCost(trace) : null;
   const traceCostDetails = isTrace ? getTraceCostBreakdown(trace) : null;
   const traceTokenUsage = isTrace ? getTraceTokenUsage(trace) : null;
+
+  // Diff mode (offline-eval): compare the current selection against its baseline —
+  // the whole trace vs `baselineTrace`, or a span vs its matched `baselineSpan`.
+  // Gated on the Diff toggle. Baseline span I/O is fetched the same lazy way (the
+  // query stays disabled unless a span-level diff is active); the trace selection
+  // diffs against the already-loaded baseline trace object, no fetch.
+  const diffActive = diffMode && (isTrace ? !!baselineTrace : !!baselineSpan);
+  const { data: baselineIO } = useSpanIO(
+    projectId,
+    baselineSpan?.trace_id ?? "",
+    diffActive && !isTrace ? (baselineSpan?.span_id ?? null) : null,
+  );
+  const baselineInput = isTrace
+    ? (baselineTrace?.input ?? null)
+    : baselineSpan
+      ? (baselineIO?.input ?? baselineSpan.input ?? null)
+      : null;
+  const baselineOutput = isTrace
+    ? (baselineTrace?.output ?? null)
+    : baselineSpan
+      ? (baselineIO?.output ?? baselineSpan.output ?? null)
+      : null;
+  const baselineMetadata = isTrace
+    ? stripInternalMetadata(baselineTrace?.metadata ?? null)
+    : baselineSpan
+      ? stripInternalMetadata(baselineIO?.metadata ?? baselineSpan.metadata ?? null)
+      : null;
+
+  // ± deltas for the latency / token / cost tags (lower is better). Candidate and
+  // baseline are the trace aggregates for the trace selection, the span values for a
+  // span selection.
+  const baselineDuration = isTrace
+    ? baselineTrace
+      ? getTraceDuration(baselineTrace)
+      : null
+    : baselineSpan
+      ? getSpanDuration(baselineSpan)
+      : null;
+  const durationDelta =
+    diffActive && duration != null && baselineDuration != null ? duration - baselineDuration : null;
+  const tokenDelta = (() => {
+    if (!diffActive) return null;
+    if (isTrace) {
+      const c = traceTokenUsage?.totalTokens ?? null;
+      const b = baselineTrace ? (getTraceTokenUsage(baselineTrace)?.totalTokens ?? null) : null;
+      return c != null && b != null ? c - b : null;
+    }
+    if (!baselineSpan || selection.span.total_tokens == null) return null;
+    return selection.span.total_tokens - (baselineSpan.total_tokens ?? 0);
+  })();
+  const costDelta = (() => {
+    if (!diffActive) return null;
+    if (isTrace) {
+      const b = baselineTrace ? getTraceTotalCost(baselineTrace) : null;
+      return traceTotalCost != null && b != null ? traceTotalCost - b : null;
+    }
+    if (!baselineSpan || selection.span.cost == null) return null;
+    return selection.span.cost - (baselineSpan.cost ?? 0);
+  })();
+  const fmtTokens = (n: number) => Math.round(n).toLocaleString();
+  const fmtCost = (n: number) => `$${n.toFixed(6)}`;
 
   // Error status
   const hasError = isTrace ? false : selection.span.status === SpanStatus.ERROR;
@@ -119,15 +214,8 @@ export function SpanInfoPanel({
 
   // Show a spinner while a selected span's I/O is in flight; trace-level I/O is
   // already loaded so it never spins.
-  const renderIOContent = (content: string | null) =>
-    !isTrace && isLoadingIO ? (
-      <div className="flex items-center gap-2 py-3 text-xs text-muted-foreground">
-        <Loader2 className="h-3 w-3 animate-spin" />
-        Loading…
-      </div>
-    ) : (
-      <ContentRenderer key={selectionId} content={content} />
-    );
+  // A selected span's I/O is fetched on demand; trace-level I/O is already loaded.
+  const ioLoading = !isTrace && isLoadingIO;
 
   return (
     <div className="h-full overflow-y-auto">
@@ -154,10 +242,12 @@ export function SpanInfoPanel({
             <span className="text-muted-foreground">Span Kind:</span>
             <span className="font-medium">{kind.toLowerCase()}</span>
           </div>
+          {extraTags}
           <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
             <DOMAIN_ICONS.latency className="h-3 w-3 text-muted-foreground" />
             <span className="text-muted-foreground">Latency:</span>
             <span className="font-medium">{formatDuration(duration)}</span>
+            <MetricDelta delta={durationDelta} format={formatDuration} />
           </div>
           {hasError && (
             <div className="inline-flex items-center gap-1.5 rounded-md bg-red-100 px-2.5 py-1 text-xs font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
@@ -179,10 +269,15 @@ export function SpanInfoPanel({
               cacheReadTokens={traceTokenUsage.cacheReadTokens}
               cacheWriteTokens={traceTokenUsage.cacheWriteTokens}
               reasoningTokens={traceTokenUsage.reasoningTokens}
+              delta={<MetricDelta delta={tokenDelta} format={fmtTokens} />}
             />
           )}
           {isTrace && traceTotalCost != null && (
-            <CostChip cost={traceTotalCost} costDetails={traceCostDetails} />
+            <CostChip
+              cost={traceTotalCost}
+              costDetails={traceCostDetails}
+              delta={<MetricDelta delta={costDelta} format={fmtCost} />}
+            />
           )}
           {!isTrace && selection.span.model_name && (
             <div className="inline-flex items-center gap-1.5 rounded-md bg-primary px-2.5 py-1 text-xs text-primary-foreground">
@@ -198,12 +293,16 @@ export function SpanInfoPanel({
               cacheReadTokens={selection.span.usage_details?.cache_read_tokens}
               cacheWriteTokens={selection.span.usage_details?.cache_write_tokens}
               reasoningTokens={selection.span.usage_details?.reasoning_tokens}
+              delta={<MetricDelta delta={tokenDelta} format={fmtTokens} />}
             />
           )}
           {!isTrace && (
-            <CostChip cost={selection.span.cost} costDetails={selection.span.cost_details} />
+            <CostChip
+              cost={selection.span.cost}
+              costDetails={selection.span.cost_details}
+              delta={<MetricDelta delta={costDelta} format={fmtCost} />}
+            />
           )}
-          {extraTags}
         </div>
 
         {/* Row 2: Git related badges */}
@@ -342,32 +441,56 @@ export function SpanInfoPanel({
           </div>
         )}
 
-        {/* Input */}
-        <ExpandableSection
-          title="Input"
-          defaultOpen={true}
-          onCopy={input ? () => copyToClipboard(input) : undefined}
-        >
-          {renderIOContent(input)}
-        </ExpandableSection>
-
-        {/* Output */}
-        <ExpandableSection
-          title="Output"
-          defaultOpen={true}
-          onCopy={output ? () => copyToClipboard(output) : undefined}
-        >
-          {renderIOContent(output)}
-        </ExpandableSection>
-
-        {/* Metadata */}
-        <ExpandableSection
-          title="Metadata"
-          defaultOpen={true}
-          onCopy={metadata ? () => copyToClipboard(metadata) : undefined}
-        >
-          {renderIOContent(metadata)}
-        </ExpandableSection>
+        {/* Input / Output / Metadata. In diff mode (eval trace with a baseline) each
+            renders as a git-style line diff vs the matched baseline span; otherwise
+            the normal value view with a header format switcher. The key resets
+            per-value state when a different span/trace is selected. */}
+        {diffActive ? (
+          <>
+            <TraceIODiffSection
+              key={`${selectionId}:input`}
+              title="Input"
+              baseline={baselineInput}
+              candidate={input}
+            />
+            <TraceIODiffSection
+              key={`${selectionId}:output`}
+              title="Output"
+              baseline={baselineOutput}
+              candidate={output}
+            />
+            <TraceIODiffSection
+              key={`${selectionId}:metadata`}
+              title="Metadata"
+              baseline={baselineMetadata}
+              candidate={metadata}
+            />
+          </>
+        ) : (
+          <>
+            <TraceIOSection
+              key={`${selectionId}:input`}
+              title="Input"
+              content={input}
+              loading={ioLoading}
+              onCopy={input ? () => copyToClipboard(input) : undefined}
+            />
+            <TraceIOSection
+              key={`${selectionId}:output`}
+              title="Output"
+              content={output}
+              loading={ioLoading}
+              onCopy={output ? () => copyToClipboard(output) : undefined}
+            />
+            <TraceIOSection
+              key={`${selectionId}:metadata`}
+              title="Metadata"
+              content={metadata}
+              loading={ioLoading}
+              onCopy={metadata ? () => copyToClipboard(metadata) : undefined}
+            />
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -97,6 +97,12 @@ interface SpanTreeViewProps {
   onHoverChange: (id: string | null) => void;
   /** The overflow-y-auto scroll container owned by TraceViewerPanel. */
   scrollRef: RefObject<HTMLDivElement | null>;
+  /**
+   * Skip the hover-prefetch (offline-eval override traces). `trace.project_id`/
+   * `trace.trace_id` are synthetic (`run.evaluationId` / `eval-<resultId>`) on an
+   * override, so every hover would fire a doomed `/span-io` request otherwise.
+   */
+  disableIOPrefetch?: boolean;
 }
 
 export interface SpanTreeViewHandle {
@@ -128,6 +134,7 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
     hoveredSpanId,
     onHoverChange,
     scrollRef,
+    disableIOPrefetch = false,
   },
   ref,
 ) {
@@ -152,6 +159,9 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
   const runSpanIOPrefetch = useCallback(
     (span: Span) => {
       if (span.pending) return;
+      // Skip prefetch under an override: trace.project_id/trace.trace_id are
+      // synthetic there, so a real /span-io request would always 404.
+      if (disableIOPrefetch) return;
       // Skip prefetch until the auth session is ready: prefetching with no user
       // would trigger a fallback session fetch per hover and could cache an
       // unauthenticated result under the shared span-io query key.
@@ -163,7 +173,7 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
         staleTime: SPAN_IO_STALE_TIME_MS,
       });
     },
-    [queryClient, authSession, trace.project_id, trace.trace_id],
+    [queryClient, authSession, trace.project_id, trace.trace_id, disableIOPrefetch],
   );
 
   // Schedule the prefetch after a short hover delay; cancel on leave / unmount so a

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -117,10 +117,7 @@ interface TraceViewerPanelProps {
    * effect once `diffBaseline` is supplied — the toggle stays user-controllable after.
    */
   defaultDiffOn?: boolean;
-  traceIdentity?: { kindLabel: string; title: string; copyValue: string };
-  /** Badge shown where a span's ERROR badge sits, at trace level. Unset in production. */
-  traceStatusBadge?: ReactNode;
-  diffBaseline?: (selection: TraceSelection) => Span | null;
+  /**
    * Scope the trace fetch: "detector" opens a detector self-trace (excluded
    * from normal reads), "user" excludes self-traces. Omit for no scoping.
    */
@@ -191,8 +188,6 @@ export function TraceViewerPanel({
   headerIdentity,
   headerStatus,
   defaultDiffOn,
-  traceIdentity,
-  traceStatusBadge,
   source,
   runTimestamp,
 }: TraceViewerPanelProps) {
@@ -401,9 +396,6 @@ export function TraceViewerPanel({
                 title={`Copy ${headerIdentity.label.toLowerCase()} id`}
               />
             )}
-            <DOMAIN_ICONS.trace className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm font-medium">Trace</span>
-            <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
           </div>
           <div className="flex items-center gap-1">
             {headerStatus}

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -62,7 +62,7 @@ interface TraceViewerPanelProps {
   /**
    * When provided, this trace is used directly instead of fetching it, and the
    * live SSE stream + detector-findings lookups are disabled. Lets the
-   * offline-eval prototype render the genuine viewer from hardcoded data.
+   * offline-eval surface render the genuine viewer from provided data.
    * Unset in production.
    */
   traceOverride?: TraceDetail;
@@ -268,10 +268,18 @@ export function TraceViewerPanel({
   // avoiding a fresh-chat flash before the id resolves.
   useEffect(() => {
     if (!autoOpenRca || !rcaSessionId) return;
-    setAiContext({ traceId });
+    setAiContext(traceOverride ? null : { traceId });
     setAiInitialSessionId(rcaSessionId);
     setAiPanelOpen(true);
-  }, [autoOpenRca, rcaSessionId, traceId, setAiContext, setAiInitialSessionId, setAiPanelOpen]);
+  }, [
+    autoOpenRca,
+    rcaSessionId,
+    traceId,
+    traceOverride,
+    setAiContext,
+    setAiInitialSessionId,
+    setAiPanelOpen,
+  ]);
 
   const {
     data: fetchedTrace,
@@ -403,7 +411,7 @@ export function TraceViewerPanel({
               <button
                 type="button"
                 onClick={() => {
-                  setAiContext({ traceId });
+                  setAiContext(traceOverride ? null : { traceId });
                   setAiInitialSessionId(rcaSessionId);
                   setAiPanelOpen(true);
                 }}
@@ -442,31 +450,35 @@ export function TraceViewerPanel({
             >
               {isFullscreen ? <Shrink className="h-4 w-4" /> : <Expand className="h-4 w-4" />}
             </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() =>
-                window.open(
-                  buildUrlWithFilters(newTabPath ?? `/projects/${projectId}/traces`, {
-                    dateFilter,
-                    customStartDate,
-                    customEndDate,
-                    // A self-trace's id matches no list row's trace_id, so the
-                    // receiving page needs the source to reopen it as a
-                    // self-trace instead of looking it up as an original.
-                    extraParams:
-                      source === "detector"
-                        ? { traceId, fullscreen: "1", source }
-                        : { traceId, fullscreen: "1" },
-                  }),
-                  "_blank",
-                )
-              }
-              className="h-7 w-7 p-0"
-              title="Open in new tab"
-            >
-              <SquareArrowOutUpRight className="h-4 w-4" />
-            </Button>
+            {/* Hidden under an override: traceId is the synthetic eval-<resultId>,
+                which nothing downstream can resolve from a URL. */}
+            {!traceOverride && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  window.open(
+                    buildUrlWithFilters(newTabPath ?? `/projects/${projectId}/traces`, {
+                      dateFilter,
+                      customStartDate,
+                      customEndDate,
+                      // A self-trace's id matches no list row's trace_id, so the
+                      // receiving page needs the source to reopen it as a
+                      // self-trace instead of looking it up as an original.
+                      extraParams:
+                        source === "detector"
+                          ? { traceId, fullscreen: "1", source }
+                          : { traceId, fullscreen: "1" },
+                    }),
+                    "_blank",
+                  )
+                }
+                className="h-7 w-7 p-0"
+                title="Open in new tab"
+              >
+                <SquareArrowOutUpRight className="h-4 w-4" />
+              </Button>
+            )}
             <div className="w-2" />
             {/* AI Assistant sits immediately left of Close, separated by a gap
                 from the navigation/view controls, so the agent button stays the
@@ -475,7 +487,7 @@ export function TraceViewerPanel({
               variant="outline"
               size="sm"
               onClick={() => {
-                setAiContext({ traceId });
+                setAiContext(traceOverride ? null : { traceId });
                 // Bot button always opens a fresh chat; an active RCA session
                 // would otherwise hijack the next message into the worker's
                 // session instead of starting a new one.
@@ -518,17 +530,22 @@ export function TraceViewerPanel({
             >
               <SquareGanttChart className="h-3.5 w-3.5" /> Timeline
             </button>
-            <button
-              onClick={() => setViewMode("detectors")}
-              className={cn(
-                "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
-                viewMode === "detectors"
-                  ? "bg-muted text-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <DOMAIN_ICONS.detector className="h-3.5 w-3.5" /> Detectors
-            </button>
+            {/* Detectors fetch by traceId, which under an override is the synthetic
+                eval-<resultId> — no ClickHouse row can ever back it, so the tab is
+                hidden rather than firing a doomed request. */}
+            {!traceOverride && (
+              <button
+                onClick={() => setViewMode("detectors")}
+                className={cn(
+                  "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
+                  viewMode === "detectors"
+                    ? "bg-muted text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <DOMAIN_ICONS.detector className="h-3.5 w-3.5" /> Detectors
+              </button>
+            )}
           </div>
           {/* Diff toggle — only when a baseline is available (offline-eval). */}
           {diffBaseline && viewMode === "tree" && (
@@ -590,6 +607,7 @@ export function TraceViewerPanel({
                         compact={viewMode === "timeline"}
                         hoveredSpanId={hoveredSpanId}
                         onHoverChange={setHoveredSpanId}
+                        disableIOPrefetch={!!traceOverride}
                       />
                     )}
                   </div>
@@ -606,7 +624,7 @@ export function TraceViewerPanel({
                   {/* Detectors fetches its own data by traceId, so it renders
                     ahead of the trace-load guards — a slow or failed *trace*
                     fetch must not hide independently-loaded detector data. */}
-                  {viewMode === "detectors" ? (
+                  {viewMode === "detectors" && !traceOverride ? (
                     <TraceDetectorsTab projectId={projectId} traceId={traceId} />
                   ) : isLoading ? (
                     <div className="flex h-full items-center justify-center">
@@ -658,6 +676,7 @@ export function TraceViewerPanel({
                       diffMode={!!diffBaseline && diffMode}
                       baselineSpan={diffBaseline?.matchSpan(selection) ?? null}
                       baselineTrace={diffBaseline?.trace ?? null}
+                      isEvalShaped={!!traceOverride}
                     />
                   ) : (
                     <SpanTimelineView

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -11,6 +11,7 @@ import {
   Expand,
   Shrink,
   SquareArrowOutUpRight,
+  GitCompare,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn, buildUrlWithFilters, parseAsUTC } from "@/lib/utils";
@@ -19,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { LoadingState } from "@/components/ui/loading-state";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { getTrace } from "@/lib/api";
+import type { Span, TraceDetail } from "@/types/api";
 import { ApiError } from "@/lib/api/errors";
 import type { TraceDetail } from "@/types/api";
 import type { TraceSelection } from "../types";
@@ -79,6 +81,25 @@ interface TraceViewerPanelProps {
    * — e.g. offline-eval's "Dataset:" chip. Unset in production.
    */
   spanExtraTags?: (selection: TraceSelection) => ReactNode;
+  /**
+   * Notified whenever the selected span (or the trace root) changes, so an open
+   * side panel can follow the tree — e.g. offline-eval's "Save as test case"
+   * drawer tracking the clicked span. Unset in production.
+   */
+  onSelectionChange?: (selection: TraceSelection) => void;
+  /**
+   * Diff mode (offline-eval only): the baseline run's trace plus a matcher that
+   * resolves the baseline counterpart of a span selection (matched structurally,
+   * since span ids differ across runs). When provided, a "Diff" toggle appears in
+   * the sub-header; turning it on renders latency/token/cost tags with ± deltas and
+   * Input/Output/Metadata as git-style line diffs vs the baseline — for the whole
+   * trace (root row) as well as each span. Unset in production.
+   */
+  diffBaseline?: {
+    trace: TraceDetail;
+    matchSpan: (selection: TraceSelection) => Span | null;
+  };
+  diffBaseline?: (selection: TraceSelection) => Span | null;
    * Scope the trace fetch: "detector" opens a detector self-trace (excluded
    * from normal reads), "user" excludes self-traces. Omit for no scoping.
    */
@@ -144,10 +165,23 @@ export function TraceViewerPanel({
   spanActions,
   spanHeaderAction,
   spanExtraTags,
+  onSelectionChange,
+  diffBaseline,
   source,
   runTimestamp,
 }: TraceViewerPanelProps) {
   const [selection, setSelection] = useState<TraceSelection>({ type: "trace" });
+  // Diff mode is opt-in per panel (offline-eval only); the toggle only appears
+  // when a baseline matcher is supplied. Persists across ↑/↓ navigation like
+  // fullscreen, since the panel instance stays mounted.
+  const [diffMode, setDiffMode] = useState(false);
+  // Emit selection changes to the parent (kept in a ref so an inline callback
+  // doesn't retrigger the effect — it fires only when `selection` actually changes).
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  onSelectionChangeRef.current = onSelectionChange;
+  useEffect(() => {
+    onSelectionChangeRef.current?.(selection);
+  }, [selection]);
   const [viewMode, setViewMode] = useState<"tree" | "timeline" | "detectors">("tree");
   // Fullscreen widens the slide-in overlay from ~70% to the full viewport.
   // Seeded from initialFullscreen so a trace opened in a new tab lands expanded.
@@ -449,6 +483,23 @@ export function TraceViewerPanel({
               <DOMAIN_ICONS.detector className="h-3.5 w-3.5" /> Detectors
             </button>
           </div>
+          {/* Diff toggle — only when a baseline is available (offline-eval). */}
+          {diffBaseline && viewMode === "tree" && (
+            <div className="ml-auto pr-3">
+              <button
+                onClick={() => setDiffMode((v) => !v)}
+                className={cn(
+                  "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
+                  diffMode
+                    ? "bg-muted text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                title="Diff each span's input, output, metadata and metrics against the baseline run"
+              >
+                <GitCompare className="h-3.5 w-3.5" /> Diff
+              </button>
+            </div>
+          )}
         </div>
 
         {/* ── CONTENT AREA ── */}
@@ -557,6 +608,9 @@ export function TraceViewerPanel({
                       spanActions={spanActions?.(selection)}
                       headerAction={spanHeaderAction?.(selection)}
                       extraTags={spanExtraTags?.(selection)}
+                      diffMode={!!diffBaseline && diffMode}
+                      baselineSpan={diffBaseline?.matchSpan(selection) ?? null}
+                      baselineTrace={diffBaseline?.trace ?? null}
                     />
                   ) : (
                     <SpanTimelineView

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -100,9 +100,17 @@ interface TraceViewerPanelProps {
     matchSpan: (selection: TraceSelection) => Span | null;
   };
   /**
-   * Replaces the trace-level identity (offline-eval), so an evaluation trace leads
-   * with its test case instead of a raw trace id. Unset in production.
+   * Replaces the main header's "Trace" label + trace id (offline-eval), so an
+   * evaluation trace leads with its test case (e.g. label "Test case", value the
+   * test-case id). Unset in production, where the header shows "Trace" + traceId.
    */
+  headerIdentity?: { label: string; value: string };
+  /**
+   * A badge rendered in the main header, immediately left of the navigation
+   * buttons — the same spot the findings "Alert" tag uses. offline-eval puts the
+   * test case's outcome (Passed / Did not pass / Errored) here. Unset in production.
+   */
+  headerStatus?: ReactNode;
   traceIdentity?: { kindLabel: string; title: string; copyValue: string };
   /** Badge shown where a span's ERROR badge sits, at trace level. Unset in production. */
   traceStatusBadge?: ReactNode;
@@ -174,6 +182,8 @@ export function TraceViewerPanel({
   spanExtraTags,
   onSelectionChange,
   diffBaseline,
+  headerIdentity,
+  headerStatus,
   traceIdentity,
   traceStatusBadge,
   source,
@@ -356,11 +366,17 @@ export function TraceViewerPanel({
         {/* ── MAIN HEADER ── */}
         <div className="flex h-12 items-center justify-between border-b border-border bg-muted/30 px-4">
           <div className="flex min-w-0 items-center gap-2">
+            <Workflow className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium">{headerIdentity?.label ?? "Trace"}</span>
+            <span className="truncate font-mono text-xs text-muted-foreground">
+              {headerIdentity?.value ?? traceId}
+            </span>
             <DOMAIN_ICONS.trace className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-medium">Trace</span>
             <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
           </div>
           <div className="flex items-center gap-1">
+            {headerStatus}
             {hasRca && (
               <button
                 type="button"
@@ -620,8 +636,6 @@ export function TraceViewerPanel({
                       diffMode={!!diffBaseline && diffMode}
                       baselineSpan={diffBaseline?.matchSpan(selection) ?? null}
                       baselineTrace={diffBaseline?.trace ?? null}
-                      traceIdentity={traceIdentity}
-                      traceStatusBadge={traceStatusBadge}
                     />
                   ) : (
                     <SpanTimelineView

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -17,6 +17,7 @@ import type { ReactNode } from "react";
 import { cn, buildUrlWithFilters, parseAsUTC } from "@/lib/utils";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
 import { LoadingState } from "@/components/ui/loading-state";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { getTrace } from "@/lib/api";
@@ -365,12 +366,22 @@ export function TraceViewerPanel({
       <div className="flex h-full flex-col bg-background">
         {/* ── MAIN HEADER ── */}
         <div className="flex h-12 items-center justify-between border-b border-border bg-muted/30 px-4">
-          <div className="flex min-w-0 items-center gap-2">
-            <Workflow className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm font-medium">{headerIdentity?.label ?? "Trace"}</span>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <Workflow className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="shrink-0 text-sm font-medium">{headerIdentity?.label ?? "Trace"}</span>
             <span className="truncate font-mono text-xs text-muted-foreground">
               {headerIdentity?.value ?? traceId}
             </span>
+            {/* Copy affordance for the header id. Only offered when an identity is
+                supplied (offline-eval's test case); the standard trace header is
+                unchanged. */}
+            {headerIdentity && (
+              <CopyButton
+                value={headerIdentity.value}
+                className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+                title={`Copy ${headerIdentity.label.toLowerCase()} id`}
+              />
+            )}
             <DOMAIN_ICONS.trace className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-medium">Trace</span>
             <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -112,6 +112,11 @@ interface TraceViewerPanelProps {
    * test case's outcome (Passed / Did not pass / Errored) here. Unset in production.
    */
   headerStatus?: ReactNode;
+  /**
+   * Open the panel with diff mode already on (offline-eval compare-with). Only has an
+   * effect once `diffBaseline` is supplied — the toggle stays user-controllable after.
+   */
+  defaultDiffOn?: boolean;
   traceIdentity?: { kindLabel: string; title: string; copyValue: string };
   /** Badge shown where a span's ERROR badge sits, at trace level. Unset in production. */
   traceStatusBadge?: ReactNode;
@@ -185,6 +190,7 @@ export function TraceViewerPanel({
   diffBaseline,
   headerIdentity,
   headerStatus,
+  defaultDiffOn,
   traceIdentity,
   traceStatusBadge,
   source,
@@ -194,7 +200,12 @@ export function TraceViewerPanel({
   // Diff mode is opt-in per panel (offline-eval only); the toggle only appears
   // when a baseline matcher is supplied. Persists across ↑/↓ navigation like
   // fullscreen, since the panel instance stays mounted.
-  const [diffMode, setDiffMode] = useState(false);
+  const [diffMode, setDiffMode] = useState(defaultDiffOn ?? false);
+  // When a compare run is picked (offline-eval), auto-open diff mode so opening a case
+  // trace lands in the diff directly. The user can still toggle it off afterward.
+  useEffect(() => {
+    if (defaultDiffOn) setDiffMode(true);
+  }, [defaultDiffOn]);
   // Emit selection changes to the parent (kept in a ref so an inline callback
   // doesn't retrigger the effect — it fires only when `selection` actually changes).
   const onSelectionChangeRef = useRef(onSelectionChange);

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -11,17 +11,14 @@ import {
   Expand,
   Shrink,
   SquareArrowOutUpRight,
-  GitCompare,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn, buildUrlWithFilters, parseAsUTC } from "@/lib/utils";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { Button } from "@/components/ui/button";
-import { CopyButton } from "@/components/ui/copy-button";
 import { LoadingState } from "@/components/ui/loading-state";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { getTrace } from "@/lib/api";
-import type { Span, TraceDetail } from "@/types/api";
 import { ApiError } from "@/lib/api/errors";
 import type { TraceDetail } from "@/types/api";
 import type { TraceSelection } from "../types";
@@ -62,7 +59,7 @@ interface TraceViewerPanelProps {
   /**
    * When provided, this trace is used directly instead of fetching it, and the
    * live SSE stream + detector-findings lookups are disabled. Lets the
-   * offline-eval surface render the genuine viewer from provided data.
+   * offline-eval prototype render the genuine viewer from hardcoded data.
    * Unset in production.
    */
   traceOverride?: TraceDetail;
@@ -82,45 +79,6 @@ interface TraceViewerPanelProps {
    * — e.g. offline-eval's "Dataset:" chip. Unset in production.
    */
   spanExtraTags?: (selection: TraceSelection) => ReactNode;
-  /**
-   * Notified whenever the selected span (or the trace root) changes, so an open
-   * side panel can follow the tree — e.g. offline-eval's "Save as test case"
-   * drawer tracking the clicked span. Unset in production.
-   */
-  onSelectionChange?: (selection: TraceSelection) => void;
-  /**
-   * Diff mode (offline-eval only): the baseline run's trace plus a matcher that
-   * resolves the baseline counterpart of a span selection (matched structurally,
-   * since span ids differ across runs). When provided, a "Diff" toggle appears in
-   * the sub-header; turning it on renders latency/token/cost tags with ± deltas and
-   * Input/Output/Metadata as git-style line diffs vs the baseline — for the whole
-   * trace (root row) as well as each span. Unset in production.
-   */
-  diffBaseline?: {
-    trace: TraceDetail;
-    matchSpan: (selection: TraceSelection) => Span | null;
-  };
-  /**
-   * Replaces the main header's "Trace" label + trace id (offline-eval), so an
-   * evaluation trace leads with its test case (e.g. label "Test case", value the
-   * test-case id). Unset in production, where the header shows "Trace" + traceId.
-   */
-  headerIdentity?: { label: string; value: string };
-  /**
-   * A badge rendered in the main header, immediately left of the navigation
-   * buttons — the same spot the findings "Alert" tag uses. offline-eval puts the
-   * test case's outcome (Passed / Did not pass / Errored) here. Unset in production.
-   */
-  headerStatus?: ReactNode;
-  /**
-   * Open the panel with diff mode already on (offline-eval compare-with). Only has an
-   * effect once `diffBaseline` is supplied — the toggle stays user-controllable after.
-   */
-  defaultDiffOn?: boolean;
-  traceIdentity?: { kindLabel: string; title: string; copyValue: string };
-  /** Badge shown where a span's ERROR badge sits, at trace level. Unset in production. */
-  traceStatusBadge?: ReactNode;
-  diffBaseline?: (selection: TraceSelection) => Span | null;
    * Scope the trace fetch: "detector" opens a detector self-trace (excluded
    * from normal reads), "user" excludes self-traces. Omit for no scoping.
    */
@@ -186,33 +144,10 @@ export function TraceViewerPanel({
   spanActions,
   spanHeaderAction,
   spanExtraTags,
-  onSelectionChange,
-  diffBaseline,
-  headerIdentity,
-  headerStatus,
-  defaultDiffOn,
-  traceIdentity,
-  traceStatusBadge,
   source,
   runTimestamp,
 }: TraceViewerPanelProps) {
   const [selection, setSelection] = useState<TraceSelection>({ type: "trace" });
-  // Diff mode is opt-in per panel (offline-eval only); the toggle only appears
-  // when a baseline matcher is supplied. Persists across ↑/↓ navigation like
-  // fullscreen, since the panel instance stays mounted.
-  const [diffMode, setDiffMode] = useState(defaultDiffOn ?? false);
-  // When a compare run is picked (offline-eval), auto-open diff mode so opening a case
-  // trace lands in the diff directly. The user can still toggle it off afterward.
-  useEffect(() => {
-    if (defaultDiffOn) setDiffMode(true);
-  }, [defaultDiffOn]);
-  // Emit selection changes to the parent (kept in a ref so an inline callback
-  // doesn't retrigger the effect — it fires only when `selection` actually changes).
-  const onSelectionChangeRef = useRef(onSelectionChange);
-  onSelectionChangeRef.current = onSelectionChange;
-  useEffect(() => {
-    onSelectionChangeRef.current?.(selection);
-  }, [selection]);
   const [viewMode, setViewMode] = useState<"tree" | "timeline" | "detectors">("tree");
   // Fullscreen widens the slide-in overlay from ~70% to the full viewport.
   // Seeded from initialFullscreen so a trace opened in a new tab lands expanded.
@@ -377,28 +312,12 @@ export function TraceViewerPanel({
       <div className="flex h-full flex-col bg-background">
         {/* ── MAIN HEADER ── */}
         <div className="flex h-12 items-center justify-between border-b border-border bg-muted/30 px-4">
-          <div className="flex min-w-0 items-center gap-1.5">
-            <Workflow className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <span className="shrink-0 text-sm font-medium">{headerIdentity?.label ?? "Trace"}</span>
-            <span className="truncate font-mono text-xs text-muted-foreground">
-              {headerIdentity?.value ?? traceId}
-            </span>
-            {/* Copy affordance for the header id. Only offered when an identity is
-                supplied (offline-eval's test case); the standard trace header is
-                unchanged. */}
-            {headerIdentity && (
-              <CopyButton
-                value={headerIdentity.value}
-                className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
-                title={`Copy ${headerIdentity.label.toLowerCase()} id`}
-              />
-            )}
+          <div className="flex min-w-0 items-center gap-2">
             <DOMAIN_ICONS.trace className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-medium">Trace</span>
             <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
           </div>
           <div className="flex items-center gap-1">
-            {headerStatus}
             {hasRca && (
               <button
                 type="button"
@@ -530,23 +449,6 @@ export function TraceViewerPanel({
               <DOMAIN_ICONS.detector className="h-3.5 w-3.5" /> Detectors
             </button>
           </div>
-          {/* Diff toggle — only when a baseline is available (offline-eval). */}
-          {diffBaseline && viewMode === "tree" && (
-            <div className="ml-auto pr-3">
-              <button
-                onClick={() => setDiffMode((v) => !v)}
-                className={cn(
-                  "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
-                  diffMode
-                    ? "bg-muted text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground",
-                )}
-                title="Diff each span's input, output, metadata and metrics against the baseline run"
-              >
-                <GitCompare className="h-3.5 w-3.5" /> Diff
-              </button>
-            </div>
-          )}
         </div>
 
         {/* ── CONTENT AREA ── */}
@@ -655,9 +557,6 @@ export function TraceViewerPanel({
                       spanActions={spanActions?.(selection)}
                       headerAction={spanHeaderAction?.(selection)}
                       extraTags={spanExtraTags?.(selection)}
-                      diffMode={!!diffBaseline && diffMode}
-                      baselineSpan={diffBaseline?.matchSpan(selection) ?? null}
-                      baselineTrace={diffBaseline?.trace ?? null}
                     />
                   ) : (
                     <SpanTimelineView

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -99,6 +99,13 @@ interface TraceViewerPanelProps {
     trace: TraceDetail;
     matchSpan: (selection: TraceSelection) => Span | null;
   };
+  /**
+   * Replaces the trace-level identity (offline-eval), so an evaluation trace leads
+   * with its test case instead of a raw trace id. Unset in production.
+   */
+  traceIdentity?: { kindLabel: string; title: string; copyValue: string };
+  /** Badge shown where a span's ERROR badge sits, at trace level. Unset in production. */
+  traceStatusBadge?: ReactNode;
   diffBaseline?: (selection: TraceSelection) => Span | null;
    * Scope the trace fetch: "detector" opens a detector self-trace (excluded
    * from normal reads), "user" excludes self-traces. Omit for no scoping.
@@ -167,6 +174,8 @@ export function TraceViewerPanel({
   spanExtraTags,
   onSelectionChange,
   diffBaseline,
+  traceIdentity,
+  traceStatusBadge,
   source,
   runTimestamp,
 }: TraceViewerPanelProps) {
@@ -611,6 +620,8 @@ export function TraceViewerPanel({
                       diffMode={!!diffBaseline && diffMode}
                       baselineSpan={diffBaseline?.matchSpan(selection) ?? null}
                       baselineTrace={diffBaseline?.trace ?? null}
+                      traceIdentity={traceIdentity}
+                      traceStatusBadge={traceStatusBadge}
                     />
                   ) : (
                     <SpanTimelineView


### PR DESCRIPTION
## Summary

Fixes: #1664

Opening a result from the run detail shows its real execution trace in the trace viewer, led by the test case's identity and status rather than the raw root span — so the result's identity and pass/fail state sit at the top while the spans below explain how it got there. The panel's up/down chevrons step between results in table order without re-animating the panel, and the view resets to the first result when the run switches. When a result reported no telemetry, the panel falls back to a clearly-labelled eval-shaped trace built from the result and its scores; span I/O falls back to the span's own values when the dedicated I/O fetch is empty.

## How it works

The run detail prefers the result's real ingested trace, sharing the trace viewer's cache key so opening the panel does not refetch. While that trace is still ingesting the panel shows a pending state with retry; once it lands it opens directly. For a fully-local result with no trace id, an eval-shaped trace is reconstructed — an evaluation-item root over a task span and one scorer span per scorer that ran — and its span I/O is seeded into the viewer's cache. The panel leads with a "Test case" header carrying the case id and a copy button and the case's status badge, and exposes per-result actions (review output, view source test case, and — for a real trace — save the selected span as a test case). Stepping walks the run's currently-visible results in table order; because the panel updates in place on trace-id change instead of remounting, the slide-in isn't replayed on each step.

## What's included

### UI
- `features/traces/components/SpanTreeView.tsx` — provides `TreeRow`, `getVisibleSpanRows`, `buildTreeRows`, `SpanTreeViewHandle`.

### Trace viewer integration
- `features/traces/components/TraceViewerPanel.tsx` — the `headerIdentity` (label + copyable id) and `headerStatus` header slots, `traceOverride` for the reconstructed trace, `onNavigate` / `newTabPath` / `spanActions` / `spanExtraTags` / `onSelectionChange` slots, and updating in place on trace-id change so stepping doesn't re-animate.
- `features/traces/components/SpanInfoPanel.tsx` — reduces the eval-shaped span rows to their I/O and falls back to the span object's own input/output/metadata when the per-span I/O fetch returns nothing.

### Shared components

### Hooks / data
- `features/traces` — `useTrace` for the result's real ingested trace.

### Tests
- `features/evaluations/run-detail-compare.smoke.test.tsx` — covers `run-detail-compare.smoke`.
- `features/traces/components/SpanInfoPanel.review.test.tsx` — covers `SpanInfoPanel.review`.

## Test plan

- [ ] A result opens its real trace, led by the test case, with the case status shown and the case id copyable from the header.
- [ ] Result stepping with the chevrons walks the run's results in table order and does not re-animate the panel on each step.
- [ ] Switching runs resets the panel to the first result rather than holding the previous run's position.
- [ ] A result with no ingested trace opens a clearly-labelled reconstructed eval-shaped trace led by the test case, with span rows reduced to their I/O.
- [ ] Span I/O falls back to the span's own values when the dedicated I/O fetch is empty.
- [ ] A result whose telemetry is still ingesting shows the pending state with a working retry.
