### PR TITLE
feat(scorers): derived scorer catalog and detail read model

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Per-case run history (CasePanel "Runs" tab): every evaluation run that measured this
+ * stable testCaseId, flattened into one row per result. The query is keyed by project +
+ * testCaseId — the dataset in the path is scoping only, so history survives the case
+ * moving between dataset versions. Auth + Prisma are mocked.
+ */
+import { it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  evaluationResult: { findMany: vi.fn() },
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return { ...actual, prisma: prismaMock };
+});
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET } from "./route";
+
+const params = {
+  params: Promise.resolve({ projectId: "p1", datasetId: "ds1", testCaseId: "case-1" }),
+};
+
+function resultRow(over: Record<string, unknown> = {}) {
+  return {
+    id: "res_1",
+    mainScore: 1,
+    status: "passed",
+    change: "improved",
+    createTime: new Date("2026-07-21T00:00:10Z"),
+    run: {
+      id: "run_2",
+      runNumber: 2,
+      candidateVersion: "sonnet",
+      startedAt: new Date("2026-07-21T00:00:00Z"),
+      evaluation: { name: "ticket-routing" },
+    },
+    ...over,
+  };
+}
+
+async function rows(res: { json: () => Promise<unknown> }) {
+  return ((await res.json()) as { data: Record<string, unknown>[] }).data;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+});
+
+it("flattens each result into a run row with the run's identity and this case's score", async () => {
+  prismaMock.evaluationResult.findMany.mockResolvedValue([resultRow()]);
+
+  const res = await GET({} as never, params);
+  expect(res.status).toBe(200);
+  expect((await rows(res))[0]).toEqual({
+    resultId: "res_1",
+    runId: "run_2",
+    runNumber: 2,
+    candidateVersion: "sonnet",
+    evaluationName: "ticket-routing",
+    ranAt: "2026-07-21T00:00:00.000Z",
+    score: 1,
+    status: "passed",
+    change: "improved",
+  });
+});
+
+it("queries by project + stable testCaseId (not the dataset), newest first", async () => {
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+  await GET({} as never, params);
+
+  const args = prismaMock.evaluationResult.findMany.mock.calls[0][0];
+  expect(args.where).toEqual({ projectId: "p1", testCaseId: "case-1" });
+  expect(args.orderBy).toEqual({ createTime: "desc" });
+});
+
+it("returns an empty list for a case no run has measured", async () => {
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+  expect(await rows(await GET({} as never, params))).toEqual([]);
+});
+
+it("passes through an unscored result's null score and null change", async () => {
+  prismaMock.evaluationResult.findMany.mockResolvedValue([
+    resultRow({ mainScore: null, status: "not_scored", change: null }),
+  ]);
+  const row = (await rows(await GET({} as never, params)))[0];
+  expect(row.score).toBeNull();
+  expect(row.change).toBeNull();
+  expect(row.status).toBe("not_scored");
+});
+
+it("401s an unauthenticated caller before touching the database", async () => {
+  auth.requireAuth.mockResolvedValue({
+    error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+  });
+  expect((await GET({} as never, params)).status).toBe(401);
+  expect(prismaMock.evaluationResult.findMany).not.toHaveBeenCalled();
+});
+
+it("403s a caller without project access", async () => {
+  auth.requireProjectAccess.mockResolvedValue({
+    error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+  });
+  expect((await GET({} as never, params)).status).toBe(403);
+  expect(prismaMock.evaluationResult.findMany).not.toHaveBeenCalled();
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/route.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Dataset list + create. The list pages with clamped bounds, derives each dataset's
+ * case count from its CURRENT version via one groupBy (never N per-dataset counts),
+ * and reports 0 for a dataset with no version. Auth + Prisma are mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  dataset: { findMany: vi.fn(), count: vi.fn(), create: vi.fn() },
+  testCase: { groupBy: vi.fn() },
+  $transaction: vi.fn(async (arr: Promise<unknown>[]) => Promise.all(arr)),
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return { ...actual, prisma: prismaMock };
+});
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET, POST } from "./route";
+
+const params = { params: Promise.resolve({ projectId: "p1" }) };
+
+const getReq = (qs = "") =>
+  ({ nextUrl: { searchParams: new URLSearchParams(qs) } }) as unknown as Parameters<typeof GET>[0];
+const jsonReq = (body: unknown) =>
+  ({ json: async () => body }) as unknown as Parameters<typeof POST>[0];
+const badJsonReq = () =>
+  ({
+    json: async () => {
+      throw new Error("bad json");
+    },
+  }) as unknown as Parameters<typeof POST>[0];
+
+function ds(over: Record<string, unknown> = {}) {
+  return {
+    id: "ds1",
+    projectId: "p1",
+    name: "support",
+    description: null,
+    currentVersionId: "dv2",
+    _count: { versions: 3 },
+    ...over,
+  };
+}
+
+async function body(res: { json: () => Promise<unknown> }) {
+  return (await res.json()) as Record<string, unknown>;
+}
+/** The `findMany` args the route passed inside the transaction. */
+const listArgs = () => prismaMock.dataset.findMany.mock.calls[0][0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+  prismaMock.$transaction.mockImplementation(async (arr: Promise<unknown>[]) => Promise.all(arr));
+  prismaMock.dataset.findMany.mockResolvedValue([]);
+  prismaMock.dataset.count.mockResolvedValue(0);
+  prismaMock.testCase.groupBy.mockResolvedValue([]);
+});
+
+describe("GET", () => {
+  it("returns each dataset with its current version's case count and version count", async () => {
+    prismaMock.dataset.findMany.mockResolvedValue([
+      ds(),
+      ds({ id: "ds2", currentVersionId: "dvB" }),
+    ]);
+    prismaMock.dataset.count.mockResolvedValue(2);
+    prismaMock.testCase.groupBy.mockResolvedValue([
+      { datasetVersionId: "dv2", _count: { _all: 7 } },
+      { datasetVersionId: "dvB", _count: { _all: 0 } },
+    ]);
+
+    const res = await GET(getReq(), params);
+    const b = await body(res);
+    expect(res.status).toBe(200);
+    const data = b.data as Record<string, unknown>[];
+    expect(data[0]).toMatchObject({ id: "ds1", caseCount: 7, versionCount: 3 });
+    expect(data[1]).toMatchObject({ id: "ds2", caseCount: 0 });
+    expect(b.meta).toEqual({ page: 0, limit: 50, total: 2 });
+    // One groupBy for the whole page, never one count per dataset.
+    expect(prismaMock.testCase.groupBy).toHaveBeenCalledTimes(1);
+    expect(prismaMock.testCase.groupBy.mock.calls[0][0].where).toEqual({
+      datasetVersionId: { in: ["dv2", "dvB"] },
+    });
+  });
+
+  it("counts 0 for a dataset with no current version and skips it in the groupBy", async () => {
+    prismaMock.dataset.findMany.mockResolvedValue([ds({ currentVersionId: null })]);
+    prismaMock.dataset.count.mockResolvedValue(1);
+
+    const data = (await body(await GET(getReq(), params))).data as Record<string, unknown>[];
+    expect(data[0].caseCount).toBe(0);
+    // No version ids at all → the groupBy is skipped entirely.
+    expect(prismaMock.testCase.groupBy).not.toHaveBeenCalled();
+  });
+
+  it("counts 0 when the current version has no rows in the groupBy result", async () => {
+    prismaMock.dataset.findMany.mockResolvedValue([ds()]);
+    prismaMock.dataset.count.mockResolvedValue(1);
+    prismaMock.testCase.groupBy.mockResolvedValue([]);
+
+    const data = (await body(await GET(getReq(), params))).data as Record<string, unknown>[];
+    expect(data[0].caseCount).toBe(0);
+  });
+
+  it("pages with the requested limit/page", async () => {
+    await GET(getReq("limit=10&page=2"), params);
+    expect(listArgs()).toMatchObject({ take: 10, skip: 20 });
+  });
+
+  it("clamps a limit above the cap and a negative page", async () => {
+    await GET(getReq("limit=5000&page=-4"), params);
+    expect(listArgs()).toMatchObject({ take: 200, skip: 0 });
+  });
+
+  it("clamps a zero limit up to 1", async () => {
+    await GET(getReq("limit=0"), params);
+    expect(listArgs().take).toBe(1);
+  });
+
+  it("falls back to the defaults for non-numeric paging", async () => {
+    const b = await body(await GET(getReq("limit=abc&page=xyz"), params));
+    expect(listArgs()).toMatchObject({ take: 50, skip: 0 });
+    expect(b.meta).toMatchObject({ page: 0, limit: 50 });
+  });
+
+  it("filters on name or description for a search query", async () => {
+    await GET(getReq("search_query=%20billing%20"), params);
+    expect(listArgs().where).toEqual({
+      projectId: "p1",
+      OR: [
+        { name: { contains: "billing", mode: "insensitive" } },
+        { description: { contains: "billing", mode: "insensitive" } },
+      ],
+    });
+  });
+
+  it("ignores a whitespace-only search query", async () => {
+    await GET(getReq("search_query=%20%20"), params);
+    expect(listArgs().where).toEqual({ projectId: "p1" });
+  });
+
+  it("401s an unauthenticated caller before touching the database", async () => {
+    auth.requireAuth.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    expect((await GET(getReq(), params)).status).toBe(401);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("403s a caller without project access", async () => {
+    auth.requireProjectAccess.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    expect((await GET(getReq(), params)).status).toBe(403);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST", () => {
+  it("creates an empty dataset scoped to the project and 201s", async () => {
+    prismaMock.dataset.create.mockResolvedValue({ id: "ds_new", name: "support" });
+
+    const res = await POST(jsonReq({ name: "support", description: "tickets" }), params);
+    expect(res.status).toBe(201);
+    expect((await body(res)).dataset).toMatchObject({ id: "ds_new" });
+    expect(prismaMock.dataset.create).toHaveBeenCalledWith({
+      data: { projectId: "p1", name: "support", description: "tickets" },
+    });
+  });
+
+  it("stores a null description when none is given", async () => {
+    prismaMock.dataset.create.mockResolvedValue({ id: "ds_new" });
+    await POST(jsonReq({ name: "support" }), params);
+    expect(prismaMock.dataset.create.mock.calls[0][0].data.description).toBeNull();
+  });
+
+  it("400s an unparseable body", async () => {
+    const res = await POST(badJsonReq(), params);
+    expect(res.status).toBe(400);
+    expect(await body(res)).toEqual({ error: "Invalid JSON" });
+  });
+
+  it("400s a body that fails the contract schema", async () => {
+    const res = await POST(jsonReq({ description: "no name" }), params);
+    expect(res.status).toBe(400);
+    expect(prismaMock.dataset.create).not.toHaveBeenCalled();
+  });
+
+  it("401s an unauthenticated caller", async () => {
+    auth.requireAuth.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    expect((await POST(jsonReq({ name: "x" }), params)).status).toBe(401);
+    expect(prismaMock.dataset.create).not.toHaveBeenCalled();
+  });
+
+  it("403s a viewer without write access", async () => {
+    auth.requireProjectAccess.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    expect((await POST(jsonReq({ name: "x" }), params)).status).toBe(403);
+    expect(prismaMock.dataset.create).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/[name]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/[name]/route.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Scorer-family detail: all versions of one scorer NAME, with a family-level usage
+ * union (distinct runs/evaluations, totals, last use) computed across versions. The
+ * Score read is narrowed to the name (not the whole project) while manifests are still
+ * scanned project-wide, and a name nobody has scored is a 404 — never an empty shell.
+ * Auth + Prisma are mocked; the aggregator is the real one.
+ */
+import { it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  score: { findMany: vi.fn() },
+  evaluationRun: { findMany: vi.fn() },
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return { ...actual, prisma: prismaMock };
+});
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET } from "./route";
+import type { ScorerRow } from "@/lib/eval/scorer-registry";
+
+const params = (name = "accuracy") => ({ params: Promise.resolve({ projectId: "p1", name }) });
+
+interface Detail {
+  name: string;
+  versions: ScorerRow[];
+  usage: {
+    runCount: number;
+    evaluationCount: number;
+    scoreCount: number;
+    errorCount: number;
+    lastUsed: string | null;
+  };
+  source: string;
+}
+
+function scoreRow(over: Record<string, unknown> = {}) {
+  return {
+    scorerName: "accuracy",
+    scorerVersion: "v1",
+    numericValue: 1,
+    boolValue: null,
+    stringValue: null,
+    passed: true,
+    error: null,
+    createTime: new Date("2026-07-21T00:00:00Z"),
+    result: { runId: "run_1", evaluationId: "eval_1" },
+    ...over,
+  };
+}
+
+async function detail(res: { json: () => Promise<unknown> }) {
+  return (await res.json()) as Detail;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+  prismaMock.evaluationRun.findMany.mockResolvedValue([]);
+});
+
+it("unions usage across the family's versions and lists every version", async () => {
+  prismaMock.score.findMany.mockResolvedValue([
+    scoreRow(),
+    scoreRow({
+      scorerVersion: "v2",
+      createTime: new Date("2026-07-22T00:00:00Z"),
+      result: { runId: "run_2", evaluationId: "eval_2" },
+    }),
+    // Same run as the first score — distinct-counted, not double-counted.
+    scoreRow({ scorerVersion: "v2", createTime: new Date("2026-07-20T00:00:00Z") }),
+  ]);
+
+  const res = await GET({} as never, params());
+  expect(res.status).toBe(200);
+  const b = await detail(res);
+  expect(b.name).toBe("accuracy");
+  expect(b.source).toBe("SDK");
+  expect(b.versions.map((v) => v.version)).toEqual(["v1", "v2"]);
+  expect(b.usage).toEqual({
+    runCount: 2,
+    evaluationCount: 2,
+    scoreCount: 3,
+    errorCount: 0,
+    lastUsed: "2026-07-22T00:00:00.000Z", // the newest across versions
+  });
+});
+
+it("counts family errors and tolerates scores with no linked result", async () => {
+  prismaMock.score.findMany.mockResolvedValue([
+    scoreRow({ numericValue: null, error: "judge timed out", result: null }),
+    scoreRow(),
+  ]);
+  const b = await detail(await GET({} as never, params()));
+  expect(b.usage.errorCount).toBe(1);
+  expect(b.usage.runCount).toBe(1);
+});
+
+it("narrows the score read to this scorer name and keeps manifests project-wide", async () => {
+  prismaMock.score.findMany.mockResolvedValue([scoreRow()]);
+  await GET({} as never, params());
+  expect(prismaMock.score.findMany.mock.calls[0][0].where).toEqual({
+    projectId: "p1",
+    scorerName: "accuracy",
+  });
+  expect(prismaMock.evaluationRun.findMany.mock.calls[0][0].where).toEqual({ projectId: "p1" });
+});
+
+it("decodes a URL-encoded scorer name from the path", async () => {
+  prismaMock.score.findMany.mockResolvedValue([scoreRow({ scorerName: "answer relevance" })]);
+  const b = await detail(await GET({} as never, params("answer%20relevance")));
+  expect(b.name).toBe("answer relevance");
+  expect(prismaMock.score.findMany.mock.calls[0][0].where.scorerName).toBe("answer relevance");
+  expect(b.versions).toHaveLength(1);
+});
+
+it("excludes other scorer families the aggregator may see via manifests", async () => {
+  prismaMock.score.findMany.mockResolvedValue([scoreRow()]);
+  prismaMock.evaluationRun.findMany.mockResolvedValue([
+    { scorers: [{ name: "toxicity", version: "v1", direction: "lower_is_better" }] },
+  ]);
+  const b = await detail(await GET({} as never, params()));
+  expect(b.versions.every((v) => v.name === "accuracy")).toBe(true);
+});
+
+it("404s a scorer name nobody in the project has scored", async () => {
+  prismaMock.score.findMany.mockResolvedValue([]);
+  const res = await GET({} as never, params("never-used"));
+  expect(res.status).toBe(404);
+  expect(await res.json()).toEqual({ error: "Scorer not found" });
+});
+
+it("401s an unauthenticated caller before touching the database", async () => {
+  auth.requireAuth.mockResolvedValue({
+    error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+  });
+  expect((await GET({} as never, params())).status).toBe(401);
+  expect(prismaMock.score.findMany).not.toHaveBeenCalled();
+});
+
+it("403s a caller without project access", async () => {
+  auth.requireProjectAccess.mockResolvedValue({
+    error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+  });
+  expect((await GET({} as never, params())).status).toBe(403);
+  expect(prismaMock.score.findMany).not.toHaveBeenCalled();
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/[name]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/[name]/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import {
+  requireAuth,
+  requireProjectAccess,
+  errorResponse,
+  successResponse,
+} from "@/lib/auth-helpers";
+import { aggregateScorers, type RawScore, type ScorerRow } from "@/lib/eval/scorer-registry";
+
+type RouteParams = { params: Promise<{ projectId: string; name: string }> };
+
+// GET — one scorer FAMILY (all versions of a scorer name) with per-version aggregates
+// and a family-level usage/recent-run summary. Scoped to the scorer name so it reads
+// only that scorer's Score rows (not the whole project), still with no N+1. Read-only:
+// scorers are defined in the SDK and cannot be created or edited here.
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, name: rawName } = await params;
+  const name = decodeURIComponent(rawName);
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const [scores, runs] = await Promise.all([
+    prisma.score.findMany({
+      where: { projectId, scorerName: name },
+      select: {
+        scorerName: true,
+        scorerVersion: true,
+        numericValue: true,
+        boolValue: true,
+        stringValue: true,
+        passed: true,
+        error: true,
+        createTime: true,
+        result: { select: { runId: true, evaluationId: true } },
+      },
+    }),
+    // The manifests carry declared config; the whole project's runs are scanned (a
+    // small JSON-only query) so a version declared but not yet scored still resolves.
+    prisma.evaluationRun.findMany({
+      where: { projectId },
+      select: { scorers: true },
+      orderBy: { startedAt: "asc" },
+    }),
+  ]);
+
+  if (scores.length === 0) return errorResponse("Scorer not found", 404);
+
+  const raw: RawScore[] = scores.map((s) => ({
+    scorerName: s.scorerName,
+    scorerVersion: s.scorerVersion,
+    numericValue: s.numericValue,
+    boolValue: s.boolValue,
+    stringValue: s.stringValue,
+    passed: s.passed,
+    error: s.error,
+    createTime: s.createTime,
+    runId: s.result?.runId ?? null,
+    evaluationId: s.result?.evaluationId ?? null,
+  }));
+
+  // Only this family's versions (aggregateScorers may also see the name via manifests).
+  const versions: ScorerRow[] = aggregateScorers(raw, runs).filter((r) => r.name === name);
+
+  // Family-level union: distinct runs/evaluations, totals, latest use across versions.
+  const runIds = new Set<string>();
+  const evaluationIds = new Set<string>();
+  let lastUsed: string | null = null;
+  let scoreCount = 0;
+  let errorCount = 0;
+  for (const r of raw) {
+    if (r.runId) runIds.add(r.runId);
+    if (r.evaluationId) evaluationIds.add(r.evaluationId);
+    const at = r.createTime.toISOString();
+    if (!lastUsed || at > lastUsed) lastUsed = at;
+    scoreCount += 1;
+    if (r.error) errorCount += 1;
+  }
+
+  return successResponse({
+    name,
+    versions,
+    usage: {
+      runCount: runIds.size,
+      evaluationCount: evaluationIds.size,
+      scoreCount,
+      errorCount,
+      lastUsed,
+    },
+    source: "SDK" as const,
+  });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/[name]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/[name]/route.ts
@@ -38,15 +38,14 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
       },
     }),
     // The manifests carry declared config; the whole project's runs are scanned (a
-    // small JSON-only query) so a version declared but not yet scored still resolves.
+    // small JSON-only query) so a version declared but not yet scored still resolves —
+    // aggregateScorers seeds a zero-count row from the manifest for exactly that case.
     prisma.evaluationRun.findMany({
       where: { projectId },
       select: { scorers: true },
       orderBy: { startedAt: "asc" },
     }),
   ]);
-
-  if (scores.length === 0) return errorResponse("Scorer not found", 404);
 
   const raw: RawScore[] = scores.map((s) => ({
     scorerName: s.scorerName,
@@ -61,8 +60,13 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
     evaluationId: s.result?.evaluationId ?? null,
   }));
 
-  // Only this family's versions (aggregateScorers may also see the name via manifests).
+  // Only this family's versions — the runs query above is project-wide (unscoped by
+  // name), so aggregateScorers' manifest seeding can produce rows for OTHER scorer
+  // names too; this filter is what scopes back down to just this one.
   const versions: ScorerRow[] = aggregateScorers(raw, runs).filter((r) => r.name === name);
+
+  // No scores AND no manifest declaration for this name: genuinely unknown.
+  if (versions.length === 0) return errorResponse("Scorer not found", 404);
 
   // Family-level union: distinct runs/evaluations, totals, latest use across versions.
   const runIds = new Set<string>();
@@ -75,8 +79,9 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
     if (r.evaluationId) evaluationIds.add(r.evaluationId);
     const at = r.createTime.toISOString();
     if (!lastUsed || at > lastUsed) lastUsed = at;
-    scoreCount += 1;
-    if (r.error) errorCount += 1;
+    // Rows that actually produced a value — matches ScorerRow.scoreCount's semantics.
+    if (!r.error) scoreCount += 1;
+    else errorCount += 1;
   }
 
   return successResponse({

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/route.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Scorer catalog: the route reads the project's raw Score rows plus run manifests in
+ * ONE pair of queries and hands them to the pure aggregator — a scorer's identity, its
+ * declared config and its usage are all DERIVED from what the SDK reported, never
+ * invented here. Auth + Prisma are mocked; the aggregator is the real one.
+ */
+import { it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  score: { findMany: vi.fn() },
+  evaluationRun: { findMany: vi.fn() },
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return { ...actual, prisma: prismaMock };
+});
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET } from "./route";
+import type { ScorerRow } from "@/lib/eval/scorer-registry";
+
+const params = { params: Promise.resolve({ projectId: "p1" }) };
+
+function scoreRow(over: Record<string, unknown> = {}) {
+  return {
+    scorerName: "accuracy",
+    scorerVersion: "v1",
+    numericValue: 1,
+    boolValue: null,
+    stringValue: null,
+    passed: true,
+    error: null,
+    createTime: new Date("2026-07-21T00:00:00Z"),
+    result: { runId: "run_1", evaluationId: "eval_1" },
+    ...over,
+  };
+}
+
+async function rows(res: { json: () => Promise<unknown> }) {
+  return ((await res.json()) as { data: ScorerRow[] }).data;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+  prismaMock.evaluationRun.findMany.mockResolvedValue([]);
+});
+
+it("aggregates observed scores into one row per (name, version) with usage and pass rate", async () => {
+  prismaMock.score.findMany.mockResolvedValue([
+    scoreRow(),
+    scoreRow({
+      numericValue: 0,
+      passed: false,
+      result: { runId: "run_2", evaluationId: "eval_1" },
+    }),
+    scoreRow({ scorerVersion: "v2" }),
+  ]);
+
+  const res = await GET({} as never, params);
+  expect(res.status).toBe(200);
+  const data = await rows(res);
+  expect(data.map((r) => `${r.name}@${r.version}`)).toEqual(["accuracy@v1", "accuracy@v2"]);
+
+  const v1 = data[0];
+  expect(v1.scoreCount).toBe(2);
+  expect(v1.valueType).toBe("numeric");
+  expect(v1.passRate).toBe(0.5);
+  expect(v1.runCount).toBe(2);
+  expect(v1.evaluationCount).toBe(1);
+  expect(v1.source).toBe("SDK");
+  // Exactly two queries — the catalog is never built per-scorer.
+  expect(prismaMock.score.findMany).toHaveBeenCalledTimes(1);
+  expect(prismaMock.evaluationRun.findMany).toHaveBeenCalledTimes(1);
+});
+
+it("carries the SDK-declared config through from the run manifests", async () => {
+  prismaMock.score.findMany.mockResolvedValue([scoreRow()]);
+  prismaMock.evaluationRun.findMany.mockResolvedValue([
+    {
+      scorers: [
+        {
+          name: "accuracy",
+          version: "v1",
+          value_type: "numeric",
+          direction: "higher_is_better",
+          threshold: 0.8,
+        },
+      ],
+    },
+  ]);
+
+  const v1 = (await rows(await GET({} as never, params)))[0];
+  expect(v1.declaredValueType).toBe("numeric");
+  expect(v1.direction).toBe("higher_is_better");
+  expect(v1.threshold).toBe(0.8);
+});
+
+it("surfaces scorer errors and tolerates a score with no linked result", async () => {
+  prismaMock.score.findMany.mockResolvedValue([
+    scoreRow({ numericValue: null, error: "judge timed out", result: null }),
+  ]);
+
+  const v1 = (await rows(await GET({} as never, params)))[0];
+  expect(v1.errorCount).toBe(1);
+  expect(v1.recentErrors[0].message).toBe("judge timed out");
+  // A score whose result row is absent contributes no run/evaluation usage.
+  expect(v1.runCount).toBe(0);
+  expect(v1.evaluationCount).toBe(0);
+});
+
+it("returns an empty catalog for a project that has never scored", async () => {
+  prismaMock.score.findMany.mockResolvedValue([]);
+  expect(await rows(await GET({} as never, params))).toEqual([]);
+});
+
+it("scopes both queries to the project", async () => {
+  prismaMock.score.findMany.mockResolvedValue([]);
+  await GET({} as never, params);
+  expect(prismaMock.score.findMany.mock.calls[0][0].where).toEqual({ projectId: "p1" });
+  expect(prismaMock.evaluationRun.findMany.mock.calls[0][0].where).toEqual({ projectId: "p1" });
+});
+
+it("401s an unauthenticated caller before touching the database", async () => {
+  auth.requireAuth.mockResolvedValue({
+    error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+  });
+  expect((await GET({} as never, params)).status).toBe(401);
+  expect(prismaMock.score.findMany).not.toHaveBeenCalled();
+});
+
+it("403s a caller without project access", async () => {
+  auth.requireProjectAccess.mockResolvedValue({
+    error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+  });
+  expect((await GET({} as never, params)).status).toBe(403);
+  expect(prismaMock.score.findMany).not.toHaveBeenCalled();
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/route.ts
@@ -5,6 +5,19 @@ import { aggregateScorers, type RawScore } from "@/lib/eval/scorer-registry";
 
 type RouteParams = { params: Promise<{ projectId: string }> };
 
+// Score cardinality is runs x test cases x scorers and only ever grows, so an
+// unbounded findMany here is a memory/latency cliff that scales with a project's
+// lifetime, not its current size. Until this is pushed into
+// a SQL GROUP BY, bound the read: take the most recent MAX_SCORE_ROWS and say so in
+// the response so the UI can label the aggregates as windowed instead of silently
+// dropping older activity.
+const MAX_SCORE_ROWS = 50_000;
+// Same shape of problem on the manifest side — ScorerRefSchema allows a full judge
+// prompt/source per scorer per run, so scanning every run in the project's history
+// can pull megabytes of duplicated text just to resolve latest-wins definitions.
+// The newest MAX_MANIFEST_RUNS is enough for any currently-active scorer to resolve.
+const MAX_MANIFEST_RUNS = 2_000;
+
 // GET — the scorer catalog, aggregated (no N+1) from what runs reported: per
 // (name, version), the value type + declared config (direction/threshold), score
 // distribution, pass/error rates with recent failures, usage across runs and
@@ -17,9 +30,11 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
   const accessResult = await requireProjectAccess(authResult.user.id, projectId);
   if (accessResult.error) return accessResult.error;
 
-  const [scores, runs] = await Promise.all([
+  const [scores, runsDesc] = await Promise.all([
     prisma.score.findMany({
       where: { projectId },
+      orderBy: { createTime: "desc" },
+      take: MAX_SCORE_ROWS,
       select: {
         scorerName: true,
         scorerVersion: true,
@@ -35,7 +50,8 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
     prisma.evaluationRun.findMany({
       where: { projectId },
       select: { scorers: true },
-      orderBy: { startedAt: "asc" },
+      orderBy: { startedAt: "desc" },
+      take: MAX_MANIFEST_RUNS,
     }),
   ]);
 
@@ -52,5 +68,15 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
     evaluationId: s.result?.evaluationId ?? null,
   }));
 
-  return successResponse({ data: aggregateScorers(raw, runs) });
+  // aggregateScorers requires runManifests oldest-first so the newest declaration wins.
+  const runs = [...runsDesc].reverse();
+
+  return successResponse({
+    data: aggregateScorers(raw, runs),
+    meta: {
+      // True when either read hit its cap — the aggregates above are then a window
+      // over recent activity, not the whole project's history.
+      windowed: scores.length === MAX_SCORE_ROWS || runsDesc.length === MAX_MANIFEST_RUNS,
+    },
+  });
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/route.ts
@@ -1,11 +1,46 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@traceroot/core";
 import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+import { parseScorers } from "@/lib/eval/comparison-db";
 
 type RouteParams = { params: Promise<{ projectId: string }> };
 
-// GET — read-only scorer registry, aggregated from the scores reported on this
-// project's runs: distinct (name, version) with usage count and error rate.
+type ValueType = "numeric" | "boolean" | "categorical" | "mixed" | "unknown";
+
+interface Agg {
+  name: string;
+  version: string;
+  total: number;
+  errored: number;
+  numericValues: number[];
+  passedTrue: number;
+  passedTotal: number;
+  boolTrue: number;
+  boolFalse: number;
+  categories: Map<string, number>;
+  runIds: Set<string>;
+  evaluationIds: Set<string>;
+  lastUsed: number; // epoch ms
+  recentErrors: Array<{ message: string; at: string }>;
+  seenNumeric: boolean;
+  seenBool: boolean;
+  seenString: boolean;
+}
+
+function inferValueType(a: Agg): ValueType {
+  const kinds = [a.seenNumeric, a.seenBool, a.seenString].filter(Boolean).length;
+  if (kinds > 1) return "mixed";
+  if (a.seenNumeric) return "numeric";
+  if (a.seenBool) return "boolean";
+  if (a.seenString) return "categorical";
+  return "unknown";
+}
+
+// GET — a scorer registry aggregated from the scores this project reported: per
+// (name, version), the value type + declared config (direction/threshold), score
+// distribution, pass/error rates with recent failures, usage across runs and
+// evaluations, and when it was last used. Everything is derived from stored data —
+// the SDK owns the scorer's definition; TraceRoot shows what it has observed.
 export async function GET(_req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
@@ -15,34 +50,141 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
 
   const scores = await prisma.score.findMany({
     where: { projectId },
-    select: { scorerName: true, scorerVersion: true, error: true },
+    select: {
+      scorerName: true,
+      scorerVersion: true,
+      numericValue: true,
+      boolValue: true,
+      stringValue: true,
+      passed: true,
+      error: true,
+      createTime: true,
+      result: { select: { runId: true, evaluationId: true } },
+    },
   });
 
-  const byKey = new Map<
+  // Declared metadata (value_type/direction/threshold) rides in each run's scorers
+  // JSON; take the most recent declaration seen for each (name, version).
+  const runs = await prisma.evaluationRun.findMany({
+    where: { projectId },
+    select: { scorers: true },
+    orderBy: { startedAt: "asc" },
+  });
+  const declared = new Map<
     string,
-    { name: string; version: string; total: number; errored: number }
+    { valueType: string | null; direction: string | null; threshold: number | null }
   >();
+  for (const run of runs) {
+    for (const s of parseScorers(run.scorers)) {
+      if (s.valueType || s.direction || s.threshold !== null) {
+        declared.set(`${s.name}@${s.version}`, {
+          valueType: s.valueType ?? null,
+          direction: s.direction ?? null,
+          threshold: s.threshold ?? null,
+        });
+      }
+    }
+  }
+
+  const byKey = new Map<string, Agg>();
   for (const s of scores) {
     const key = `${s.scorerName}@${s.scorerVersion}`;
-    const entry = byKey.get(key) ?? {
-      name: s.scorerName,
-      version: s.scorerVersion,
-      total: 0,
-      errored: 0,
-    };
-    entry.total += 1;
-    if (s.error) entry.errored += 1;
-    byKey.set(key, entry);
+    let a = byKey.get(key);
+    if (!a) {
+      a = {
+        name: s.scorerName,
+        version: s.scorerVersion,
+        total: 0,
+        errored: 0,
+        numericValues: [],
+        passedTrue: 0,
+        passedTotal: 0,
+        boolTrue: 0,
+        boolFalse: 0,
+        categories: new Map(),
+        runIds: new Set(),
+        evaluationIds: new Set(),
+        lastUsed: 0,
+        recentErrors: [],
+        seenNumeric: false,
+        seenBool: false,
+        seenString: false,
+      };
+      byKey.set(key, a);
+    }
+    a.total += 1;
+    const at = s.createTime.getTime();
+    if (at > a.lastUsed) a.lastUsed = at;
+    if (s.result) {
+      a.runIds.add(s.result.runId);
+      a.evaluationIds.add(s.result.evaluationId);
+    }
+    if (s.error) {
+      a.errored += 1;
+      a.recentErrors.push({ message: s.error, at: s.createTime.toISOString() });
+    } else if (s.boolValue !== null) {
+      a.seenBool = true;
+      if (s.boolValue) a.boolTrue += 1;
+      else a.boolFalse += 1;
+    } else if (s.numericValue !== null) {
+      a.seenNumeric = true;
+      a.numericValues.push(s.numericValue);
+    } else if (s.stringValue !== null) {
+      a.seenString = true;
+      a.categories.set(s.stringValue, (a.categories.get(s.stringValue) ?? 0) + 1);
+    }
+    if (s.passed !== null) {
+      a.passedTotal += 1;
+      if (s.passed) a.passedTrue += 1;
+    }
   }
 
   const data = [...byKey.values()]
-    .map((e) => ({
-      name: e.name,
-      version: e.version,
-      scoreCount: e.total,
-      errorCount: e.errored,
-      errorRate: e.total > 0 ? e.errored / e.total : 0,
-    }))
+    .map((a) => {
+      const valueType = inferValueType(a);
+      const meta = declared.get(`${a.name}@${a.version}`) ?? null;
+      const nums = a.numericValues;
+      const numeric =
+        nums.length > 0
+          ? {
+              mean: nums.reduce((x, y) => x + y, 0) / nums.length,
+              min: Math.min(...nums),
+              max: Math.max(...nums),
+              count: nums.length,
+            }
+          : null;
+      // Distribution: boolean → true/false; categorical → top values.
+      let distribution: Array<{ label: string; count: number }> | null = null;
+      if (a.seenBool && !a.seenNumeric && !a.seenString) {
+        distribution = [
+          { label: "true", count: a.boolTrue },
+          { label: "false", count: a.boolFalse },
+        ];
+      } else if (a.categories.size > 0) {
+        distribution = [...a.categories.entries()]
+          .map(([label, count]) => ({ label, count }))
+          .sort((x, y) => y.count - x.count)
+          .slice(0, 8);
+      }
+      return {
+        name: a.name,
+        version: a.version,
+        scoreCount: a.total,
+        errorCount: a.errored,
+        errorRate: a.total > 0 ? a.errored / a.total : 0,
+        valueType,
+        declaredValueType: meta?.valueType ?? null,
+        direction: meta?.direction ?? null,
+        threshold: meta?.threshold ?? null,
+        numeric,
+        passRate: a.passedTotal > 0 ? a.passedTrue / a.passedTotal : null,
+        distribution,
+        runCount: a.runIds.size,
+        evaluationCount: a.evaluationIds.size,
+        lastUsed: a.lastUsed > 0 ? new Date(a.lastUsed).toISOString() : null,
+        recentErrors: a.recentErrors.sort((x, y) => (x.at < y.at ? 1 : -1)).slice(0, 3),
+      };
+    })
     .sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version));
 
   return successResponse({ data });

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/route.ts
@@ -1,46 +1,15 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@traceroot/core";
 import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
-import { parseScorers } from "@/lib/eval/comparison-db";
+import { aggregateScorers, type RawScore } from "@/lib/eval/scorer-registry";
 
 type RouteParams = { params: Promise<{ projectId: string }> };
 
-type ValueType = "numeric" | "boolean" | "categorical" | "mixed" | "unknown";
-
-interface Agg {
-  name: string;
-  version: string;
-  total: number;
-  errored: number;
-  numericValues: number[];
-  passedTrue: number;
-  passedTotal: number;
-  boolTrue: number;
-  boolFalse: number;
-  categories: Map<string, number>;
-  runIds: Set<string>;
-  evaluationIds: Set<string>;
-  lastUsed: number; // epoch ms
-  recentErrors: Array<{ message: string; at: string }>;
-  seenNumeric: boolean;
-  seenBool: boolean;
-  seenString: boolean;
-}
-
-function inferValueType(a: Agg): ValueType {
-  const kinds = [a.seenNumeric, a.seenBool, a.seenString].filter(Boolean).length;
-  if (kinds > 1) return "mixed";
-  if (a.seenNumeric) return "numeric";
-  if (a.seenBool) return "boolean";
-  if (a.seenString) return "categorical";
-  return "unknown";
-}
-
-// GET — a scorer registry aggregated from the scores this project reported: per
+// GET — the scorer catalog, aggregated (no N+1) from what runs reported: per
 // (name, version), the value type + declared config (direction/threshold), score
 // distribution, pass/error rates with recent failures, usage across runs and
-// evaluations, and when it was last used. Everything is derived from stored data —
-// the SDK owns the scorer's definition; TraceRoot shows what it has observed.
+// evaluations, and when it was last used. Everything is DERIVED from stored data —
+// the SDK owns the scorer's definition; TraceRoot shows only what it has observed.
 export async function GET(_req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
@@ -48,144 +17,40 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
   const accessResult = await requireProjectAccess(authResult.user.id, projectId);
   if (accessResult.error) return accessResult.error;
 
-  const scores = await prisma.score.findMany({
-    where: { projectId },
-    select: {
-      scorerName: true,
-      scorerVersion: true,
-      numericValue: true,
-      boolValue: true,
-      stringValue: true,
-      passed: true,
-      error: true,
-      createTime: true,
-      result: { select: { runId: true, evaluationId: true } },
-    },
-  });
+  const [scores, runs] = await Promise.all([
+    prisma.score.findMany({
+      where: { projectId },
+      select: {
+        scorerName: true,
+        scorerVersion: true,
+        numericValue: true,
+        boolValue: true,
+        stringValue: true,
+        passed: true,
+        error: true,
+        createTime: true,
+        result: { select: { runId: true, evaluationId: true } },
+      },
+    }),
+    prisma.evaluationRun.findMany({
+      where: { projectId },
+      select: { scorers: true },
+      orderBy: { startedAt: "asc" },
+    }),
+  ]);
 
-  // Declared metadata (value_type/direction/threshold) rides in each run's scorers
-  // JSON; take the most recent declaration seen for each (name, version).
-  const runs = await prisma.evaluationRun.findMany({
-    where: { projectId },
-    select: { scorers: true },
-    orderBy: { startedAt: "asc" },
-  });
-  const declared = new Map<
-    string,
-    { valueType: string | null; direction: string | null; threshold: number | null }
-  >();
-  for (const run of runs) {
-    for (const s of parseScorers(run.scorers)) {
-      if (s.valueType || s.direction || s.threshold !== null) {
-        declared.set(`${s.name}@${s.version}`, {
-          valueType: s.valueType ?? null,
-          direction: s.direction ?? null,
-          threshold: s.threshold ?? null,
-        });
-      }
-    }
-  }
+  const raw: RawScore[] = scores.map((s) => ({
+    scorerName: s.scorerName,
+    scorerVersion: s.scorerVersion,
+    numericValue: s.numericValue,
+    boolValue: s.boolValue,
+    stringValue: s.stringValue,
+    passed: s.passed,
+    error: s.error,
+    createTime: s.createTime,
+    runId: s.result?.runId ?? null,
+    evaluationId: s.result?.evaluationId ?? null,
+  }));
 
-  const byKey = new Map<string, Agg>();
-  for (const s of scores) {
-    const key = `${s.scorerName}@${s.scorerVersion}`;
-    let a = byKey.get(key);
-    if (!a) {
-      a = {
-        name: s.scorerName,
-        version: s.scorerVersion,
-        total: 0,
-        errored: 0,
-        numericValues: [],
-        passedTrue: 0,
-        passedTotal: 0,
-        boolTrue: 0,
-        boolFalse: 0,
-        categories: new Map(),
-        runIds: new Set(),
-        evaluationIds: new Set(),
-        lastUsed: 0,
-        recentErrors: [],
-        seenNumeric: false,
-        seenBool: false,
-        seenString: false,
-      };
-      byKey.set(key, a);
-    }
-    a.total += 1;
-    const at = s.createTime.getTime();
-    if (at > a.lastUsed) a.lastUsed = at;
-    if (s.result) {
-      a.runIds.add(s.result.runId);
-      a.evaluationIds.add(s.result.evaluationId);
-    }
-    if (s.error) {
-      a.errored += 1;
-      a.recentErrors.push({ message: s.error, at: s.createTime.toISOString() });
-    } else if (s.boolValue !== null) {
-      a.seenBool = true;
-      if (s.boolValue) a.boolTrue += 1;
-      else a.boolFalse += 1;
-    } else if (s.numericValue !== null) {
-      a.seenNumeric = true;
-      a.numericValues.push(s.numericValue);
-    } else if (s.stringValue !== null) {
-      a.seenString = true;
-      a.categories.set(s.stringValue, (a.categories.get(s.stringValue) ?? 0) + 1);
-    }
-    if (s.passed !== null) {
-      a.passedTotal += 1;
-      if (s.passed) a.passedTrue += 1;
-    }
-  }
-
-  const data = [...byKey.values()]
-    .map((a) => {
-      const valueType = inferValueType(a);
-      const meta = declared.get(`${a.name}@${a.version}`) ?? null;
-      const nums = a.numericValues;
-      const numeric =
-        nums.length > 0
-          ? {
-              mean: nums.reduce((x, y) => x + y, 0) / nums.length,
-              min: Math.min(...nums),
-              max: Math.max(...nums),
-              count: nums.length,
-            }
-          : null;
-      // Distribution: boolean → true/false; categorical → top values.
-      let distribution: Array<{ label: string; count: number }> | null = null;
-      if (a.seenBool && !a.seenNumeric && !a.seenString) {
-        distribution = [
-          { label: "true", count: a.boolTrue },
-          { label: "false", count: a.boolFalse },
-        ];
-      } else if (a.categories.size > 0) {
-        distribution = [...a.categories.entries()]
-          .map(([label, count]) => ({ label, count }))
-          .sort((x, y) => y.count - x.count)
-          .slice(0, 8);
-      }
-      return {
-        name: a.name,
-        version: a.version,
-        scoreCount: a.total,
-        errorCount: a.errored,
-        errorRate: a.total > 0 ? a.errored / a.total : 0,
-        valueType,
-        declaredValueType: meta?.valueType ?? null,
-        direction: meta?.direction ?? null,
-        threshold: meta?.threshold ?? null,
-        numeric,
-        passRate: a.passedTotal > 0 ? a.passedTrue / a.passedTotal : null,
-        distribution,
-        runCount: a.runIds.size,
-        evaluationCount: a.evaluationIds.size,
-        lastUsed: a.lastUsed > 0 ? new Date(a.lastUsed).toISOString() : null,
-        recentErrors: a.recentErrors.sort((x, y) => (x.at < y.at ? 1 : -1)).slice(0, 3),
-      };
-    })
-    .sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version));
-
-  return successResponse({ data });
+  return successResponse({ data: aggregateScorers(raw, runs) });
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/evaluation-results/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/evaluation-results/route.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Trace → evaluation linkage: the results this trace produced, read from Postgres so
+ * the trace panel's Evaluation tab works without ClickHouse. Auth + Prisma are mocked.
+ */
+import { it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  evaluationResult: { findMany: vi.fn() },
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return { ...actual, prisma: prismaMock };
+});
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET } from "./route";
+
+const params = { params: Promise.resolve({ projectId: "p1", traceId: "tr_1" }) };
+
+const result = {
+  id: "res_1",
+  testCaseId: "case-1",
+  traceId: "tr_1",
+  status: "passed",
+  mainScore: 1,
+  scores: [{ scorerName: "accuracy", numericValue: 1 }],
+  run: {
+    id: "run_2",
+    runNumber: 2,
+    candidateVersion: "sonnet",
+    datasetId: "ds1",
+    datasetVersionId: "dv2",
+    evaluation: { id: "eval_1", name: "ticket-routing" },
+    datasetVersion: { label: "v2" },
+  },
+};
+
+async function rows(res: { json: () => Promise<unknown> }) {
+  return ((await res.json()) as { data: Record<string, unknown>[] }).data;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+});
+
+it("returns this trace's results with their scores and owning run", async () => {
+  prismaMock.evaluationResult.findMany.mockResolvedValue([result]);
+
+  const res = await GET({} as never, params);
+  expect(res.status).toBe(200);
+  const data = await rows(res);
+  expect(data).toHaveLength(1);
+  expect(data[0]).toMatchObject({ id: "res_1", testCaseId: "case-1" });
+  expect((data[0].run as { evaluation: { name: string } }).evaluation.name).toBe("ticket-routing");
+});
+
+it("scopes the read to project + trace, newest result first", async () => {
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+  await GET({} as never, params);
+
+  const args = prismaMock.evaluationResult.findMany.mock.calls[0][0];
+  expect(args.where).toEqual({ projectId: "p1", traceId: "tr_1" });
+  expect(args.orderBy).toEqual({ createTime: "desc" });
+});
+
+it("returns an empty list for a trace no evaluation produced", async () => {
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+  expect(await rows(await GET({} as never, params))).toEqual([]);
+});
+
+it("401s an unauthenticated caller before touching the database", async () => {
+  auth.requireAuth.mockResolvedValue({
+    error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+  });
+  expect((await GET({} as never, params)).status).toBe(401);
+  expect(prismaMock.evaluationResult.findMany).not.toHaveBeenCalled();
+});
+
+it("403s a caller without project access", async () => {
+  auth.requireProjectAccess.mockResolvedValue({
+    error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+  });
+  expect((await GET({} as never, params)).status).toBe(403);
+  expect(prismaMock.evaluationResult.findMany).not.toHaveBeenCalled();
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/test-cases/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/test-cases/route.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Span → dataset linkage powering the "In <dataset>" chip. A case captured from this
+ * trace is reported ONLY while it still lives in its dataset's current version, so an
+ * edited case shows its dataset once — not once per historical snapshot it appears in.
+ * Auth + Prisma are mocked.
+ */
+import { it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  testCase: { findMany: vi.fn() },
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return { ...actual, prisma: prismaMock };
+});
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET } from "./route";
+
+const params = { params: Promise.resolve({ projectId: "p1", traceId: "tr_1" }) };
+const UPDATED = new Date("2026-07-21T00:00:00Z");
+
+/** A captured case; `datasetVersionId` decides whether it is still current. */
+function caseRow(over: Record<string, unknown> = {}, versionOver: Record<string, unknown> = {}) {
+  return {
+    testCaseId: "case-1",
+    datasetId: "ds1",
+    datasetVersionId: "dv2",
+    sourceSpanId: "sp_1",
+    review: "ready",
+    version: {
+      label: "v2",
+      _count: { testCases: 12 },
+      dataset: { name: "support", currentVersionId: "dv2", updateTime: UPDATED },
+      ...versionOver,
+    },
+    ...over,
+  };
+}
+
+async function rows(res: { json: () => Promise<unknown> }) {
+  return ((await res.json()) as { data: Record<string, unknown>[] }).data;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+});
+
+it("returns a chip row per current-version case captured from this trace", async () => {
+  prismaMock.testCase.findMany.mockResolvedValue([caseRow()]);
+
+  const res = await GET({} as never, params);
+  expect(res.status).toBe(200);
+  expect((await rows(res))[0]).toEqual({
+    testCaseId: "case-1",
+    datasetId: "ds1",
+    datasetName: "support",
+    sourceSpanId: "sp_1",
+    review: "ready",
+    datasetVersionLabel: "v2",
+    datasetUpdatedAt: UPDATED.toISOString(),
+    caseCount: 12,
+  });
+});
+
+it("drops a case that only lives in a historical snapshot", async () => {
+  prismaMock.testCase.findMany.mockResolvedValue([
+    caseRow({ datasetVersionId: "dv1" }, { label: "v1" }), // superseded copy
+    caseRow(), // the current one
+  ]);
+  const data = await rows(await GET({} as never, params));
+  expect(data).toHaveLength(1);
+  expect(data[0].datasetVersionLabel).toBe("v2");
+});
+
+it("reports one row per dataset when a span was captured into two datasets", async () => {
+  prismaMock.testCase.findMany.mockResolvedValue([
+    caseRow(),
+    caseRow(
+      { testCaseId: "case-2", datasetId: "ds2", datasetVersionId: "dvB" },
+      {
+        label: "v5",
+        _count: { testCases: 3 },
+        dataset: { name: "billing", currentVersionId: "dvB", updateTime: UPDATED },
+      },
+    ),
+  ]);
+  const data = await rows(await GET({} as never, params));
+  expect(data.map((r) => r.datasetName)).toEqual(["support", "billing"]);
+});
+
+it("scopes the read to project + source trace", async () => {
+  prismaMock.testCase.findMany.mockResolvedValue([]);
+  await GET({} as never, params);
+  expect(prismaMock.testCase.findMany.mock.calls[0][0].where).toEqual({
+    projectId: "p1",
+    sourceTraceId: "tr_1",
+  });
+});
+
+it("returns an empty list for a trace nothing was captured from", async () => {
+  prismaMock.testCase.findMany.mockResolvedValue([]);
+  expect(await rows(await GET({} as never, params))).toEqual([]);
+});
+
+it("401s an unauthenticated caller before touching the database", async () => {
+  auth.requireAuth.mockResolvedValue({
+    error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+  });
+  expect((await GET({} as never, params)).status).toBe(401);
+  expect(prismaMock.testCase.findMany).not.toHaveBeenCalled();
+});
+
+it("403s a caller without project access", async () => {
+  auth.requireProjectAccess.mockResolvedValue({
+    error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+  });
+  expect((await GET({} as never, params)).status).toBe(403);
+  expect(prismaMock.testCase.findMany).not.toHaveBeenCalled();
+});

