### PR TITLE
feat(compare): shareable candidate-vs-baseline comparison view

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/evaluations/compare/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/evaluations/compare/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { CompareRunsView } from "@/features/evaluations/views/compare-runs-view";
+
+// Shareable comparison route: /evaluations/compare?baseline=<run>&candidate=<run>.
+// The static `compare` segment takes priority over the sibling `[runId]` route, so
+// run-detail URLs are unaffected. Baseline/candidate live in the URL so the view is
+// shareable and works with browser back/forward.
+export default function CompareRunsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const projectId = params.projectId as string;
+
+  const setPair = (baseline: string | null, candidate: string | null) => {
+    const q = new URLSearchParams();
+    if (baseline) q.set("baseline", baseline);
+    if (candidate) q.set("candidate", candidate);
+    const qs = q.toString();
+    router.push(`/projects/${projectId}/evaluations/compare${qs ? `?${qs}` : ""}`);
+  };
+
+  return (
+    <CompareRunsView
+      projectId={projectId}
+      candidateId={searchParams.get("candidate")}
+      baselineId={searchParams.get("baseline")}
+      onChange={setPair}
+    />
+  );
+}

--- a/frontend/ui/src/features/evaluations/compare-case-drawer.usage.test.tsx
+++ b/frontend/ui/src/features/evaluations/compare-case-drawer.usage.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+/**
+ * The case drawer's operational block must keep the candidate's task cost SEPARATE
+ * from the evaluation judge's overhead, and report the models it actually OBSERVED
+ * in each side's trace (never inferred from a candidate label). This mounts the
+ * drawer over a candidate trace that has an LLM judge and a baseline trace that has
+ * none, then asserts the three rows read correctly.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { CompareResultRow, CompareRunSummary } from "./types";
+
+// Per-trace spans: candidate has a judge subtree (SCORER→LLM), baseline does not.
+const TRACES: Record<string, unknown[]> = {
+  tr_cand: [
+    { span_id: "r", parent_span_id: null, span_kind: "EVALUATION" },
+    { span_id: "t", parent_span_id: "r", span_kind: "TASK" },
+    {
+      span_id: "t-llm",
+      parent_span_id: "t",
+      span_kind: "LLM",
+      total_tokens: 120,
+      cost: 0.003,
+      model_name: "claude-sonnet-4",
+    },
+    { span_id: "s", parent_span_id: "r", span_kind: "SCORER" },
+    {
+      span_id: "j-llm",
+      parent_span_id: "s",
+      span_kind: "LLM",
+      total_tokens: 45,
+      cost: 0.001,
+      model_name: "gpt-4o-judge",
+    },
+  ],
+  tr_base: [
+    { span_id: "r", parent_span_id: null, span_kind: "EVALUATION" },
+    { span_id: "t", parent_span_id: "r", span_kind: "TASK" },
+    {
+      span_id: "t-llm",
+      parent_span_id: "t",
+      span_kind: "LLM",
+      total_tokens: 100,
+      cost: 0.002,
+      model_name: "claude-opus-4",
+    },
+  ],
+};
+
+vi.mock("@/features/traces/hooks", () => ({
+  useTrace: (_p: string, traceId: string) => ({
+    data: TRACES[traceId] ? { spans: TRACES[traceId] } : undefined,
+  }),
+}));
+vi.mock("@/features/traces/components/TraceIOValue", () => ({
+  TraceIOSection: ({ title, content }: { title: string; content?: string }) => (
+    <div>
+      {title}: {content}
+    </div>
+  ),
+}));
+vi.mock("@/features/traces/components/TraceIODiff", () => ({
+  TraceIODiffSection: () => <div data-testid="io-diff" />,
+}));
+
+import { CompareCaseDrawer } from "./views/compare-case-drawer";
+
+const ROW = {
+  testCaseId: "case-1",
+  input: "Produce a report about Q2 performance",
+  expectedOutput: null,
+  candidateOutput: "Q2 grew 12%.",
+  baselineOutput: "Q2 grew 10%.",
+  candidateTraceId: "tr_cand",
+  baselineTraceId: "tr_base",
+  candidateCost: 0.004,
+  baselineCost: 0.002,
+  candidateTaskError: null,
+  baselineTaskError: null,
+  candidateScores: [],
+  baselineScores: [],
+  outputChanged: true,
+  inputMatchesDataset: true,
+  provenance: null,
+  comparison: { scorerCells: [], baselineDurationMs: 2100, durationMs: 2400 },
+} as unknown as CompareResultRow;
+
+const RUN = (n: number, ver: string): CompareRunSummary =>
+  ({ runNumber: n, candidateVersion: ver }) as unknown as CompareRunSummary;
+
+function rowText(label: string): string {
+  return screen.getByText(label).parentElement?.textContent ?? "";
+}
+
+afterEach(() => cleanup());
+
+describe("CompareCaseDrawer — task vs judge overhead and observed models", () => {
+  it("keeps candidate tokens separate from evaluation overhead and shows observed models", () => {
+    render(
+      <CompareCaseDrawer
+        projectId="p1"
+        row={ROW}
+        candidate={RUN(2, "sonnet")}
+        baseline={RUN(1, "opus")}
+        onClose={() => {}}
+      />,
+    );
+
+    // Candidate task tokens: baseline 100 → candidate 120 (the judge's 45 is NOT here).
+    expect(rowText("Candidate tokens")).toMatch(/100.*→.*120/);
+
+    // The judge's own tokens are reported apart, and never folded into the candidate:
+    // baseline had no judge (None), candidate's judge spent 45.
+    expect(rowText("Evaluation overhead")).toMatch(/None.*→.*45/);
+    expect(rowText("Evaluation overhead")).toMatch(/judge tokens/);
+
+    // Observed models are measured per side from the trace, not the "opus"/"sonnet"
+    // candidate labels.
+    expect(rowText("Observed model")).toMatch(/claude-opus-4.*→.*claude-sonnet-4/);
+  });
+});

--- a/frontend/ui/src/features/evaluations/views/compare-case-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-case-drawer.tsx
@@ -138,6 +138,7 @@ export function CompareCaseDrawer({
   baseline,
   onClose,
   traceSlot,
+  enabled = true,
 }: {
   projectId: string;
   row: CompareResultRow;
@@ -146,17 +147,29 @@ export function CompareCaseDrawer({
   onClose: () => void;
   /** Trace-access controls (candidate/baseline), wired by the page. */
   traceSlot?: React.ReactNode;
+  /**
+   * Set to false while a non-nested overlay stacked above the drawer (e.g. the trace
+   * viewer opened via traceSlot) should own Escape instead of the drawer.
+   */
+  enabled?: boolean;
 }) {
+  // Close on Escape. Listen on `document` in the bubble phase — the convention used by
+  // TraceViewerPanel — and bail if the key was already consumed by a nested overlay
+  // (Radix select/popover), signaled via `defaultPrevented`; call preventDefault() here
+  // so any layer further out also knows Escape was handled. `enabled` additionally lets
+  // the page suppress this while a sibling overlay (not a descendant, so it can't rely on
+  // defaultPrevented) is stacked on top and should own Escape instead.
   React.useEffect(() => {
+    if (!enabled) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.stopPropagation();
-        onClose();
-      }
+      if (e.key !== "Escape") return;
+      if (e.defaultPrevented) return;
+      e.preventDefault();
+      onClose();
     };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [onClose]);
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose, enabled]);
 
   const candUsage = useUsage(projectId, row.candidateTraceId);
   const baseUsage = useUsage(projectId, row.baselineTraceId);
