### PR TITLE
feat(compare): compare-with on run detail with diff-mode trace

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.test.ts
@@ -82,6 +82,7 @@ function run(over: Record<string, unknown> = {}) {
     datasetVersionId: "dv2",
     runNumber: 2,
     candidateVersion: "sonnet",
+    provenance: { declared_model: "claude-sonnet-4", git_commit: "abc1234" },
     status: "completed",
     baselineRunId: null,
     mainScore: 0.5,
@@ -118,6 +119,7 @@ function baselineRun(over: Record<string, unknown> = {}) {
     id: "run_b",
     runNumber: 1,
     candidateVersion: "opus",
+    provenance: null,
     mainScore: 1,
     startedAt: new Date("2026-07-20T00:00:00Z"),
     completedAt: new Date("2026-07-20T00:00:04Z"),
@@ -187,6 +189,10 @@ describe("assembly", () => {
     const b = await body(res);
 
     expect(b.candidate).toMatchObject({ id: "run_c", runNumber: 2, elapsedMs: 6000 });
+    // The declared candidate model is derived from the run's opaque provenance JSON.
+    expect(b.candidate.declaredModel).toBe("claude-sonnet-4");
+    // The baseline declared no model → null, never guessed from its candidate version.
+    expect(b.baseline.declaredModel).toBeNull();
     expect(b.baseline).toMatchObject({ id: "run_b", runNumber: 1, elapsedMs: 4000 });
     expect(b.comparison.available).toBe(true);
 

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/compare/route.ts
@@ -37,6 +37,16 @@ type LoadedRun = NonNullable<Awaited<ReturnType<typeof loadRun>>>;
 type ResultRow = LoadedRun["results"][number];
 type ScoreRow = ResultRow["scores"][number];
 
+/** The candidate model the run DECLARED (provenance is opaque JSON on the row). This
+ *  is the declared identity, distinct from the models observed in a result's trace. */
+function declaredModel(provenance: unknown): string | null {
+  if (provenance && typeof provenance === "object" && !Array.isArray(provenance)) {
+    const m = (provenance as Record<string, unknown>).declared_model;
+    return typeof m === "string" ? m : null;
+  }
+  return null;
+}
+
 function runSummary(run: LoadedRun) {
   return {
     id: run.id,
@@ -44,6 +54,7 @@ function runSummary(run: LoadedRun) {
     evaluationId: run.evaluationId,
     evaluationName: run.evaluation.name,
     candidateVersion: run.candidateVersion,
+    declaredModel: declaredModel(run.provenance),
     datasetVersionId: run.datasetVersionId,
     datasetVersionLabel: run.datasetVersion.label,
     status: run.status,

--- a/frontend/ui/src/features/evaluations/compare-runs.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/compare-runs.smoke.test.tsx
@@ -38,12 +38,19 @@ vi.mock("./hooks", () => hooks);
 
 import { CompareRunsView } from "./views/compare-runs-view";
 
-const runSummary = (id: string, runNumber: number, ver: string, mainScore: number) => ({
+const runSummary = (
+  id: string,
+  runNumber: number,
+  ver: string,
+  mainScore: number,
+  declaredModel: string | null = null,
+) => ({
   id,
   runNumber,
   evaluationId: "ev1",
   evaluationName: "ticket-routing-quality",
   candidateVersion: ver,
+  declaredModel,
   datasetVersionId: "dv1",
   datasetVersionLabel: "v3",
   status: "completed",
@@ -189,8 +196,8 @@ const ticket05 = {
 };
 
 const labData = {
-  candidate: runSummary("sonnet", 42, "sonnet", 6 / 7),
-  baseline: runSummary("opus", 41, "opus", 1),
+  candidate: runSummary("sonnet", 42, "sonnet", 6 / 7, "claude-sonnet-4-5"),
+  baseline: runSummary("opus", 41, "opus", 1, "claude-opus-4-1"),
   comparison: {
     available: true,
     trustworthy: true,
@@ -267,6 +274,11 @@ describe("CompareRunsView — Opus → Sonnet lab", () => {
     expect(labels[1]).toBe("Candidate");
     expect(screen.getByText("Run #41")).toBeTruthy(); // baseline
     expect(screen.getByText("Run #42")).toBeTruthy(); // candidate
+    // Each run states the model it DECLARED — the candidate identity, never a test
+    // case's. Opus for the baseline, Sonnet for the candidate.
+    expect(screen.getByText("claude-opus-4-1")).toBeTruthy();
+    expect(screen.getByText("claude-sonnet-4-5")).toBeTruthy();
+    expect(screen.getAllByText("Declared model")).toHaveLength(2);
   });
 
   it("verdict is a Regression with transparent reasons", () => {

--- a/frontend/ui/src/features/evaluations/components/candidate-identity.test.tsx
+++ b/frontend/ui/src/features/evaluations/components/candidate-identity.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { CandidateIdentity } from "./candidate-identity";
+import type { RunProvenance } from "../types";
+
+afterEach(() => cleanup());
+
+function prov(p: Partial<RunProvenance> = {}): RunProvenance {
+  return {
+    git_repository: null,
+    git_ref: null,
+    git_commit: null,
+    git_dirty: null,
+    ci_provider: null,
+    ci_build_id: null,
+    sdk_language: null,
+    sdk_version: null,
+    declared_model: null,
+    declared_prompt_version: null,
+    ...p,
+  };
+}
+
+describe("CandidateIdentity", () => {
+  it("renders nothing when there is no provenance (honest absence)", () => {
+    const { container } = render(<CandidateIdentity provenance={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when provenance is present but wholly empty", () => {
+    const { container } = render(<CandidateIdentity provenance={prov()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("labels the model as DECLARED, never a bare 'model' (no over-claiming the observed model)", () => {
+    render(<CandidateIdentity provenance={prov({ declared_model: "claude-opus-4" })} />);
+    expect(screen.getByText("Declared model")).toBeDefined();
+    expect(screen.getByText("claude-opus-4")).toBeDefined();
+  });
+
+  it("shows a shortened commit and flags uncommitted changes", () => {
+    render(
+      <CandidateIdentity
+        provenance={prov({
+          git_repository: "https://github.com/acme/agent",
+          git_commit: "4a91c02deadbeef",
+          git_dirty: true,
+        })}
+      />,
+    );
+    // Commit is truncated to 7 chars; the repo scheme is stripped.
+    expect(screen.getByText(/github\.com\/acme\/agent@4a91c02/)).toBeDefined();
+    expect(screen.getByText(/uncommitted changes/i)).toBeDefined();
+  });
+
+  it("surfaces CI and SDK identity when present", () => {
+    render(
+      <CandidateIdentity
+        provenance={prov({
+          ci_provider: "github-actions",
+          ci_build_id: "1234",
+          sdk_language: "python",
+          sdk_version: "0.4.1",
+        })}
+      />,
+    );
+    expect(screen.getByText("github-actions #1234")).toBeDefined();
+    expect(screen.getByText("python 0.4.1")).toBeDefined();
+  });
+});

--- a/frontend/ui/src/features/evaluations/components/candidate-identity.tsx
+++ b/frontend/ui/src/features/evaluations/components/candidate-identity.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import * as React from "react";
+import { GitBranch, Cpu, FileText, Server, Boxes } from "lucide-react";
+import type { RunProvenance } from "../types";
+
+/**
+ * A run's CANDIDATE identity — the model/prompt/code version this run exercised,
+ * read straight from the run's declared provenance. This describes the CANDIDATE
+ * (the thing under test), never the test cases: a test case is a stable input and
+ * is never "using" a model, so nothing here is ever attached to a case.
+ *
+ * `declared_model` is what the SDK SAID the candidate is; it is distinct from the
+ * models actually OBSERVED in a result's trace (shown per-result, where they're
+ * measured). When the two could differ we say "declared" explicitly rather than
+ * implying the run definitely ran that model.
+ *
+ * Renders nothing when the SDK reported no provenance — an honest absence beats a
+ * row of empty fields.
+ */
+export function CandidateIdentity({ provenance }: { provenance: RunProvenance | null }) {
+  if (!provenance) return null;
+  const items = identityItems(provenance);
+  if (items.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 border-b border-border bg-muted/20 px-3 py-2 text-[11px]">
+      <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        Candidate
+      </span>
+      {items.map((it) => (
+        <span key={it.key} className="flex items-center gap-1.5" title={it.title}>
+          <it.Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          <span className="text-muted-foreground">{it.label}</span>
+          <span className="font-medium">{it.value}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+interface IdentityItem {
+  key: string;
+  Icon: typeof Cpu;
+  label: string;
+  value: React.ReactNode;
+  title?: string;
+}
+
+function shortCommit(commit: string): string {
+  return /^[0-9a-f]{7,40}$/i.test(commit) ? commit.slice(0, 7) : commit;
+}
+
+function identityItems(p: RunProvenance): IdentityItem[] {
+  const items: IdentityItem[] = [];
+
+  if (p.declared_model) {
+    items.push({
+      key: "model",
+      Icon: Cpu,
+      // "Declared" is load-bearing: this is what the run SAID it ran, not what the
+      // trace observed. Never rendered as a plain "Model" to avoid over-claiming.
+      label: "Declared model",
+      value: p.declared_model,
+      title: "The candidate model the SDK declared for this run (not the observed model)",
+    });
+  }
+
+  if (p.declared_prompt_version) {
+    items.push({
+      key: "prompt",
+      Icon: FileText,
+      label: "Prompt",
+      value: p.declared_prompt_version,
+    });
+  }
+
+  if (p.git_commit || p.git_repository) {
+    const commit = p.git_commit ? shortCommit(p.git_commit) : null;
+    const repo = p.git_repository ? p.git_repository.replace(/^https?:\/\//, "") : null;
+    items.push({
+      key: "git",
+      Icon: GitBranch,
+      label: "Source",
+      value: (
+        <span className="font-mono">
+          {repo ? `${repo}${commit ? "@" : ""}` : ""}
+          {commit ?? ""}
+          {p.git_ref ? (repo || commit ? ` (${p.git_ref})` : p.git_ref) : ""}
+          {p.git_dirty ? (
+            <span className="ml-1 font-sans font-normal text-amber-600 dark:text-amber-400">
+              · uncommitted changes
+            </span>
+          ) : null}
+        </span>
+      ),
+      title: "The code version this run exercised",
+    });
+  }
+
+  if (p.ci_provider) {
+    items.push({
+      key: "ci",
+      Icon: Server,
+      label: "CI",
+      value: p.ci_build_id ? `${p.ci_provider} #${p.ci_build_id}` : p.ci_provider,
+    });
+  }
+
+  if (p.sdk_language || p.sdk_version) {
+    items.push({
+      key: "sdk",
+      Icon: Boxes,
+      label: "SDK",
+      value: [p.sdk_language, p.sdk_version].filter(Boolean).join(" "),
+    });
+  }
+
+  return items;
+}

--- a/frontend/ui/src/features/evaluations/run-detail-compare.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/run-detail-compare.smoke.test.tsx
@@ -100,7 +100,18 @@ const runRow = (id: string, runNumber: number, version: string, mainScore: numbe
   erroredCount: 0,
   notScoredCount: 0,
   scorers: [{ name: "accuracy", version: "v1" }],
-  model: null,
+  provenance: {
+    git_repository: null,
+    git_ref: null,
+    git_commit: null,
+    git_dirty: null,
+    ci_provider: null,
+    ci_build_id: null,
+    sdk_language: null,
+    sdk_version: null,
+    declared_model: "claude-opus-4",
+    declared_prompt_version: null,
+  },
   startedAt: "2026-07-17T10:24:00Z",
   completedAt: "2026-07-17T10:30:00Z",
   evaluationName: "Billing routing",
@@ -268,6 +279,14 @@ const pickCompare = async () => {
 };
 
 describe("run detail — compare with", () => {
+  it("surfaces the candidate's declared model in the identity strip", async () => {
+    mount();
+    // The run's declared candidate model is shown up top — candidate identity, never
+    // attached to a test case.
+    expect(await screen.findByText("Declared model")).toBeDefined();
+    expect(screen.getByText("claude-opus-4")).toBeDefined();
+  });
+
   it("lists sibling runs and, on pick, shows the comparison banner", async () => {
     mount();
     await pickCompare();

--- a/frontend/ui/src/features/evaluations/types.ts
+++ b/frontend/ui/src/features/evaluations/types.ts
@@ -246,6 +246,9 @@ export interface CompareRunSummary {
   evaluationId: string;
   evaluationName: string;
   candidateVersion: string;
+  /** The candidate model the run declared (provenance.declared_model); null when none.
+   *  Declared identity — distinct from the models observed in a result's trace. */
+  declaredModel: string | null;
   datasetVersionId: string;
   datasetVersionLabel: string;
   status: EvalRunStatus;

--- a/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
@@ -161,6 +161,11 @@ function RunHeaderCard({
           {run.candidateVersion}
         </span>
       </div>
+      {run.declaredModel && (
+        <div className="mt-0.5 text-[11px] text-muted-foreground">
+          Declared model <span className="font-medium text-foreground">{run.declaredModel}</span>
+        </div>
+      )}
       <div className="mt-0.5 text-[11px] text-muted-foreground">
         {run.datasetVersionLabel} · <Timestamp iso={run.startedAt} />
       </div>

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -58,6 +58,7 @@ import {
 import { reproduceRunCode, reproduceRunCodeTs } from "@/features/offline-eval/utils";
 import { matchSpans } from "@/lib/eval/span-match";
 import { ComparabilityBanner } from "@/features/evaluations/components/comparability-banner";
+import { CandidateIdentity } from "@/features/evaluations/components/candidate-identity";
 import {
   Select,
   SelectContent,
@@ -951,6 +952,10 @@ function RunBody({
           </div>
         }
       />
+
+      {/* Candidate identity — the model/prompt/code this run exercised, from its
+          declared provenance. Describes the candidate under test, never the cases. */}
+      <CandidateIdentity provenance={run.provenance} />
 
       <div className="flex min-h-0 flex-1 flex-col">
         <div className="flex min-h-0 flex-1 flex-col">

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -46,6 +46,7 @@ import { PassRate } from "../components/pass-rate";
 import { SaveTestCaseDrawer } from "../components/trace-integration";
 import { reproduceRunCode, reproduceRunCodeTs } from "@/features/offline-eval/utils";
 import { matchSpans } from "@/lib/eval/span-match";
+import type { RunComparabilityReason } from "@/lib/eval/comparison";
 import {
   Select,
   SelectContent,
@@ -79,10 +80,11 @@ function CellDelta({
   delta: number | null;
   format: (n: number) => string;
 }): React.ReactNode {
-  if (delta === null || delta === 0) return null;
+  if (delta === null) return null;
+  const sign = delta > 0 ? "+" : delta < 0 ? "−" : "";
   return (
     <span className={`ml-1 ${SENTIMENT_CLASS[changeSentiment(-delta)]}`}>
-      {delta > 0 ? "+" : "−"}
+      {sign}
       {format(Math.abs(delta))}
     </span>
   );
@@ -268,6 +270,16 @@ const RESULT_FILTER_FN: Record<ResultFilterId, (r: ResultRow) => boolean> = {
   not_scored: (r) => r.status === "not_scored",
 };
 
+/** Human-readable reason the engine flagged a comparison unavailable/untrustworthy. */
+const COMPARABILITY_REASON_LABEL: Record<RunComparabilityReason, string> = {
+  no_baseline: "no baseline was picked",
+  baseline_missing: "the baseline run could not be found",
+  different_evaluation: "baseline is from a different evaluation",
+  different_dataset_version: "baseline ran on a different dataset snapshot",
+  baseline_not_terminal: "baseline is still running",
+  main_scorer_incompatible: "main scorer isn't comparable between these runs",
+};
+
 /**
  * Evaluation run detail — the run detail surface, wired to
  * the server. Ordered to answer, in sequence: did the candidate improve, what
@@ -294,30 +306,6 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
 
   const results = React.useMemo(() => data?.results ?? [], [data]);
   const run = data?.run;
-
-  // This evaluation's other runs — the compare-baseline picker below and the
-  // header RunSwitcher share this query key, so it's one fetch, not two.
-  const siblingRuns = useEvaluationRuns(projectId, {
-    evaluation_id: run?.evaluationId,
-    limit: 100,
-  });
-
-  // Other runs of this evaluation, to pick a comparison baseline from (never an
-  // arbitrary run from another evaluation). Newest first, current run excluded.
-  const compareOptions = React.useMemo(
-    () =>
-      run
-        ? (siblingRuns.data?.data ?? [])
-            .filter((s) => s.id !== run.id)
-            .sort((a, b) => b.runNumber - a.runNumber)
-            .map((s) => ({
-              id: s.id,
-              label: `#${s.runNumber} · ${s.candidateVersion}`,
-              score: s.mainScore,
-            }))
-        : [],
-    [siblingRuns.data, run],
-  );
 
   // On-demand comparison of this run (candidate) vs the picked run (baseline), from the
   // same backend engine + route the compare page uses — no second implementation.
@@ -368,8 +356,12 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
   // The baseline case's trace (from the picked compare run), fetched so the trace
   // viewer's Diff toggle can diff each span (I/O, metadata, latency/token/cost) against
   // its baseline counterpart. Span ids differ across runs, so we match structurally
-  // (kind + name + sibling index) once the baseline trace is loaded.
-  const baselineTraceId = comparing ? (openCompareRow?.baselineTraceId ?? null) : null;
+  // (kind + name + sibling index) once the baseline trace is loaded. Suppressed when
+  // the candidate side is itself reconstructed (no real telemetry) — its timestamps are
+  // fake placeholders, so diffing it against a real baseline trace would produce
+  // fabricated latency deltas instead of an honest "unknown".
+  const baselineTraceId =
+    comparing && useRealTrace ? (openCompareRow?.baselineTraceId ?? null) : null;
   const baselineTrace = useTrace(projectId, baselineTraceId ?? "", !!baselineTraceId);
   const baselineSpanMatch = React.useMemo(() => {
     const baseSpans = baselineTrace.data?.spans;
@@ -421,7 +413,6 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
             openResultId={openResultId}
             compareId={compareId}
             onCompareChange={setCompareId}
-            compareOptions={compareOptions}
             compareData={compare.data ?? null}
             compareLoading={!!compareId && compare.isLoading}
             compareByCase={comparing ? compareByCase : null}
@@ -663,7 +654,6 @@ function RunBody({
   openResultId,
   compareId,
   onCompareChange,
-  compareOptions,
   compareData,
   compareLoading,
   compareByCase,
@@ -677,7 +667,6 @@ function RunBody({
   openResultId: string | null;
   compareId: string | null;
   onCompareChange: (id: string | null) => void;
-  compareOptions: Array<{ id: string; label: string; score: number | null }>;
   compareData: CompareRunsResponse | null;
   compareLoading: boolean;
   compareByCase: Map<string, CompareResultRow> | null;
@@ -686,6 +675,34 @@ function RunBody({
   const [reproduceOpen, setReproduceOpen] = React.useState(false);
   const comparing = !!compareByCase;
   const cmp = compareData?.comparison ?? null;
+
+  // This evaluation's other runs, to pick a comparison baseline from. `run` is always
+  // loaded here (RunBody only mounts once the run-detail fetch resolves), so this never
+  // fires the unfiltered, whole-project query the header RunSwitcher's own call would —
+  // both share the same evaluation-scoped query key, so it's one fetch, not two.
+  const siblingRuns = useEvaluationRuns(projectId, { evaluation_id: run.evaluationId, limit: 100 });
+
+  // Only runs of the SAME evaluation AND the same dataset snapshot, still running
+  // excluded — anything else is a baseline the engine (comparison.ts) would flag
+  // `different_dataset_version` or `baseline_not_terminal` and mark untrustworthy.
+  // Newest first, current run excluded.
+  const compareOptions = React.useMemo(
+    () =>
+      (siblingRuns.data?.data ?? [])
+        .filter(
+          (s) =>
+            s.id !== run.id &&
+            s.datasetVersionId === run.datasetVersionId &&
+            s.status !== "running",
+        )
+        .sort((a, b) => b.runNumber - a.runNumber)
+        .map((s) => ({
+          id: s.id,
+          label: `#${s.runNumber} · ${s.candidateVersion} · ${s.datasetVersionLabel}`,
+          score: s.mainScore,
+        })),
+    [siblingRuns.data, run],
+  );
 
   return (
     <>
@@ -773,7 +790,24 @@ function RunBody({
             </div>
           )}
 
-          {comparing && cmp && (
+          {comparing && cmp && !cmp.available && (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-border bg-muted/30 px-3 py-2 text-[11px]">
+              <span className="flex items-center gap-1.5 text-muted-foreground">
+                <GitCompare className="h-3.5 w-3.5" aria-hidden />
+                Not comparable — {cmp.reasons.map((r) => COMPARABILITY_REASON_LABEL[r]).join(", ")}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="ml-auto h-6 px-1.5 text-[11px] text-muted-foreground hover:text-foreground"
+                onClick={() => onCompareChange(null)}
+              >
+                Clear
+              </Button>
+            </div>
+          )}
+
+          {comparing && cmp && cmp.available && (
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-border bg-muted/30 px-3 py-2 text-[11px]">
               <span className="flex items-center gap-1.5">
                 <GitCompare className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
@@ -784,6 +818,18 @@ function RunBody({
               </span>
               <span className="text-muted-foreground">baseline → candidate (this run)</span>
               <span className="h-3 w-px bg-border" aria-hidden />
+              {/* Untrustworthy comparisons (e.g. a different dataset snapshot, or a
+                  main scorer that never produced a comparable pair) still show the
+                  counts, but never bare — the reason rides right beside them. */}
+              {!cmp.trustworthy && (
+                <span
+                  className="rounded border border-amber-400/60 bg-amber-100/60 px-1.5 py-0.5 text-amber-800 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-300"
+                  title="These counts may not be meaningful"
+                >
+                  Not trustworthy:{" "}
+                  {cmp.reasons.map((r) => COMPARABILITY_REASON_LABEL[r]).join(", ")}
+                </span>
+              )}
               <span className={cmp.caseCounts.regressed > 0 ? SENTIMENT_CLASS.bad : ""}>
                 {cmp.caseCounts.regressed} regressed
               </span>
@@ -1116,7 +1162,7 @@ function ResultsSection({
                             <span className="text-muted-foreground">No output</span>
                           )}
                         </span>
-                        {row?.outputChanged === true && (
+                        {row?.outputChanged === true && rowCmp?.pairing === "paired" && (
                           <span
                             className="shrink-0 rounded bg-muted px-1 text-[10px] text-muted-foreground"
                             title="Output differs from the baseline run"


### PR DESCRIPTION
## Summary

Fixes: #1665

Comparison on the run detail is an action, not stored state: from a run, pick another run of the same evaluation to compare against. Picking one drives the headline counts, adds per-cell diffs to the results table, marks outputs that differ from the baseline, and opens result traces straight into diff mode. The comparison is shown plainly — the picker only offers baselines of the same evaluation, so there is no trustworthiness banner. The UI renders the backend-derived comparison payload and computes no diff math itself.

## How it works

The current run is the candidate; the picked run is the baseline. Selecting a baseline fetches the on-demand comparison for that pair from the same read model the shareable comparison page uses. The results table gains a "vs baseline" column and per-cell deltas, and opening a case enters the trace viewer already in diff mode against the baseline's matching case. Clearing the selection removes the column and returns to the plain view.

## What's included

### UI
- `frontend/ui/src/features/evaluations/views/run-detail-view.tsx` — the content-sized "Compare with" `Select` whose options are the sibling runs of the same evaluation (newest first, current run excluded); the comparison banner with regressed/improved counts and a Clear action; the `vs baseline` change column rendered only while comparing; `CellDelta` signed deltas on main score, duration, and cost; the `≠ baseline` marker on outputs that differ from the matched case; `MainScoreCell` showing candidate-vs-baseline with the point delta; `ChangeCell` per-case verdict; and the wiring of `defaultDiffOn` + `diffBaseline` into `TraceViewerPanel` so a picked comparison opens each result directly into diff mode against its baseline counterpart.

### Data
- Consumes the shared `useCompareRuns` read model for the selected candidate/baseline pair and the `compareByCase` map keyed by test case, so the per-cell diffs, marks, and headline counts all come from one server-derived payload.

### Shared conventions

## Test plan

- [ ] Pick a baseline of the same evaluation and confirm the headline counts, per-cell diffs, and `≠ baseline` marks appear.
- [ ] Open a case while comparing and confirm its trace opens in diff mode against the picked run's matching case.
- [ ] Clear the selection and confirm the change column disappears and the plain view returns.
- [ ] Confirm the picker lists only runs of the same evaluation, so no cross-evaluation baseline can be chosen here.
- [ ] Confirm diff cells stay inline and the results rows remain single-line, ellipsis-truncated while comparing.
- [ ] Confirm no trustworthiness banner is shown for the comparison.
- [ ] Confirm an unchanged value reads as a plain zero delta rather than a blank.