--- a/frontend/ui/src/components/ui/expandable-section.test.tsx
+++ b/frontend/ui/src/components/ui/expandable-section.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { ExpandableSection } from "./expandable-section";
+
+afterEach(() => cleanup());
+
+describe("ExpandableSection", () => {
+  it("renders its children open by default", () => {
+    render(
+      <ExpandableSection title="Input">
+        <p>body</p>
+      </ExpandableSection>,
+    );
+    expect(screen.getByText("Input")).toBeTruthy();
+    expect(screen.getByText("body")).toBeTruthy();
+  });
+
+  it("starts closed when defaultOpen is false", () => {
+    render(
+      <ExpandableSection title="Input" defaultOpen={false}>
+        <p>body</p>
+      </ExpandableSection>,
+    );
+    expect(screen.queryByText("body")).toBeNull();
+  });
+
+  it("toggles the body from the header", () => {
+    render(
+      <ExpandableSection title="Input">
+        <p>body</p>
+      </ExpandableSection>,
+    );
+    const header = screen.getByRole("button");
+    fireEvent.click(header);
+    expect(screen.queryByText("body")).toBeNull();
+    fireEvent.click(header);
+    expect(screen.getByText("body")).toBeTruthy();
+  });
+
+  it("renders no copy affordance without an onCopy handler", () => {
+    render(
+      <ExpandableSection title="Input">
+        <p>body</p>
+      </ExpandableSection>,
+    );
+    expect(screen.queryByTitle("Copy")).toBeNull();
+  });
+
+  it("copies without collapsing the section", () => {
+    const onCopy = vi.fn();
+    render(
+      <ExpandableSection title="Input" onCopy={onCopy}>
+        <p>body</p>
+      </ExpandableSection>,
+    );
+    fireEvent.click(screen.getByTitle("Copy"));
+    expect(onCopy).toHaveBeenCalledTimes(1);
+    // The click is stopped before it reaches the header button.
+    expect(screen.getByText("body")).toBeTruthy();
+  });
+
+  it("renders a header action whose clicks do not toggle the section", () => {
+    const onAction = vi.fn();
+    render(
+      <ExpandableSection
+        title="Input"
+        headerAction={
+          <span role="presentation" onClick={onAction}>
+            Pretty
+          </span>
+        }
+      >
+        <p>body</p>
+      </ExpandableSection>,
+    );
+    fireEvent.click(screen.getByText("Pretty"));
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("body")).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/components/ui/markdown-view.blocks.test.tsx
+++ b/frontend/ui/src/components/ui/markdown-view.blocks.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+/**
+ * Block-level coverage for MarkdownView's component map — headings, lists,
+ * quotes, rules, links and tables. Complements markdown-view.test.tsx, which
+ * covers inline emphasis, underline and fenced-code highlighting.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MarkdownView } from "./markdown-view";
+
+describe("MarkdownView block elements", () => {
+  it("renders every heading level", () => {
+    const { container } = render(
+      <MarkdownView content={"# h1\n\n## h2\n\n### h3\n\n#### h4\n\n##### h5\n\n###### h6"} />,
+    );
+    for (const level of [1, 2, 3, 4, 5, 6]) {
+      expect(container.querySelector(`h${level}`)?.textContent).toBe(`h${level}`);
+    }
+  });
+
+  it("renders paragraphs", () => {
+    const { container } = render(<MarkdownView content={"one\n\ntwo"} />);
+    expect(container.querySelectorAll("p")).toHaveLength(2);
+  });
+
+  it("renders ordered and unordered lists", () => {
+    const { container } = render(<MarkdownView content={"1. one\n2. two\n\n- a\n- b"} />);
+    expect(container.querySelector("ol")).not.toBeNull();
+    expect(container.querySelector("ul")).not.toBeNull();
+    expect(container.querySelectorAll("li")).toHaveLength(4);
+  });
+
+  it("renders blockquotes and horizontal rules", () => {
+    const { container } = render(<MarkdownView content={"> quoted\n\n---\n"} />);
+    expect(container.querySelector("blockquote")?.textContent).toContain("quoted");
+    expect(container.querySelector("hr")).not.toBeNull();
+  });
+
+  it("renders links that open in a new tab safely", () => {
+    const { container } = render(<MarkdownView content="[docs](https://example.com)" />);
+    const a = container.querySelector("a");
+    expect(a?.getAttribute("href")).toBe("https://example.com");
+    expect(a?.getAttribute("target")).toBe("_blank");
+    expect(a?.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("renders table headers and body cells", () => {
+    const { container } = render(<MarkdownView content={"| a | b |\n| - | - |\n| 1 | 2 |"} />);
+    expect(container.querySelectorAll("th")).toHaveLength(2);
+    expect(container.querySelectorAll("td")).toHaveLength(2);
+    expect(container.querySelector("td")?.textContent).toBe("1");
+  });
+
+  it("renders inline code and inline emphasis", () => {
+    const { container } = render(<MarkdownView content="**b** *i* ~~s~~ `inline`" />);
+    expect(container.querySelector("strong")?.textContent).toBe("b");
+    expect(container.querySelector("em")?.textContent).toBe("i");
+    expect(container.querySelector("del")?.textContent).toBe("s");
+    expect(container.querySelector("code")?.textContent).toBe("inline");
+  });
+
+  it("renders a labelled fenced block with its language chip", () => {
+    const { container } = render(<MarkdownView content={"```python\nx = 1\n```"} />);
+    expect(screen.getByText("python")).toBeTruthy();
+    expect(container.querySelector("pre")?.textContent).toContain("x = 1");
+  });
+
+  it("renders an unlabelled fence without a language chip", () => {
+    const { container } = render(<MarkdownView content={"```\nraw\n```"} />);
+    expect(container.querySelector("pre")?.textContent).toContain("raw");
+    expect(container.querySelectorAll("pre")).toHaveLength(1);
+  });
+
+  it("accepts an extra class name on the wrapper", () => {
+    const { container } = render(<MarkdownView content="hi" className="mt-4" />);
+    expect((container.firstElementChild as HTMLElement).className).toContain("mt-4");
+  });
+
+  it("renders an empty document without crashing", () => {
+    const { container } = render(<MarkdownView content="" />);
+    expect(container.textContent).toBe("");
+  });
+});

--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -1,0 +1,623 @@
+// @vitest-environment jsdom
+/**
+ * View-mount ("e2e") smoke for the real, server-backed Dataset detail page.
+ * The route sits behind auth and can't be driven over HTTP without a session,
+ * so mounting the view against a stubbed fetch (server-shaped payloads) is how
+ * the browser path is checked — same harness as evaluations.smoke.test.tsx.
+ *
+ * It drives the surfaces the list-level smoke never reaches: the version
+ * selector (current vs. an older read-only snapshot), the keyword filter, the
+ * slide-in case panel (details / runs / edit + save), the review drawer, the
+ * pull-code drawer, and the Evaluation history tab.
+ */
+import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@/components/ui/toast";
+
+/** Mutable so a test can exercise the ?case=<id> deep link. */
+let searchParams = new URLSearchParams();
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1", datasetId: "ds1" }),
+  useRouter: () => ({ push: mockPush, replace: vi.fn() }),
+  useSearchParams: () => searchParams,
+  usePathname: () => "/projects/p1/datasets/ds1",
+}));
+// ProjectBreadcrumb pulls layout/workspace context we don't mount here.
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+
+import { DatasetDetailView } from "./views/dataset-detail-view";
+import { caseDisplayId } from "@/features/offline-eval/utils";
+
+// ---------------------------------------------------------------------------
+// Server-shaped fixtures
+// ---------------------------------------------------------------------------
+
+const DATASET = {
+  id: "ds1",
+  projectId: "p1",
+  name: "Billing routing",
+  description: "Routing tickets",
+  currentVersionId: "dv2",
+  createTime: "2026-07-16T00:00:00Z",
+  updateTime: "2026-07-17T00:00:00Z",
+  caseCount: 3,
+  versionCount: 2,
+};
+
+const V1 = {
+  id: "dv1",
+  datasetId: "ds1",
+  projectId: "p1",
+  versionNumber: 1,
+  label: "seed",
+  note: null,
+  createdBy: null,
+  createTime: "2026-07-16T00:00:00Z",
+};
+const V2 = { ...V1, id: "dv2", versionNumber: 2, label: "v2", createTime: "2026-07-17T00:00:00Z" };
+
+function testCase(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "row-1",
+    testCaseId: "tc_1",
+    datasetVersionId: "dv2",
+    datasetId: "ds1",
+    projectId: "p1",
+    input: "I was charged twice for my July invoice",
+    expected: "billing",
+    recordedOutput: null,
+    metadata: null,
+    review: "needs_review",
+    captureReason: "manual",
+    sourceTraceId: null,
+    sourceSpanId: null,
+    sourceSpanName: null,
+    sourceSpanKind: null,
+    addedBy: null,
+    createTime: "2026-07-17T10:24:00Z",
+    ...over,
+  };
+}
+
+const CASES = [
+  testCase(),
+  testCase({
+    id: "row-2",
+    testCaseId: "tc_2",
+    input: "Reset my password please",
+    expected: "account-management",
+    // Exercises the metadata preview + the recorded-output block + a real source span.
+    metadata: { channel: "email", priority: "high" },
+    recordedOutput: "escalation",
+    review: "ready",
+    captureReason: "detector",
+    sourceTraceId: "tr_9",
+    sourceSpanId: "sp_9",
+    sourceSpanName: "handle_ticket",
+    sourceSpanKind: "AGENT",
+  }),
+  testCase({
+    id: "row-3",
+    testCaseId: "tc_3",
+    // Empty input + null expected exercise the "-" placeholders.
+    input: "",
+    expected: null,
+    createTime: "2026-07-17T11:00:00Z",
+  }),
+];
+
+const RUN = {
+  id: "run1",
+  evaluationId: "eval1",
+  datasetId: "ds1",
+  datasetVersionId: "dv2",
+  runNumber: 27,
+  candidateVersion: "git:4a91c02",
+  environment: "ci",
+  status: "completed",
+  baselineRunId: null,
+  mainScore: 0.938,
+  mainScoreName: "Routing accuracy",
+  caseCount: 3,
+  scoredCount: 3,
+  taskErrorCount: 0,
+  scorerErrorCount: 0,
+  passedCount: 3,
+  failedCount: 0,
+  erroredCount: 0,
+  notScoredCount: 0,
+  scorers: [{ name: "routing-accuracy", version: "v3" }],
+  model: null,
+  metadata: null,
+  startedAt: "2026-07-17T10:24:00Z",
+  completedAt: "2026-07-17T10:30:00Z",
+  evaluationName: "Billing routing nightly",
+  datasetName: "Billing routing",
+  datasetVersionLabel: "v2",
+  changeFromBaseline: null,
+  errorCount: 0,
+  baselineComparable: false,
+  elapsedMs: 360000,
+  cost: 0.42,
+};
+
+const CASE_RUNS = [
+  {
+    resultId: "res1",
+    runId: "run1",
+    runNumber: 27,
+    candidateVersion: "git:4a91c02",
+    evaluationName: "Billing routing nightly",
+    ranAt: "2026-07-17T10:24:00Z",
+    score: 1,
+    status: "passed",
+    change: "improved",
+  },
+];
+
+/** Records every request so tests can assert what was persisted. */
+let requests: Array<{ url: string; method: string; body: unknown }> = [];
+
+function detail(versionId: string | null) {
+  const older = versionId === "dv1";
+  return {
+    dataset: DATASET,
+    currentVersion: V2,
+    selectedVersion: older ? V1 : V2,
+    isCurrentVersion: !older,
+    // The older snapshot holds a single, pre-edit case.
+    testCases: older
+      ? [testCase({ id: "old-1", datasetVersionId: "dv1", input: "seeded ticket" })]
+      : CASES,
+    versions: [V2, V1],
+  };
+}
+
+function payloadFor(url: string): unknown {
+  if (url.includes("/test-cases/") && url.endsWith("/runs")) return { data: CASE_RUNS };
+  if (url.includes("/test-cases")) {
+    return { duplicate: false, testCaseId: "tc_new", versionId: "dv3" };
+  }
+  if (url.includes("/evaluations/runs")) {
+    return { data: [RUN], meta: { page: 0, limit: 50, total: 1 } };
+  }
+  if (url.includes("/datasets/ds1")) {
+    const versionId = new URL(url, "http://x").searchParams.get("version_id");
+    return detail(versionId);
+  }
+  return {};
+}
+
+beforeAll(() => {
+  // jsdom lacks these; Radix Select/Dialog call them on pointer handling + focus.
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  window.HTMLElement.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+  window.open = vi.fn();
+  Object.assign(navigator, { clipboard: { writeText: vi.fn(async () => {}) } });
+});
+
+beforeEach(() => {
+  searchParams = new URLSearchParams();
+  requests = [];
+  mockPush.mockClear();
+  global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+    requests.push({
+      url: String(url),
+      method: init?.method ?? "GET",
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => payloadFor(String(url)),
+    };
+  }) as unknown as typeof fetch;
+});
+afterEach(() => cleanup());
+
+function mount(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ToastProvider>{node}</ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function mountDetail() {
+  return mount(<DatasetDetailView projectId="p1" datasetId="ds1" />);
+}
+
+/**
+ * Opens the slide-in panel for a case by clicking its Input cell. "Copy ID" is
+ * the panel's unique anchor ("Row" also labels the add-row button).
+ */
+async function openCase(text: string | RegExp) {
+  fireEvent.click((await screen.findAllByText(text))[0]);
+  return screen.findByTitle("Copy ID");
+}
+
+describe("Dataset detail view renders server data", () => {
+  it("shows the dataset name, its id, and every test case of the current version", async () => {
+    mountDetail();
+    expect(await screen.findByText("Billing routing")).toBeDefined();
+    expect(screen.getAllByText("ds1").length).toBeGreaterThan(0);
+    expect(screen.getByText(/charged twice/)).toBeDefined();
+    expect(screen.getByText("Reset my password please")).toBeDefined();
+    // The metadata preview renders the flat key: value join.
+    expect(screen.getByText(/channel: email/)).toBeDefined();
+    // Tab counts come from the loaded data.
+    expect(screen.getByRole("tab", { name: /Test cases/ }).textContent).toContain("3");
+  });
+
+  it("renders a loading state before the dataset resolves", () => {
+    mountDetail();
+    expect(screen.getByText("Loading dataset...")).toBeDefined();
+  });
+
+  it("shows a not-found state when the dataset request fails", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: "not found" }),
+    })) as unknown as typeof fetch;
+    mountDetail();
+    expect(await screen.findByText("Dataset not found")).toBeDefined();
+    expect(screen.getByText(/No dataset with the id/)).toBeDefined();
+    expect(screen.getByText("Back to datasets")).toBeDefined();
+  });
+});
+
+describe("Dataset detail — versions", () => {
+  it("switching to an older version loads its snapshot read-only", async () => {
+    mountDetail();
+    await screen.findByText(/charged twice/);
+    // The current version is preselected and its immutable id is shown.
+    expect(screen.getAllByText("dv2").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Viewing an older version/)).toBeNull();
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(await screen.findByRole("option", { name: /v1/ }));
+
+    expect(await screen.findByText(/Viewing an older version — read only/)).toBeDefined();
+    expect(await screen.findByText("seeded ticket")).toBeDefined();
+    // Editing branches from the current version, so adding a row is disabled here.
+    expect(screen.getByRole("button", { name: /Row/ }).hasAttribute("disabled")).toBe(true);
+    // The request carried the requested snapshot.
+    expect(requests.some((r) => r.url.includes("version_id=dv1"))).toBe(true);
+  });
+
+  it("copies the selected version id", async () => {
+    mountDetail();
+    await screen.findByText(/charged twice/);
+    fireEvent.click(screen.getByTitle("Copy version ID"));
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith("dv2"));
+  });
+});
+
+describe("Dataset detail — filtering and adding rows", () => {
+  it("the keyword filter matches input and expected, and shows a no-match empty state", async () => {
+    mountDetail();
+    const search = await screen.findByPlaceholderText("Search cases...");
+
+    fireEvent.change(search, { target: { value: "password" } });
+    expect(screen.queryByText(/charged twice/)).toBeNull();
+    expect(screen.getByText("Reset my password please")).toBeDefined();
+
+    // Matching on the expected column, not the input.
+    fireEvent.change(search, { target: { value: "account-management" } });
+    expect(screen.getByText("Reset my password please")).toBeDefined();
+
+    fireEvent.change(search, { target: { value: "nothing matches this" } });
+    expect(await screen.findByText("No cases match your search.")).toBeDefined();
+  });
+
+  it("shows the empty-dataset guidance when a version has no cases", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        const s = String(url);
+        if (s.includes("/evaluations/runs")) {
+          return { data: [], meta: { page: 0, limit: 50, total: 0 } };
+        }
+        return { ...detail(null), testCases: [] };
+      },
+    })) as unknown as typeof fetch;
+    mountDetail();
+    expect(await screen.findByText(/No test cases yet/)).toBeDefined();
+  });
+
+  it("Row posts an empty, needs-review test case and toasts", async () => {
+    mountDetail();
+    await screen.findByText(/charged twice/);
+    fireEvent.click(screen.getByRole("button", { name: /Row/ }));
+    expect(await screen.findByText("Empty row added")).toBeDefined();
+    const post = requests.find((r) => r.method === "POST");
+    expect(post?.body).toEqual({ input: "", review: "needs_review", capture_reason: "manual" });
+  });
+});
+
+describe("Dataset detail — the slide-in case panel", () => {
+  it("opens a case, shows its identity, source, and capture reason", async () => {
+    mountDetail();
+    await openCase("Reset my password please");
+    // The opened row carries a real source span and a detector capture reason.
+    expect(screen.getByText("handle_ticket")).toBeDefined();
+    expect(screen.getByText("Captured:")).toBeDefined();
+    // Editable value blocks are seeded from the case, each addressed by its label.
+    expect((screen.getByLabelText("Input") as HTMLTextAreaElement).value).toContain(
+      "Reset my password please",
+    );
+    expect((screen.getByLabelText("Expected") as HTMLTextAreaElement).value).toContain(
+      "account-management",
+    );
+    // The recorded production output is a separate, read-only block.
+    const recorded = screen.getByLabelText("What happened in production") as HTMLTextAreaElement;
+    expect(recorded.value).toContain("escalation");
+    expect(recorded.readOnly).toBe(true);
+    expect((screen.getByLabelText("Metadata") as HTMLTextAreaElement).value).toContain("channel");
+  });
+
+  it("a manually added case shows the manual source chip", async () => {
+    mountDetail();
+    await openCase(/charged twice/);
+    expect(screen.getByText("Added manually")).toBeDefined();
+  });
+
+  it("navigates between cases with the up/down controls", async () => {
+    mountDetail();
+    await openCase(/charged twice/);
+    // First row: up is disabled, down moves to the second case.
+    expect(screen.getByTitle("Previous row").hasAttribute("disabled")).toBe(true);
+    fireEvent.click(screen.getByTitle("Next row"));
+    expect(await screen.findByText(caseDisplayId("tc_2"))).toBeDefined();
+    fireEvent.click(screen.getByTitle("Previous row"));
+    expect(await screen.findByText(caseDisplayId("tc_1"))).toBeDefined();
+  });
+
+  it("expands to full screen and opens the row in a new tab", async () => {
+    mountDetail();
+    await openCase(/charged twice/);
+    fireEvent.click(screen.getByTitle("Expand to full screen"));
+    fireEvent.click(await screen.findByTitle("Restore default size"));
+    fireEvent.click(screen.getByTitle("Open in new tab"));
+    expect(window.open).toHaveBeenCalledWith("/projects/p1/datasets/ds1", "_blank");
+  });
+
+  it("the Runs view lists every evaluation run that measured the case", async () => {
+    mountDetail();
+    await openCase(/charged twice/);
+    fireEvent.click(screen.getByRole("button", { name: /Runs/ }));
+    expect(await screen.findByText("Billing routing nightly")).toBeDefined();
+    expect(screen.getByText(/Run #27 ·/)).toBeDefined();
+    // Clicking a run navigates to its detail.
+    fireEvent.click(screen.getByText("Billing routing nightly"));
+    expect(mockPush).toHaveBeenCalledWith("/projects/p1/evaluations/run1");
+    // Back to Details.
+    fireEvent.click(screen.getByRole("button", { name: /Details/ }));
+    expect(await screen.findByLabelText("Input")).toBeDefined();
+  });
+
+  it("shows an empty Runs state when nothing has measured the case", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        const s = String(url);
+        if (s.includes("/test-cases/") && s.endsWith("/runs")) return { data: [] };
+        if (s.includes("/evaluations/runs")) {
+          return { data: [], meta: { page: 0, limit: 50, total: 0 } };
+        }
+        return detail(null);
+      },
+    })) as unknown as typeof fetch;
+    mountDetail();
+    await openCase(/charged twice/);
+    fireEvent.click(screen.getByRole("button", { name: /Runs/ }));
+    expect(
+      await screen.findByText(/No evaluation run has measured this test case yet/),
+    ).toBeDefined();
+  });
+
+  it("editing a field reveals Save, which PATCHes and publishes a new version", async () => {
+    mountDetail();
+    await openCase(/charged twice/);
+    // Nothing is dirty yet.
+    expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Input"), { target: { value: "edited input" } });
+    fireEvent.change(screen.getByLabelText("Expected"), { target: { value: "" } });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+    expect(await screen.findByText(/Saved — new dataset version published/)).toBeDefined();
+
+    const patch = requests.find((r) => r.method === "PATCH");
+    expect(patch?.url).toContain("/datasets/ds1/test-cases/tc_1");
+    // A cleared Expected persists as null, never as "".
+    expect(patch?.body).toEqual({ input: "edited input", expected: null });
+  });
+
+  it("only persists metadata once it parses back to an object", async () => {
+    mountDetail();
+    await openCase("Reset my password please");
+    const metadataBox = screen.getByLabelText("Metadata");
+
+    // Half-typed JSON leaves the stored metadata untouched — the patch is empty,
+    // so nothing is sent at all rather than blowing the value away.
+    fireEvent.change(metadataBox, { target: { value: "{ not json" } });
+    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+    expect(requests.some((r) => r.method === "PATCH")).toBe(false);
+
+    // ...and valid JSON is sent through.
+    fireEvent.change(metadataBox, { target: { value: '{"channel":"chat"}' } });
+    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+    await waitFor(() =>
+      expect(
+        requests
+          .filter((r) => r.method === "PATCH")
+          .some((r) => {
+            const body = r.body as { metadata?: Record<string, unknown> };
+            return body.metadata?.channel === "chat";
+          }),
+      ).toBe(true),
+    );
+  });
+
+  it("closes the panel", async () => {
+    mountDetail();
+    await openCase(/charged twice/);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    await waitFor(() => expect(screen.queryByTitle("Copy ID")).toBeNull());
+  });
+});
+
+describe("Dataset detail — review drawer", () => {
+  it("Mark ready PATCHes the review and toasts", async () => {
+    mountDetail();
+    await openCase(/charged twice/);
+    fireEvent.click(screen.getByRole("button", { name: "Review" }));
+
+    const drawer = await screen.findByText("Review test case");
+    expect(drawer).toBeDefined();
+    // The drawer names the case it is reviewing.
+    expect(screen.getByText(`${caseDisplayId("tc_1")} · Billing routing`)).toBeDefined();
+
+    // Tick a couple of the verification checks.
+    const boxes = screen.getAllByRole("checkbox");
+    fireEvent.click(boxes[0]);
+    fireEvent.click(boxes[1]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark ready" }));
+    await waitFor(() => expect(requests.some((r) => r.method === "PATCH")).toBe(true));
+    expect(requests.find((r) => r.method === "PATCH")?.body).toEqual({ review: "ready" });
+    expect(await screen.findByText(/Review saved — new dataset version published/)).toBeDefined();
+  });
+
+  it("a corrected expected outcome is sent alongside the review", async () => {
+    mountDetail();
+    await openCase(/charged twice/);
+    fireEvent.click(screen.getByRole("button", { name: "Review" }));
+    fireEvent.change(await screen.findByLabelText(/Correct the expected outcome/), {
+      target: { value: "  refunds  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Needs work" }));
+    await waitFor(() => expect(requests.some((r) => r.method === "PATCH")).toBe(true));
+    expect(requests.find((r) => r.method === "PATCH")?.body).toEqual({
+      review: "needs_review",
+      expected: "refunds",
+    });
+  });
+
+  it("a case with no expected outcome says a scorer judges the output", async () => {
+    mountDetail();
+    // Row 3 has a null expected; its Input cell renders as "-", so open by created time.
+    await openCase(/charged twice/);
+    fireEvent.click(screen.getByTitle("Next row"));
+    fireEvent.click(screen.getByTitle("Next row"));
+    fireEvent.click(await screen.findByRole("button", { name: "Review" }));
+    expect(
+      await screen.findByText(/Not required — a scorer judges the output directly/),
+    ).toBeDefined();
+  });
+});
+
+describe("Dataset detail — pull code", () => {
+  it("opens the drawer with the dataset's real id in both languages", async () => {
+    mountDetail();
+    await screen.findByText(/charged twice/);
+    fireEvent.click(screen.getByRole("button", { name: /Pull code/ }));
+
+    const drawer = await screen.findByText("Pull this dataset in code");
+    const panel = drawer.closest("div.fixed") as HTMLElement;
+    // The Python snippet pulls this dataset by its real id.
+    expect(panel.textContent).toContain('pull_dataset("ds1")');
+
+    fireEvent.click(screen.getByRole("button", { name: "TypeScript" }));
+    await waitFor(() => expect(panel.textContent).toContain('await pullDataset("ds1")'));
+    expect(panel.textContent).not.toContain("pull_dataset");
+  });
+});
+
+describe("Dataset detail — evaluation history tab", () => {
+  it("lists the runs against this dataset and opens one", async () => {
+    mountDetail();
+    fireEvent.click(await screen.findByRole("tab", { name: /Evaluation history/ }));
+    expect(await screen.findByText("Billing routing nightly")).toBeDefined();
+    expect(screen.getByText(/Run #27 ·/)).toBeDefined();
+    fireEvent.click(screen.getByText("Billing routing nightly"));
+    expect(mockPush).toHaveBeenCalledWith("/projects/p1/evaluations/run1");
+  });
+
+  it("filters the history and falls back to a search-specific empty state", async () => {
+    mountDetail();
+    fireEvent.click(await screen.findByRole("tab", { name: /Evaluation history/ }));
+    const search = await screen.findByPlaceholderText("Search evaluations...");
+    fireEvent.change(search, { target: { value: "nightly" } });
+    expect(screen.getByText("Billing routing nightly")).toBeDefined();
+    fireEvent.change(search, { target: { value: "zzz" } });
+    expect(await screen.findByText("No evaluations match your search.")).toBeDefined();
+  });
+
+  it("names the dataset when nothing has been run against it", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        const s = String(url);
+        if (s.includes("/evaluations/runs")) {
+          return { data: [], meta: { page: 0, limit: 50, total: 0 } };
+        }
+        return detail(null);
+      },
+    })) as unknown as typeof fetch;
+    mountDetail();
+    fireEvent.click(await screen.findByRole("tab", { name: /Evaluation history/ }));
+    expect(
+      await screen.findByText(/Nothing has been run against Billing routing yet/),
+    ).toBeDefined();
+  });
+});
+
+describe("Dataset detail — deep link", () => {
+  it("?case=<testCaseId> opens that case's panel on load", async () => {
+    searchParams = new URLSearchParams("case=tc_2");
+    mountDetail();
+    // The panel opens on the matching stable testCaseId, not the per-version row id.
+    expect(await screen.findByTitle("Copy ID")).toBeDefined();
+    expect(await screen.findByText(caseDisplayId("tc_2"))).toBeDefined();
+    expect(screen.getByText("handle_ticket")).toBeDefined();
+  });
+
+  it("ignores a ?case that no row matches", async () => {
+    searchParams = new URLSearchParams("case=tc_missing");
+    mountDetail();
+    await screen.findByText(/charged twice/);
+    expect(screen.queryByTitle("Copy ID")).toBeNull();
+  });
+});
+
+describe("Dataset detail — tabs behave as an ARIA tablist", () => {
+  it("arrow keys move between the two tabs", async () => {
+    mountDetail();
+    const cases = await screen.findByRole("tab", { name: /Test cases/ });
+    const list = screen.getByRole("tablist");
+    cases.focus();
+    fireEvent.keyDown(list, { key: "ArrowRight" });
+    expect(
+      screen.getByRole("tab", { name: /Evaluation history/ }).getAttribute("aria-selected"),
+    ).toBe("true");
+    fireEvent.keyDown(list, { key: "End" });
+    fireEvent.keyDown(list, { key: "Home" });
+    expect(screen.getByRole("tab", { name: /Test cases/ }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    // A key the tablist doesn't own is ignored.
+    fireEvent.keyDown(list, { key: "a" });
+    expect(within(list).getAllByRole("tab").length).toBe(2);
+  });
+});

--- a/frontend/ui/src/features/offline-eval/components/code.test.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.test.tsx
@@ -1,0 +1,466 @@
+// @vitest-environment jsdom
+/**
+ * Coverage for the offline-eval code helpers: the value formatters (YAML / text
+ * / JSON / pretty / markdown), the line-numbered editable field with its JSON
+ * tokenizer and collapse control, and the read-only / editable value blocks.
+ */
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import * as React from "react";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import {
+  LineNumberedTextarea,
+  ValueBlock,
+  EditableValueBlock,
+  formatValue,
+  seedFormat,
+} from "./code";
+
+beforeAll(() => {
+  // Radix popovers measure their trigger; jsdom has no layout engine.
+  if (!globalThis.ResizeObserver) {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+    Element.prototype.setPointerCapture = () => {};
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => cleanup());
+
+describe("formatValue — yaml", () => {
+  it("renders empty values as null", () => {
+    expect(formatValue(null, "yaml")).toBe("null");
+    expect(formatValue(undefined, "yaml")).toBe("null");
+    expect(formatValue("", "yaml")).toBe("null");
+  });
+
+  it("renders a single-line string inline", () => {
+    expect(formatValue("hello", "yaml")).toBe("hello");
+  });
+
+  it("renders a multi-line string as a block scalar", () => {
+    expect(formatValue("a\nb", "yaml")).toBe("|\n  a\n  b");
+  });
+
+  it("renders numbers and booleans directly", () => {
+    expect(formatValue(42, "yaml")).toBe("42");
+    expect(formatValue(true, "yaml")).toBe("true");
+  });
+
+  it("renders arrays as dashed items and an empty array as []", () => {
+    expect(formatValue(["a", "b"], "yaml")).toBe("- a\n- b");
+    expect(formatValue([], "yaml")).toBe("[]");
+  });
+
+  it("renders objects as key: value pairs and an empty object as null", () => {
+    expect(formatValue({ a: 1, b: "x" }, "yaml")).toBe("a: 1\nb: x");
+    expect(formatValue({}, "yaml")).toBe("null");
+  });
+});
+
+describe("formatValue — other kinds", () => {
+  it("passes markdown through verbatim", () => {
+    expect(formatValue("# hi", "markdown")).toBe("# hi");
+    expect(formatValue(null, "markdown")).toBe("");
+    expect(formatValue(undefined, "markdown")).toBe("");
+    expect(formatValue({ a: 1 }, "markdown")).toBe('{"a":1}');
+  });
+
+  it("renders text, using the literal null for empty values", () => {
+    expect(formatValue("hi", "text")).toBe("hi");
+    expect(formatValue("", "text")).toBe("null");
+    expect(formatValue(null, "text")).toBe("null");
+    expect(formatValue({ a: 1 }, "text")).toBe('{"a":1}');
+  });
+
+  it("renders compact and pretty JSON", () => {
+    expect(formatValue({ a: 1 }, "json")).toBe('{"a":1}');
+    expect(formatValue(undefined, "json")).toBe("null");
+    expect(formatValue({ a: 1 }, "pretty")).toBe('{\n  "a": 1\n}');
+  });
+});
+
+describe("seedFormat", () => {
+  it("leaves non-JSON text alone", () => {
+    expect(seedFormat("just text", "expanded")).toEqual({ kind: "text", text: "just text" });
+    expect(seedFormat("", "compact")).toEqual({ kind: "text", text: "" });
+  });
+
+  it("falls back to text for something that only looks like JSON", () => {
+    expect(seedFormat("{not json", "compact")).toEqual({ kind: "text", text: "{not json" });
+  });
+
+  it("keeps a small flat object on one line when compact is preferred", () => {
+    expect(seedFormat('{"a": 1}', "compact")).toEqual({ kind: "json", text: '{"a":1}' });
+  });
+
+  it("expands a nested value even when compact is preferred", () => {
+    const out = seedFormat('{"a":{"b":1}}', "compact");
+    expect(out.kind).toBe("pretty");
+  });
+
+  it("expands a long value even when compact is preferred", () => {
+    const long = JSON.stringify({ a: "x".repeat(200) });
+    expect(seedFormat(long, "compact").kind).toBe("pretty");
+  });
+
+  it("always expands when expanded is preferred", () => {
+    expect(seedFormat('{"a":1}', "expanded")).toEqual({
+      kind: "pretty",
+      text: '{\n  "a": 1\n}',
+    });
+  });
+});
+
+describe("LineNumberedTextarea", () => {
+  it("numbers each line and pads to minRows", () => {
+    render(<LineNumberedTextarea value={"a"} onChange={vi.fn()} minRows={4} aria-label="field" />);
+    expect(screen.getByText("4")).toBeTruthy();
+  });
+
+  it("strips the display-only trailing newline from what it reports", () => {
+    const onChange = vi.fn();
+    render(<LineNumberedTextarea value="a" onChange={onChange} aria-label="field" />);
+    fireEvent.change(screen.getByLabelText("field"), { target: { value: "abc\n" } });
+    expect(onChange).toHaveBeenCalledWith("abc");
+  });
+
+  it("keeps a value that does not end in a newline", () => {
+    const onChange = vi.fn();
+    render(<LineNumberedTextarea value="a" onChange={onChange} aria-label="field" />);
+    fireEvent.change(screen.getByLabelText("field"), { target: { value: "abc" } });
+    expect(onChange).toHaveBeenCalledWith("abc");
+  });
+
+  it("ignores edits while read-only", () => {
+    const onChange = vi.fn();
+    render(<LineNumberedTextarea value="a" onChange={onChange} readOnly aria-label="field" />);
+    fireEvent.change(screen.getByLabelText("field"), { target: { value: "abc" } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("renders a placeholder", () => {
+    render(
+      <LineNumberedTextarea
+        value=""
+        onChange={vi.fn()}
+        placeholder="type here"
+        aria-label="field"
+      />,
+    );
+    expect(screen.getByPlaceholderText("type here")).toBeTruthy();
+  });
+
+  it("colours JSON tokens when highlighting is on", () => {
+    const json = '{"a": "s", "b": 1, "c": true, "d": false, "e": null, "f": [1,-2.5e3]}';
+    const { container } = render(
+      <LineNumberedTextarea value={json} onChange={vi.fn()} highlightJson aria-label="field" />,
+    );
+    const classes = Array.from(container.querySelectorAll("span"))
+      .map((s) => s.className)
+      .join(" ");
+    expect(classes).toContain("text-sky-600"); // keys
+    expect(classes).toContain("text-green-700"); // strings
+    expect(classes).toContain("text-blue-600"); // numbers
+    expect(classes).toContain("text-purple-600"); // booleans
+    expect(classes).toContain("text-orange-600"); // null
+  });
+
+  it("handles escaped quotes inside a highlighted string", () => {
+    const { container } = render(
+      <LineNumberedTextarea
+        value={'{"a": "he said \\"hi\\""}'}
+        onChange={vi.fn()}
+        highlightJson
+        aria-label="field"
+      />,
+    );
+    expect(container.textContent).toContain("he said");
+  });
+
+  it("falls back to plain text when the content is not valid JSON", () => {
+    const { container } = render(
+      <LineNumberedTextarea value="not json" onChange={vi.fn()} highlightJson aria-label="field" />,
+    );
+    expect(container.textContent).toContain("not json");
+  });
+
+  it("treats empty content as unhighlightable", () => {
+    const { container } = render(
+      <LineNumberedTextarea value="" onChange={vi.fn()} highlightJson aria-label="field" />,
+    );
+    expect(container.querySelector("textarea")).toBeTruthy();
+  });
+
+  it("clips a long value behind an inline expand control", () => {
+    const onExpand = vi.fn();
+    const long = "x".repeat(600);
+    render(
+      <LineNumberedTextarea
+        value={long}
+        onChange={vi.fn()}
+        collapsed
+        collapseAt={500}
+        onExpand={onExpand}
+        aria-label="field"
+      />,
+    );
+    // No editable overlay while collapsed, so the inline control stays clickable.
+    expect(screen.queryByLabelText("field")).toBeNull();
+    fireEvent.click(screen.getByText(/…expand \(100 more characters\)/));
+    expect(onExpand).toHaveBeenCalled();
+  });
+
+  it("does not collapse a value under the threshold", () => {
+    render(
+      <LineNumberedTextarea
+        value="short"
+        onChange={vi.fn()}
+        collapsed
+        collapseAt={500}
+        aria-label="field"
+      />,
+    );
+    expect(screen.getByLabelText("field")).toBeTruthy();
+  });
+
+  it("falls back to the label when no aria-label is given", () => {
+    const { container } = render(<LineNumberedTextarea value="a" onChange={vi.fn()} />);
+    expect(container.querySelector("textarea")).toBeTruthy();
+  });
+});
+
+describe("ValueBlock", () => {
+  it("renders the label and the default YAML view", () => {
+    render(<ValueBlock label="Input" value={{ a: 1 }} />);
+    expect(screen.getByText("Input")).toBeTruthy();
+    expect(screen.getByText("YAML")).toBeTruthy();
+    expect(screen.getByText("a: 1")).toBeTruthy();
+  });
+
+  it("switches to another format from the popover", async () => {
+    render(<ValueBlock label="Input" value={{ a: 1 }} />);
+    fireEvent.click(screen.getByText("YAML"));
+    fireEvent.click(await screen.findByRole("button", { name: "Pretty" }));
+    expect(screen.getByText("Pretty")).toBeTruthy();
+  });
+
+  it("renders markdown through the markdown view", async () => {
+    render(<ValueBlock label="Output" value={"# Heading"} defaultKind="markdown" />);
+    expect(screen.getByText("Heading").tagName).toBe("H1");
+  });
+
+  it("renders an empty value as a single numbered line", () => {
+    render(<ValueBlock label="Meta" value={null} defaultKind="text" />);
+    expect(screen.getByText("null")).toBeTruthy();
+  });
+});
+
+describe("EditableValueBlock", () => {
+  function Editable(props: Partial<React.ComponentProps<typeof EditableValueBlock>> = {}) {
+    const [text, setText] = React.useState((props.text as string) ?? "hello");
+    return (
+      <EditableValueBlock
+        label="Input"
+        {...props}
+        text={text}
+        onChange={(t) => {
+          setText(t);
+          props.onChange?.(t);
+        }}
+      />
+    );
+  }
+
+  it("edits through the line-numbered field", () => {
+    const onChange = vi.fn();
+    render(<Editable onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText("Input"), { target: { value: "world" } });
+    expect(onChange).toHaveBeenCalledWith("world");
+  });
+
+  it("uses an explicit aria-label when given", () => {
+    render(<Editable ariaLabel="Expected output" />);
+    expect(screen.getByLabelText("Expected output")).toBeTruthy();
+  });
+
+  it("collapses and expands via the heading chevron", () => {
+    render(<Editable />);
+    const heading = screen.getByRole("button", { name: "Input" });
+    expect(heading.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(heading);
+    expect(heading.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByLabelText("Input")).toBeNull();
+    fireEvent.click(heading);
+    expect(screen.getByLabelText("Input")).toBeTruthy();
+  });
+
+  it("renders the boxed chrome variant", () => {
+    const { container } = render(<Editable boxed />);
+    expect(container.querySelector(".rounded-md.border")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Input" })).toBeTruthy();
+  });
+
+  it("shows a copy button when copyable", () => {
+    render(<Editable copyable />);
+    expect(screen.getByTitle("Copy")).toBeTruthy();
+  });
+
+  it("auto-detects pretty JSON from multi-line content", () => {
+    render(<Editable text={'{\n  "a": 1\n}'} autoDetectKind />);
+    expect(screen.getByText("Pretty")).toBeTruthy();
+  });
+
+  it("auto-detects compact JSON from single-line content", () => {
+    render(<Editable text={'{"a":1}'} autoDetectKind />);
+    expect(screen.getByText("JSON")).toBeTruthy();
+  });
+
+  it("auto-detects text for something that only looks like JSON", () => {
+    render(<Editable text={"{not json"} autoDetectKind />);
+    expect(screen.getByText("Text")).toBeTruthy();
+  });
+
+  it("seeds and normalises the value per field role", () => {
+    const onChange = vi.fn();
+    render(<Editable text={'{"a":1}'} seedJson="expanded" onChange={onChange} />);
+    expect(screen.getByText("Pretty")).toBeTruthy();
+    expect(onChange).toHaveBeenCalledWith('{\n  "a": 1\n}');
+  });
+
+  it("seeds a read-only field without touching the parent value", () => {
+    const onChange = vi.fn();
+    render(
+      <EditableValueBlock
+        label="Input"
+        text={'{"a":1}'}
+        onChange={onChange}
+        seedJson="expanded"
+        readOnly
+      />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText("Pretty")).toBeTruthy();
+  });
+
+  it("reformats JSON when the user picks another format", async () => {
+    const onChange = vi.fn();
+    render(<Editable text={'{"a":1}'} onChange={onChange} />);
+    fireEvent.click(screen.getByText("YAML"));
+    fireEvent.click(await screen.findByRole("button", { name: "Pretty" }));
+    expect(onChange).toHaveBeenCalledWith('{\n  "a": 1\n}');
+  });
+
+  it("leaves non-JSON text as typed when the format changes", async () => {
+    const onChange = vi.fn();
+    render(<Editable text="plain text" onChange={onChange} />);
+    fireEvent.click(screen.getByText("YAML"));
+    fireEvent.click(await screen.findByRole("button", { name: "JSON" }));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText("JSON")).toBeTruthy();
+  });
+
+  it("reformats a read-only field locally", async () => {
+    const onChange = vi.fn();
+    render(<EditableValueBlock label="Input" text={'{"a":1}'} onChange={onChange} readOnly />);
+    fireEvent.click(screen.getByText("YAML"));
+    fireEvent.click(await screen.findByRole("button", { name: "Pretty" }));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Input")).toBeTruthy();
+  });
+
+  it("switches to markdown without rewriting the stored value", async () => {
+    const onChange = vi.fn();
+    render(<Editable text={"# Heading"} onChange={onChange} />);
+    fireEvent.click(screen.getByText("YAML"));
+    fireEvent.click(await screen.findByRole("button", { name: "Markdown" }));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText("Heading").tagName).toBe("H1");
+    expect(screen.getByText(/Preview — switch to Text to edit/)).toBeTruthy();
+  });
+
+  it("hides the preview hint on a read-only markdown field", () => {
+    render(
+      <EditableValueBlock
+        label="Input"
+        text={"# Heading"}
+        onChange={vi.fn()}
+        defaultKind="markdown"
+        readOnly
+      />,
+    );
+    expect(screen.queryByText(/Preview — switch to Text to edit/)).toBeNull();
+  });
+
+  it("clips a long collapsible value and expands it in place", () => {
+    const long = "x".repeat(700);
+    render(<Editable text={long} collapsible />);
+    expect(screen.queryByLabelText("Input")).toBeNull();
+    fireEvent.click(screen.getByText(/…expand \(200 more characters\)/));
+    expect(screen.getByLabelText("Input")).toBeTruthy();
+  });
+
+  it("clips a long collapsible markdown value behind its own expand control", () => {
+    const long = `# Heading\n\n${"word ".repeat(200)}`;
+    render(
+      <EditableValueBlock
+        label="Input"
+        text={long}
+        onChange={vi.fn()}
+        defaultKind="markdown"
+        collapsible
+      />,
+    );
+    const expand = screen.getByText(/…expand \(\d+ more characters\)/);
+    fireEvent.click(expand);
+    expect(screen.queryByText(/…expand \(/)).toBeNull();
+  });
+
+  it("re-collapses when the reset key changes", () => {
+    const long = "x".repeat(700);
+    const { rerender } = render(
+      <EditableValueBlock
+        label="Input"
+        text={long}
+        onChange={vi.fn()}
+        collapsible
+        collapseResetKey="span-1"
+      />,
+    );
+    fireEvent.click(screen.getByText(/…expand/));
+    expect(screen.getByLabelText("Input")).toBeTruthy();
+    rerender(
+      <EditableValueBlock
+        label="Input"
+        text={long}
+        onChange={vi.fn()}
+        collapsible
+        collapseResetKey="span-2"
+      />,
+    );
+    expect(screen.queryByLabelText("Input")).toBeNull();
+  });
+
+  it("leaves an empty value unseeded", () => {
+    const onChange = vi.fn();
+    render(<Editable text="" seedJson="compact" onChange={onChange} />);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("stops seeding once the user pins a format", async () => {
+    const onChange = vi.fn();
+    render(<Editable text={'{"a":1}'} autoDetectKind onChange={onChange} />);
+    fireEvent.click(screen.getByText("JSON"));
+    fireEvent.click(await screen.findByRole("button", { name: "Text" }));
+    expect(screen.getByText("Text")).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/features/offline-eval/utils.test.ts
+++ b/frontend/ui/src/features/offline-eval/utils.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import {
+  REVIEW_STATUS_VARIANT,
+  RESULT_STATUS_VARIANT,
+  SENTIMENT_CLASS,
+  caseDisplayId,
+  changeSentiment,
+  datasetInitCode,
+  datasetInitCodeTs,
+  datasetPullCode,
+  datasetPullCodeTs,
+  datasetPullVersionCode,
+  datasetPullVersionCodeTs,
+  evalRoutes,
+  formatStamp,
+  parseMetadata,
+  pct,
+  pctFraction,
+  reproduceRunCode,
+  reproduceRunCodeTs,
+  scoreDisplay,
+  signed,
+  signedPoints,
+  truncate,
+} from "./utils";
+
+describe("evalRoutes", () => {
+  const routes = evalRoutes("proj-1");
+
+  it("builds the static section routes under the project", () => {
+    expect(routes.base).toBe("/projects/proj-1/offline-eval");
+    expect(routes.traces).toBe("/projects/proj-1/offline-eval/traces");
+    expect(routes.datasets).toBe("/projects/proj-1/offline-eval/datasets");
+    expect(routes.evaluations).toBe("/projects/proj-1/offline-eval/evaluations");
+    expect(routes.scorers).toBe("/projects/proj-1/offline-eval/scorers");
+  });
+
+  it("builds the parameterised routes", () => {
+    expect(routes.trace("tr_1")).toBe("/projects/proj-1/offline-eval/traces?trace=tr_1");
+    expect(routes.dataset("ds1")).toBe("/projects/proj-1/offline-eval/datasets/ds1");
+    expect(routes.datasetCase("ds1", "case-001")).toBe(
+      "/projects/proj-1/offline-eval/datasets/ds1?case=case-001",
+    );
+    expect(routes.evaluation("eval1")).toBe("/projects/proj-1/offline-eval/evaluations/eval1");
+  });
+});
+
+describe("status variant maps", () => {
+  it("maps every result status to a badge tone", () => {
+    expect(RESULT_STATUS_VARIANT.passed).toBe("success");
+    expect(RESULT_STATUS_VARIANT.failed).toBe("danger");
+    expect(RESULT_STATUS_VARIANT.needs_review).toBe("warning");
+  });
+
+  it("maps every review status to a badge tone", () => {
+    expect(REVIEW_STATUS_VARIANT.ready).toBe("success");
+    expect(REVIEW_STATUS_VARIANT.needs_review).toBe("warning");
+  });
+});
+
+describe("number formatting", () => {
+  it("formats percentage points", () => {
+    expect(pct(93.75)).toBe("93.8%");
+    expect(pct(93.75, 0)).toBe("94%");
+  });
+
+  it("formats a 0–1 fraction as a percentage", () => {
+    expect(pctFraction(0.857)).toBe("85.7%");
+    expect(pctFraction(1, 0)).toBe("100%");
+  });
+
+  it("signs a value with a true minus", () => {
+    expect(signed(22.4)).toBe("+22.4");
+    expect(signed(-9.5)).toBe("−9.5");
+    expect(signed(0)).toBe("0.0");
+  });
+
+  it("signs a 0–1 delta as percentage points", () => {
+    expect(signedPoints(-0.143)).toBe("−14.3");
+    expect(signedPoints(0.224)).toBe("+22.4");
+  });
+});
+
+describe("changeSentiment", () => {
+  it("is neutral for no change", () => {
+    expect(changeSentiment(0)).toBe("neutral");
+  });
+
+  it("reads up as good when higher is better", () => {
+    expect(changeSentiment(0.1)).toBe("good");
+    expect(changeSentiment(-0.1)).toBe("bad");
+  });
+
+  it("inverts when lower is better", () => {
+    expect(changeSentiment(0.1, false)).toBe("bad");
+    expect(changeSentiment(-0.1, false)).toBe("good");
+  });
+
+  it("has a class for every sentiment", () => {
+    expect(SENTIMENT_CLASS.good).toContain("emerald");
+    expect(SENTIMENT_CLASS.bad).toContain("red");
+    expect(SENTIMENT_CLASS.neutral).toContain("muted");
+  });
+});
+
+describe("scoreDisplay", () => {
+  it("renders a dash for a missing score", () => {
+    expect(scoreDisplay(null)).toBe("—");
+  });
+
+  it("reads 0/1 as Fail/Pass", () => {
+    expect(scoreDisplay(1)).toBe("Pass");
+    expect(scoreDisplay(0)).toBe("Fail");
+  });
+
+  it("reads a fractional score as a rounded percentage", () => {
+    expect(scoreDisplay(0.857)).toBe("86%");
+  });
+});
+
+describe("formatStamp", () => {
+  it("delegates to the app-wide absolute timestamp format", () => {
+    expect(formatStamp("2026-07-16T15:41:12Z")).toMatch(/2026-07-16/);
+  });
+});
+
+describe("caseDisplayId", () => {
+  it("produces a stable trace-id-looking id", () => {
+    const id = caseDisplayId("case-001");
+    expect(id).toMatch(/^tc_[0-9a-f]{12}$/);
+    expect(id).toHaveLength(15);
+    expect(caseDisplayId("case-001")).toBe(id);
+  });
+
+  it("distinguishes different case ids", () => {
+    expect(caseDisplayId("case-001")).not.toBe(caseDisplayId("case-002"));
+  });
+
+  it("handles an empty id", () => {
+    expect(caseDisplayId("")).toMatch(/^tc_/);
+  });
+});
+
+describe("truncate", () => {
+  it("leaves a short string alone", () => {
+    expect(truncate("short")).toBe("short");
+  });
+
+  it("clips past the limit with an ellipsis", () => {
+    expect(truncate("abcdef", 4)).toBe("abc…");
+  });
+
+  it("leaves a string exactly at the limit alone", () => {
+    expect(truncate("abcd", 4)).toBe("abcd");
+  });
+});
+
+describe("SDK snippets", () => {
+  it("embeds the dataset name in the init snippets", () => {
+    expect(datasetInitCode("Billing routing")).toContain('Dataset("Billing routing")');
+    expect(datasetInitCodeTs("Billing routing")).toContain('dataset("Billing routing")');
+  });
+
+  it("embeds the dataset id in the pull snippets", () => {
+    expect(datasetPullCode("ds1")).toContain('pull_dataset("ds1")');
+    expect(datasetPullCodeTs("ds1")).toContain('pullDataset("ds1")');
+  });
+
+  it("embeds the version id in the version-pull snippets", () => {
+    expect(datasetPullVersionCode("dv1")).toContain('pull_dataset_version("dv1")');
+    expect(datasetPullVersionCodeTs("dv1")).toContain('pullDatasetVersion("dv1")');
+  });
+
+  it("pins the version and the baseline run in the reproduce snippets", () => {
+    const py = reproduceRunCode("dv1", "Billing routing", "run1");
+    expect(py).toContain('pull_dataset_version("dv1")');
+    expect(py).toContain('name="Billing routing"');
+    expect(py).toContain('baseline="run1"');
+
+    const ts = reproduceRunCodeTs("dv1", "Billing routing", "run1");
+    expect(ts).toContain('pullDatasetVersion("dv1")');
+    expect(ts).toContain('name: "Billing routing"');
+    expect(ts).toContain('baseline: "run1"');
+  });
+});
+
+describe("parseMetadata", () => {
+  it("returns an empty record for missing metadata", () => {
+    expect(parseMetadata(null)).toEqual({});
+    expect(parseMetadata(undefined)).toEqual({});
+    expect(parseMetadata("")).toEqual({});
+  });
+
+  it("flattens a JSON object into strings", () => {
+    expect(parseMetadata('{"a":1,"b":true,"c":"x"}')).toEqual({ a: "1", b: "true", c: "x" });
+  });
+
+  it("shows non-JSON metadata as a single value", () => {
+    expect(parseMetadata("plain text")).toEqual({ value: "plain text" });
+  });
+
+  it("returns an empty record for valid JSON that is not an object", () => {
+    expect(parseMetadata("42")).toEqual({});
+    expect(parseMetadata("null")).toEqual({});
+  });
+});

--- a/frontend/ui/src/features/projects/components/ProjectBreadcrumb.trail.test.tsx
+++ b/frontend/ui/src/features/projects/components/ProjectBreadcrumb.trail.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+/**
+ * ProjectBreadcrumb renders nothing itself — it pushes a <Breadcrumb> into the
+ * app header. These tests capture what it pushes, so the trail's shape (labels,
+ * hrefs, dropdown options, create actions) is checked directly.
+ *
+ * Complements ProjectBreadcrumb.test.tsx, which covers the current-option flags.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import * as React from "react";
+import { render, cleanup, screen, act } from "@testing-library/react";
+import type { BreadcrumbItem } from "@/components/layout/breadcrumb";
+
+const state = vi.hoisted(() => ({
+  project: undefined as unknown,
+  workspace: undefined as unknown,
+  workspaces: undefined as unknown,
+  setHeaderContent: vi.fn(),
+}));
+
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({ setHeaderContent: state.setHeaderContent }),
+}));
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/projects/proj-1/traces",
+}));
+vi.mock("../hooks", () => ({ useProject: () => ({ data: state.project }) }));
+vi.mock("@/features/workspaces/hooks", () => ({
+  useWorkspace: () => ({ data: state.workspace }),
+  useWorkspaces: () => ({ data: state.workspaces }),
+}));
+vi.mock("./CreateProjectDialog", () => ({
+  CreateProjectDialog: ({ open, workspaceId }: { open: boolean; workspaceId: string }) => (
+    <div data-testid="create-project" data-open={String(open)} data-ws={workspaceId} />
+  ),
+}));
+vi.mock("@/features/workspaces/components", () => ({
+  CreateWorkspaceDialog: ({ open }: { open: boolean }) => (
+    <div data-testid="create-workspace" data-open={String(open)} />
+  ),
+}));
+
+import { ProjectBreadcrumb } from "./ProjectBreadcrumb";
+
+/** The items from the most recent non-null header push. */
+function pushedItems(): BreadcrumbItem[] {
+  const calls = state.setHeaderContent.mock.calls.filter(([node]) => node !== null);
+  const node = calls[calls.length - 1][0] as React.ReactElement<{ items: BreadcrumbItem[] }>;
+  return node.props.items;
+}
+
+beforeEach(() => {
+  state.project = { id: "proj-1", name: "Billing", workspace_id: "ws-1" };
+  state.workspace = {
+    id: "ws-1",
+    name: "Acme",
+    projects: [
+      { id: "proj-1", name: "Billing" },
+      { id: "proj-2", name: "Search" },
+    ],
+  };
+  state.workspaces = [
+    { id: "ws-1", name: "Acme" },
+    { id: "ws-2", name: "Globex" },
+  ];
+  state.setHeaderContent.mockClear();
+});
+afterEach(() => cleanup());
+
+describe("ProjectBreadcrumb trail", () => {
+  it("pushes the workspace and project segments", () => {
+    render(<ProjectBreadcrumb projectId="proj-1" />);
+    const items = pushedItems();
+    expect(items).toHaveLength(2);
+    expect(items[0].label).toBe("Acme");
+    expect(items[0].href).toBe("/workspaces/ws-1/projects");
+    expect(items[1].label).toBe("Billing");
+    // Nothing follows it, so the project is the current page and not a link.
+    expect(items[1].href).toBeUndefined();
+  });
+
+  it("renders placeholder labels while the data loads", () => {
+    state.project = undefined;
+    state.workspace = undefined;
+    state.workspaces = undefined;
+    render(<ProjectBreadcrumb projectId="proj-1" />);
+    const items = pushedItems();
+    expect(items[0].label).toBe("...");
+    expect(items[1].label).toBe("...");
+    expect(items[0].href).toBeUndefined();
+    expect(items[0].options).toBeUndefined();
+    expect(items[1].options).toBeUndefined();
+  });
+
+  it("links the project once a current segment is appended", () => {
+    render(<ProjectBreadcrumb projectId="proj-1" current="Settings" />);
+    const items = pushedItems();
+    expect(items[1].href).toBe("/projects/proj-1/traces");
+    expect(items[2].label).toBe("Settings");
+  });
+
+  it("inserts trail segments between the project and the current page", () => {
+    render(
+      <ProjectBreadcrumb
+        projectId="proj-1"
+        trail={[{ label: "Datasets", href: "/projects/proj-1/datasets" }]}
+        current="Billing routing"
+      />,
+    );
+    expect(pushedItems().map((i) => i.label)).toEqual([
+      "Acme",
+      "Billing",
+      "Datasets",
+      "Billing routing",
+    ]);
+    // A trail alone is enough to make the project a link.
+    expect(pushedItems()[1].href).toBe("/projects/proj-1/traces");
+  });
+
+  it("builds switcher options and menu headers for both segments", () => {
+    render(<ProjectBreadcrumb projectId="proj-1" />);
+    const items = pushedItems();
+    expect(items[0].options?.map((o) => o.label)).toEqual(["Acme", "Globex"]);
+    expect(items[0].options?.[0].settingsHref).toBe("/workspaces/ws-1/settings");
+    expect(items[0].menuHeader).toEqual({ label: "Workspaces", href: "/workspaces" });
+
+    expect(items[1].options?.map((o) => o.label)).toEqual(["Billing", "Search"]);
+    expect(items[1].options?.[1].settingsHref).toBe("/projects/proj-2/settings");
+    expect(items[1].menuHeader?.href).toBe("/workspaces/ws-1/projects");
+  });
+
+  it("opens the create dialogs from the segment create actions", () => {
+    render(<ProjectBreadcrumb projectId="proj-1" />);
+    expect(screen.getByTestId("create-workspace").dataset.open).toBe("false");
+    expect(screen.getByTestId("create-project").dataset.open).toBe("false");
+    expect(screen.getByTestId("create-project").dataset.ws).toBe("ws-1");
+
+    const items = pushedItems();
+    act(() => items[0].createNew!.onSelect());
+    expect(screen.getByTestId("create-workspace").dataset.open).toBe("true");
+
+    act(() => items[1].createNew!.onSelect());
+    expect(screen.getByTestId("create-project").dataset.open).toBe("true");
+  });
+
+  it("omits the project dialog until the workspace is known", () => {
+    state.project = { id: "proj-1", name: "Billing", workspace_id: null };
+    render(<ProjectBreadcrumb projectId="proj-1" />);
+    expect(screen.queryByTestId("create-project")).toBeNull();
+  });
+
+  it("does not re-push the header for an equivalent inline trail", () => {
+    const { rerender } = render(
+      <ProjectBreadcrumb projectId="proj-1" trail={[{ label: "Datasets" }]} />,
+    );
+    const calls = state.setHeaderContent.mock.calls.length;
+    rerender(<ProjectBreadcrumb projectId="proj-1" trail={[{ label: "Datasets" }]} />);
+    expect(state.setHeaderContent.mock.calls.length).toBe(calls);
+  });
+
+  it("clears the header on unmount", () => {
+    const { unmount } = render(<ProjectBreadcrumb projectId="proj-1" />);
+    unmount();
+    expect(state.setHeaderContent).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.eval.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.eval.test.tsx
@@ -1,0 +1,419 @@
+// @vitest-environment jsdom
+/**
+ * Render coverage for the span detail panel and the metric chips it composes
+ * (TokenChip / CostChip / MetricDelta), across the trace selection, a span
+ * selection, the error state and diff mode.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { SpanStatus } from "@traceroot/core";
+import type { Span, SpanIO, TraceDetail } from "@/types/api";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, replace: vi.fn() }),
+}));
+
+// Per-span I/O is a lazy fetch in production; serve it from a fixture map keyed
+// by span id so the panel's fetched-vs-inline fallbacks are both exercised.
+const ioMocks = vi.hoisted(() => ({
+  byId: new Map<string, Partial<SpanIO>>(),
+  loading: false,
+}));
+vi.mock("../hooks", () => ({
+  useSpanIO: (_p: string, _t: string, spanId: string | null) => ({
+    data: spanId ? ioMocks.byId.get(spanId) : undefined,
+    isLoading: spanId ? ioMocks.loading : false,
+  }),
+}));
+
+import { SpanInfoPanel } from "./SpanInfoPanel";
+import { MetricDelta } from "./MetricDelta";
+import { CostChip } from "./CostChip";
+import { TokenChip } from "./TokenChip";
+
+function makeSpan(overrides: Partial<Span> = {}): Span {
+  return {
+    span_id: "span-1",
+    trace_id: "trace-1",
+    parent_span_id: null,
+    name: "root span",
+    span_kind: "LLM",
+    span_start_time: "2026-07-17T10:24:00.000Z",
+    span_end_time: "2026-07-17T10:24:02.500Z",
+    status: SpanStatus.OK,
+    status_message: null,
+    model_name: "claude-opus-5",
+    cost: 0.012345,
+    input_tokens: 1200,
+    output_tokens: 300,
+    total_tokens: 1500,
+    usage_details: { cache_read_tokens: 100, cache_write_tokens: 50, reasoning_tokens: 25 },
+    cost_details: {
+      input_uncached_cost: 0.004,
+      cache_read_cost: 0.001,
+      cache_write_cost: 0.002,
+      output_cost: 0.005345,
+    },
+    input: '{"prompt":"hi"}',
+    output: '{"reply":"hello"}',
+    metadata: '{"user":"ada","traceroot.span.kind":"LLM"}',
+    git_source_file: "app/agent.py",
+    git_source_line: 42,
+    git_source_function: "run",
+    ...overrides,
+  };
+}
+
+function makeTrace(overrides: Partial<TraceDetail> = {}): TraceDetail {
+  return {
+    trace_id: "trace-1",
+    project_id: "proj-1",
+    name: "billing routing",
+    trace_start_time: "2026-07-17T10:24:00.000Z",
+    user_id: "user-7",
+    session_id: "sess-9",
+    git_ref: "4a91c02deadbeef",
+    git_repo: "traceroot-ai/traceroot",
+    environment: "production",
+    release: null,
+    input: '{"question":"why was I charged twice"}',
+    output: '{"answer":"billing"}',
+    metadata: '{"tier":"pro","traceroot.span.internal":"x"}',
+    spans: [makeSpan()],
+    ...overrides,
+  };
+}
+
+function renderPanel(props: Partial<React.ComponentProps<typeof SpanInfoPanel>> = {}) {
+  return render(
+    <SpanInfoPanel
+      projectId="proj-1"
+      trace={makeTrace()}
+      selection={{ type: "trace" }}
+      {...props}
+    />,
+  );
+}
+
+beforeEach(() => {
+  ioMocks.byId.clear();
+  ioMocks.loading = false;
+  push.mockReset();
+});
+afterEach(() => cleanup());
+
+describe("SpanInfoPanel — trace selection", () => {
+  it("renders the trace header, aggregates and git/user/session rows", () => {
+    renderPanel();
+    expect(screen.getByText("billing routing")).toBeTruthy();
+    expect(screen.getByText("trace")).toBeTruthy(); // span-kind chip, lowercased
+    expect(screen.getByText("Latency:")).toBeTruthy();
+    expect(screen.getByText("production")).toBeTruthy();
+    // Token rollup chip (input → output (total)) and the summed cost chip.
+    expect(screen.getByText(/→/)).toBeTruthy();
+    expect(screen.getByText("0.012345")).toBeTruthy();
+    expect(screen.getByText("traceroot-ai/traceroot")).toBeTruthy();
+    expect(screen.getByText("4a91c02")).toBeTruthy();
+    expect(screen.getByText("user-7")).toBeTruthy();
+    expect(screen.getByText("sess-9")).toBeTruthy();
+  });
+
+  it("links the git repo and commit to GitHub", () => {
+    const { container } = renderPanel();
+    const links = Array.from(container.querySelectorAll("a")).map((a) => a.getAttribute("href"));
+    expect(links).toContain("https://github.com/traceroot-ai/traceroot");
+    expect(links).toContain("https://github.com/traceroot-ai/traceroot/commit/4a91c02deadbeef");
+  });
+
+  it("leaves the ref link hrefless when there is no repo", () => {
+    const { container } = renderPanel({ trace: makeTrace({ git_repo: null }) });
+    const ref = Array.from(container.querySelectorAll("a")).find((a) =>
+      a.textContent?.includes("4a91c02"),
+    );
+    expect(ref).toBeTruthy();
+    expect(ref?.getAttribute("href")).toBeNull();
+  });
+
+  it("navigates to the filtered traces list from the user chip", () => {
+    const onClose = vi.fn();
+    renderPanel({ onClose });
+    fireEvent.click(screen.getByText("user-7").closest("button")!);
+    expect(onClose).toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith(expect.stringContaining("/projects/proj-1/traces"));
+    expect(push.mock.calls[0][0]).toContain("user_id=user-7");
+  });
+
+  it("navigates to the session from the session chip", () => {
+    renderPanel();
+    fireEvent.click(screen.getByText("sess-9").closest("button")!);
+    expect(push).toHaveBeenCalledWith(expect.stringContaining("/projects/proj-1/sessions"));
+    expect(push.mock.calls[0][0]).toContain("sessionId=sess-9");
+  });
+
+  it("strips traceroot.span.* keys from the metadata section", () => {
+    const { container } = renderPanel();
+    expect(container.textContent).toContain("tier");
+    expect(container.textContent).not.toContain("traceroot.span.internal");
+  });
+
+  it("passes non-JSON metadata through untouched", () => {
+    const { container } = renderPanel({ trace: makeTrace({ metadata: "not json at all" }) });
+    expect(container.textContent).toContain("not json at all");
+  });
+
+  it("omits the git and user rows when the trace carries none", () => {
+    renderPanel({
+      trace: makeTrace({ git_ref: null, git_repo: null, user_id: null, session_id: null }),
+    });
+    expect(screen.queryByText("Repo:")).toBeNull();
+    expect(screen.queryByText("User:")).toBeNull();
+    expect(screen.queryByText("Session:")).toBeNull();
+  });
+
+  it("hides the token and cost chips when no span reports them", () => {
+    renderPanel({
+      trace: makeTrace({
+        spans: [makeSpan({ total_tokens: null, cost: null, cost_details: undefined })],
+      }),
+    });
+    expect(screen.queryByText("0.012345")).toBeNull();
+  });
+
+  it("renders the injected offline-eval slots", () => {
+    renderPanel({
+      spanActions: <button type="button">Save as test case</button>,
+      headerAction: <span>header-action</span>,
+      extraTags: <span>Dataset: billing</span>,
+    });
+    expect(screen.getByText("Save as test case")).toBeTruthy();
+    expect(screen.getByText("header-action")).toBeTruthy();
+    expect(screen.getByText("Dataset: billing")).toBeTruthy();
+  });
+});
+
+describe("SpanInfoPanel — span selection", () => {
+  it("renders per-span model, tokens and cost from the lazy I/O fetch", () => {
+    ioMocks.byId.set("span-1", {
+      input: "fetched input",
+      output: "fetched output",
+      metadata: '{"fetched":"yes"}',
+    });
+    const { container } = renderPanel({ selection: { type: "span", span: makeSpan() } });
+    expect(screen.getByText("claude-opus-5")).toBeTruthy();
+    expect(screen.getByText("llm")).toBeTruthy();
+    expect(container.textContent).toContain("fetched input");
+    expect(container.textContent).toContain("fetched output");
+    expect(container.textContent).toContain("fetched");
+  });
+
+  it("falls back to the span's own I/O when the fetch returns nothing", () => {
+    const { container } = renderPanel({ selection: { type: "span", span: makeSpan() } });
+    expect(container.textContent).toContain("prompt");
+    expect(container.textContent).toContain("reply");
+  });
+
+  it("shows the loading state while span I/O is in flight", () => {
+    ioMocks.loading = true;
+    renderPanel({ selection: { type: "span", span: makeSpan() } });
+    expect(screen.getAllByText("Loading…").length).toBeGreaterThan(0);
+  });
+
+  it("renders the ERROR badge, message and source location", () => {
+    const span = makeSpan({
+      status: SpanStatus.ERROR,
+      status_message: "RateLimitError: slow down",
+    });
+    const { container } = renderPanel({ selection: { type: "span", span } });
+    expect(screen.getByText("ERROR")).toBeTruthy();
+    expect(screen.getByText("RateLimitError: slow down")).toBeTruthy();
+    expect(container.textContent).toContain("app/agent.py:42");
+  });
+
+  it("renders the error block without a source file", () => {
+    const span = makeSpan({
+      status: SpanStatus.ERROR,
+      status_message: "boom",
+      git_source_file: null,
+      git_source_line: null,
+    });
+    renderPanel({
+      trace: makeTrace({ git_repo: null, git_ref: null }),
+      selection: { type: "span", span },
+    });
+    expect(screen.getByText("boom")).toBeTruthy();
+  });
+
+  it("omits the token chip when the span has no token counts", () => {
+    const span = makeSpan({ total_tokens: null, model_name: null });
+    renderPanel({ selection: { type: "span", span } });
+    expect(screen.queryByText("claude-opus-5")).toBeNull();
+  });
+});
+
+describe("SpanInfoPanel — diff mode", () => {
+  const baselineSpan = makeSpan({
+    span_id: "span-0",
+    trace_id: "trace-0",
+    span_end_time: "2026-07-17T10:24:01.000Z",
+    cost: 0.01,
+    total_tokens: 1000,
+    input_tokens: 800,
+    output_tokens: 200,
+    input: '{"prompt":"hi there"}',
+    output: '{"reply":"hey"}',
+    metadata: '{"user":"grace"}',
+    cost_details: { input_uncached_cost: 0.006, output_cost: 0.004 },
+  });
+
+  it("renders line diffs and ± deltas for a span selection", () => {
+    const { container } = renderPanel({
+      selection: { type: "span", span: makeSpan() },
+      diffMode: true,
+      baselineSpan,
+    });
+    // The diff header markers replace the plain format switcher.
+    expect(screen.getAllByText("− baseline").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("+ candidate").length).toBeGreaterThan(0);
+    // Positive (worse) deltas render in red with a leading "+".
+    expect(container.querySelector(".text-red-600")).toBeTruthy();
+  });
+
+  it("renders trace-level diffs against a baseline trace", () => {
+    const baselineTrace = makeTrace({
+      trace_id: "trace-0",
+      input: '{"question":"why the charge"}',
+      output: '{"answer":"support"}',
+      metadata: '{"tier":"free"}',
+      spans: [baselineSpan],
+    });
+    const { container } = renderPanel({
+      diffMode: true,
+      baselineTrace,
+    });
+    expect(screen.getAllByText("− baseline").length).toBeGreaterThan(0);
+    expect(container.textContent).toContain("Metadata");
+  });
+
+  it("stays in the plain (non-diff) view when no baseline is supplied", () => {
+    renderPanel({ diffMode: true, baselineSpan: null, baselineTrace: null });
+    expect(screen.queryByText("− baseline")).toBeNull();
+  });
+
+  it("renders an unchanged marker when candidate and baseline match", () => {
+    const same = makeSpan({ span_id: "span-0", trace_id: "trace-0" });
+    renderPanel({
+      selection: { type: "span", span: makeSpan() },
+      diffMode: true,
+      baselineSpan: same,
+    });
+    expect(screen.getAllByText("unchanged").length).toBeGreaterThan(0);
+  });
+
+  it("skips the token/cost deltas when the candidate span has no counts", () => {
+    renderPanel({
+      selection: {
+        type: "span",
+        span: makeSpan({ total_tokens: null, cost: null }),
+      },
+      diffMode: true,
+      baselineSpan,
+    });
+    expect(screen.getAllByText("− baseline").length).toBeGreaterThan(0);
+  });
+
+  it("reads baseline span I/O from the lazy fetch when present", () => {
+    ioMocks.byId.set("span-0", { input: "baseline fetched", output: null, metadata: null });
+    const { container } = renderPanel({
+      selection: { type: "span", span: makeSpan() },
+      diffMode: true,
+      baselineSpan,
+    });
+    expect(container.textContent).toContain("baseline fetched");
+  });
+});
+
+describe("MetricDelta", () => {
+  const fmt = (n: number) => n.toFixed(1);
+
+  it("renders nothing without a delta", () => {
+    const { container } = render(<MetricDelta delta={null} format={fmt} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing for a non-finite delta", () => {
+    const { container } = render(<MetricDelta delta={Number.NaN} format={fmt} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders a muted ±0 when unchanged", () => {
+    render(<MetricDelta delta={0} format={fmt} />);
+    const el = screen.getByText("±0");
+    expect(el.className).toContain("text-muted-foreground");
+  });
+
+  it("renders a red + for a worse (higher) value", () => {
+    const { container } = render(<MetricDelta delta={2.5} format={fmt} />);
+    expect(container.textContent).toBe("+2.5");
+    expect(container.firstElementChild?.className).toContain("text-red-600");
+  });
+
+  it("renders a green true-minus for a better (lower) value", () => {
+    const { container } = render(<MetricDelta delta={-2.5} format={fmt} />);
+    expect(container.textContent).toBe("−2.5");
+    expect(container.firstElementChild?.className).toContain("text-emerald-600");
+  });
+});
+
+describe("CostChip", () => {
+  it("renders nothing without a cost", () => {
+    const { container } = render(<CostChip cost={null} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing for a non-finite cost", () => {
+    const { container } = render(<CostChip cost={Number.POSITIVE_INFINITY} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders a plain chip when there is no breakdown", () => {
+    render(<CostChip cost={0.5} costDetails={{}} />);
+    expect(screen.getByText("0.500000")).toBeTruthy();
+  });
+
+  it("renders a tooltip-wrapped chip when a breakdown exists", () => {
+    render(<CostChip cost={0.5} costDetails={{ output_cost: 0.5 }} delta={<span>+0.1</span>} />);
+    expect(screen.getByText("0.500000")).toBeTruthy();
+    expect(screen.getByText("+0.1")).toBeTruthy();
+  });
+
+  it("renders the tooltip wrapper when only the baseline has a breakdown", () => {
+    render(<CostChip cost={0.5} costDetails={null} baselineDetails={{ output_cost: 0.4 }} />);
+    expect(screen.getByText("0.500000")).toBeTruthy();
+  });
+});
+
+describe("TokenChip", () => {
+  it("renders the token flow with a delta suffix", () => {
+    render(
+      <TokenChip
+        inputTokens={100}
+        outputTokens={20}
+        totalTokens={120}
+        cacheReadTokens={5}
+        cacheWriteTokens={2}
+        reasoningTokens={1}
+        delta={<span>+10</span>}
+      />,
+    );
+    expect(screen.getByText("+10")).toBeTruthy();
+    expect(screen.getByText(/120/)).toBeTruthy();
+  });
+
+  it("renders with unknown input/output counts", () => {
+    const { container } = render(
+      <TokenChip inputTokens={null} outputTokens={null} totalTokens={42} />,
+    );
+    expect(container.textContent).toContain("42");
+  });
+});

--- a/frontend/ui/src/lib/eval/scorer-registry.test.ts
+++ b/frontend/ui/src/lib/eval/scorer-registry.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { aggregateScorers, type RawScore } from "./scorer-registry";
+
+const score = (
+  p: Partial<RawScore> & Pick<RawScore, "scorerName" | "scorerVersion">,
+): RawScore => ({
+  numericValue: null,
+  boolValue: null,
+  stringValue: null,
+  passed: null,
+  error: null,
+  createTime: new Date("2026-07-25T10:00:00.000Z"),
+  runId: "run1",
+  evaluationId: "ev1",
+  ...p,
+});
+
+describe("aggregateScorers", () => {
+  it("aggregates one row per (name, version) and preserves all versions", () => {
+    const rows = aggregateScorers(
+      [
+        score({ scorerName: "helpfulness", scorerVersion: "v1", numericValue: 0.8 }),
+        score({ scorerName: "helpfulness", scorerVersion: "v1", numericValue: 0.6 }),
+        score({ scorerName: "helpfulness", scorerVersion: "v2", numericValue: 1 }),
+      ],
+      [],
+    );
+    expect(rows.map((r) => `${r.name}@${r.version}`)).toEqual(["helpfulness@v1", "helpfulness@v2"]);
+    const v1 = rows.find((r) => r.version === "v1")!;
+    expect(v1.scoreCount).toBe(2);
+    expect(v1.valueType).toBe("numeric");
+    expect(v1.numeric).toEqual({ mean: 0.7, min: 0.6, max: 0.8, count: 2 });
+    expect(v1.source).toBe("SDK");
+  });
+
+  it("counts a scorer error into error stats but never as a 0 score", () => {
+    const rows = aggregateScorers(
+      [
+        score({ scorerName: "judge", scorerVersion: "v1", numericValue: 1 }),
+        score({ scorerName: "judge", scorerVersion: "v1", error: "Judge returned malformed JSON" }),
+      ],
+      [],
+    );
+    const r = rows[0];
+    expect(r.scoreCount).toBe(2);
+    expect(r.errorCount).toBe(1);
+    expect(r.errorRate).toBe(0.5);
+    // The error did not push a 0 into the numeric distribution.
+    expect(r.numeric).toEqual({ mean: 1, min: 1, max: 1, count: 1 });
+    expect(r.recentErrors[0].message).toContain("JSON");
+  });
+
+  it("surfaces declared value_type/direction/threshold from the newest manifest", () => {
+    const rows = aggregateScorers(
+      [score({ scorerName: "acc", scorerVersion: "v3", numericValue: 0.9 })],
+      [
+        { scorers: [{ name: "acc", version: "v3", direction: "higher_is_better" }] },
+        {
+          scorers: [
+            {
+              name: "acc",
+              version: "v3",
+              value_type: "numeric",
+              direction: "lower_is_better",
+              threshold: 0.5,
+            },
+          ],
+        },
+      ],
+    );
+    const r = rows[0];
+    expect(r.declaredValueType).toBe("numeric");
+    expect(r.direction).toBe("lower_is_better"); // newest declaration wins
+    expect(r.threshold).toBe(0.5);
+  });
+
+  it("builds boolean and categorical distributions and pass rate", () => {
+    const boolRows = aggregateScorers(
+      [
+        score({ scorerName: "b", scorerVersion: "v1", boolValue: true, passed: true }),
+        score({ scorerName: "b", scorerVersion: "v1", boolValue: false, passed: false }),
+        score({ scorerName: "b", scorerVersion: "v1", boolValue: true, passed: true }),
+      ],
+      [],
+    );
+    const b = boolRows[0];
+    expect(b.valueType).toBe("boolean");
+    expect(b.distribution).toEqual([
+      { label: "true", count: 2 },
+      { label: "false", count: 1 },
+    ]);
+    expect(b.passRate).toBeCloseTo(2 / 3);
+
+    const catRows = aggregateScorers(
+      [
+        score({ scorerName: "c", scorerVersion: "v1", stringValue: "billing" }),
+        score({ scorerName: "c", scorerVersion: "v1", stringValue: "billing" }),
+        score({ scorerName: "c", scorerVersion: "v1", stringValue: "tech" }),
+      ],
+      [],
+    );
+    expect(catRows[0].valueType).toBe("categorical");
+    expect(catRows[0].distribution?.[0]).toEqual({ label: "billing", count: 2 });
+  });
+
+  it("counts distinct runs and evaluations for usage", () => {
+    const rows = aggregateScorers(
+      [
+        score({
+          scorerName: "u",
+          scorerVersion: "v1",
+          numericValue: 1,
+          runId: "r1",
+          evaluationId: "e1",
+        }),
+        score({
+          scorerName: "u",
+          scorerVersion: "v1",
+          numericValue: 1,
+          runId: "r2",
+          evaluationId: "e1",
+        }),
+        score({
+          scorerName: "u",
+          scorerVersion: "v1",
+          numericValue: 1,
+          runId: "r2",
+          evaluationId: "e2",
+        }),
+      ],
+      [],
+    );
+    expect(rows[0].runCount).toBe(2);
+    expect(rows[0].evaluationCount).toBe(2);
+  });
+});

--- a/frontend/ui/src/lib/eval/scorer-registry.test.ts
+++ b/frontend/ui/src/lib/eval/scorer-registry.test.ts
@@ -42,12 +42,41 @@ describe("aggregateScorers", () => {
       [],
     );
     const r = rows[0];
-    expect(r.scoreCount).toBe(2);
+    // scoreCount is rows that actually produced a value (1 numeric), not attempts
+    // (2 total including the error): an all-errored scorer reports 0 scored, not attempts.
+    expect(r.scoreCount).toBe(1);
     expect(r.errorCount).toBe(1);
     expect(r.errorRate).toBe(0.5);
     // The error did not push a 0 into the numeric distribution.
     expect(r.numeric).toEqual({ mean: 1, min: 1, max: 1, count: 1 });
     expect(r.recentErrors[0].message).toContain("JSON");
+  });
+
+  it("reports a zero score count (not the attempt count) when every attempt errored", () => {
+    const rows = aggregateScorers(
+      [
+        score({ scorerName: "judge", scorerVersion: "v1", error: "timeout" }),
+        score({ scorerName: "judge", scorerVersion: "v1", error: "timeout" }),
+      ],
+      [],
+    );
+    const r = rows[0];
+    expect(r.scoreCount).toBe(0);
+    expect(r.errorCount).toBe(2);
+    expect(r.errorRate).toBe(1);
+    expect(r.numeric).toBeNull();
+  });
+
+  it("handles a project's worth of numeric scores without a stack overflow", () => {
+    // Regression for the Math.min(...nums)/Math.max(...nums) spread, which blows
+    // the engine's argument limit well before this many scores for one scorer.
+    const scores = Array.from({ length: 150_000 }, (_, i) =>
+      score({ scorerName: "bulk", scorerVersion: "v1", numericValue: i % 100 }),
+    );
+    const rows = aggregateScorers(scores, []);
+    const r = rows[0];
+    expect(r.numeric).toEqual({ mean: 49.5, min: 0, max: 99, count: 150_000 });
+    expect(r.scoreCount).toBe(150_000);
   });
 
   it("surfaces declared value_type/direction/threshold from the newest manifest", () => {
@@ -132,5 +161,186 @@ describe("aggregateScorers", () => {
     );
     expect(rows[0].runCount).toBe(2);
     expect(rows[0].evaluationCount).toBe(2);
+  });
+
+  it("seeds a zero-count row for a scorer declared in a manifest but never scored", () => {
+    const rows = aggregateScorers(
+      [],
+      [
+        {
+          scorers: [
+            { name: "faithfulness", version: "v2", scorer_type: "llm_judge", model: "gpt-4o" },
+          ],
+        },
+      ],
+    );
+    const r = rows.find((x) => x.name === "faithfulness" && x.version === "v2")!;
+    expect(r).toBeDefined();
+    expect(r.scoreCount).toBe(0);
+    expect(r.errorCount).toBe(0);
+    expect(r.valueType).toBe("unknown");
+    expect(r.numeric).toBeNull();
+    expect(r.runCount).toBe(0);
+    expect(r.lastUsed).toBeNull();
+    // The declared definition is still surfaced even with zero observed scores.
+    expect(r.model).toBe("gpt-4o");
+  });
+});
+
+describe("aggregateScorers — definition folding", () => {
+  it("uses the latest run's definition, not the first (definition is part of identity)", () => {
+    const rows = aggregateScorers(
+      [score({ scorerName: "judge", scorerVersion: "unversioned", numericValue: 1 })],
+      [
+        {
+          scorers: [
+            { name: "judge", version: "unversioned", scorer_type: "llm_judge", model: "a" },
+          ],
+        },
+        {
+          scorers: [
+            { name: "judge", version: "unversioned", scorer_type: "llm_judge", model: "b" },
+          ],
+        },
+      ],
+    );
+    expect(rows[0].model).toBe("b");
+  });
+
+  it("leaves undeclared definition fields absent, never inferred", () => {
+    const rows = aggregateScorers(
+      [score({ scorerName: "acc", scorerVersion: "v1", numericValue: 1 })],
+      [{ scorers: [{ name: "acc", version: "v1" }] }],
+    );
+    const r = rows[0];
+    expect(r.scorerType).toBeNull();
+    expect(r.model).toBeNull();
+    expect(r.messages).toBeNull();
+    expect(r.sourceCode).toBeNull();
+    // Value type is still INFERRED from the observed score, independent of the
+    // (absent) declared definition.
+    expect(r.valueType).toBe("numeric");
+  });
+
+  it("tolerates malformed manifests instead of throwing", () => {
+    const rows = aggregateScorers(
+      [score({ scorerName: "acc", scorerVersion: "v1", numericValue: 1 })],
+      [
+        { scorers: null },
+        { scorers: "[]" },
+        { scorers: [{ version: "v1" }] }, // no name
+        { scorers: [{ name: "acc", version: "v1", messages: [{ role: 1 }] }] }, // bad message shape
+      ],
+    );
+    const r = rows[0];
+    // None of the malformed manifests threw, and the bad `messages` entry was
+    // dropped rather than surfaced.
+    expect(r.messages).toBeNull();
+  });
+
+  it("flags divergent definitions reported under the identical (name, version) key", () => {
+    const rows = aggregateScorers(
+      [
+        score({ scorerName: "judge", scorerVersion: "unversioned", numericValue: 0.9 }),
+        score({ scorerName: "judge", scorerVersion: "unversioned", numericValue: 0.5 }),
+      ],
+      [
+        {
+          scorers: [
+            {
+              name: "judge",
+              version: "unversioned",
+              scorer_type: "llm_judge",
+              model: "gpt-4o",
+              messages: [{ role: "system", content: "promptA" }],
+            },
+          ],
+        },
+        {
+          scorers: [
+            {
+              name: "judge",
+              version: "unversioned",
+              scorer_type: "llm_judge",
+              model: "claude-sonnet-5",
+              messages: [{ role: "system", content: "promptB" }],
+            },
+          ],
+        },
+      ],
+    );
+    const r = rows[0];
+    expect(r.distinctDefinitions).toBe(2);
+    expect(r.definitionHash).not.toBeNull();
+  });
+
+  it("reports exactly one distinct definition when every manifest agrees", () => {
+    const rows = aggregateScorers(
+      [score({ scorerName: "judge", scorerVersion: "v1", numericValue: 1 })],
+      [
+        { scorers: [{ name: "judge", version: "v1", scorer_type: "code", language: "python" }] },
+        { scorers: [{ name: "judge", version: "v1", scorer_type: "code", language: "python" }] },
+      ],
+    );
+    expect(rows[0].distinctDefinitions).toBe(1);
+  });
+});
+
+describe("aggregateScorers — value type and shaping edge cases", () => {
+  it("reports mixed when a (name, version) key observed more than one value kind", () => {
+    const rows = aggregateScorers(
+      [
+        score({ scorerName: "flaky", scorerVersion: "v1", numericValue: 1 }),
+        score({ scorerName: "flaky", scorerVersion: "v1", boolValue: true }),
+      ],
+      [],
+    );
+    expect(rows[0].valueType).toBe("mixed");
+  });
+
+  it("truncates the category distribution to the top 8", () => {
+    const scores: RawScore[] = [];
+    for (let i = 0; i < 10; i++) {
+      // Give each category a distinct count so the ordering is unambiguous, and
+      // make sure there are more than 8 categories.
+      for (let j = 0; j <= i; j++) {
+        scores.push(score({ scorerName: "cat", scorerVersion: "v1", stringValue: `label-${i}` }));
+      }
+    }
+    const rows = aggregateScorers(scores, []);
+    expect(rows[0].distribution).toHaveLength(8);
+    // Highest-count categories first.
+    expect(rows[0].distribution?.[0]).toEqual({ label: "label-9", count: 10 });
+  });
+
+  it("keeps only the 3 most recent errors, newest first", () => {
+    const scores = [
+      score({
+        scorerName: "e",
+        scorerVersion: "v1",
+        error: "e1",
+        createTime: new Date("2026-01-01"),
+      }),
+      score({
+        scorerName: "e",
+        scorerVersion: "v1",
+        error: "e2",
+        createTime: new Date("2026-01-02"),
+      }),
+      score({
+        scorerName: "e",
+        scorerVersion: "v1",
+        error: "e3",
+        createTime: new Date("2026-01-03"),
+      }),
+      score({
+        scorerName: "e",
+        scorerVersion: "v1",
+        error: "e4",
+        createTime: new Date("2026-01-04"),
+      }),
+    ];
+    const rows = aggregateScorers(scores, []);
+    expect(rows[0].recentErrors.map((e) => e.message)).toEqual(["e4", "e3", "e2"]);
   });
 });

--- a/frontend/ui/src/lib/eval/scorer-registry.ts
+++ b/frontend/ui/src/lib/eval/scorer-registry.ts
@@ -27,9 +27,39 @@ export interface RawScore {
   evaluationId: string | null;
 }
 
-export interface ScorerRow {
+/** The SDK-reported scorer DEFINITION (see offline-eval/sdk-ask/scorer-definition-reporting.md).
+ *  Every field is optional — absent → "Not provided by SDK", never inferred/fabricated. */
+export interface ScorerDefinition {
+  /** Discriminator; drives the detail's top-half. */
+  scorerType: "llm_judge" | "code" | null;
+  outputType: "score" | "classification" | null;
+  description: string | null;
+  metadata: unknown | null;
+  // llm_judge
+  model: string | null;
+  messages: Array<{ role: string; content: string }> | null;
+  // code
+  language: "python" | "typescript" | null;
+  sourceCode: string | null;
+}
+
+function emptyDefinition(): ScorerDefinition {
+  return {
+    scorerType: null,
+    outputType: null,
+    description: null,
+    metadata: null,
+    model: null,
+    messages: null,
+    language: null,
+    sourceCode: null,
+  };
+}
+
+export interface ScorerRow extends ScorerDefinition {
   name: string;
   version: string;
+  /** Rows that actually produced a value (excludes errored attempts). */
   scoreCount: number;
   errorCount: number;
   errorRate: number;
@@ -48,6 +78,14 @@ export interface ScorerRow {
   recentErrors: Array<{ message: string; at: string }>;
   /** Always "SDK" — the catalog only ever shows what the SDK reported. */
   source: "SDK";
+  /** Fingerprint of the latest-reported definition (null when no definition was ever
+   *  reported). Lets the UI tell whether `distinctDefinitions` above 1 means this
+   *  exact definition, or one since superseded, is what the aggregates reflect. */
+  definitionHash: string | null;
+  /** How many distinct definition fingerprints were reported under this identical
+   *  (name, version) key. >1 means the pooled aggregates below span genuinely
+   *  different measurement instruments (see module docs on identity). */
+  distinctDefinitions: number;
 }
 
 interface Agg {
@@ -55,7 +93,10 @@ interface Agg {
   version: string;
   total: number;
   errored: number;
-  numericValues: number[];
+  numSum: number;
+  numMin: number;
+  numMax: number;
+  numCount: number;
   passedTrue: number;
   passedTotal: number;
   boolTrue: number;
@@ -68,6 +109,31 @@ interface Agg {
   seenNumeric: boolean;
   seenBool: boolean;
   seenString: boolean;
+}
+
+function newAgg(name: string, version: string): Agg {
+  return {
+    name,
+    version,
+    total: 0,
+    errored: 0,
+    numSum: 0,
+    numMin: Infinity,
+    numMax: -Infinity,
+    numCount: 0,
+    passedTrue: 0,
+    passedTotal: 0,
+    boolTrue: 0,
+    boolFalse: 0,
+    categories: new Map(),
+    runIds: new Set(),
+    evaluationIds: new Set(),
+    lastUsed: 0,
+    recentErrors: [],
+    seenNumeric: false,
+    seenBool: false,
+    seenString: false,
+  };
 }
 
 function inferValueType(a: Agg): InferredValueType {
@@ -100,6 +166,119 @@ function declaredByKey(runManifests: Array<{ scorers: unknown }>) {
   return declared;
 }
 
+/** Cheap, non-cryptographic fingerprint of a definition payload — good enough to
+ *  detect "two manifests disagree", not to dedupe against an adversary. */
+function hashDefinition(def: ScorerDefinition): string {
+  const payload = JSON.stringify([
+    def.scorerType,
+    def.outputType,
+    def.model,
+    def.messages,
+    def.language,
+    def.sourceCode,
+  ]);
+  let h = 0;
+  for (let i = 0; i < payload.length; i++) {
+    h = (Math.imul(h, 31) + payload.charCodeAt(i)) | 0;
+  }
+  return h.toString(36);
+}
+
+/** Latest-reported scorer DEFINITION per (name, version), read from the raw manifest,
+ *  plus every distinct definition fingerprint observed under that key. A later run
+ *  that reports any definition field wins for the returned definition (definition is
+ *  part of identity; changing it should bump the scorer version) — but `hashesByKey`
+ *  still records when more than one distinct definition was reported under the same
+ *  key, so callers can flag that the pooled aggregates span more than one instrument.
+ *  Unknown fields are ignored. */
+function definitionByKey(runManifests: Array<{ scorers: unknown }>): {
+  map: Map<string, ScorerDefinition>;
+  hashesByKey: Map<string, Set<string>>;
+} {
+  const map = new Map<string, ScorerDefinition>();
+  const hashesByKey = new Map<string, Set<string>>();
+  for (const run of runManifests) {
+    if (!Array.isArray(run.scorers)) continue;
+    for (const raw of run.scorers) {
+      if (!raw || typeof raw !== "object") continue;
+      const o = raw as Record<string, unknown>;
+      if (typeof o.name !== "string") continue;
+      const version = typeof o.version === "string" ? o.version : "";
+      const def = emptyDefinition();
+      let any = false;
+      if (o.scorer_type === "llm_judge" || o.scorer_type === "code") {
+        def.scorerType = o.scorer_type;
+        any = true;
+      }
+      if (o.output_type === "score" || o.output_type === "classification") {
+        def.outputType = o.output_type;
+        any = true;
+      }
+      if (typeof o.description === "string") {
+        def.description = o.description;
+        any = true;
+      }
+      if (o.metadata !== undefined && o.metadata !== null) {
+        def.metadata = o.metadata;
+        any = true;
+      }
+      if (typeof o.model === "string") {
+        def.model = o.model;
+        any = true;
+      }
+      if (Array.isArray(o.messages)) {
+        const msgs = o.messages
+          .filter(
+            (m): m is { role: string; content: string } =>
+              !!m &&
+              typeof m === "object" &&
+              typeof (m as Record<string, unknown>).role === "string" &&
+              typeof (m as Record<string, unknown>).content === "string",
+          )
+          .map((m) => ({ role: m.role, content: m.content }));
+        if (msgs.length > 0) {
+          def.messages = msgs;
+          any = true;
+        }
+      }
+      if (o.language === "python" || o.language === "typescript") {
+        def.language = o.language;
+        any = true;
+      }
+      if (typeof o.source === "string") {
+        def.sourceCode = o.source;
+        any = true;
+      }
+      if (any) {
+        const key = `${o.name}@${version}`;
+        map.set(key, def);
+        let hashes = hashesByKey.get(key);
+        if (!hashes) {
+          hashes = new Set();
+          hashesByKey.set(key, hashes);
+        }
+        hashes.add(hashDefinition(def));
+      }
+    }
+  }
+  return { map, hashesByKey };
+}
+
+/** Every (name, version) pair any run manifest referenced, regardless of whether it
+ *  carried rich fields — used to seed a catalog row for a scorer that has been
+ *  declared but never yet scored (or a version whose first result hasn't landed). */
+function allManifestKeys(
+  runManifests: Array<{ scorers: unknown }>,
+): Map<string, { name: string; version: string }> {
+  const keys = new Map<string, { name: string; version: string }>();
+  for (const run of runManifests) {
+    for (const s of parseScorers(run.scorers)) {
+      keys.set(`${s.name}@${s.version}`, { name: s.name, version: s.version });
+    }
+  }
+  return keys;
+}
+
 /**
  * Aggregate raw scores + run manifests into per-(name, version) registry rows, sorted
  * by name then version. `runManifests` must be ordered oldest-first so the newest
@@ -110,31 +289,14 @@ export function aggregateScorers(
   runManifests: Array<{ scorers: unknown }>,
 ): ScorerRow[] {
   const declared = declaredByKey(runManifests);
+  const { map: definitions, hashesByKey } = definitionByKey(runManifests);
   const byKey = new Map<string, Agg>();
 
   for (const s of scores) {
     const key = `${s.scorerName}@${s.scorerVersion}`;
     let a = byKey.get(key);
     if (!a) {
-      a = {
-        name: s.scorerName,
-        version: s.scorerVersion,
-        total: 0,
-        errored: 0,
-        numericValues: [],
-        passedTrue: 0,
-        passedTotal: 0,
-        boolTrue: 0,
-        boolFalse: 0,
-        categories: new Map(),
-        runIds: new Set(),
-        evaluationIds: new Set(),
-        lastUsed: 0,
-        recentErrors: [],
-        seenNumeric: false,
-        seenBool: false,
-        seenString: false,
-      };
+      a = newAgg(s.scorerName, s.scorerVersion);
       byKey.set(key, a);
     }
     a.total += 1;
@@ -152,7 +314,10 @@ export function aggregateScorers(
       else a.boolFalse += 1;
     } else if (s.numericValue !== null) {
       a.seenNumeric = true;
-      a.numericValues.push(s.numericValue);
+      a.numCount += 1;
+      a.numSum += s.numericValue;
+      if (s.numericValue < a.numMin) a.numMin = s.numericValue;
+      if (s.numericValue > a.numMax) a.numMax = s.numericValue;
     } else if (s.stringValue !== null) {
       a.seenString = true;
       a.categories.set(s.stringValue, (a.categories.get(s.stringValue) ?? 0) + 1);
@@ -163,18 +328,20 @@ export function aggregateScorers(
     }
   }
 
+  // Seed a zero-count row for every (name, version) a manifest declared but that
+  // never produced a Score row — a version declared and not yet scored (or whose
+  // first result hasn't landed) should still resolve.
+  for (const [key, { name, version }] of allManifestKeys(runManifests)) {
+    if (!byKey.has(key)) byKey.set(key, newAgg(name, version));
+  }
+
   return [...byKey.values()]
     .map((a): ScorerRow => {
-      const meta = declared.get(`${a.name}@${a.version}`) ?? null;
-      const nums = a.numericValues;
+      const key = `${a.name}@${a.version}`;
+      const meta = declared.get(key) ?? null;
       const numeric =
-        nums.length > 0
-          ? {
-              mean: nums.reduce((x, y) => x + y, 0) / nums.length,
-              min: Math.min(...nums),
-              max: Math.max(...nums),
-              count: nums.length,
-            }
+        a.numCount > 0
+          ? { mean: a.numSum / a.numCount, min: a.numMin, max: a.numMax, count: a.numCount }
           : null;
       let distribution: Array<{ label: string; count: number }> | null = null;
       if (a.seenBool && !a.seenNumeric && !a.seenString) {
@@ -188,10 +355,15 @@ export function aggregateScorers(
           .sort((x, y) => y.count - x.count)
           .slice(0, 8);
       }
+      const definition = definitions.get(key) ?? null;
+      const hashes = hashesByKey.get(key);
       return {
+        ...(definition ?? emptyDefinition()),
         name: a.name,
         version: a.version,
-        scoreCount: a.total,
+        // Rows that actually produced a value — an all-errored scorer reports 0,
+        // never `total`, so it doesn't read as having "scored" anything.
+        scoreCount: a.total - a.errored,
         errorCount: a.errored,
         errorRate: a.total > 0 ? a.errored / a.total : 0,
         valueType: inferValueType(a),
@@ -201,6 +373,8 @@ export function aggregateScorers(
         numeric,
         passRate: a.passedTotal > 0 ? a.passedTrue / a.passedTotal : null,
         distribution,
+        definitionHash: definition ? hashDefinition(definition) : null,
+        distinctDefinitions: hashes?.size ?? 0,
         runCount: a.runIds.size,
         evaluationCount: a.evaluationIds.size,
         lastUsed: a.lastUsed > 0 ? new Date(a.lastUsed).toISOString() : null,

--- a/frontend/ui/src/lib/eval/scorer-registry.ts
+++ b/frontend/ui/src/lib/eval/scorer-registry.ts
@@ -27,36 +27,7 @@ export interface RawScore {
   evaluationId: string | null;
 }
 
-/** The SDK-reported scorer DEFINITION (see offline-eval/sdk-ask/scorer-definition-reporting.md).
- *  Every field is optional — absent → "Not provided by SDK", never inferred/fabricated. */
-export interface ScorerDefinition {
-  /** Discriminator; drives the detail's top-half. */
-  scorerType: "llm_judge" | "code" | null;
-  outputType: "score" | "classification" | null;
-  description: string | null;
-  metadata: unknown | null;
-  // llm_judge
-  model: string | null;
-  messages: Array<{ role: string; content: string }> | null;
-  // code
-  language: "python" | "typescript" | null;
-  sourceCode: string | null;
-}
-
-function emptyDefinition(): ScorerDefinition {
-  return {
-    scorerType: null,
-    outputType: null,
-    description: null,
-    metadata: null,
-    model: null,
-    messages: null,
-    language: null,
-    sourceCode: null,
-  };
-}
-
-export interface ScorerRow extends ScorerDefinition {
+export interface ScorerRow {
   name: string;
   version: string;
   scoreCount: number;
@@ -129,69 +100,6 @@ function declaredByKey(runManifests: Array<{ scorers: unknown }>) {
   return declared;
 }
 
-/** Latest-reported scorer DEFINITION per (name, version), read from the raw manifest.
- *  A later run that reports any definition field wins (definition is part of identity;
- *  changing it should bump the scorer version). Unknown fields are ignored. */
-function definitionByKey(runManifests: Array<{ scorers: unknown }>) {
-  const map = new Map<string, ScorerDefinition>();
-  for (const run of runManifests) {
-    if (!Array.isArray(run.scorers)) continue;
-    for (const raw of run.scorers) {
-      if (!raw || typeof raw !== "object") continue;
-      const o = raw as Record<string, unknown>;
-      if (typeof o.name !== "string") continue;
-      const version = typeof o.version === "string" ? o.version : "";
-      const def = emptyDefinition();
-      let any = false;
-      if (o.scorer_type === "llm_judge" || o.scorer_type === "code") {
-        def.scorerType = o.scorer_type;
-        any = true;
-      }
-      if (o.output_type === "score" || o.output_type === "classification") {
-        def.outputType = o.output_type;
-        any = true;
-      }
-      if (typeof o.description === "string") {
-        def.description = o.description;
-        any = true;
-      }
-      if (o.metadata !== undefined && o.metadata !== null) {
-        def.metadata = o.metadata;
-        any = true;
-      }
-      if (typeof o.model === "string") {
-        def.model = o.model;
-        any = true;
-      }
-      if (Array.isArray(o.messages)) {
-        const msgs = o.messages
-          .filter(
-            (m): m is { role: string; content: string } =>
-              !!m &&
-              typeof m === "object" &&
-              typeof (m as Record<string, unknown>).role === "string" &&
-              typeof (m as Record<string, unknown>).content === "string",
-          )
-          .map((m) => ({ role: m.role, content: m.content }));
-        if (msgs.length > 0) {
-          def.messages = msgs;
-          any = true;
-        }
-      }
-      if (o.language === "python" || o.language === "typescript") {
-        def.language = o.language;
-        any = true;
-      }
-      if (typeof o.source === "string") {
-        def.sourceCode = o.source;
-        any = true;
-      }
-      if (any) map.set(`${o.name}@${version}`, def);
-    }
-  }
-  return map;
-}
-
 /**
  * Aggregate raw scores + run manifests into per-(name, version) registry rows, sorted
  * by name then version. `runManifests` must be ordered oldest-first so the newest
@@ -202,7 +110,6 @@ export function aggregateScorers(
   runManifests: Array<{ scorers: unknown }>,
 ): ScorerRow[] {
   const declared = declaredByKey(runManifests);
-  const definitions = definitionByKey(runManifests);
   const byKey = new Map<string, Agg>();
 
   for (const s of scores) {
@@ -282,7 +189,6 @@ export function aggregateScorers(
           .slice(0, 8);
       }
       return {
-        ...(definitions.get(`${a.name}@${a.version}`) ?? emptyDefinition()),
         name: a.name,
         version: a.version,
         scoreCount: a.total,

--- a/frontend/ui/src/lib/eval/versions.test.ts
+++ b/frontend/ui/src/lib/eval/versions.test.ts
@@ -1,0 +1,169 @@
+/**
+ * publishDatasetVersion's pointer-swap concurrency.
+ *
+ * The dataset row has no row lock during the surrounding transaction, so two
+ * publishes that both read `currentVersionId = V1` must not both succeed in
+ * moving the pointer — the loser has to see its base has moved, not silently
+ * overwrite the winner. This drives the real function against a tiny in-memory
+ * fake prisma that lets a test control the read/write interleaving directly,
+ * rather than relying on real transaction timing.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type FakeDataset = { id: string; projectId: string; currentVersionId: string | null };
+type FakeVersion = {
+  id: string;
+  datasetId: string;
+  versionNumber: number;
+  idempotencyKey?: string | null;
+};
+type FakeTestCase = { id: string; datasetVersionId: string; testCaseId: string; createTime: Date };
+
+function makeFakeDb() {
+  const dataset: FakeDataset = { id: "ds1", projectId: "p1", currentVersionId: "v0" };
+  const versions: FakeVersion[] = [{ id: "v0", datasetId: "ds1", versionNumber: 1 }];
+  const testCases: FakeTestCase[] = [];
+  let nextVersionN = 1;
+
+  // Lets a test pause a specific call's `dataset.findFirst` mid-flight, to force
+  // a stale-read race deterministically instead of hoping for real timing.
+  let findFirstGate: Promise<void> | null = null;
+
+  const tx = {
+    dataset: {
+      findFirst: vi.fn(async ({ where }: { where: { id: string; projectId?: string } }) => {
+        if (where.id !== dataset.id) return null;
+        const snapshot = { id: dataset.id, currentVersionId: dataset.currentVersionId };
+        if (findFirstGate) {
+          const gate = findFirstGate;
+          findFirstGate = null; // only the next call after arming waits
+          await gate;
+        }
+        return snapshot;
+      }),
+      updateMany: vi.fn(
+        async ({
+          where,
+          data,
+        }: {
+          where: { id: string; projectId: string; currentVersionId: string | null };
+          data: { currentVersionId: string };
+        }) => {
+          if (
+            where.id === dataset.id &&
+            where.projectId === dataset.projectId &&
+            where.currentVersionId === dataset.currentVersionId
+          ) {
+            dataset.currentVersionId = data.currentVersionId;
+            return { count: 1 };
+          }
+          return { count: 0 };
+        },
+      ),
+    },
+    datasetVersion: {
+      findFirst: vi.fn(
+        async ({ where, orderBy }: { where: Record<string, unknown>; orderBy?: unknown }) => {
+          if ("idempotencyKey" in where) {
+            return versions.find((v) => v.idempotencyKey === where.idempotencyKey) ?? null;
+          }
+          if (orderBy) {
+            const sorted = [...versions].sort((a, b) => b.versionNumber - a.versionNumber);
+            return sorted[0] ?? null;
+          }
+          return null;
+        },
+      ),
+      create: vi.fn(async ({ data }: { data: Omit<FakeVersion, "id"> }) => {
+        nextVersionN += 1;
+        const v: FakeVersion = { ...data, id: `v${nextVersionN}` };
+        versions.push(v);
+        return v;
+      }),
+    },
+    testCase: {
+      findMany: vi.fn(async ({ where }: { where: { datasetVersionId: string } }) =>
+        testCases.filter((c) => c.datasetVersionId === where.datasetVersionId),
+      ),
+      count: vi.fn(
+        async ({ where }: { where: { datasetVersionId: string } }) =>
+          testCases.filter((c) => c.datasetVersionId === where.datasetVersionId).length,
+      ),
+      createMany: vi.fn(async ({ data }: { data: FakeTestCase[] }) => {
+        testCases.push(...data);
+      }),
+    },
+  };
+
+  const prisma = { $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(tx)) };
+
+  return {
+    prisma,
+    dataset,
+    versions,
+    armFindFirstGate: (gate: Promise<void>) => {
+      findFirstGate = gate;
+    },
+  };
+}
+
+const fakeDb = vi.hoisted(() => ({ current: null as ReturnType<typeof makeFakeDb> | null }));
+
+vi.mock("@traceroot/core", () => ({
+  get prisma() {
+    return fakeDb.current!.prisma;
+  },
+}));
+
+import { publishDatasetVersion, VersionConflict } from "./versions";
+
+beforeEach(() => {
+  fakeDb.current = makeFakeDb();
+});
+
+describe("publishDatasetVersion — pointer compare-and-swap", () => {
+  it("publishes normally when nothing else touched the dataset", async () => {
+    const result = await publishDatasetVersion({
+      datasetId: "ds1",
+      projectId: "p1",
+      transform: (current) => ({ cases: current, focusTestCaseId: "" }),
+    });
+    expect(result.versionNumber).toBe(2);
+    expect(fakeDb.current!.dataset.currentVersionId).toBe(result.versionId);
+  });
+
+  it("rejects a publish whose base moved between its read and its write, instead of silently overwriting", async () => {
+    // B reads `currentVersionId = v0` first, then pauses (simulating another
+    // request winning the race in between); A then publishes fully on top of
+    // that same v0 and moves the pointer. When B resumes, its write must see
+    // that its base is stale rather than clobbering A's published version.
+    let releaseB!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseB = resolve;
+    });
+    fakeDb.current!.armFindFirstGate(gate);
+
+    const bPromise = publishDatasetVersion({
+      datasetId: "ds1",
+      projectId: "p1",
+      transform: (current) => ({ cases: current, focusTestCaseId: "" }),
+    });
+
+    const aResult = await publishDatasetVersion({
+      datasetId: "ds1",
+      projectId: "p1",
+      transform: (current) => ({ cases: current, focusTestCaseId: "" }),
+    });
+    expect(aResult.versionNumber).toBe(2);
+    expect(fakeDb.current!.dataset.currentVersionId).toBe(aResult.versionId);
+
+    releaseB();
+    await expect(bPromise).rejects.toBeInstanceOf(VersionConflict);
+
+    // A's publish is still the live version — the pointer never moved to B's,
+    // which is the invariant the compare-and-swap exists to protect. (The real
+    // transaction also rolls back B's created version row; this fake isn't
+    // transactional, so that part isn't re-asserted here.)
+    expect(fakeDb.current!.dataset.currentVersionId).toBe(aResult.versionId);
+  });
+});

--- a/frontend/ui/src/lib/eval/versions.ts
+++ b/frontend/ui/src/lib/eval/versions.ts
@@ -1,6 +1,12 @@
 import { prisma, type Prisma, type TestCase } from "@traceroot/core";
 import { randomUUID } from "crypto";
 
+/** Deterministic read order for a version's cases (see the ordering note where
+ *  it's used): every case a publish writes shares one `create_time` (Postgres'
+ *  `CURRENT_TIMESTAMP` default is the transaction start time), so `testCaseId`
+ *  breaks the tie and makes the order total instead of "whatever the plan does". */
+export const TEST_CASE_ORDER = [{ createTime: "asc" as const }, { testCaseId: "asc" as const }];
+
 /**
  * Dataset-version publishing — the immutability core.
  *
@@ -9,6 +15,9 @@ import { randomUUID } from "crypto";
  * cases (new row ids, same stable `testCaseId`) with the change applied, then
  * repoints `Dataset.currentVersionId`. Any run that pinned an older version
  * keeps reading exactly what it ran against.
+ *
+ * Concurrency: repointing the pointer is a compare-and-swap, not a read-then-write
+ * — see the `updateMany` at the end of `publishDatasetVersion`.
  */
 
 /** The persisted fields of a test case, minus row/version identity. */
@@ -65,7 +74,10 @@ export function newTestCaseId(): string {
  * pointer move together.
  */
 export async function publishDatasetVersion(opts: {
-  datasetId: string;
+  /** Server-side dataset id (session/UI routes). */
+  datasetId?: string;
+  /** SDK-chosen, project-scoped id (public routes) — resolved via resolvePublicDataset. */
+  clientDatasetId?: string;
   projectId: string;
   note?: string | null;
   createdBy?: string | null;
@@ -85,6 +97,7 @@ export async function publishDatasetVersion(opts: {
   idempotencyKey?: string | null;
   transform: (current: TestCaseSeed[]) => { cases: TestCaseSeed[]; focusTestCaseId: string };
 }): Promise<{
+  datasetId: string;
   versionId: string;
   versionNumber: number;
   focusTestCaseId: string;
@@ -92,21 +105,30 @@ export async function publishDatasetVersion(opts: {
   replayed: boolean;
 }> {
   return prisma.$transaction(async (tx) => {
-    const dataset = await tx.dataset.findFirst({
-      where: { id: opts.datasetId, projectId: opts.projectId },
-      select: { id: true, currentVersionId: true },
-    });
+    const dataset =
+      opts.clientDatasetId !== undefined
+        ? await resolvePublicDataset(tx, opts.projectId, opts.clientDatasetId)
+        : opts.datasetId
+          ? await tx.dataset.findFirst({
+              where: { id: opts.datasetId, projectId: opts.projectId },
+              select: { id: true, currentVersionId: true },
+            })
+          : (() => {
+              throw new Error("publishDatasetVersion needs a datasetId or a clientDatasetId");
+            })();
     if (!dataset) throw new DatasetNotFound();
+    const datasetId = dataset.id;
 
     // Idempotent replay: a publish already recorded for this key wins over the
     // conflict check below, so a network retry after success returns that version.
     if (opts.idempotencyKey) {
       const prior = await tx.datasetVersion.findFirst({
-        where: { datasetId: opts.datasetId, idempotencyKey: opts.idempotencyKey },
+        where: { datasetId, idempotencyKey: opts.idempotencyKey },
         select: { id: true, versionNumber: true },
       });
       if (prior) {
         return {
+          datasetId,
           versionId: prior.id,
           versionNumber: prior.versionNumber,
           focusTestCaseId: "",
@@ -127,14 +149,14 @@ export async function publishDatasetVersion(opts: {
     const current = dataset.currentVersionId
       ? await tx.testCase.findMany({
           where: { datasetVersionId: dataset.currentVersionId },
-          orderBy: { createTime: "asc" },
+          orderBy: TEST_CASE_ORDER,
         })
       : [];
 
     const { cases, focusTestCaseId } = opts.transform(current.map(toSeed));
 
     const last = await tx.datasetVersion.findFirst({
-      where: { datasetId: opts.datasetId },
+      where: { datasetId },
       orderBy: { versionNumber: "desc" },
       select: { versionNumber: true },
     });
@@ -142,7 +164,7 @@ export async function publishDatasetVersion(opts: {
 
     const version = await tx.datasetVersion.create({
       data: {
-        datasetId: opts.datasetId,
+        datasetId,
         projectId: opts.projectId,
         versionNumber,
         label: opts.label ?? `v${versionNumber}`,
@@ -161,18 +183,38 @@ export async function publishDatasetVersion(opts: {
           // brand-new case (no createTime on the seed) omits it and defaults to now.
           ...(createTime ? { createTime } : {}),
           datasetVersionId: version.id,
-          datasetId: opts.datasetId,
+          datasetId,
           projectId: opts.projectId,
         })),
       });
     }
 
-    await tx.dataset.update({
-      where: { id: opts.datasetId },
+    // Compare-and-swap, not a plain write: Postgres runs this transaction at READ
+    // COMMITTED with no lock on the dataset row, so two publishes that both read
+    // `currentVersionId = dataset.currentVersionId` above would otherwise both
+    // reach an unconditional update and race — the loser's version would be
+    // created and left the dataset's current pointer, with nothing to signal that
+    // its base was stale. Gating the write on the pointer still being what this
+    // publish read turns that race into a deliberate conflict instead.
+    const moved = await tx.dataset.updateMany({
+      where: {
+        id: datasetId,
+        projectId: opts.projectId,
+        currentVersionId: dataset.currentVersionId,
+      },
       data: { currentVersionId: version.id },
     });
+    if (moved.count === 0) {
+      const now = await tx.dataset.findFirst({
+        where: { id: datasetId },
+        select: { currentVersionId: true },
+      });
+      // Rolls the whole transaction back, so the losing version is never persisted.
+      throw new VersionConflict(now?.currentVersionId ?? null);
+    }
 
     return {
+      datasetId,
       versionId: version.id,
       versionNumber,
       focusTestCaseId,
@@ -180,6 +222,24 @@ export async function publishDatasetVersion(opts: {
       replayed: false,
     };
   });
+}
+
+type DatasetReader = Pick<Prisma.TransactionClient, "dataset">;
+
+/**
+ * Resolve the id an SDK addresses a dataset by, always within the caller's project.
+ *
+ * Preference order is the project-scoped `clientDatasetId`, then the row id — the
+ * fallback keeps datasets created in the UI (which have no client id) addressable,
+ * without putting SDK-chosen ids back into a global keyspace where one tenant could
+ * squat another's names.
+ */
+export async function resolvePublicDataset(tx: DatasetReader, projectId: string, ref: string) {
+  const byClientId = await tx.dataset.findUnique({
+    where: { projectId_clientDatasetId: { projectId, clientDatasetId: ref } },
+  });
+  if (byClientId) return byClientId;
+  return tx.dataset.findFirst({ where: { id: ref, projectId } });
 }
 
 export class DatasetNotFound extends Error {

--- a/frontend/ui/vitest.config.ts
+++ b/frontend/ui/vitest.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
         "**/*.spec.ts",
         "**/*.d.ts",
         "**/types.ts",
+        // Next.js route entrypoints are thin composition (params -> view) and are
+        // exercised by the view mount smokes, not unit-covered directly.
+        "**/app/**/page.tsx",
+        "**/app/**/layout.tsx",
         // Local dev-server build output; its compiled chunks lack usable
         // sourcemaps and crash the untested-files coverage scan.
         "**/.next/**",


### PR DESCRIPTION
## Summary

Fixes: #1654

There is no scorer table — the catalog is derived at read time from what runs reported. A pure aggregation (`lib/eval/scorer-registry.ts`) folds `Score` rows and per-run scorer manifests into per-`(name, version)` registry rows and a per-scorer detail, with the latest-reported definition winning. It only ever surfaces what the SDK reported and never fabricates a field: value type is inferred from observed values, but absent config/definition stays absent.

## What's included

### Derivation module (`frontend/ui/src/lib/eval`)
- `scorer-registry.ts` — `aggregateScorers(scores, runManifests)` folds observed scores and run manifests into per-`(name, version)` rows (observed value type, score/error counts, distributions, run/evaluation counts, last-used) and rolls them up into a per-scorer detail keyed by name across all versions. `inferValueType` resolves the populated value column (numeric / boolean / categorical / mixed / unknown) without inventing a type; `definitionByKey` / `declaredByKey` pick the latest-reported definition and declared config per `(name, version)` by walking runs newest-first, so latest-wins falls out of iteration order rather than a separate sort.
- `lib/eval/versions.ts` — provides `TEST_CASE_ORDER`, `TestCaseSeed`, `newTestCaseId`, `publishDatasetVersion`.

### Backend (route handlers)
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/route.ts` — project-scoped catalog: reads `Score` rows + run manifests and returns `aggregateScorers` output.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/scorers/[name]/route.ts` — per-scorer detail: the same aggregation filtered to one scorer family's versions.

### Tests
- `frontend/ui/src/lib/eval/scorer-registry.test.ts` — latest-wins definition, inferred vs declared type, error-only scorers, and honest gaps for undeclared fields.
- `app/api/projects/[projectId]/evaluations/scorers/[name]/route.test.ts` — covers `route`.
- `app/api/projects/[projectId]/evaluations/scorers/route.test.ts` — covers `route`.
- `lib/eval/versions.test.ts` — covers `versions`.
- `components/ui/expandable-section.test.tsx` — covers `expandable-section`.
- `components/ui/markdown-view.blocks.test.tsx` — covers `markdown-view.blocks`.
- `features/evaluations/datasets-detail.smoke.test.tsx` — covers `datasets-detail.smoke`.
- `features/offline-eval/components/code.test.tsx` — covers `code`.
- `features/offline-eval/utils.test.ts` — covers `utils`.
- `features/projects/components/ProjectBreadcrumb.trail.test.tsx` — covers `ProjectBreadcrumb.trail`.
- `features/traces/components/SpanInfoPanel.eval.test.tsx` — covers `SpanInfoPanel.eval`.
- `app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.test.ts` — covers `route`.
- `app/api/projects/[projectId]/datasets/route.test.ts` — covers `route`.
- `app/api/projects/[projectId]/traces/[traceId]/evaluation-results/route.test.ts` — covers `route`.
- `app/api/projects/[projectId]/traces/[traceId]/test-cases/route.test.ts` — covers `route`.

### Frontend
- `frontend/ui/vitest.config.ts` — part of this change.

## Test plan
- [ ] Catalog rows aggregate correctly from scores + manifests, per `(name, version)`.
- [ ] A scorer's definition comes from its latest reporting run, not its first.
- [ ] Undeclared fields surface as absent, never inferred.
- [ ] Error-only scorers (all `error`, no value) still appear, with a zero score count and their error count.
- [ ] Distributions and run/evaluation counts reflect only runs that actually reported the scorer.
- [ ] Confirm both endpoints are project-scoped.
