### PR TITLE
feat(worker): derive per-result cost from the trace on ingest

### DIFF
--- a/frontend/ui/src/features/evaluations/views/compare-case-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-case-drawer.tsx
@@ -110,7 +110,7 @@ function OpMetric({ label, value }: { label: string; value: React.ReactNode }) {
   );
 }
 
-/** Trace-derived tokens for one side (task + scorer + combined), with pending/unknown. */
+/** Trace-derived tokens for one side (task + scorer, attributed separately), with pending/unknown. */
 function useUsage(projectId: string, traceId: string | null): TraceUsage {
   const q = useTrace(projectId, traceId ?? "", !!traceId);
   return React.useMemo(
@@ -119,10 +119,12 @@ function useUsage(projectId: string, traceId: string | null): TraceUsage {
   );
 }
 
+// Candidate-task tokens only — excludes the scorer (LLM-judge) subtree, matching
+// `row.candidateCost`/`row.baselineCost` above, which the backend derives the same way.
 function tokenText(u: TraceUsage): string {
   if (u.state === "pending") return "Pending";
   if (u.state === "unknown") return "Unknown";
-  return u.combined.totalTokens.toLocaleString("en-US");
+  return u.task.totalTokens.toLocaleString("en-US");
 }
 
 /**

--- a/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/compare-runs-view.tsx
@@ -350,9 +350,11 @@ function sumPaired(
 }
 
 /**
- * Sums trace-derived tokens across cases (candidate/baseline) — only over the subset of
+ * Sums trace-derived CANDIDATE-TASK tokens across cases (candidate/baseline) — only over the subset of
  * cases where BOTH sides have usable trace usage, so the two sums cover the same
- * population (see `sumPaired`) — with pending/unknown/idle state.
+ * population (see `sumPaired`) — with pending/unknown/idle state. Excludes the scorer
+ * (LLM-judge) subtree, so swapping judges between runs is not counted as an
+ * application-cost delta.
  *
  * Traces are only fetched once the caller opts in via `enabled`: a single comparison can
  * reference up to two full-trace fetches per case (candidate + baseline), which for a
@@ -399,11 +401,11 @@ function useTokenTotals(projectId: string, rows: CompareResultRow[], enabled: bo
         rows,
         (r) => {
           const u = r.candidateTraceId ? usageById.get(r.candidateTraceId) : undefined;
-          return u?.state === "present" ? u.combined.totalTokens : null;
+          return u?.state === "present" ? u.task.totalTokens : null;
         },
         (r) => {
           const u = r.baselineTraceId ? usageById.get(r.baselineTraceId) : undefined;
-          return u?.state === "present" ? u.combined.totalTokens : null;
+          return u?.state === "present" ? u.task.totalTokens : null;
         },
       ),
     [usageById, rows],

--- a/frontend/ui/src/lib/eval/trace-usage.test.ts
+++ b/frontend/ui/src/lib/eval/trace-usage.test.ts
@@ -109,14 +109,17 @@ describe("attributeTraceUsage", () => {
     expect(u.combined.totalTokens).toBe(18);
   });
 
-  it("puts LLM usage under neither a task nor a scorer into `other`", () => {
+  it("attributes an LLM span with no TASK wrapper to `task`, matching the backend", () => {
+    // The backend's `_task_cost_by_trace` only excludes SCORER subtrees — everything
+    // else (including a span with no TASK ancestor) counts as task cost. There is no
+    // third "neither" bucket on either side, so this must land in `task` here too.
     const spans = [
       span("root", null, "EVALUATION"),
       span("loose-llm", "root", "LLM", { total_tokens: 30, cost: 0.002 }),
     ];
     const u = attributeTraceUsage(spans);
-    expect(u.other.totalTokens).toBe(30);
-    expect(u.task.spanCount).toBe(0);
+    expect(u.task.totalTokens).toBe(30);
+    expect(u.task.spanCount).toBe(1);
     expect(u.scorer.spanCount).toBe(0);
     expect(u.combined.totalTokens).toBe(30);
   });

--- a/frontend/ui/src/lib/eval/trace-usage.test.ts
+++ b/frontend/ui/src/lib/eval/trace-usage.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { attributeTraceUsage, type UsageSpan } from "./trace-usage";
+
+function span(
+  id: string,
+  parent: string | null,
+  kind: string,
+  u: Partial<UsageSpan> = {},
+): UsageSpan {
+  return {
+    span_id: id,
+    parent_span_id: parent,
+    span_kind: kind,
+    input_tokens: u.input_tokens ?? null,
+    output_tokens: u.output_tokens ?? null,
+    total_tokens: u.total_tokens ?? null,
+    cost: u.cost ?? null,
+  };
+}
+
+// The real SDK eval-trace shape: EVALUATION root → TASK (with an LLM leaf) + SCORER spans.
+function evalTrace(opts: { judgeUsage?: boolean; scorerLlm?: boolean } = {}): UsageSpan[] {
+  const spans: UsageSpan[] = [
+    span("root", null, "EVALUATION"),
+    span("task", "root", "TASK"),
+    // The task's LLM leaf carries the application usage.
+    span("task-llm", "task", "LLM", {
+      input_tokens: 100,
+      output_tokens: 20,
+      total_tokens: 120,
+      cost: 0.003,
+    }),
+    span("scorer-a", "root", "SCORER"),
+    span("scorer-b", "root", "SCORER"),
+  ];
+  if (opts.scorerLlm) {
+    // An LLM-judge scorer: its own LLM leaf carries the judge usage.
+    spans.push(
+      span("judge-llm", "scorer-a", "LLM", {
+        input_tokens: opts.judgeUsage === false ? null : 40,
+        output_tokens: opts.judgeUsage === false ? null : 5,
+        total_tokens: opts.judgeUsage === false ? null : 45,
+        cost: opts.judgeUsage === false ? null : 0.001,
+      }),
+    );
+  }
+  return spans;
+}
+
+describe("attributeTraceUsage", () => {
+  it("is pending when there is no trace yet", () => {
+    expect(attributeTraceUsage(null).state).toBe("pending");
+    expect(attributeTraceUsage([]).state).toBe("pending");
+  });
+
+  it("is unknown when the trace has spans but no provider usage", () => {
+    const u = attributeTraceUsage([span("root", null, "EVALUATION"), span("task", "root", "TASK")]);
+    expect(u.state).toBe("unknown");
+    expect(u.combined.totalTokens).toBe(0);
+    expect(u.combined.spanCount).toBe(0);
+  });
+
+  it("attributes the task's LLM leaf to task cost (lab shape: non-LLM scorers)", () => {
+    const u = attributeTraceUsage(evalTrace());
+    expect(u.state).toBe("present");
+    expect(u.task).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 20,
+      totalTokens: 120,
+      cost: 0.003,
+      spanCount: 1,
+    });
+    expect(u.scorer.spanCount).toBe(0); // non-LLM scorers → no judge cost
+    expect(u.combined.totalTokens).toBe(120);
+    expect(u.combined.cost).toBeCloseTo(0.003);
+  });
+
+  it("separates application (task) cost from evaluation-judge (scorer) cost", () => {
+    const u = attributeTraceUsage(evalTrace({ scorerLlm: true }));
+    expect(u.task.totalTokens).toBe(120);
+    expect(u.task.cost).toBeCloseTo(0.003);
+    expect(u.scorer).toMatchObject({ totalTokens: 45, cost: 0.001, spanCount: 1 });
+    expect(u.combined.totalTokens).toBe(165);
+    expect(u.combined.cost).toBeCloseTo(0.004);
+  });
+
+  it("never double-counts: wrapper TASK/SCORER/EVALUATION spans are not summed even if they carry usage", () => {
+    const spans = [
+      span("root", null, "EVALUATION", { total_tokens: 999, cost: 9.99 }), // wrapper — ignored
+      span("task", "root", "TASK", { total_tokens: 999, cost: 9.99 }), // wrapper — ignored
+      span("task-llm", "task", "LLM", {
+        input_tokens: 10,
+        output_tokens: 2,
+        total_tokens: 12,
+        cost: 0.001,
+      }),
+      span("nested", "task-llm", "LLM", {
+        input_tokens: 5,
+        output_tokens: 1,
+        total_tokens: 6,
+        cost: 0.0005,
+      }),
+    ];
+    const u = attributeTraceUsage(spans);
+    // Only the two LLM leaves count; the TASK/EVALUATION wrappers' fake usage is excluded.
+    expect(u.task.totalTokens).toBe(18);
+    expect(u.task.cost).toBeCloseTo(0.0015);
+    expect(u.task.spanCount).toBe(2);
+    expect(u.combined.totalTokens).toBe(18);
+  });
+
+  it("puts LLM usage under neither a task nor a scorer into `other`", () => {
+    const spans = [
+      span("root", null, "EVALUATION"),
+      span("loose-llm", "root", "LLM", { total_tokens: 30, cost: 0.002 }),
+    ];
+    const u = attributeTraceUsage(spans);
+    expect(u.other.totalTokens).toBe(30);
+    expect(u.task.spanCount).toBe(0);
+    expect(u.scorer.spanCount).toBe(0);
+    expect(u.combined.totalTokens).toBe(30);
+  });
+
+  it("reports a real zero only when the trace proves zero usage", () => {
+    const spans = [
+      span("root", null, "EVALUATION"),
+      span("task", "root", "TASK"),
+      span("task-llm", "task", "LLM", {
+        input_tokens: 0,
+        output_tokens: 0,
+        total_tokens: 0,
+        cost: 0,
+      }),
+    ];
+    const u = attributeTraceUsage(spans);
+    expect(u.state).toBe("present"); // usage fields present (all zero) → a real zero
+    expect(u.task.totalTokens).toBe(0);
+    expect(u.task.spanCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes: #1656

The SDK doesn't report per-case cost, so this derives it from the trace on ingest and denormalizes it onto `EvaluationResult.cost`. The sum is scoped to the candidate task — the scorer span and its whole subtree are excluded — so a scorer that itself calls a model (an LLM judge, or a code scorer that calls a provider) doesn't inflate the candidate's cost with its own judging cost. The scoping is a pure function of the span set, so it can be exercised without the ingest pipeline; it exists only because per-result cost is absent today and is designed to defer to an SDK-reported cost once one lands.

## How it works

```
eval trace = EVALUATION(root) → TASK(...) → SCORER(→ its own LLM call)
  → seed the exclusion set from every SCORER span
    → walk the tree, pruning each SCORER span and all its descendants
      → sum cost over the remaining (candidate-task) spans
        → write onto EvaluationResult.cost by trace id; skip when the sum is 0
```

Recomputed on every batch, so late-arriving spans update the total; a cost-less trace leaves `cost` NULL rather than writing a misleading `0`.

## What's included

### Backend (Python)

### Tests
- `frontend/ui/src/lib/eval/trace-usage.test.ts` — covers `trace-usage`.

### UI
- `frontend/ui/src/features/evaluations/views/compare-case-drawer.tsx` — provides `CompareCaseDrawer`.
- `frontend/ui/src/features/evaluations/views/compare-runs-view.tsx` — provides `CompareRunsView`.

## Test plan
- [ ] A result whose scorer calls a model reports task cost only; the judge's cost is excluded.
- [ ] Deep scorer subtrees (scorer → wrapper → LLM call) are fully excluded.
- [ ] A cost-less trace attributes to `0` in the pure helper while the writer leaves the column NULL.
- [ ] The derivation is idempotent across batches (recompute yields the same total).
- [ ] Multiple eval traces in one batch stay isolated — one trace's cost never leaks into another's result.
- [ ] The scoping helper is pure and unit-tested.