@@ -164,7 +177,10 @@ export function CompareCaseDrawer({
   const outputSame = row.outputChanged === false;
 
   return (
-    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[620px] max-w-[96vw] flex-col border-l border-border bg-background text-[12px] shadow-xl">
+    <div
+      id="compare-case-drawer"
+      className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[620px] max-w-[96vw] flex-col border-l border-border bg-background text-[12px] shadow-xl"
+    >
       <div className="flex shrink-0 items-start justify-between gap-2 border-b border-border px-4 py-3">
         <div className="min-w-0">
           <div className="text-[13px] font-medium">Case comparison</div>

--- a/frontend/ui/src/features/evaluations/views/compare-case-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-case-drawer.tsx
@@ -125,6 +125,30 @@ function tokenText(u: TraceUsage): string {
   return u.combined.totalTokens.toLocaleString("en-US");
 }
 
+// Evaluation-judge (scorer subtree) tokens — the cost of GRADING, kept apart from the
+// candidate's task tokens so it never enters the candidate verdict. "None" is a proven
+// zero (a trace with no judge usage), distinct from pending/unknown.
+function overheadTokenText(u: TraceUsage): string {
+  if (u.state === "pending") return "Pending";
+  if (u.state === "unknown") return "Unknown";
+  if (u.scorer.spanCount === 0) return "None";
+  return u.scorer.totalTokens.toLocaleString("en-US");
+}
+
+/** Distinct OBSERVED models in a bucket — measured from the trace, never inferred from
+ *  a candidate label. Em dash when the trace reported none. */
+function modelsText(u: TraceUsage, bucket: "task" | "scorer"): string {
+  if (u.state === "pending") return "Pending";
+  const models = u[bucket].models;
+  return models.length > 0 ? models.join(", ") : "—";
+}
+
+/** True once either side's trace has real usage — gates the judge/model rows so they
+ *  don't render a wall of "Unknown" before any trace has loaded. */
+function anyUsagePresent(a: TraceUsage, b: TraceUsage): boolean {
+  return a.state === "present" || b.state === "present";
+}
+
 /**
  * Selected-case diagnosis drawer: context, Baseline|Candidate outputs, per-scorer
  * breakdown with explanations, operational metrics (duration server-derived; cost
@@ -302,13 +326,39 @@ export function CompareCaseDrawer({
             }
           />
           <OpMetric
-            label="Tokens (trace)"
+            label="Candidate tokens"
             value={
               <span>
                 {tokenText(baseUsage)} → {tokenText(candUsage)}
               </span>
             }
           />
+          {/* The judge's own token cost — reported, but explicitly separate from the
+              candidate above so it never colours the candidate verdict. */}
+          {anyUsagePresent(baseUsage, candUsage) &&
+            (baseUsage.scorer.spanCount > 0 || candUsage.scorer.spanCount > 0) && (
+              <OpMetric
+                label="Evaluation overhead"
+                value={
+                  <span className="text-muted-foreground">
+                    {overheadTokenText(baseUsage)} → {overheadTokenText(candUsage)}
+                    <span className="ml-1 text-[10px]">judge tokens</span>
+                  </span>
+                }
+              />
+            )}
+          {/* Observed candidate models — measured from each side's trace, kept distinct
+              from the run's declared model (which can differ). */}
+          {anyUsagePresent(baseUsage, candUsage) && (
+            <OpMetric
+              label="Observed model"
+              value={
+                <span>
+                  {modelsText(baseUsage, "task")} → {modelsText(candUsage, "task")}
+                </span>
+              }
+            />
+          )}
         </div>
 
         {/* Trace access (wired by the page) */}

--- a/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { useRouter } from "next/navigation";
-import { ArrowLeftRight, ArrowRight, Info } from "lucide-react";
+import { useQueries } from "@tanstack/react-query";
+import { ArrowLeftRight, ArrowRight, ChevronDown, ChevronRight, Info } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -14,37 +14,50 @@ import { Button } from "@/components/ui/button";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { EmptyState, Timestamp } from "@/features/offline-eval/components";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import {
-  changeSentiment,
-  pctFraction,
-  SENTIMENT_CLASS,
-  signedPoints,
-} from "@/features/offline-eval/utils";
+import { changeSentiment, pctFraction, SENTIMENT_CLASS } from "@/features/offline-eval/utils";
+import { cn } from "@/lib/utils";
+import { getTrace } from "@/lib/api";
+import { useSession as useAuthSession } from "@/lib/auth-client";
+import { TraceViewerPanel } from "@/features/traces/components";
+import { attributeTraceUsage, type TraceUsage, type UsageSpan } from "@/lib/eval/trace-usage";
 import { useCompareRuns, useEvaluationRuns, useEvaluations } from "../hooks";
-import type { CompareRunSummary, RunComparison, Classification } from "../types";
+import type {
+  CompareRunSummary,
+  RunComparison,
+  Classification,
+  CompareResultRow,
+  ScorerCellComparison,
+} from "../types";
 import { RunStatusBadge } from "./evaluations-view";
+import { CompareCaseDrawer } from "./compare-case-drawer";
+import {
+  deriveVerdict,
+  VERDICT_META,
+  BLOCKING_REASONS,
+  REASON_LABEL,
+  CASE_FILTERS,
+  CASE_SORTS,
+  matchesFilter,
+  filterCounts,
+  sortCases,
+  caseStatus,
+  type CaseFilterId,
+  type CaseSortId,
+  type CaseStatus,
+} from "../compare-derive";
 
-/** Reasons that make a comparison's deltas untrustworthy. `different_evaluation` is
- *  intentionally NOT here — cross-evaluation comparison is allowed and merely labeled;
- *  what disables trusted deltas is a dataset-version mismatch, a non-terminal baseline,
- *  a missing baseline, or an incompatible main scorer. */
-const BLOCKING_REASONS = new Set([
-  "different_dataset_version",
-  "baseline_not_terminal",
-  "baseline_missing",
-  "no_baseline",
-  "main_scorer_incompatible",
-]);
+// ── Small formatters ──────────────────────────────────────────────────────
+const fmtScore = (v: number | null) => (v === null ? "—" : pctFraction(v));
+const fmtMs = (n: number | null) =>
+  n === null ? "Unknown" : n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`;
+const fmtCost = (n: number | null) => (n === null ? "Unknown" : `$${n.toFixed(4)}`);
+const truncate = (s: string, n = 90) => (s.length > n ? `${s.slice(0, n)}…` : s);
 
-const REASON_LABEL: Record<string, string> = {
-  no_baseline: "No baseline chosen.",
-  baseline_missing: "The baseline run wasn't found.",
-  different_evaluation: "These runs are from different evaluations.",
-  different_dataset_version:
-    "The runs used different immutable dataset versions — their cases don't line up.",
-  baseline_not_terminal: "The baseline run hasn't finished.",
-  main_scorer_incompatible:
-    "The main scorer's name/version differs, so no comparable pair exists — trusted deltas are disabled.",
+const VERDICT_TONE: Record<"good" | "bad" | "warn" | "neutral", string> = {
+  good: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  bad: "border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300",
+  warn: "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  neutral: "border-border bg-muted/30 text-foreground",
 };
 
 const CHANGE_LABEL: Record<Classification, { label: string; className: string }> = {
@@ -56,141 +69,15 @@ const CHANGE_LABEL: Record<Classification, { label: string; className: string }>
   not_comparable: { label: "Not comparable", className: "text-amber-600 dark:text-amber-400" },
 };
 
-function fmtScore(v: number | null): string {
-  return v === null ? "—" : pctFraction(v);
-}
-function fmtMs(n: number): string {
-  return n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`;
-}
+const STATUS_LABEL: Record<CaseStatus, { label: string; className: string }> = {
+  ...CHANGE_LABEL,
+  task_error: { label: "Task error", className: "text-red-600 dark:text-red-400" },
+  scorer_error: { label: "Scorer error", className: "text-amber-600 dark:text-amber-400" },
+  pending: { label: "Pending", className: "text-muted-foreground" },
+};
 
-function StatRow({
-  label,
-  candidate,
-  baseline,
-  delta,
-  format,
-  higherIsBetter = true,
-}: {
-  label: string;
-  candidate: number | null;
-  baseline: number | null;
-  delta: number | null;
-  format: (n: number) => string;
-  higherIsBetter?: boolean;
-}) {
-  return (
-    <tr>
-      <td className="py-1 pr-2 text-muted-foreground">{label}</td>
-      <td className="py-1 text-right tabular-nums">
-        {candidate === null ? "—" : format(candidate)}
-      </td>
-      <td className="py-1 text-right tabular-nums text-muted-foreground">
-        {baseline === null ? "—" : format(baseline)}
-      </td>
-      <td className="py-1 pl-2 pr-2.5 text-right tabular-nums">
-        {delta === null || delta === 0 ? (
-          <span className="text-muted-foreground">{delta === 0 ? "±0" : "—"}</span>
-        ) : (
-          <span className={SENTIMENT_CLASS[changeSentiment(higherIsBetter ? delta : -delta)]}>
-            {delta > 0 ? "+" : "−"}
-            {format(Math.abs(delta))}
-          </span>
-        )}
-      </td>
-    </tr>
-  );
-}
+// ── Layer 1: run identity (Baseline → Candidate) ──────────────────────────
 
-function RunHeaderCard({
-  run,
-  role,
-  crossEval,
-}: {
-  run: CompareRunSummary;
-  role: "Candidate" | "Baseline";
-  crossEval: boolean;
-}) {
-  return (
-    <div className="min-w-0 flex-1 rounded border border-border bg-muted/20 px-3 py-2">
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{role}</span>
-        <RunStatusBadge status={run.status} />
-      </div>
-      {/* In a cross-evaluation comparison both evaluation names are shown prominently. */}
-      {crossEval && <div className="mt-1 text-[12px] font-medium">{run.evaluationName}</div>}
-      <div className="mt-1 flex items-baseline gap-1.5">
-        <span className="text-[13px] font-semibold">Run #{run.runNumber}</span>
-        <span className="truncate font-mono text-[11px] text-muted-foreground">
-          {run.candidateVersion}
-        </span>
-      </div>
-      <div className="mt-0.5 text-[11px] text-muted-foreground">
-        {run.datasetVersionLabel} · <Timestamp iso={run.startedAt} />
-      </div>
-    </div>
-  );
-}
-
-function SummaryTable({ comparison }: { comparison: RunComparison }) {
-  const c = comparison;
-  return (
-    <div className="overflow-hidden rounded border border-border">
-      <table className="w-full text-[12px]">
-        <thead>
-          <tr className="text-[10px] text-muted-foreground">
-            <th className="py-1 pl-2.5 text-left font-normal"></th>
-            <th className="py-1 text-right font-normal">Candidate</th>
-            <th className="py-1 text-right font-normal">Baseline</th>
-            <th className="py-1 pr-2.5 text-right font-normal">Δ</th>
-          </tr>
-        </thead>
-        <tbody className="[&_td:first-child]:pl-2.5">
-          <StatRow
-            label="Main score"
-            candidate={c.mainScore.candidate}
-            baseline={c.mainScore.baseline}
-            delta={c.mainScore.delta}
-            format={(n) => pctFraction(n)}
-          />
-          {c.scorers.map((s) => (
-            <StatRow
-              key={`${s.name}@${s.version}`}
-              label={s.name}
-              candidate={s.candidateMean}
-              baseline={s.baselineMean}
-              delta={s.delta}
-              format={(n) => pctFraction(n)}
-              higherIsBetter={s.direction !== "lower_is_better"}
-            />
-          ))}
-          <StatRow
-            label="Avg case duration"
-            candidate={c.duration.candidateMeanMs}
-            baseline={c.duration.baselineMeanMs}
-            delta={c.duration.deltaMs}
-            format={fmtMs}
-            higherIsBetter={false}
-          />
-        </tbody>
-      </table>
-      <div className="flex flex-wrap gap-x-4 gap-y-0.5 border-t border-border px-2.5 py-1.5 text-[11px] text-muted-foreground">
-        <span>
-          <span className={SENTIMENT_CLASS.good}>{c.caseCounts.improved} improved</span> ·{" "}
-          <span className={SENTIMENT_CLASS.bad}>{c.caseCounts.regressed} regressed</span> ·{" "}
-          {c.caseCounts.unchanged} unchanged
-        </span>
-        {(c.caseCounts.unpaired > 0 || c.caseCounts.not_comparable > 0) && (
-          <span>
-            {c.caseCounts.unpaired} unpaired · {c.caseCounts.not_comparable} not comparable
-          </span>
-        )}
-      </div>
-    </div>
-  );
-}
-
-/** An evaluation + run picker for one side (candidate or baseline). Supports picking a
- *  run from ANY evaluation, so a cross-evaluation pair can be assembled here too. */
 function RunChooser({
   projectId,
   label,
@@ -217,12 +104,11 @@ function RunChooser({
     evalId ? { evaluation_id: evalId } : undefined,
   );
   const runs = React.useMemo(() => runsData?.data ?? [], [runsData]);
-
   return (
     <div className="flex items-center gap-1.5">
       <span className="text-[11px] text-muted-foreground">{label}</span>
       <Select value={evalId} onValueChange={setEvalId}>
-        <SelectTrigger className="h-7 w-[170px] text-[12px]">
+        <SelectTrigger className="h-7 w-[160px] text-[12px]">
           <SelectValue placeholder="Evaluation" />
         </SelectTrigger>
         <SelectContent>
@@ -234,7 +120,7 @@ function RunChooser({
         </SelectContent>
       </Select>
       <Select value={runId ?? ""} onValueChange={onPick}>
-        <SelectTrigger className="h-7 w-[200px] text-[12px]">
+        <SelectTrigger className="h-7 w-[190px] text-[12px]">
           <SelectValue placeholder="Run" />
         </SelectTrigger>
         <SelectContent>
@@ -254,13 +140,477 @@ function RunChooser({
   );
 }
 
-/**
- * The shareable comparison view: `?baseline=&candidate=` in the URL. Baseline and
- * candidate roles are explicit and swappable. Reuses the server-derived comparison
- * engine (via the compare route) — no comparison logic here. Cross-evaluation pairs
- * are allowed and clearly labeled; trusted deltas are disabled (with the exact reason)
- * only for a genuine incompatibility, never merely because the evaluations differ.
- */
+function RunHeaderCard({
+  run,
+  role,
+  crossEval,
+}: {
+  run: CompareRunSummary;
+  role: "Baseline" | "Candidate";
+  crossEval: boolean;
+}) {
+  return (
+    <div className="min-w-0 flex-1 rounded border border-border bg-muted/20 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{role}</span>
+        <RunStatusBadge status={run.status} />
+      </div>
+      <div className="mt-1 text-[12px] font-medium">{run.evaluationName}</div>
+      <div className="mt-0.5 flex items-baseline gap-1.5">
+        <span className="text-[13px] font-semibold">Run #{run.runNumber}</span>
+        <span className="truncate font-mono text-[11px] text-muted-foreground">
+          {run.candidateVersion}
+        </span>
+      </div>
+      <div className="mt-0.5 text-[11px] text-muted-foreground">
+        {run.datasetVersionLabel} · <Timestamp iso={run.startedAt} />
+      </div>
+      {crossEval && (
+        <div className="mt-0.5 text-[10px] text-muted-foreground">{run.evaluationName}</div>
+      )}
+    </div>
+  );
+}
+
+// ── Layer 3: decision metrics ─────────────────────────────────────────────
+
+type MetricState = "present" | "unknown" | "pending";
+
+function MetricCard({
+  label,
+  baseline,
+  candidate,
+  delta,
+  format,
+  lowerIsBetter = false,
+  state = "present",
+  sub,
+}: {
+  label: string;
+  baseline: number | null;
+  candidate: number | null;
+  delta: number | null;
+  format: (n: number) => string;
+  lowerIsBetter?: boolean;
+  state?: MetricState;
+  sub?: string;
+}) {
+  const stateNote = state === "pending" ? "Pending" : state === "unknown" ? "Unknown" : null;
+  return (
+    <div className="rounded border border-border px-2.5 py-2">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      {stateNote ? (
+        <div className="mt-0.5 text-[13px] text-muted-foreground">{stateNote}</div>
+      ) : (
+        <>
+          <div className="mt-0.5 flex items-baseline gap-1.5 tabular-nums">
+            <span className="text-muted-foreground">
+              {baseline === null ? "—" : format(baseline)}
+            </span>
+            <ArrowRight className="h-3 w-3 text-muted-foreground" aria-hidden />
+            <span className="text-[15px] font-medium">
+              {candidate === null ? "—" : format(candidate)}
+            </span>
+          </div>
+          <div className="mt-1.5 text-[11px] tabular-nums">
+            {delta === null || delta === 0 ? (
+              <span className="text-muted-foreground">{delta === 0 ? "±0" : (sub ?? "—")}</span>
+            ) : (
+              <span className={SENTIMENT_CLASS[changeSentiment(lowerIsBetter ? -delta : delta)]}>
+                {delta > 0 ? "+" : "−"}
+                {format(Math.abs(delta))}
+              </span>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Count card (regressed/improved cases, errors) — a plain baseline→candidate/Δ tile. */
+function CountCard({
+  label,
+  baseline,
+  candidate,
+  badTone = false,
+}: {
+  label: string;
+  baseline: number;
+  candidate: number;
+  badTone?: boolean;
+}) {
+  const delta = candidate - baseline;
+  return (
+    <div className="rounded border border-border px-2.5 py-2">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className="mt-0.5 flex items-baseline gap-1.5 tabular-nums">
+        <span className="text-muted-foreground">{baseline}</span>
+        <ArrowRight className="h-3 w-3 text-muted-foreground" aria-hidden />
+        <span
+          className={cn("text-[15px] font-medium", badTone && candidate > 0 && SENTIMENT_CLASS.bad)}
+        >
+          {candidate}
+        </span>
+      </div>
+      <div className="mt-1.5 text-[11px] tabular-nums text-muted-foreground">
+        {delta === 0 ? "±0" : delta > 0 ? `+${delta}` : `−${Math.abs(delta)}`}
+      </div>
+    </div>
+  );
+}
+
+/** Sums trace-derived tokens across cases (candidate/baseline), with pending/unknown. */
+function useTokenTotals(projectId: string, rows: CompareResultRow[]) {
+  const { data: authSession } = useAuthSession();
+  const user = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
+  const ids = React.useMemo(
+    () => [
+      ...new Set(
+        rows
+          .flatMap((r) => [r.candidateTraceId, r.baselineTraceId])
+          .filter((x): x is string => !!x),
+      ),
+    ],
+    [rows],
+  );
+  const queries = useQueries({
+    queries: ids.map((id) => ({
+      queryKey: ["trace", projectId, id],
+      queryFn: () => getTrace(projectId, id, "", user),
+      enabled: !!user,
+    })),
+  });
+  const usageById = new Map<string, TraceUsage>();
+  let loading = false;
+  ids.forEach((id, i) => {
+    const q = queries[i];
+    if (q.isLoading || q.isFetching) loading = true;
+    usageById.set(id, attributeTraceUsage(q.data?.spans as UsageSpan[] | undefined));
+  });
+  const sum = (getId: (r: CompareResultRow) => string | null) => {
+    let total = 0;
+    let any = false;
+    for (const r of rows) {
+      const id = getId(r);
+      const u = id ? usageById.get(id) : undefined;
+      if (u && u.state === "present") {
+        total += u.combined.totalTokens;
+        any = true;
+      }
+    }
+    return any ? total : null;
+  };
+  const candidate = sum((r) => r.candidateTraceId);
+  const baseline = sum((r) => r.baselineTraceId);
+  const state: MetricState =
+    ids.length === 0
+      ? "unknown"
+      : loading
+        ? "pending"
+        : candidate === null && baseline === null
+          ? "unknown"
+          : "present";
+  return { candidate, baseline, state };
+}
+
+function DecisionMetrics({
+  projectId,
+  comparison,
+  candidate,
+  baseline,
+  rows,
+}: {
+  projectId: string;
+  comparison: RunComparison;
+  candidate: CompareRunSummary;
+  baseline: CompareRunSummary;
+  rows: CompareResultRow[];
+}) {
+  const tokens = useTokenTotals(projectId, rows);
+  const costCand = rows.reduce<number | null>(
+    (acc, r) => (r.candidateCost === null ? acc : (acc ?? 0) + r.candidateCost),
+    null,
+  );
+  const costBase = rows.reduce<number | null>(
+    (acc, r) => (r.baselineCost === null ? acc : (acc ?? 0) + r.baselineCost),
+    null,
+  );
+  const costDelta = costCand !== null && costBase !== null ? costCand - costBase : null;
+  const dur = comparison.duration;
+  const candErrors = candidate.taskErrorCount + candidate.scorerErrorCount;
+  const baseErrors = baseline.taskErrorCount + baseline.scorerErrorCount;
+  return (
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+      <MetricCard
+        label={comparison.scorers[0] ? "Main score" : "Main score"}
+        baseline={comparison.mainScore.baseline}
+        candidate={comparison.mainScore.candidate}
+        delta={comparison.mainScore.delta}
+        format={(n) => pctFraction(n)}
+      />
+      <CountCard
+        label="Regressed test cases"
+        baseline={0}
+        candidate={comparison.caseCounts.regressed}
+        badTone
+      />
+      <CountCard
+        label="Improved test cases"
+        baseline={0}
+        candidate={comparison.caseCounts.improved}
+      />
+      <CountCard label="Errors" baseline={baseErrors} candidate={candErrors} badTone />
+      <MetricCard
+        label="Avg case duration"
+        baseline={dur.baselineMeanMs}
+        candidate={dur.candidateMeanMs}
+        delta={dur.deltaMs}
+        format={fmtMs}
+        lowerIsBetter
+        state={dur.pairedCount === 0 ? "unknown" : "present"}
+      />
+      <MetricCard
+        label="Total cost"
+        baseline={costBase}
+        candidate={costCand}
+        delta={costDelta}
+        format={(n) => `$${n.toFixed(4)}`}
+        lowerIsBetter
+        state={costCand === null && costBase === null ? "unknown" : "present"}
+      />
+      <MetricCard
+        label="Total tokens"
+        baseline={tokens.baseline}
+        candidate={tokens.candidate}
+        delta={
+          tokens.candidate !== null && tokens.baseline !== null
+            ? tokens.candidate - tokens.baseline
+            : null
+        }
+        format={(n) => Math.round(n).toLocaleString("en-US")}
+        lowerIsBetter
+        state={tokens.state}
+      />
+    </div>
+  );
+}
+
+// ── Layer 3b: per-scorer summary ──────────────────────────────────────────
+
+function ScorerSummary({ comparison }: { comparison: RunComparison }) {
+  const [open, setOpen] = React.useState(true);
+  const scorers = comparison.scorers;
+  if (scorers.length === 0) return null;
+  // Per-scorer improved/regressed cell counts from the cell tally isn't per-scorer in
+  // RunComparison; derive from the aggregate's transitions/means only. Show means +
+  // paired; categorical shows changed/unchanged.
+  return (
+    <div className="overflow-hidden rounded border border-border">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-1.5 border-b border-border bg-muted/40 px-2.5 py-1.5 text-left text-[12px] font-medium hover:bg-muted"
+      >
+        {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+        Scorers
+      </button>
+      {open && (
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr className="text-[10px] text-muted-foreground">
+              <th className="py-1 pl-2.5 text-left font-normal">Scorer</th>
+              <th className="py-1 text-right font-normal">Baseline</th>
+              <th className="py-1 text-right font-normal">Candidate</th>
+              <th className="py-1 text-right font-normal">Δ</th>
+              <th className="py-1 pr-2.5 text-right font-normal">Paired</th>
+            </tr>
+          </thead>
+          <tbody className="[&_td:first-child]:pl-2.5 [&_td:last-child]:pr-2.5">
+            {scorers.map((s) => {
+              const better = s.direction !== "lower_is_better";
+              const numeric = s.valueType !== "categorical";
+              return (
+                <tr key={`${s.name}@${s.version}`}>
+                  <td className="py-1">
+                    <span className="font-medium">{s.name}</span>{" "}
+                    <span className="text-[10px] text-muted-foreground">{s.version}</span>
+                  </td>
+                  {numeric ? (
+                    <>
+                      <td className="py-1 text-right tabular-nums text-muted-foreground">
+                        {s.baselineMean === null ? "—" : pctFraction(s.baselineMean)}
+                      </td>
+                      <td className="py-1 text-right tabular-nums">
+                        {s.candidateMean === null ? "—" : pctFraction(s.candidateMean)}
+                      </td>
+                      <td className="py-1 text-right tabular-nums">
+                        {s.delta === null || s.delta === 0 ? (
+                          <span className="text-muted-foreground">
+                            {s.delta === 0 ? "±0" : "—"}
+                          </span>
+                        ) : (
+                          <span
+                            className={
+                              SENTIMENT_CLASS[changeSentiment(better ? s.delta : -s.delta)]
+                            }
+                          >
+                            {s.delta > 0 ? "+" : "−"}
+                            {pctFraction(Math.abs(s.delta))}
+                          </span>
+                        )}
+                      </td>
+                    </>
+                  ) : (
+                    <>
+                      <td className="py-1 text-right text-[11px] text-muted-foreground" colSpan={2}>
+                        categorical
+                      </td>
+                      <td className="py-1 text-right text-[11px] tabular-nums">
+                        {s.transitions ? `${s.transitions.changed} changed` : "—"}
+                      </td>
+                    </>
+                  )}
+                  <td className="py-1 text-right tabular-nums text-muted-foreground">
+                    {s.pairedCount}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+// ── Layer 4: case table ───────────────────────────────────────────────────
+
+function scorerCellText(c: ScorerCellComparison): string {
+  const v = (x: number | boolean | string | null) =>
+    x === null
+      ? "—"
+      : typeof x === "boolean"
+        ? x
+          ? "pass"
+          : "fail"
+        : typeof x === "number"
+          ? Number.isInteger(x)
+            ? String(x)
+            : x.toFixed(2)
+          : x;
+  return `${v(c.baselineValue)} → ${v(c.candidateValue)}`;
+}
+
+function CaseRow({ r, onOpen }: { r: CompareResultRow; onOpen: () => void }) {
+  const cmp = r.comparison;
+  const st = caseStatus(r);
+  const changedCells = (cmp?.scorerCells ?? []).filter(
+    (c) =>
+      c.classification === "regressed" ||
+      c.classification === "improved" ||
+      c.classification === "changed" ||
+      c.reason,
+  );
+  const mainDelta = cmp?.mainScore.delta ?? null;
+  const mainChange = cmp?.caseChange ?? null;
+  return (
+    <TR interactive onClick={onOpen}>
+      {/* Input (primary) + expected + id secondary */}
+      <Td>
+        <div className="max-w-[280px] truncate" title={r.input}>
+          {truncate(r.input, 120)}
+        </div>
+        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+          <span className="font-mono">{r.testCaseId}</span>
+          {r.provenance && <span title="Saved from a production trace">· from trace</span>}
+        </div>
+      </Td>
+      {/* Output change */}
+      <Td className="max-w-[220px]">
+        {r.outputChanged === false ? (
+          <span className="text-[11px] text-muted-foreground">No output change</span>
+        ) : (
+          <div className="text-[11px]">
+            <div className="truncate text-muted-foreground" title={r.baselineOutput ?? ""}>
+              {r.baselineOutput === null ? "—" : truncate(r.baselineOutput, 40)}
+            </div>
+            <div className="truncate" title={r.candidateOutput ?? ""}>
+              {r.candidateOutput === null ? "—" : truncate(r.candidateOutput, 40)}
+            </div>
+          </div>
+        )}
+      </Td>
+      {/* Main score (typed) */}
+      <Td className="text-[11px]">
+        {cmp ? (
+          <>
+            <div className="tabular-nums">
+              {fmtScore(cmp.mainScore.baseline)} → {fmtScore(cmp.mainScore.candidate)}
+            </div>
+            {mainChange && (
+              <div className={CHANGE_LABEL[mainChange].className}>
+                {mainDelta !== null && mainDelta !== 0
+                  ? `${mainDelta > 0 ? "+" : "−"}${pctFraction(Math.abs(mainDelta))} · `
+                  : ""}
+                {CHANGE_LABEL[mainChange].label}
+              </div>
+            )}
+          </>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </Td>
+      {/* Scorer changes (only changed/error cells) */}
+      <Td className="text-[11px]">
+        {changedCells.length === 0 ? (
+          <span className="text-muted-foreground">—</span>
+        ) : changedCells.length <= 2 ? (
+          <div className="space-y-0.5">
+            {changedCells.map((c) => (
+              <div key={`${c.scorerName}@${c.scorerVersion}`} className="tabular-nums">
+                <span className="text-muted-foreground">{c.scorerName}</span> {scorerCellText(c)}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <span className={SENTIMENT_CLASS.bad}>
+            {cmp?.regressedCellCount ?? 0} scorer regressions
+          </span>
+        )}
+      </Td>
+      {/* Duration */}
+      <Td className="whitespace-nowrap text-right text-[11px] tabular-nums">
+        {cmp?.durationDeltaMs != null ? (
+          <span className={SENTIMENT_CLASS[changeSentiment(-cmp.durationDeltaMs)]}>
+            {fmtMs(cmp.durationMs ?? null)}
+          </span>
+        ) : (
+          <span className="text-muted-foreground">{fmtMs(cmp?.durationMs ?? null)}</span>
+        )}
+      </Td>
+      {/* Cost */}
+      <Td className="whitespace-nowrap text-right text-[11px] tabular-nums">
+        {r.candidateCost === null && r.baselineCost === null ? (
+          <span className="text-muted-foreground">Unknown</span>
+        ) : (
+          <span>{fmtCost(r.candidateCost)}</span>
+        )}
+      </Td>
+      {/* Status */}
+      <Td>
+        <span className={cn("text-[11px]", STATUS_LABEL[st].className)}>
+          {STATUS_LABEL[st].label}
+        </span>
+      </Td>
+    </TR>
+  );
+}
+
+// ── The page ──────────────────────────────────────────────────────────────
+
 export function CompareRunsView({
   projectId,
   candidateId,
@@ -272,25 +622,51 @@ export function CompareRunsView({
   baselineId: string | null;
   onChange: (baseline: string | null, candidate: string | null) => void;
 }) {
-  const router = useRouter();
   const compare = useCompareRuns(projectId, candidateId, baselineId);
   const data = compare.data;
+  const [filter, setFilter] = React.useState<CaseFilterId>("all");
+  const [sort, setSort] = React.useState<CaseSortId>("default");
+  const [openCaseId, setOpenCaseId] = React.useState<string | null>(null);
+  const [traceView, setTraceView] = React.useState<{ traceId: string; label: string } | null>(null);
 
-  const candEval = data?.candidate.evaluationId ?? null;
-  const baseEval = data?.baseline.evaluationId ?? null;
-  const crossEval = !!data && candEval !== baseEval;
+  const crossEval = !!data && data.candidate.evaluationId !== data.baseline.evaluationId;
   const blocking = (data?.comparison.reasons ?? []).filter((r) => BLOCKING_REASONS.has(r));
-  const deltasTrusted = !!data?.comparison.available && blocking.length === 0;
+
+  const rows = React.useMemo(() => data?.results ?? [], [data]);
+  const durationWorsened = (data?.comparison.duration.deltaMs ?? 0) > 0;
+  const verdict = data
+    ? deriveVerdict(data.comparison, data.candidate.status, data.baseline.status, durationWorsened)
+    : null;
+  const counts = React.useMemo(() => filterCounts(rows), [rows]);
+  const visible = React.useMemo(
+    () =>
+      sortCases(
+        rows.filter((r) => matchesFilter(r, filter)),
+        sort,
+      ),
+    [rows, filter, sort],
+  );
+  const openCase = openCaseId ? (rows.find((r) => r.testCaseId === openCaseId) ?? null) : null;
 
   return (
     <div className="flex h-full flex-col text-[12px]">
       <ProjectBreadcrumb projectId={projectId} current="Compare runs" />
 
+      {/* Chooser — Baseline first, then Candidate */}
       <div className="flex flex-wrap items-center gap-3 border-b border-border px-3 py-2">
         <RunChooser
           projectId={projectId}
+          label="Baseline"
+          seedEvaluationId={data?.baseline.evaluationId ?? null}
+          runId={baselineId}
+          otherRunId={candidateId}
+          onPick={(id) => onChange(id, candidateId)}
+        />
+        <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+        <RunChooser
+          projectId={projectId}
           label="Candidate"
-          seedEvaluationId={candEval}
+          seedEvaluationId={data?.candidate.evaluationId ?? null}
           runId={candidateId}
           otherRunId={baselineId}
           onPick={(id) => onChange(baselineId, id)}
@@ -306,19 +682,11 @@ export function CompareRunsView({
           <ArrowLeftRight className="h-3.5 w-3.5" aria-hidden />
           Swap
         </Button>
-        <RunChooser
-          projectId={projectId}
-          label="Baseline"
-          seedEvaluationId={baseEval}
-          runId={baselineId}
-          otherRunId={candidateId}
-          onPick={(id) => onChange(id, candidateId)}
-        />
       </div>
 
       <div className="min-h-0 flex-1 space-y-3 overflow-auto p-3">
         {!candidateId || !baselineId ? (
-          <EmptyState>Pick a candidate and a baseline run to compare.</EmptyState>
+          <EmptyState>Pick a baseline and a candidate run to compare.</EmptyState>
         ) : candidateId === baselineId ? (
           <EmptyState>Pick two different runs.</EmptyState>
         ) : compare.isLoading ? (
@@ -327,10 +695,14 @@ export function CompareRunsView({
           <EmptyState>Couldn’t compare these runs.</EmptyState>
         ) : (
           <>
-            <div className="flex items-stretch gap-2">
-              <RunHeaderCard run={data.candidate} role="Candidate" crossEval={crossEval} />
-              <ArrowRight className="mt-6 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+            {/* Layer 1 — identity, Baseline → Candidate */}
+            <div className="flex flex-col items-stretch gap-2 sm:flex-row">
               <RunHeaderCard run={data.baseline} role="Baseline" crossEval={crossEval} />
+              <ArrowRight
+                className="mx-auto h-4 w-4 shrink-0 rotate-90 self-center text-muted-foreground sm:mt-6 sm:rotate-0"
+                aria-hidden
+              />
+              <RunHeaderCard run={data.candidate} role="Candidate" crossEval={crossEval} />
             </div>
 
             {crossEval && (
@@ -338,76 +710,186 @@ export function CompareRunsView({
                 <Info className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" aria-hidden />
                 <span>
                   <span className="font-medium">Cross-evaluation comparison</span> —{" "}
-                  {data.candidate.evaluationName} vs {data.baseline.evaluationName}. No baseline
+                  {data.baseline.evaluationName} → {data.candidate.evaluationName}. No baseline
                   relationship is saved.
                 </span>
               </div>
             )}
 
-            {!deltasTrusted && blocking.length > 0 && (
-              <div className="flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-300">
-                <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
-                <span>{blocking.map((r) => REASON_LABEL[r] ?? r).join(" ")}</span>
+            {/* Layer 2 — verdict */}
+            {verdict && (
+              <div
+                className={cn(
+                  "rounded border px-3 py-2",
+                  VERDICT_TONE[VERDICT_META[verdict.verdict].tone],
+                )}
+              >
+                <div className="text-[13px] font-semibold">
+                  {VERDICT_META[verdict.verdict].label}
+                </div>
+                <div className="mt-0.5 space-y-0.5 text-[11px] leading-relaxed">
+                  {verdict.reasons.map((line, i) => (
+                    <div key={i}>{line}</div>
+                  ))}
+                  {verdict.verdict === "not_comparable" &&
+                    blocking.length === 0 &&
+                    data.comparison.reasons.map((r) => <div key={r}>{REASON_LABEL[r] ?? r}</div>)}
+                </div>
               </div>
             )}
 
-            <SummaryTable comparison={data.comparison} />
+            {/* Layer 3 — aggregate metrics + per-scorer */}
+            <DecisionMetrics
+              projectId={projectId}
+              comparison={data.comparison}
+              candidate={data.candidate}
+              baseline={data.baseline}
+              rows={rows}
+            />
+            <ScorerSummary comparison={data.comparison} />
 
-            <div className="overflow-hidden rounded border border-border">
-              <Table>
-                <THead>
-                  <TRHead>
-                    <Th>Test case</Th>
-                    <Th className="w-[110px] text-right">Candidate</Th>
-                    <Th className="w-[110px] text-right">Baseline</Th>
-                    <Th className="w-[130px]">Change</Th>
-                  </TRHead>
-                </THead>
-                <TBody>
-                  {data.results.map((r) => {
-                    const cmp = r.comparison;
-                    const change = cmp?.caseChange ?? null;
-                    return (
-                      <TR
-                        key={r.testCaseId}
-                        interactive={!!r.traceId}
-                        onClick={() =>
-                          r.traceId &&
-                          router.push(
-                            `/projects/${projectId}/evaluations/${candidateId}?result=${r.testCaseId}`,
-                          )
-                        }
-                      >
-                        <Td className="font-mono text-[11px]">{r.testCaseId}</Td>
-                        <Td className="text-right tabular-nums">
-                          {fmtScore(cmp?.mainScore.candidate ?? null)}
-                        </Td>
-                        <Td className="text-right tabular-nums text-muted-foreground">
-                          {fmtScore(cmp?.mainScore.baseline ?? null)}
-                        </Td>
-                        <Td>
-                          {change ? (
-                            <span className={CHANGE_LABEL[change].className}>
-                              {CHANGE_LABEL[change].label}
-                              {cmp && cmp.mainScore.delta !== null && cmp.mainScore.delta !== 0 && (
-                                <span className="ml-1 text-[11px]">
-                                  ({signedPoints(cmp.mainScore.delta)} pp)
-                                </span>
-                              )}
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground">—</span>
-                          )}
-                        </Td>
-                      </TR>
-                    );
-                  })}
-                </TBody>
-              </Table>
+            {/* Layer 4 — case table */}
+            <div>
+              <div className="mb-1.5 flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <div className="text-[12px] font-medium">Test cases</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    Each row is one dataset input run through both the baseline and candidate ·{" "}
+                    {data.baseline.datasetVersionLabel === data.candidate.datasetVersionLabel
+                      ? data.candidate.datasetVersionLabel
+                      : `${data.baseline.datasetVersionLabel} vs ${data.candidate.datasetVersionLabel}`}{" "}
+                    · matched by test-case id
+                  </div>
+                </div>
+                <Select value={sort} onValueChange={(v) => setSort(v as CaseSortId)}>
+                  <SelectTrigger className="h-7 w-[190px] text-[12px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CASE_SORTS.map((s) => (
+                      <SelectItem key={s.id} value={s.id} className="text-[12px]">
+                        {s.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Filters with counts */}
+              <div className="mb-1.5 flex flex-wrap gap-1">
+                {CASE_FILTERS.map((f) => (
+                  <button
+                    key={f.id}
+                    type="button"
+                    onClick={() => setFilter(f.id)}
+                    className={cn(
+                      "flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-[12px] transition-colors",
+                      filter === f.id
+                        ? "border-foreground/30 bg-muted text-foreground"
+                        : "border-input text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {f.label}
+                    <span className="tabular-nums text-muted-foreground">{counts[f.id]}</span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="overflow-x-auto rounded border border-border">
+                <Table>
+                  <THead>
+                    <TRHead>
+                      <Th>Input</Th>
+                      <Th>Output change</Th>
+                      <Th className="w-[130px]">Main score</Th>
+                      <Th className="w-[150px]">Scorer changes</Th>
+                      <Th className="w-[90px] text-right">Duration</Th>
+                      <Th className="w-[90px] text-right">Cost</Th>
+                      <Th className="w-[110px]">Status</Th>
+                    </TRHead>
+                  </THead>
+                  <TBody>
+                    {visible.length === 0 ? (
+                      <tr>
+                        <td colSpan={7}>
+                          <EmptyState>No cases match this filter.</EmptyState>
+                        </td>
+                      </tr>
+                    ) : (
+                      visible.map((r) => (
+                        <CaseRow
+                          key={r.testCaseId}
+                          r={r}
+                          onOpen={() => setOpenCaseId(r.testCaseId)}
+                        />
+                      ))
+                    )}
+                  </TBody>
+                </Table>
+              </div>
             </div>
           </>
         )}
       </div>
+
+      {/* Layer 5 — selected-case diagnosis drawer */}
+      {openCase && data && (
+        <CompareCaseDrawer
+          projectId={projectId}
+          row={openCase}
+          candidate={data.candidate}
+          baseline={data.baseline}
+          onClose={() => setOpenCaseId(null)}
+          traceSlot={
+            <div className="flex flex-wrap gap-1.5">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-[12px]"
+                disabled={!openCase.candidateTraceId}
+                onClick={() =>
+                  openCase.candidateTraceId &&
+                  setTraceView({ traceId: openCase.candidateTraceId, label: "Candidate trace" })
+                }
+              >
+                Open candidate trace
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-[12px]"
+                disabled={!openCase.baselineTraceId}
+                onClick={() =>
+                  openCase.baselineTraceId &&
+                  setTraceView({ traceId: openCase.baselineTraceId, label: "Baseline trace" })
+                }
+              >
+                Open baseline trace
+              </Button>
+              {!openCase.candidateTraceId && !openCase.baselineTraceId && (
+                <span className="text-[11px] text-muted-foreground">
+                  No trace was emitted for this case.
+                </span>
+              )}
+            </div>
+          }
+        />
+      )}
+
+      {/* Trace viewer — opens over the drawer; switching baseline/candidate keeps the
+          case drawer mounted underneath. */}
+      {traceView && (
+        <TraceViewerPanel
+          key={traceView.traceId}
+          projectId={projectId}
+          traceId={traceView.traceId}
+          headerIdentity={{ label: traceView.label, value: traceView.traceId }}
+          onClose={() => setTraceView(null)}
+          onNavigate={() => {}}
+          canNavigateUp={false}
+          canNavigateDown={false}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
@@ -53,6 +53,25 @@ const fmtMs = (n: number | null) =>
 const fmtCost = (n: number | null) => (n === null ? "Unknown" : `$${n.toFixed(4)}`);
 const truncate = (s: string, n = 90) => (s.length > n ? `${s.slice(0, n)}…` : s);
 
+/** The signed candidate−baseline delta shown beside a value cell (duration/cost) when
+ *  comparing. Lower is better, so an increase is red and a decrease green. */
+function CellDelta({
+  delta,
+  format,
+}: {
+  delta: number | null;
+  format: (n: number) => string;
+}): React.ReactNode {
+  if (delta === null) return null;
+  if (delta === 0) return <span className="ml-1 text-muted-foreground">±0</span>;
+  return (
+    <span className={`ml-1 ${SENTIMENT_CLASS[changeSentiment(-delta)]}`}>
+      {delta > 0 ? "+" : "−"}
+      {format(Math.abs(delta))}
+    </span>
+  );
+}
+
 const VERDICT_TONE: Record<"good" | "bad" | "warn" | "neutral", string> = {
   good: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
   bad: "border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300",
@@ -581,22 +600,29 @@ function CaseRow({ r, onOpen }: { r: CompareResultRow; onOpen: () => void }) {
           </span>
         )}
       </Td>
-      {/* Duration */}
+      {/* Duration — candidate value + Δ vs baseline. */}
       <Td className="whitespace-nowrap text-right text-[11px] tabular-nums">
-        {cmp?.durationDeltaMs != null ? (
-          <span className={SENTIMENT_CLASS[changeSentiment(-cmp.durationDeltaMs)]}>
-            {fmtMs(cmp.durationMs ?? null)}
-          </span>
-        ) : (
-          <span className="text-muted-foreground">{fmtMs(cmp?.durationMs ?? null)}</span>
-        )}
+        <span className={cmp?.durationMs == null ? "text-muted-foreground" : undefined}>
+          {fmtMs(cmp?.durationMs ?? null)}
+        </span>
+        <CellDelta delta={cmp?.durationDeltaMs ?? null} format={(n) => fmtMs(n)} />
       </Td>
-      {/* Cost */}
+      {/* Cost — candidate value + Δ vs baseline. */}
       <Td className="whitespace-nowrap text-right text-[11px] tabular-nums">
         {r.candidateCost === null && r.baselineCost === null ? (
           <span className="text-muted-foreground">Unknown</span>
         ) : (
-          <span>{fmtCost(r.candidateCost)}</span>
+          <>
+            <span>{fmtCost(r.candidateCost)}</span>
+            <CellDelta
+              delta={
+                r.candidateCost !== null && r.baselineCost !== null
+                  ? r.candidateCost - r.baselineCost
+                  : null
+              }
+              format={(n) => fmtCost(n)}
+            />
+          </>
         )}
       </Td>
       {/* Status */}

--- a/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
@@ -193,7 +193,7 @@ function RunHeaderCard({
 
 // ── Layer 3: decision metrics ─────────────────────────────────────────────
 
-type MetricState = "present" | "unknown" | "pending";
+type MetricState = "present" | "unknown" | "pending" | "idle";
 
 function MetricCard({
   label,
@@ -204,6 +204,7 @@ function MetricCard({
   lowerIsBetter = false,
   state = "present",
   sub,
+  onRequestLoad,
 }: {
   label: string;
   baseline: number | null;
@@ -213,12 +214,23 @@ function MetricCard({
   lowerIsBetter?: boolean;
   state?: MetricState;
   sub?: string;
+  /** When state is "idle", renders a "Load" affordance that invokes this instead of the
+   *  value — used to defer expensive, opt-in-only data (e.g. per-trace token totals). */
+  onRequestLoad?: () => void;
 }) {
   const stateNote = state === "pending" ? "Pending" : state === "unknown" ? "Unknown" : null;
   return (
     <div className="rounded border border-border px-2.5 py-2">
       <div className="text-[11px] text-muted-foreground">{label}</div>
-      {stateNote ? (
+      {state === "idle" ? (
+        <button
+          type="button"
+          onClick={onRequestLoad}
+          className="mt-0.5 text-[12px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+        >
+          Load
+        </button>
+      ) : stateNote ? (
         <div className="mt-0.5 text-[13px] text-muted-foreground">{stateNote}</div>
       ) : (
         <>
@@ -279,8 +291,74 @@ function CountCard({
   );
 }
 
-/** Sums trace-derived tokens across cases (candidate/baseline), with pending/unknown. */
-function useTokenTotals(projectId: string, rows: CompareResultRow[]) {
+/**
+ * Single-value tile — a plain count with no baseline/delta. For quantities that are
+ * comparison-level (already defined relative to the baseline, e.g. "cases that
+ * regressed") there is no per-run baseline to show; rendering one anyway (as `0`) reads
+ * as a real measurement instead of the placeholder it is. Use CountCard instead for
+ * quantities that genuinely exist independently on each run (e.g. per-run error counts).
+ */
+function ValueCard({
+  label,
+  value,
+  badTone = false,
+}: {
+  label: string;
+  value: number;
+  badTone?: boolean;
+}) {
+  return (
+    <div className="rounded border border-border px-2.5 py-2">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div
+        className={cn(
+          "mt-0.5 text-[15px] font-medium tabular-nums",
+          badTone && value > 0 && SENTIMENT_CLASS.bad,
+        )}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Sums two parallel per-case values only over cases where BOTH sides have a value, so
+ * the two totals cover the same population and their difference is a meaningful delta —
+ * mirroring how `comparison.duration.pairedCount` already gates the duration tile —
+ * instead of each side silently skipping its own nulls independently.
+ */
+function sumPaired(
+  rows: CompareResultRow[],
+  getCandidate: (r: CompareResultRow) => number | null,
+  getBaseline: (r: CompareResultRow) => number | null,
+): { candidate: number | null; baseline: number | null; pairedCount: number } {
+  let candidate = 0;
+  let baseline = 0;
+  let pairedCount = 0;
+  for (const r of rows) {
+    const c = getCandidate(r);
+    const b = getBaseline(r);
+    if (c === null || b === null) continue;
+    candidate += c;
+    baseline += b;
+    pairedCount += 1;
+  }
+  return pairedCount === 0
+    ? { candidate: null, baseline: null, pairedCount: 0 }
+    : { candidate, baseline, pairedCount };
+}
+
+/**
+ * Sums trace-derived tokens across cases (candidate/baseline) — only over the subset of
+ * cases where BOTH sides have usable trace usage, so the two sums cover the same
+ * population (see `sumPaired`) — with pending/unknown/idle state.
+ *
+ * Traces are only fetched once the caller opts in via `enabled`: a single comparison can
+ * reference up to two full-trace fetches per case (candidate + baseline), which for a
+ * few hundred cases is a few hundred requests just to fill this one tile.
+ */
+function useTokenTotals(projectId: string, rows: CompareResultRow[], enabled: boolean) {
   const { data: authSession } = useAuthSession();
   const user = authSession?.user
     ? { id: authSession.user.id, email: authSession.user.email }
@@ -299,37 +377,44 @@ function useTokenTotals(projectId: string, rows: CompareResultRow[]) {
     queries: ids.map((id) => ({
       queryKey: ["trace", projectId, id],
       queryFn: () => getTrace(projectId, id, "", user),
-      enabled: !!user,
+      enabled: enabled && !!user,
     })),
   });
-  const usageById = new Map<string, TraceUsage>();
-  let loading = false;
-  ids.forEach((id, i) => {
-    const q = queries[i];
-    if (q.isLoading || q.isFetching) loading = true;
-    usageById.set(id, attributeTraceUsage(q.data?.spans as UsageSpan[] | undefined));
-  });
-  const sum = (getId: (r: CompareResultRow) => string | null) => {
-    let total = 0;
-    let any = false;
-    for (const r of rows) {
-      const id = getId(r);
-      const u = id ? usageById.get(id) : undefined;
-      if (u && u.state === "present") {
-        total += u.combined.totalTokens;
-        any = true;
-      }
-    }
-    return any ? total : null;
-  };
-  const candidate = sum((r) => r.candidateTraceId);
-  const baseline = sum((r) => r.baselineTraceId);
-  const state: MetricState =
-    ids.length === 0
+  const loading = queries.some((q) => q.isLoading || q.isFetching);
+  // A fingerprint of the query results, so the map/sum below (built from raw spans) only
+  // recompute when a query's data actually changes — not on every render of this
+  // frequently re-rendered page (filter click, sort change, opening a case).
+  const dataFingerprint = queries.map((q) => q.dataUpdatedAt ?? 0).join(",");
+  const usageById = React.useMemo(() => {
+    const map = new Map<string, TraceUsage>();
+    ids.forEach((id, i) => {
+      map.set(id, attributeTraceUsage(queries[i].data?.spans as UsageSpan[] | undefined));
+    });
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ids, dataFingerprint]);
+  const { candidate, baseline, pairedCount } = React.useMemo(
+    () =>
+      sumPaired(
+        rows,
+        (r) => {
+          const u = r.candidateTraceId ? usageById.get(r.candidateTraceId) : undefined;
+          return u?.state === "present" ? u.combined.totalTokens : null;
+        },
+        (r) => {
+          const u = r.baselineTraceId ? usageById.get(r.baselineTraceId) : undefined;
+          return u?.state === "present" ? u.combined.totalTokens : null;
+        },
+      ),
+    [usageById, rows],
+  );
+  const state: MetricState = !enabled
+    ? "idle"
+    : ids.length === 0
       ? "unknown"
       : loading
         ? "pending"
-        : candidate === null && baseline === null
+        : pairedCount === 0
           ? "unknown"
           : "present";
   return { candidate, baseline, state };
@@ -348,16 +433,19 @@ function DecisionMetrics({
   baseline: CompareRunSummary;
   rows: CompareResultRow[];
 }) {
-  const tokens = useTokenTotals(projectId, rows);
-  const costCand = rows.reduce<number | null>(
-    (acc, r) => (r.candidateCost === null ? acc : (acc ?? 0) + r.candidateCost),
-    null,
+  const [tokensRequested, setTokensRequested] = React.useState(false);
+  const tokens = useTokenTotals(projectId, rows, tokensRequested);
+  const cost = React.useMemo(
+    () =>
+      sumPaired(
+        rows,
+        (r) => r.candidateCost,
+        (r) => r.baselineCost,
+      ),
+    [rows],
   );
-  const costBase = rows.reduce<number | null>(
-    (acc, r) => (r.baselineCost === null ? acc : (acc ?? 0) + r.baselineCost),
-    null,
-  );
-  const costDelta = costCand !== null && costBase !== null ? costCand - costBase : null;
+  const costDelta =
+    cost.candidate !== null && cost.baseline !== null ? cost.candidate - cost.baseline : null;
   const dur = comparison.duration;
   const candErrors = candidate.taskErrorCount + candidate.scorerErrorCount;
   const baseErrors = baseline.taskErrorCount + baseline.scorerErrorCount;
@@ -370,17 +458,8 @@ function DecisionMetrics({
         delta={comparison.mainScore.delta}
         format={(n) => pctFraction(n)}
       />
-      <CountCard
-        label="Regressed test cases"
-        baseline={0}
-        candidate={comparison.caseCounts.regressed}
-        badTone
-      />
-      <CountCard
-        label="Improved test cases"
-        baseline={0}
-        candidate={comparison.caseCounts.improved}
-      />
+      <ValueCard label="Regressed test cases" value={comparison.caseCounts.regressed} badTone />
+      <ValueCard label="Improved test cases" value={comparison.caseCounts.improved} />
       <CountCard label="Errors" baseline={baseErrors} candidate={candErrors} badTone />
       <MetricCard
         label="Avg case duration"
@@ -393,12 +472,12 @@ function DecisionMetrics({
       />
       <MetricCard
         label="Total cost"
-        baseline={costBase}
-        candidate={costCand}
+        baseline={cost.baseline}
+        candidate={cost.candidate}
         delta={costDelta}
         format={(n) => `$${n.toFixed(4)}`}
         lowerIsBetter
-        state={costCand === null && costBase === null ? "unknown" : "present"}
+        state={cost.pairedCount === 0 ? "unknown" : "present"}
       />
       <MetricCard
         label="Total tokens"
@@ -412,6 +491,7 @@ function DecisionMetrics({
         format={(n) => Math.round(n).toLocaleString("en-US")}
         lowerIsBetter
         state={tokens.state}
+        onRequestLoad={() => setTokensRequested(true)}
       />
     </div>
   );
@@ -523,7 +603,16 @@ function scorerCellText(c: ScorerCellComparison): string {
   return `${v(c.baselineValue)} → ${v(c.candidateValue)}`;
 }
 
-function CaseRow({ r, onOpen }: { r: CompareResultRow; onOpen: () => void }) {
+function CaseRow({
+  r,
+  isOpen,
+  onOpen,
+}: {
+  r: CompareResultRow;
+  /** Whether this row's case is the one currently shown in CompareCaseDrawer. */
+  isOpen: boolean;
+  onOpen: () => void;
+}) {
   const cmp = r.comparison;
   const st = caseStatus(r);
   const changedCells = (cmp?.scorerCells ?? []).filter(
@@ -536,7 +625,20 @@ function CaseRow({ r, onOpen }: { r: CompareResultRow; onOpen: () => void }) {
   const mainDelta = cmp?.mainScore.delta ?? null;
   const mainChange = cmp?.caseChange ?? null;
   return (
-    <TR interactive onClick={onOpen}>
+    <TR
+      interactive
+      role="button"
+      tabIndex={0}
+      aria-expanded={isOpen}
+      aria-controls="compare-case-drawer"
+      className="focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key !== "Enter" && e.key !== " ") return;
+        e.preventDefault();
+        onOpen();
+      }}
+    >
       {/* Input (primary) + expected + id secondary */}
       <Td>
         <div className="max-w-[280px] truncate" title={r.input}>
@@ -846,6 +948,7 @@ export function CompareRunsView({
                         <CaseRow
                           key={r.testCaseId}
                           r={r}
+                          isOpen={r.testCaseId === openCaseId}
                           onOpen={() => setOpenCaseId(r.testCaseId)}
                         />
                       ))
@@ -866,6 +969,7 @@ export function CompareRunsView({
           candidate={data.candidate}
           baseline={data.baseline}
           onClose={() => setOpenCaseId(null)}
+          enabled={!traceView}
           traceSlot={
             <div className="flex flex-wrap gap-1.5">
               <Button

--- a/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { useQueries } from "@tanstack/react-query";
-import { ArrowLeftRight, ArrowRight, ChevronDown, ChevronRight, Info } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { ArrowLeftRight, ArrowRight, Info } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -14,50 +14,37 @@ import { Button } from "@/components/ui/button";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { EmptyState, Timestamp } from "@/features/offline-eval/components";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import { changeSentiment, pctFraction, SENTIMENT_CLASS } from "@/features/offline-eval/utils";
-import { cn } from "@/lib/utils";
-import { getTrace } from "@/lib/api";
-import { useSession as useAuthSession } from "@/lib/auth-client";
-import { TraceViewerPanel } from "@/features/traces/components";
-import { attributeTraceUsage, type TraceUsage, type UsageSpan } from "@/lib/eval/trace-usage";
-import { useCompareRuns, useEvaluationRuns, useEvaluations } from "../hooks";
-import type {
-  CompareRunSummary,
-  RunComparison,
-  Classification,
-  CompareResultRow,
-  ScorerCellComparison,
-} from "../types";
-import { RunStatusBadge } from "./evaluations-view";
-import { CompareCaseDrawer } from "./compare-case-drawer";
 import {
-  deriveVerdict,
-  VERDICT_META,
-  BLOCKING_REASONS,
-  REASON_LABEL,
-  CASE_FILTERS,
-  CASE_SORTS,
-  matchesFilter,
-  filterCounts,
-  sortCases,
-  caseStatus,
-  type CaseFilterId,
-  type CaseSortId,
-  type CaseStatus,
-} from "../compare-derive";
+  changeSentiment,
+  pctFraction,
+  SENTIMENT_CLASS,
+  signedPoints,
+} from "@/features/offline-eval/utils";
+import { useCompareRuns, useEvaluationRuns, useEvaluations } from "../hooks";
+import type { CompareRunSummary, RunComparison, Classification } from "../types";
+import { RunStatusBadge } from "./evaluations-view";
 
-// ── Small formatters ──────────────────────────────────────────────────────
-const fmtScore = (v: number | null) => (v === null ? "—" : pctFraction(v));
-const fmtMs = (n: number | null) =>
-  n === null ? "Unknown" : n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`;
-const fmtCost = (n: number | null) => (n === null ? "Unknown" : `$${n.toFixed(4)}`);
-const truncate = (s: string, n = 90) => (s.length > n ? `${s.slice(0, n)}…` : s);
+/** Reasons that make a comparison's deltas untrustworthy. `different_evaluation` is
+ *  intentionally NOT here — cross-evaluation comparison is allowed and merely labeled;
+ *  what disables trusted deltas is a dataset-version mismatch, a non-terminal baseline,
+ *  a missing baseline, or an incompatible main scorer. */
+const BLOCKING_REASONS = new Set([
+  "different_dataset_version",
+  "baseline_not_terminal",
+  "baseline_missing",
+  "no_baseline",
+  "main_scorer_incompatible",
+]);
 
-const VERDICT_TONE: Record<"good" | "bad" | "warn" | "neutral", string> = {
-  good: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-  bad: "border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300",
-  warn: "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
-  neutral: "border-border bg-muted/30 text-foreground",
+const REASON_LABEL: Record<string, string> = {
+  no_baseline: "No baseline chosen.",
+  baseline_missing: "The baseline run wasn't found.",
+  different_evaluation: "These runs are from different evaluations.",
+  different_dataset_version:
+    "The runs used different immutable dataset versions — their cases don't line up.",
+  baseline_not_terminal: "The baseline run hasn't finished.",
+  main_scorer_incompatible:
+    "The main scorer's name/version differs, so no comparable pair exists — trusted deltas are disabled.",
 };
 
 const CHANGE_LABEL: Record<Classification, { label: string; className: string }> = {
@@ -69,15 +56,141 @@ const CHANGE_LABEL: Record<Classification, { label: string; className: string }>
   not_comparable: { label: "Not comparable", className: "text-amber-600 dark:text-amber-400" },
 };
 
-const STATUS_LABEL: Record<CaseStatus, { label: string; className: string }> = {
-  ...CHANGE_LABEL,
-  task_error: { label: "Task error", className: "text-red-600 dark:text-red-400" },
-  scorer_error: { label: "Scorer error", className: "text-amber-600 dark:text-amber-400" },
-  pending: { label: "Pending", className: "text-muted-foreground" },
-};
+function fmtScore(v: number | null): string {
+  return v === null ? "—" : pctFraction(v);
+}
+function fmtMs(n: number): string {
+  return n < 1000 ? `${Math.round(n)}ms` : `${(n / 1000).toFixed(1)}s`;
+}
 
-// ── Layer 1: run identity (Baseline → Candidate) ──────────────────────────
+function StatRow({
+  label,
+  candidate,
+  baseline,
+  delta,
+  format,
+  higherIsBetter = true,
+}: {
+  label: string;
+  candidate: number | null;
+  baseline: number | null;
+  delta: number | null;
+  format: (n: number) => string;
+  higherIsBetter?: boolean;
+}) {
+  return (
+    <tr>
+      <td className="py-1 pr-2 text-muted-foreground">{label}</td>
+      <td className="py-1 text-right tabular-nums">
+        {candidate === null ? "—" : format(candidate)}
+      </td>
+      <td className="py-1 text-right tabular-nums text-muted-foreground">
+        {baseline === null ? "—" : format(baseline)}
+      </td>
+      <td className="py-1 pl-2 pr-2.5 text-right tabular-nums">
+        {delta === null || delta === 0 ? (
+          <span className="text-muted-foreground">{delta === 0 ? "±0" : "—"}</span>
+        ) : (
+          <span className={SENTIMENT_CLASS[changeSentiment(higherIsBetter ? delta : -delta)]}>
+            {delta > 0 ? "+" : "−"}
+            {format(Math.abs(delta))}
+          </span>
+        )}
+      </td>
+    </tr>
+  );
+}
 
+function RunHeaderCard({
+  run,
+  role,
+  crossEval,
+}: {
+  run: CompareRunSummary;
+  role: "Candidate" | "Baseline";
+  crossEval: boolean;
+}) {
+  return (
+    <div className="min-w-0 flex-1 rounded border border-border bg-muted/20 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{role}</span>
+        <RunStatusBadge status={run.status} />
+      </div>
+      {/* In a cross-evaluation comparison both evaluation names are shown prominently. */}
+      {crossEval && <div className="mt-1 text-[12px] font-medium">{run.evaluationName}</div>}
+      <div className="mt-1 flex items-baseline gap-1.5">
+        <span className="text-[13px] font-semibold">Run #{run.runNumber}</span>
+        <span className="truncate font-mono text-[11px] text-muted-foreground">
+          {run.candidateVersion}
+        </span>
+      </div>
+      <div className="mt-0.5 text-[11px] text-muted-foreground">
+        {run.datasetVersionLabel} · <Timestamp iso={run.startedAt} />
+      </div>
+    </div>
+  );
+}
+
+function SummaryTable({ comparison }: { comparison: RunComparison }) {
+  const c = comparison;
+  return (
+    <div className="overflow-hidden rounded border border-border">
+      <table className="w-full text-[12px]">
+        <thead>
+          <tr className="text-[10px] text-muted-foreground">
+            <th className="py-1 pl-2.5 text-left font-normal"></th>
+            <th className="py-1 text-right font-normal">Candidate</th>
+            <th className="py-1 text-right font-normal">Baseline</th>
+            <th className="py-1 pr-2.5 text-right font-normal">Δ</th>
+          </tr>
+        </thead>
+        <tbody className="[&_td:first-child]:pl-2.5">
+          <StatRow
+            label="Main score"
+            candidate={c.mainScore.candidate}
+            baseline={c.mainScore.baseline}
+            delta={c.mainScore.delta}
+            format={(n) => pctFraction(n)}
+          />
+          {c.scorers.map((s) => (
+            <StatRow
+              key={`${s.name}@${s.version}`}
+              label={s.name}
+              candidate={s.candidateMean}
+              baseline={s.baselineMean}
+              delta={s.delta}
+              format={(n) => pctFraction(n)}
+              higherIsBetter={s.direction !== "lower_is_better"}
+            />
+          ))}
+          <StatRow
+            label="Avg case duration"
+            candidate={c.duration.candidateMeanMs}
+            baseline={c.duration.baselineMeanMs}
+            delta={c.duration.deltaMs}
+            format={fmtMs}
+            higherIsBetter={false}
+          />
+        </tbody>
+      </table>
+      <div className="flex flex-wrap gap-x-4 gap-y-0.5 border-t border-border px-2.5 py-1.5 text-[11px] text-muted-foreground">
+        <span>
+          <span className={SENTIMENT_CLASS.good}>{c.caseCounts.improved} improved</span> ·{" "}
+          <span className={SENTIMENT_CLASS.bad}>{c.caseCounts.regressed} regressed</span> ·{" "}
+          {c.caseCounts.unchanged} unchanged
+        </span>
+        {(c.caseCounts.unpaired > 0 || c.caseCounts.not_comparable > 0) && (
+          <span>
+            {c.caseCounts.unpaired} unpaired · {c.caseCounts.not_comparable} not comparable
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** An evaluation + run picker for one side (candidate or baseline). Supports picking a
+ *  run from ANY evaluation, so a cross-evaluation pair can be assembled here too. */
 function RunChooser({
   projectId,
   label,
@@ -104,11 +217,12 @@ function RunChooser({
     evalId ? { evaluation_id: evalId } : undefined,
   );
   const runs = React.useMemo(() => runsData?.data ?? [], [runsData]);
+
   return (
     <div className="flex items-center gap-1.5">
       <span className="text-[11px] text-muted-foreground">{label}</span>
       <Select value={evalId} onValueChange={setEvalId}>
-        <SelectTrigger className="h-7 w-[160px] text-[12px]">
+        <SelectTrigger className="h-7 w-[170px] text-[12px]">
           <SelectValue placeholder="Evaluation" />
         </SelectTrigger>
         <SelectContent>
@@ -120,7 +234,7 @@ function RunChooser({
         </SelectContent>
       </Select>
       <Select value={runId ?? ""} onValueChange={onPick}>
-        <SelectTrigger className="h-7 w-[190px] text-[12px]">
+        <SelectTrigger className="h-7 w-[200px] text-[12px]">
           <SelectValue placeholder="Run" />
         </SelectTrigger>
         <SelectContent>
@@ -140,477 +254,13 @@ function RunChooser({
   );
 }
 
-function RunHeaderCard({
-  run,
-  role,
-  crossEval,
-}: {
-  run: CompareRunSummary;
-  role: "Baseline" | "Candidate";
-  crossEval: boolean;
-}) {
-  return (
-    <div className="min-w-0 flex-1 rounded border border-border bg-muted/20 px-3 py-2">
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{role}</span>
-        <RunStatusBadge status={run.status} />
-      </div>
-      <div className="mt-1 text-[12px] font-medium">{run.evaluationName}</div>
-      <div className="mt-0.5 flex items-baseline gap-1.5">
-        <span className="text-[13px] font-semibold">Run #{run.runNumber}</span>
-        <span className="truncate font-mono text-[11px] text-muted-foreground">
-          {run.candidateVersion}
-        </span>
-      </div>
-      <div className="mt-0.5 text-[11px] text-muted-foreground">
-        {run.datasetVersionLabel} · <Timestamp iso={run.startedAt} />
-      </div>
-      {crossEval && (
-        <div className="mt-0.5 text-[10px] text-muted-foreground">{run.evaluationName}</div>
-      )}
-    </div>
-  );
-}
-
-// ── Layer 3: decision metrics ─────────────────────────────────────────────
-
-type MetricState = "present" | "unknown" | "pending";
-
-function MetricCard({
-  label,
-  baseline,
-  candidate,
-  delta,
-  format,
-  lowerIsBetter = false,
-  state = "present",
-  sub,
-}: {
-  label: string;
-  baseline: number | null;
-  candidate: number | null;
-  delta: number | null;
-  format: (n: number) => string;
-  lowerIsBetter?: boolean;
-  state?: MetricState;
-  sub?: string;
-}) {
-  const stateNote = state === "pending" ? "Pending" : state === "unknown" ? "Unknown" : null;
-  return (
-    <div className="rounded border border-border px-2.5 py-2">
-      <div className="text-[11px] text-muted-foreground">{label}</div>
-      {stateNote ? (
-        <div className="mt-0.5 text-[13px] text-muted-foreground">{stateNote}</div>
-      ) : (
-        <>
-          <div className="mt-0.5 flex items-baseline gap-1.5 tabular-nums">
-            <span className="text-muted-foreground">
-              {baseline === null ? "—" : format(baseline)}
-            </span>
-            <ArrowRight className="h-3 w-3 text-muted-foreground" aria-hidden />
-            <span className="text-[15px] font-medium">
-              {candidate === null ? "—" : format(candidate)}
-            </span>
-          </div>
-          <div className="mt-0.5 text-[11px] tabular-nums">
-            {delta === null || delta === 0 ? (
-              <span className="text-muted-foreground">{delta === 0 ? "±0" : (sub ?? "—")}</span>
-            ) : (
-              <span className={SENTIMENT_CLASS[changeSentiment(lowerIsBetter ? -delta : delta)]}>
-                {delta > 0 ? "+" : "−"}
-                {format(Math.abs(delta))}
-              </span>
-            )}
-          </div>
-        </>
-      )}
-    </div>
-  );
-}
-
-/** Count card (regressed/improved cases, errors) — a plain baseline→candidate/Δ tile. */
-function CountCard({
-  label,
-  baseline,
-  candidate,
-  badTone = false,
-}: {
-  label: string;
-  baseline: number;
-  candidate: number;
-  badTone?: boolean;
-}) {
-  const delta = candidate - baseline;
-  return (
-    <div className="rounded border border-border px-2.5 py-2">
-      <div className="text-[11px] text-muted-foreground">{label}</div>
-      <div className="mt-0.5 flex items-baseline gap-1.5 tabular-nums">
-        <span className="text-muted-foreground">{baseline}</span>
-        <ArrowRight className="h-3 w-3 text-muted-foreground" aria-hidden />
-        <span
-          className={cn("text-[15px] font-medium", badTone && candidate > 0 && SENTIMENT_CLASS.bad)}
-        >
-          {candidate}
-        </span>
-      </div>
-      <div className="mt-0.5 text-[11px] tabular-nums text-muted-foreground">
-        {delta === 0 ? "±0" : delta > 0 ? `+${delta}` : `−${Math.abs(delta)}`}
-      </div>
-    </div>
-  );
-}
-
-/** Sums trace-derived tokens across cases (candidate/baseline), with pending/unknown. */
-function useTokenTotals(projectId: string, rows: CompareResultRow[]) {
-  const { data: authSession } = useAuthSession();
-  const user = authSession?.user
-    ? { id: authSession.user.id, email: authSession.user.email }
-    : undefined;
-  const ids = React.useMemo(
-    () => [
-      ...new Set(
-        rows
-          .flatMap((r) => [r.candidateTraceId, r.baselineTraceId])
-          .filter((x): x is string => !!x),
-      ),
-    ],
-    [rows],
-  );
-  const queries = useQueries({
-    queries: ids.map((id) => ({
-      queryKey: ["trace", projectId, id],
-      queryFn: () => getTrace(projectId, id, "", user),
-      enabled: !!user,
-    })),
-  });
-  const usageById = new Map<string, TraceUsage>();
-  let loading = false;
-  ids.forEach((id, i) => {
-    const q = queries[i];
-    if (q.isLoading || q.isFetching) loading = true;
-    usageById.set(id, attributeTraceUsage(q.data?.spans as UsageSpan[] | undefined));
-  });
-  const sum = (getId: (r: CompareResultRow) => string | null) => {
-    let total = 0;
-    let any = false;
-    for (const r of rows) {
-      const id = getId(r);
-      const u = id ? usageById.get(id) : undefined;
-      if (u && u.state === "present") {
-        total += u.combined.totalTokens;
-        any = true;
-      }
-    }
-    return any ? total : null;
-  };
-  const candidate = sum((r) => r.candidateTraceId);
-  const baseline = sum((r) => r.baselineTraceId);
-  const state: MetricState =
-    ids.length === 0
-      ? "unknown"
-      : loading
-        ? "pending"
-        : candidate === null && baseline === null
-          ? "unknown"
-          : "present";
-  return { candidate, baseline, state };
-}
-
-function DecisionMetrics({
-  projectId,
-  comparison,
-  candidate,
-  baseline,
-  rows,
-}: {
-  projectId: string;
-  comparison: RunComparison;
-  candidate: CompareRunSummary;
-  baseline: CompareRunSummary;
-  rows: CompareResultRow[];
-}) {
-  const tokens = useTokenTotals(projectId, rows);
-  const costCand = rows.reduce<number | null>(
-    (acc, r) => (r.candidateCost === null ? acc : (acc ?? 0) + r.candidateCost),
-    null,
-  );
-  const costBase = rows.reduce<number | null>(
-    (acc, r) => (r.baselineCost === null ? acc : (acc ?? 0) + r.baselineCost),
-    null,
-  );
-  const costDelta = costCand !== null && costBase !== null ? costCand - costBase : null;
-  const dur = comparison.duration;
-  const candErrors = candidate.taskErrorCount + candidate.scorerErrorCount;
-  const baseErrors = baseline.taskErrorCount + baseline.scorerErrorCount;
-  return (
-    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
-      <MetricCard
-        label={comparison.scorers[0] ? "Main score" : "Main score"}
-        baseline={comparison.mainScore.baseline}
-        candidate={comparison.mainScore.candidate}
-        delta={comparison.mainScore.delta}
-        format={(n) => pctFraction(n)}
-      />
-      <CountCard
-        label="Regressed test cases"
-        baseline={0}
-        candidate={comparison.caseCounts.regressed}
-        badTone
-      />
-      <CountCard
-        label="Improved test cases"
-        baseline={0}
-        candidate={comparison.caseCounts.improved}
-      />
-      <CountCard label="Errors" baseline={baseErrors} candidate={candErrors} badTone />
-      <MetricCard
-        label="Avg case duration"
-        baseline={dur.baselineMeanMs}
-        candidate={dur.candidateMeanMs}
-        delta={dur.deltaMs}
-        format={fmtMs}
-        lowerIsBetter
-        state={dur.pairedCount === 0 ? "unknown" : "present"}
-      />
-      <MetricCard
-        label="Total cost"
-        baseline={costBase}
-        candidate={costCand}
-        delta={costDelta}
-        format={(n) => `$${n.toFixed(4)}`}
-        lowerIsBetter
-        state={costCand === null && costBase === null ? "unknown" : "present"}
-      />
-      <MetricCard
-        label="Total tokens"
-        baseline={tokens.baseline}
-        candidate={tokens.candidate}
-        delta={
-          tokens.candidate !== null && tokens.baseline !== null
-            ? tokens.candidate - tokens.baseline
-            : null
-        }
-        format={(n) => Math.round(n).toLocaleString("en-US")}
-        lowerIsBetter
-        state={tokens.state}
-      />
-    </div>
-  );
-}
-
-// ── Layer 3b: per-scorer summary ──────────────────────────────────────────
-
-function ScorerSummary({ comparison }: { comparison: RunComparison }) {
-  const [open, setOpen] = React.useState(true);
-  const scorers = comparison.scorers;
-  if (scorers.length === 0) return null;
-  // Per-scorer improved/regressed cell counts from the cell tally isn't per-scorer in
-  // RunComparison; derive from the aggregate's transitions/means only. Show means +
-  // paired; categorical shows changed/unchanged.
-  return (
-    <div className="overflow-hidden rounded border border-border">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center gap-1.5 border-b border-border bg-muted/40 px-2.5 py-1.5 text-left text-[12px] font-medium hover:bg-muted"
-      >
-        {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-        Scorers
-      </button>
-      {open && (
-        <table className="w-full text-[12px]">
-          <thead>
-            <tr className="text-[10px] text-muted-foreground">
-              <th className="py-1 pl-2.5 text-left font-normal">Scorer</th>
-              <th className="py-1 text-right font-normal">Baseline</th>
-              <th className="py-1 text-right font-normal">Candidate</th>
-              <th className="py-1 text-right font-normal">Δ</th>
-              <th className="py-1 pr-2.5 text-right font-normal">Paired</th>
-            </tr>
-          </thead>
-          <tbody className="[&_td:first-child]:pl-2.5 [&_td:last-child]:pr-2.5">
-            {scorers.map((s) => {
-              const better = s.direction !== "lower_is_better";
-              const numeric = s.valueType !== "categorical";
-              return (
-                <tr key={`${s.name}@${s.version}`}>
-                  <td className="py-1">
-                    <span className="font-medium">{s.name}</span>{" "}
-                    <span className="text-[10px] text-muted-foreground">{s.version}</span>
-                  </td>
-                  {numeric ? (
-                    <>
-                      <td className="py-1 text-right tabular-nums text-muted-foreground">
-                        {s.baselineMean === null ? "—" : pctFraction(s.baselineMean)}
-                      </td>
-                      <td className="py-1 text-right tabular-nums">
-                        {s.candidateMean === null ? "—" : pctFraction(s.candidateMean)}
-                      </td>
-                      <td className="py-1 text-right tabular-nums">
-                        {s.delta === null || s.delta === 0 ? (
-                          <span className="text-muted-foreground">
-                            {s.delta === 0 ? "±0" : "—"}
-                          </span>
-                        ) : (
-                          <span
-                            className={
-                              SENTIMENT_CLASS[changeSentiment(better ? s.delta : -s.delta)]
-                            }
-                          >
-                            {s.delta > 0 ? "+" : "−"}
-                            {pctFraction(Math.abs(s.delta))}
-                          </span>
-                        )}
-                      </td>
-                    </>
-                  ) : (
-                    <>
-                      <td className="py-1 text-right text-[11px] text-muted-foreground" colSpan={2}>
-                        categorical
-                      </td>
-                      <td className="py-1 text-right text-[11px] tabular-nums">
-                        {s.transitions ? `${s.transitions.changed} changed` : "—"}
-                      </td>
-                    </>
-                  )}
-                  <td className="py-1 text-right tabular-nums text-muted-foreground">
-                    {s.pairedCount}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      )}
-    </div>
-  );
-}
-
-// ── Layer 4: case table ───────────────────────────────────────────────────
-
-function scorerCellText(c: ScorerCellComparison): string {
-  const v = (x: number | boolean | string | null) =>
-    x === null
-      ? "—"
-      : typeof x === "boolean"
-        ? x
-          ? "pass"
-          : "fail"
-        : typeof x === "number"
-          ? Number.isInteger(x)
-            ? String(x)
-            : x.toFixed(2)
-          : x;
-  return `${v(c.baselineValue)} → ${v(c.candidateValue)}`;
-}
-
-function CaseRow({ r, onOpen }: { r: CompareResultRow; onOpen: () => void }) {
-  const cmp = r.comparison;
-  const st = caseStatus(r);
-  const changedCells = (cmp?.scorerCells ?? []).filter(
-    (c) =>
-      c.classification === "regressed" ||
-      c.classification === "improved" ||
-      c.classification === "changed" ||
-      c.reason,
-  );
-  const mainDelta = cmp?.mainScore.delta ?? null;
-  const mainChange = cmp?.caseChange ?? null;
-  return (
-    <TR interactive onClick={onOpen}>
-      {/* Input (primary) + expected + id secondary */}
-      <Td>
-        <div className="max-w-[280px] truncate" title={r.input}>
-          {truncate(r.input, 120)}
-        </div>
-        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-          <span className="font-mono">{r.testCaseId}</span>
-          {r.provenance && <span title="Saved from a production trace">· from trace</span>}
-        </div>
-      </Td>
-      {/* Output change */}
-      <Td className="max-w-[220px]">
-        {r.outputChanged === false ? (
-          <span className="text-[11px] text-muted-foreground">No output change</span>
-        ) : (
-          <div className="text-[11px]">
-            <div className="truncate text-muted-foreground" title={r.baselineOutput ?? ""}>
-              {r.baselineOutput === null ? "—" : truncate(r.baselineOutput, 40)}
-            </div>
-            <div className="truncate" title={r.candidateOutput ?? ""}>
-              {r.candidateOutput === null ? "—" : truncate(r.candidateOutput, 40)}
-            </div>
-          </div>
-        )}
-      </Td>
-      {/* Main score (typed) */}
-      <Td className="text-[11px]">
-        {cmp ? (
-          <>
-            <div className="tabular-nums">
-              {fmtScore(cmp.mainScore.baseline)} → {fmtScore(cmp.mainScore.candidate)}
-            </div>
-            {mainChange && (
-              <div className={CHANGE_LABEL[mainChange].className}>
-                {mainDelta !== null && mainDelta !== 0
-                  ? `${mainDelta > 0 ? "+" : "−"}${pctFraction(Math.abs(mainDelta))} · `
-                  : ""}
-                {CHANGE_LABEL[mainChange].label}
-              </div>
-            )}
-          </>
-        ) : (
-          <span className="text-muted-foreground">—</span>
-        )}
-      </Td>
-      {/* Scorer changes (only changed/error cells) */}
-      <Td className="text-[11px]">
-        {changedCells.length === 0 ? (
-          <span className="text-muted-foreground">—</span>
-        ) : changedCells.length <= 2 ? (
-          <div className="space-y-0.5">
-            {changedCells.map((c) => (
-              <div key={`${c.scorerName}@${c.scorerVersion}`} className="tabular-nums">
-                <span className="text-muted-foreground">{c.scorerName}</span> {scorerCellText(c)}
-              </div>
-            ))}
-          </div>
-        ) : (
-          <span className={SENTIMENT_CLASS.bad}>
-            {cmp?.regressedCellCount ?? 0} scorer regressions
-          </span>
-        )}
-      </Td>
-      {/* Duration */}
-      <Td className="whitespace-nowrap text-right text-[11px] tabular-nums">
-        {cmp?.durationDeltaMs != null ? (
-          <span className={SENTIMENT_CLASS[changeSentiment(-cmp.durationDeltaMs)]}>
-            {fmtMs(cmp.durationMs ?? null)}
-          </span>
-        ) : (
-          <span className="text-muted-foreground">{fmtMs(cmp?.durationMs ?? null)}</span>
-        )}
-      </Td>
-      {/* Cost */}
-      <Td className="whitespace-nowrap text-right text-[11px] tabular-nums">
-        {r.candidateCost === null && r.baselineCost === null ? (
-          <span className="text-muted-foreground">Unknown</span>
-        ) : (
-          <span>{fmtCost(r.candidateCost)}</span>
-        )}
-      </Td>
-      {/* Status */}
-      <Td>
-        <span className={cn("text-[11px]", STATUS_LABEL[st].className)}>
-          {STATUS_LABEL[st].label}
-        </span>
-      </Td>
-    </TR>
-  );
-}
-
-// ── The page ──────────────────────────────────────────────────────────────
-
+/**
+ * The shareable comparison view: `?baseline=&candidate=` in the URL. Baseline and
+ * candidate roles are explicit and swappable. Reuses the server-derived comparison
+ * engine (via the compare route) — no comparison logic here. Cross-evaluation pairs
+ * are allowed and clearly labeled; trusted deltas are disabled (with the exact reason)
+ * only for a genuine incompatibility, never merely because the evaluations differ.
+ */
 export function CompareRunsView({
   projectId,
   candidateId,
@@ -622,51 +272,25 @@ export function CompareRunsView({
   baselineId: string | null;
   onChange: (baseline: string | null, candidate: string | null) => void;
 }) {
+  const router = useRouter();
   const compare = useCompareRuns(projectId, candidateId, baselineId);
   const data = compare.data;
-  const [filter, setFilter] = React.useState<CaseFilterId>("all");
-  const [sort, setSort] = React.useState<CaseSortId>("default");
-  const [openCaseId, setOpenCaseId] = React.useState<string | null>(null);
-  const [traceView, setTraceView] = React.useState<{ traceId: string; label: string } | null>(null);
 
-  const crossEval = !!data && data.candidate.evaluationId !== data.baseline.evaluationId;
+  const candEval = data?.candidate.evaluationId ?? null;
+  const baseEval = data?.baseline.evaluationId ?? null;
+  const crossEval = !!data && candEval !== baseEval;
   const blocking = (data?.comparison.reasons ?? []).filter((r) => BLOCKING_REASONS.has(r));
-
-  const rows = React.useMemo(() => data?.results ?? [], [data]);
-  const durationWorsened = (data?.comparison.duration.deltaMs ?? 0) > 0;
-  const verdict = data
-    ? deriveVerdict(data.comparison, data.candidate.status, data.baseline.status, durationWorsened)
-    : null;
-  const counts = React.useMemo(() => filterCounts(rows), [rows]);
-  const visible = React.useMemo(
-    () =>
-      sortCases(
-        rows.filter((r) => matchesFilter(r, filter)),
-        sort,
-      ),
-    [rows, filter, sort],
-  );
-  const openCase = openCaseId ? (rows.find((r) => r.testCaseId === openCaseId) ?? null) : null;
+  const deltasTrusted = !!data?.comparison.available && blocking.length === 0;
 
   return (
     <div className="flex h-full flex-col text-[12px]">
       <ProjectBreadcrumb projectId={projectId} current="Compare runs" />
 
-      {/* Chooser — Baseline first, then Candidate */}
       <div className="flex flex-wrap items-center gap-3 border-b border-border px-3 py-2">
         <RunChooser
           projectId={projectId}
-          label="Baseline"
-          seedEvaluationId={data?.baseline.evaluationId ?? null}
-          runId={baselineId}
-          otherRunId={candidateId}
-          onPick={(id) => onChange(id, candidateId)}
-        />
-        <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
-        <RunChooser
-          projectId={projectId}
           label="Candidate"
-          seedEvaluationId={data?.candidate.evaluationId ?? null}
+          seedEvaluationId={candEval}
           runId={candidateId}
           otherRunId={baselineId}
           onPick={(id) => onChange(baselineId, id)}
@@ -682,11 +306,19 @@ export function CompareRunsView({
           <ArrowLeftRight className="h-3.5 w-3.5" aria-hidden />
           Swap
         </Button>
+        <RunChooser
+          projectId={projectId}
+          label="Baseline"
+          seedEvaluationId={baseEval}
+          runId={baselineId}
+          otherRunId={candidateId}
+          onPick={(id) => onChange(id, candidateId)}
+        />
       </div>
 
       <div className="min-h-0 flex-1 space-y-3 overflow-auto p-3">
         {!candidateId || !baselineId ? (
-          <EmptyState>Pick a baseline and a candidate run to compare.</EmptyState>
+          <EmptyState>Pick a candidate and a baseline run to compare.</EmptyState>
         ) : candidateId === baselineId ? (
           <EmptyState>Pick two different runs.</EmptyState>
         ) : compare.isLoading ? (
@@ -695,14 +327,10 @@ export function CompareRunsView({
           <EmptyState>Couldn’t compare these runs.</EmptyState>
         ) : (
           <>
-            {/* Layer 1 — identity, Baseline → Candidate */}
-            <div className="flex flex-col items-stretch gap-2 sm:flex-row">
-              <RunHeaderCard run={data.baseline} role="Baseline" crossEval={crossEval} />
-              <ArrowRight
-                className="mx-auto h-4 w-4 shrink-0 rotate-90 self-center text-muted-foreground sm:mt-6 sm:rotate-0"
-                aria-hidden
-              />
+            <div className="flex items-stretch gap-2">
               <RunHeaderCard run={data.candidate} role="Candidate" crossEval={crossEval} />
+              <ArrowRight className="mt-6 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+              <RunHeaderCard run={data.baseline} role="Baseline" crossEval={crossEval} />
             </div>
 
             {crossEval && (
@@ -710,186 +338,76 @@ export function CompareRunsView({
                 <Info className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" aria-hidden />
                 <span>
                   <span className="font-medium">Cross-evaluation comparison</span> —{" "}
-                  {data.baseline.evaluationName} → {data.candidate.evaluationName}. No baseline
+                  {data.candidate.evaluationName} vs {data.baseline.evaluationName}. No baseline
                   relationship is saved.
                 </span>
               </div>
             )}
 
-            {/* Layer 2 — verdict */}
-            {verdict && (
-              <div
-                className={cn(
-                  "rounded border px-3 py-2",
-                  VERDICT_TONE[VERDICT_META[verdict.verdict].tone],
-                )}
-              >
-                <div className="text-[13px] font-semibold">
-                  {VERDICT_META[verdict.verdict].label}
-                </div>
-                <div className="mt-0.5 space-y-0.5 text-[11px] leading-relaxed">
-                  {verdict.reasons.map((line, i) => (
-                    <div key={i}>{line}</div>
-                  ))}
-                  {verdict.verdict === "not_comparable" &&
-                    blocking.length === 0 &&
-                    data.comparison.reasons.map((r) => <div key={r}>{REASON_LABEL[r] ?? r}</div>)}
-                </div>
+            {!deltasTrusted && blocking.length > 0 && (
+              <div className="flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-300">
+                <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+                <span>{blocking.map((r) => REASON_LABEL[r] ?? r).join(" ")}</span>
               </div>
             )}
 
-            {/* Layer 3 — aggregate metrics + per-scorer */}
-            <DecisionMetrics
-              projectId={projectId}
-              comparison={data.comparison}
-              candidate={data.candidate}
-              baseline={data.baseline}
-              rows={rows}
-            />
-            <ScorerSummary comparison={data.comparison} />
+            <SummaryTable comparison={data.comparison} />
 
-            {/* Layer 4 — case table */}
-            <div>
-              <div className="mb-1.5 flex flex-wrap items-center justify-between gap-2">
-                <div>
-                  <div className="text-[12px] font-medium">Test cases</div>
-                  <div className="text-[11px] text-muted-foreground">
-                    Each row is one dataset input run through both the baseline and candidate ·{" "}
-                    {data.baseline.datasetVersionLabel === data.candidate.datasetVersionLabel
-                      ? data.candidate.datasetVersionLabel
-                      : `${data.baseline.datasetVersionLabel} vs ${data.candidate.datasetVersionLabel}`}{" "}
-                    · matched by test-case id
-                  </div>
-                </div>
-                <Select value={sort} onValueChange={(v) => setSort(v as CaseSortId)}>
-                  <SelectTrigger className="h-7 w-[190px] text-[12px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {CASE_SORTS.map((s) => (
-                      <SelectItem key={s.id} value={s.id} className="text-[12px]">
-                        {s.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {/* Filters with counts */}
-              <div className="mb-1.5 flex flex-wrap gap-1">
-                {CASE_FILTERS.map((f) => (
-                  <button
-                    key={f.id}
-                    type="button"
-                    onClick={() => setFilter(f.id)}
-                    className={cn(
-                      "flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-[12px] transition-colors",
-                      filter === f.id
-                        ? "border-foreground/30 bg-muted text-foreground"
-                        : "border-input text-muted-foreground hover:text-foreground",
-                    )}
-                  >
-                    {f.label}
-                    <span className="tabular-nums text-muted-foreground">{counts[f.id]}</span>
-                  </button>
-                ))}
-              </div>
-
-              <div className="overflow-x-auto rounded border border-border">
-                <Table>
-                  <THead>
-                    <TRHead>
-                      <Th>Input</Th>
-                      <Th>Output change</Th>
-                      <Th className="w-[130px]">Main score</Th>
-                      <Th className="w-[150px]">Scorer changes</Th>
-                      <Th className="w-[90px] text-right">Duration</Th>
-                      <Th className="w-[90px] text-right">Cost</Th>
-                      <Th className="w-[110px]">Status</Th>
-                    </TRHead>
-                  </THead>
-                  <TBody>
-                    {visible.length === 0 ? (
-                      <tr>
-                        <td colSpan={7}>
-                          <EmptyState>No cases match this filter.</EmptyState>
-                        </td>
-                      </tr>
-                    ) : (
-                      visible.map((r) => (
-                        <CaseRow
-                          key={r.testCaseId}
-                          r={r}
-                          onOpen={() => setOpenCaseId(r.testCaseId)}
-                        />
-                      ))
-                    )}
-                  </TBody>
-                </Table>
-              </div>
+            <div className="overflow-hidden rounded border border-border">
+              <Table>
+                <THead>
+                  <TRHead>
+                    <Th>Test case</Th>
+                    <Th className="w-[110px] text-right">Candidate</Th>
+                    <Th className="w-[110px] text-right">Baseline</Th>
+                    <Th className="w-[130px]">Change</Th>
+                  </TRHead>
+                </THead>
+                <TBody>
+                  {data.results.map((r) => {
+                    const cmp = r.comparison;
+                    const change = cmp?.caseChange ?? null;
+                    return (
+                      <TR
+                        key={r.testCaseId}
+                        interactive={!!r.traceId}
+                        onClick={() =>
+                          r.traceId &&
+                          router.push(
+                            `/projects/${projectId}/evaluations/${candidateId}?result=${r.testCaseId}`,
+                          )
+                        }
+                      >
+                        <Td className="font-mono text-[11px]">{r.testCaseId}</Td>
+                        <Td className="text-right tabular-nums">
+                          {fmtScore(cmp?.mainScore.candidate ?? null)}
+                        </Td>
+                        <Td className="text-right tabular-nums text-muted-foreground">
+                          {fmtScore(cmp?.mainScore.baseline ?? null)}
+                        </Td>
+                        <Td>
+                          {change ? (
+                            <span className={CHANGE_LABEL[change].className}>
+                              {CHANGE_LABEL[change].label}
+                              {cmp && cmp.mainScore.delta !== null && cmp.mainScore.delta !== 0 && (
+                                <span className="ml-1 text-[11px]">
+                                  ({signedPoints(cmp.mainScore.delta)} pp)
+                                </span>
+                              )}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </Td>
+                      </TR>
+                    );
+                  })}
+                </TBody>
+              </Table>
             </div>
           </>
         )}
       </div>
-
-      {/* Layer 5 — selected-case diagnosis drawer */}
-      {openCase && data && (
-        <CompareCaseDrawer
-          projectId={projectId}
-          row={openCase}
-          candidate={data.candidate}
-          baseline={data.baseline}
-          onClose={() => setOpenCaseId(null)}
-          traceSlot={
-            <div className="flex flex-wrap gap-1.5">
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 text-[12px]"
-                disabled={!openCase.candidateTraceId}
-                onClick={() =>
-                  openCase.candidateTraceId &&
-                  setTraceView({ traceId: openCase.candidateTraceId, label: "Candidate trace" })
-                }
-              >
-                Open candidate trace
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 text-[12px]"
-                disabled={!openCase.baselineTraceId}
-                onClick={() =>
-                  openCase.baselineTraceId &&
-                  setTraceView({ traceId: openCase.baselineTraceId, label: "Baseline trace" })
-                }
-              >
-                Open baseline trace
-              </Button>
-              {!openCase.candidateTraceId && !openCase.baselineTraceId && (
-                <span className="text-[11px] text-muted-foreground">
-                  No trace was emitted for this case.
-                </span>
-              )}
-            </div>
-          }
-        />
-      )}
-
-      {/* Trace viewer — opens over the drawer; switching baseline/candidate keeps the
-          case drawer mounted underneath. */}
-      {traceView && (
-        <TraceViewerPanel
-          key={traceView.traceId}
-          projectId={projectId}
-          traceId={traceView.traceId}
-          headerIdentity={{ label: traceView.label, value: traceView.traceId }}
-          onClose={() => setTraceView(null)}
-          onNavigate={() => {}}
-          canNavigateUp={false}
-          canNavigateDown={false}
-        />
-      )}
     </div>
   );
 }

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -12,6 +12,7 @@ import {
   GitCommitHorizontal,
   FileCode,
 } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { ChevronRight, GitBranch, GitCommitHorizontal, FileCode, Loader2 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
@@ -157,7 +158,7 @@ export function SpanInfoPanel({
   // query stays disabled unless a span-level diff is active); the trace selection
   // diffs against the already-loaded baseline trace object, no fetch.
   const diffActive = diffMode && (isTrace ? !!baselineTrace : !!baselineSpan);
-  const { data: baselineIO } = useSpanIO(
+  const { data: baselineIO, isLoading: isLoadingBaselineIO } = useSpanIO(
     projectId,
     baselineSpan?.trace_id ?? "",
     diffActive && !isTrace ? (baselineSpan?.span_id ?? null) : null,
@@ -250,6 +251,10 @@ export function SpanInfoPanel({
   // already loaded so it never spins.
   // A selected span's I/O is fetched on demand; trace-level I/O is already loaded.
   const ioLoading = !isTrace && isLoadingIO;
+  // Diff mode also depends on the baseline span's I/O fetch: while it's in flight,
+  // baselineInput/Output/Metadata fall back to `null`, which would render as a
+  // bogus all-added/all-removed diff. Gate the diff sections on both fetches.
+  const diffIoLoading = diffActive && (ioLoading || (!isTrace && isLoadingBaselineIO));
 
   return (
     <div className="h-full overflow-y-auto">
@@ -500,18 +505,21 @@ export function SpanInfoPanel({
               title="Input"
               baseline={baselineInput}
               candidate={input}
+              loading={diffIoLoading}
             />
             <TraceIODiffSection
               key={`${selectionId}:output`}
               title="Output"
               baseline={baselineOutput}
               candidate={output}
+              loading={diffIoLoading}
             />
             <TraceIODiffSection
               key={`${selectionId}:metadata`}
               title="Metadata"
               baseline={baselineMetadata}
               candidate={metadata}
+              loading={diffIoLoading}
             />
           </>
         ) : (

--- a/frontend/ui/src/features/traces/components/TraceIODiff.tsx
+++ b/frontend/ui/src/features/traces/components/TraceIODiff.tsx
@@ -47,11 +47,15 @@ export function TraceIODiffSection({
       {empty ? (
         <span className="text-[11px] text-muted-foreground">No content</span>
       ) : (
-        <pre className="overflow-x-auto whitespace-pre font-mono text-[11px] leading-relaxed">
+        <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed">
           {lines.map((l, i) => (
             <div
               key={i}
               className={cn(
+                // Wrap long lines instead of scrolling sideways (matching the
+                // non-diff I/O sections); the hanging indent keeps wrapped
+                // continuation lines clear of the +/− gutter.
+                "pl-4 -indent-4",
                 l.type === "add" && "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
                 l.type === "remove" && "bg-red-500/10 text-red-700 dark:text-red-400",
                 l.type === "context" && "text-muted-foreground",

--- a/frontend/ui/src/features/traces/components/TraceIODiff.tsx
+++ b/frontend/ui/src/features/traces/components/TraceIODiff.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { ExpandableSection } from "@/components/ui/expandable-section";
+import { diffLines } from "@/lib/eval/line-diff";
+
+/**
+ * A single Input/Output/Metadata section rendered as a git-style line diff of the
+ * baseline value vs the candidate value. Used only when the trace viewer is in diff
+ * mode (an eval trace with a baseline). Values are pretty-printed before diffing
+ * (see `normalizeForDiff`), so a structured payload diffs line-by-line rather than
+ * as one long string.
+ *
+ * Wraps ExpandableSection so it gets the same collapse/minimize chevron as the
+ * non-diff I/O sections; the "− baseline / + candidate" (or "unchanged") indicator
+ * sits in the header.
+ */
+export function TraceIODiffSection({
+  title,
+  baseline,
+  candidate,
+}: {
+  title: string;
+  baseline: string | null;
+  candidate: string | null;
+}) {
+  const lines = useMemo(() => diffLines(baseline ?? "", candidate ?? ""), [baseline, candidate]);
+  const empty = !(baseline ?? "") && !(candidate ?? "");
+  const changed = lines.some((l) => l.type !== "context");
+
+  return (
+    <ExpandableSection
+      title={title}
+      defaultOpen
+      headerAction={
+        empty ? undefined : changed ? (
+          <span className="text-[10px]">
+            <span className="text-red-600 dark:text-red-400">− baseline</span>{" "}
+            <span className="text-emerald-600 dark:text-emerald-400">+ candidate</span>
+          </span>
+        ) : (
+          <span className="text-[10px] text-muted-foreground">unchanged</span>
+        )
+      }
+    >
+      {empty ? (
+        <span className="text-[11px] text-muted-foreground">No content</span>
+      ) : (
+        <pre className="overflow-x-auto whitespace-pre font-mono text-[11px] leading-relaxed">
+          {lines.map((l, i) => (
+            <div
+              key={i}
+              className={cn(
+                l.type === "add" && "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+                l.type === "remove" && "bg-red-500/10 text-red-700 dark:text-red-400",
+                l.type === "context" && "text-muted-foreground",
+              )}
+            >
+              <span className="select-none opacity-60">
+                {l.type === "add" ? "+" : l.type === "remove" ? "−" : " "}{" "}
+              </span>
+              {l.text || " "}
+            </div>
+          ))}
+        </pre>
+      )}
+    </ExpandableSection>
+  );
+}

--- a/frontend/ui/src/features/traces/components/TraceIOValue.tsx
+++ b/frontend/ui/src/features/traces/components/TraceIOValue.tsx
@@ -26,6 +26,26 @@ const FORMAT_LABEL: Record<IOFormat, string> = {
 };
 const FORMATS: IOFormat[] = ["pretty", "json", "text", "yaml", "markdown"];
 
+/**
+ * Above this many characters, the JSON/Text/YAML/Markdown branches skip their real
+ * renderer (tokenizeJson, MarkdownView, toYaml/toText) and show a truncated preview
+ * instead. Those renderers walk the whole payload synchronously — a multi-MB blob
+ * would flood the DOM (JSON) or blow the call stack (YAML) on a single span click.
+ * The Pretty branch is unaffected: ContentRenderer/JsonRenderer already truncate and
+ * collapse for exactly this reason.
+ */
+const MAX_INLINE_CONTENT = 200_000;
+
+/** Recursion cap for toYaml: an arbitrarily deep untrusted payload (e.g. deeply
+ *  nested tool-call args) must not be able to overflow the call stack. */
+const MAX_YAML_DEPTH = 40;
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+}
+
 function parseMaybe(content: string): unknown {
   try {
     return JSON.parse(content);
@@ -42,6 +62,7 @@ function toText(value: unknown): string {
 /** Minimal YAML for the shapes span I/O holds (scalars, flat-ish objects/arrays). */
 function toYaml(value: unknown, indent = 0): string {
   const pad = "  ".repeat(indent);
+  if (indent > MAX_YAML_DEPTH) return `${pad}"...(max depth exceeded)"`;
   if (value === null || value === undefined) return `${pad}null`;
   if (typeof value === "string") {
     if (value.includes("\n")) {
@@ -155,6 +176,15 @@ function FormatSwitcher({
           role="button"
           tabIndex={0}
           title="Change format"
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              // Required: expandable-section.tsx only stops *click* propagation from
+              // the header action, so a bare onKeyDown would also toggle the section.
+              e.stopPropagation();
+              setOpen((o) => !o);
+            }
+          }}
           className="flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         >
           {FORMAT_LABEL[format]}
@@ -197,8 +227,15 @@ export function TraceIOSection({
   defaultOpen?: boolean;
 }) {
   const [format, setFormat] = useState<IOFormat>("pretty");
-  const parsed = useMemo(() => (content ? parseMaybe(content) : null), [content]);
   const hasContent = content !== null && content !== "";
+  // Non-pretty formats serialize/parse the whole blob synchronously (tokenizeJson,
+  // MarkdownView, toYaml/toText) with no truncation of their own, unlike Pretty's
+  // ContentRenderer. Cap them up front rather than rendering multi-MB payloads.
+  const isOversized = hasContent && content!.length > MAX_INLINE_CONTENT;
+  const parsed = useMemo(
+    () => (content && !isOversized ? parseMaybe(content) : null),
+    [content, isOversized],
+  );
 
   return (
     <ExpandableSection
@@ -218,6 +255,16 @@ export function TraceIOSection({
         <span className="text-[11px] text-muted-foreground">-</span>
       ) : format === "pretty" ? (
         <ContentRenderer content={content} />
+      ) : isOversized ? (
+        <div>
+          <p className="mb-1 text-[11px] italic text-muted-foreground">
+            Showing first {formatBytes(MAX_INLINE_CONTENT)} of {formatBytes(content!.length)} — copy
+            to see all.
+          </p>
+          <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed">
+            {content!.slice(0, MAX_INLINE_CONTENT)}
+          </pre>
+        </div>
       ) : format === "markdown" ? (
         // Model output is very often markdown; render it rather than showing the raw source.
         <MarkdownView content={content} />

--- a/frontend/ui/src/lib/eval/trace-usage.ts
+++ b/frontend/ui/src/lib/eval/trace-usage.ts
@@ -1,0 +1,128 @@
+/**
+ * Trace-derived token/cost attribution for an evaluation trace.
+ *
+ * An evaluation trace is shaped:
+ *
+ *   evaluation-item (EVALUATION, root)
+ *   ├── task (TASK)            ← the candidate application; app/LLM/tool spans nest here
+ *   │   └── … LLM leaf(s)      ← carry provider token usage + cost
+ *   ├── scorer (SCORER)        ← an LLM judge's calls (if any) nest here
+ *   └── scorer (SCORER)
+ *
+ * Usage lives on the **LLM leaf spans**, never on the TASK/SCORER/EVALUATION wrappers.
+ * We therefore sum only usage-bearing leaves and attribute each by whether it falls
+ * under a SCORER subtree — so application (task) cost is separated from evaluation-judge
+ * (scorer) cost, and a wrapper is never summed on top of its children (no double count).
+ *
+ * The attribution rule matches the backend's `_task_cost_by_trace`
+ * (backend/worker/ingest_tasks.py): a span under a SCORER (an LLM judge or a hand-rolled
+ * scorer that calls a provider directly) is scorer cost; everything else is task cost.
+ * There is no third "neither" bucket on either side — an LLM span with no TASK wrapper
+ * (e.g. emitted directly under the EVALUATION root) is task cost, not excluded, on both
+ * surfaces, so the two numbers rendered side by side on the compare views never disagree.
+ *
+ * States: `pending` (no trace yet — it may still be ingesting), `unknown` (a trace with
+ * no provider usage anywhere), `present` (real usage found). A real zero is only reported
+ * when the trace proves zero; missing usage is never coerced to 0.
+ */
+
+export interface UsageSpan {
+  span_id: string;
+  parent_span_id: string | null;
+  span_kind: string;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  total_tokens: number | null;
+  cost: number | null;
+}
+
+export interface UsageBucket {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cost: number;
+  /** How many usage-bearing leaf spans were summed into this bucket. */
+  spanCount: number;
+}
+
+export type UsageState = "pending" | "unknown" | "present";
+
+export interface TraceUsage {
+  /** Candidate-task LLM usage: everything not under a SCORER subtree. */
+  task: UsageBucket;
+  /** Evaluation-judge (scorer) LLM usage: spans under a SCORER subtree. */
+  scorer: UsageBucket;
+  /** task + scorer. */
+  combined: UsageBucket;
+  state: UsageState;
+}
+
+const WRAPPER_KINDS = new Set(["EVALUATION", "TASK", "SCORER"]);
+
+function emptyBucket(): UsageBucket {
+  return { inputTokens: 0, outputTokens: 0, totalTokens: 0, cost: 0, spanCount: 0 };
+}
+
+/** A span carries provider usage if any token count or a cost is present. */
+function hasUsage(s: UsageSpan): boolean {
+  return (
+    s.input_tokens !== null ||
+    s.output_tokens !== null ||
+    s.total_tokens !== null ||
+    s.cost !== null
+  );
+}
+
+function addUsage(bucket: UsageBucket, s: UsageSpan): void {
+  bucket.inputTokens += s.input_tokens ?? 0;
+  bucket.outputTokens += s.output_tokens ?? 0;
+  bucket.totalTokens += s.total_tokens ?? (s.input_tokens ?? 0) + (s.output_tokens ?? 0);
+  bucket.cost += s.cost ?? 0;
+  bucket.spanCount += 1;
+}
+
+/**
+ * Walk from a span up its parent chain: if any ancestor is a SCORER, the span is
+ * judge (scorer) usage; otherwise it's candidate-task usage. This mirrors the
+ * backend's `_task_cost_by_trace`, which excludes every span under a SCORER subtree
+ * and counts everything else as task cost — there is no third "neither" bucket, so
+ * a span with no TASK wrapper in its ancestry still counts as task, on both surfaces.
+ * Guards against cycles.
+ */
+function attributionOf(span: UsageSpan, byId: Map<string, UsageSpan>): "task" | "scorer" {
+  const seen = new Set<string>();
+  let cur: UsageSpan | undefined = span;
+  while (cur) {
+    if (seen.has(cur.span_id)) break;
+    seen.add(cur.span_id);
+    if (cur.span_kind === "SCORER") return "scorer";
+    cur = cur.parent_span_id ? byId.get(cur.parent_span_id) : undefined;
+  }
+  return "task";
+}
+
+export function attributeTraceUsage(spans: UsageSpan[] | null | undefined): TraceUsage {
+  const task = emptyBucket();
+  const scorer = emptyBucket();
+  const combined = emptyBucket();
+
+  if (!spans || spans.length === 0) {
+    return { task, scorer, combined, state: "pending" };
+  }
+
+  const byId = new Map(spans.map((s) => [s.span_id, s]));
+  let found = false;
+
+  for (const s of spans) {
+    // Sum only usage-bearing LEAF spans — never the TASK/SCORER/EVALUATION wrappers,
+    // whose children already carry the usage (summing both would double-count).
+    if (WRAPPER_KINDS.has(s.span_kind)) continue;
+    if (!hasUsage(s)) continue;
+    found = true;
+    const where = attributionOf(s, byId);
+    addUsage(where === "task" ? task : scorer, s);
+    addUsage(combined, s);
+  }
+
+  return { task, scorer, combined, state: found ? "present" : "unknown" };
+}


### PR DESCRIPTION
## Summary

Fixes: #1666

A dedicated, linkable candidate-vs-baseline comparison view: an aggregate decision summary up front, then a per-case table with signed duration and cost deltas aligned case-to-case. Because the pair travels in the URL, the whole view reconstructs from a shared link with no prior in-app selection. Comparing runs from two different evaluations is allowed but clearly labeled and never persisted as a lineage relationship.

## How it works

The route reads `baseline` and `candidate` run ids from the query string, so the view is shareable and works with browser back/forward. It renders the backend-derived comparison for that pair — the aggregate verdict, then the per-case rows. Each row opens either side's result trace and enters diff mode when both sides are present. Cases present on only one side are still shown, not dropped.

## What's included

### Routing
- `frontend/ui/src/app/projects/[projectId]/evaluations/compare/page.tsx` — the shareable `compare` route; keeps the pair in the URL and pushes updates through it. The static segment takes priority over the sibling run-detail route, so run-detail URLs are unaffected.

### UI
- `frontend/ui/src/features/evaluations/views/compare-runs-view.tsx` — the candidate-vs-baseline surface: baseline-left orientation, the aggregate decision summary with its verdict tone, cross-evaluation labeling, per-case filters/sorts, and the per-case table with signed duration/cost `CellDelta`s.
- `frontend/ui/src/features/evaluations/views/compare-case-drawer.tsx` — the per-case detail drawer: scorer-by-scorer baseline → candidate transitions with explanations, and the shared trace I/O and I/O-diff sections for each side.
- `frontend/ui/src/features/traces/components/TraceIODiff.tsx` — provides `TraceIODiffSection`.
- `frontend/ui/src/features/traces/components/TraceIOValue.tsx` — provides `TraceIOSection`.
- `frontend/ui/src/features/traces/components/SpanInfoPanel.tsx` — provides `SpanInfoPanel`.

### Data
- `frontend/ui/src/lib/eval/trace-usage.ts` — Trace-derived token/cost attribution for an evaluation trace.

### Tests

## Test plan

- [ ] Open the compare route with a `baseline`/`candidate` pair in the URL and confirm it renders candidate vs baseline from the link alone.
- [ ] Confirm per-case duration and cost deltas display in-cell as signed values.
- [ ] Confirm a cross-evaluation comparison is clearly labeled and not persisted as a relationship.
- [ ] Confirm cases present on only one side are shown, not silently dropped.
- [ ] Confirm the aggregate decision summary renders above the per-case table.
- [ ] Open a per-case row with both sides present and confirm each side's trace opens in diff mode.
- [ ] Confirm the deltas use the same signed convention as the run-detail per-cell diffs.
