### PR TITLE
feat(evaluations): data-fetching hooks over the read models

### DIFF
--- a/frontend/ui/src/features/evaluations/hooks.ts
+++ b/frontend/ui/src/features/evaluations/hooks.ts
@@ -54,13 +54,20 @@ export function useDatasets(
   if (query.limit !== undefined) params.set("limit", String(query.limit));
   const qs = params.toString();
   return useQuery({
-    queryKey: ["datasets", "list", projectId, query.search_query ?? null, query.page ?? 0],
+    queryKey: [
+      "datasets",
+      "list",
+      projectId,
+      query.search_query ?? null,
+      query.page ?? 0,
+      query.limit ?? null,
+    ],
     queryFn: () =>
       getJson<{ data: DatasetRow[]; meta: Meta }>(
         `/api/projects/${projectId}/datasets${qs ? `?${qs}` : ""}`,
       ),
     enabled: !!projectId,
-    placeholderData: (prev) => prev,
+    placeholderData: (prev, prevQuery) => (prevQuery?.queryKey[2] === projectId ? prev : undefined),
   });
 }
 
@@ -71,7 +78,7 @@ export function useDataset(projectId: string, datasetId: string, versionId?: str
     queryFn: () =>
       getJson<DatasetDetailResponse>(`/api/projects/${projectId}/datasets/${datasetId}${qs}`),
     enabled: !!projectId && !!datasetId,
-    placeholderData: (prev) => prev,
+    placeholderData: (prev, prevQuery) => (prevQuery?.queryKey[2] === projectId ? prev : undefined),
   });
 }
 
@@ -153,7 +160,7 @@ export function useUpdateTestCase(projectId: string, datasetId: string) {
       };
     }) =>
       sendJson<{ versionId: string; versionNumber: number; focusTestCaseId: string }>(
-        `/api/projects/${projectId}/datasets/${datasetId}/test-cases/${args.testCaseId}`,
+        `/api/projects/${projectId}/datasets/${datasetId}/test-cases/${encodeURIComponent(args.testCaseId)}`,
         "PATCH",
         args.patch,
       ),
@@ -179,7 +186,7 @@ export function useTestCaseRuns(projectId: string, datasetId: string, testCaseId
     queryKey: ["datasets", projectId, datasetId, "test-case-runs", testCaseId],
     queryFn: () =>
       getJson<{ data: TestCaseRunRow[] }>(
-        `/api/projects/${projectId}/datasets/${datasetId}/test-cases/${testCaseId}/runs`,
+        `/api/projects/${projectId}/datasets/${datasetId}/test-cases/${encodeURIComponent(testCaseId!)}/runs`,
       ),
     enabled: !!projectId && !!datasetId && !!testCaseId,
   });
@@ -233,7 +240,7 @@ export function useEvaluationRuns(
         `/api/projects/${projectId}/evaluations/runs${qs ? `?${qs}` : ""}`,
       ),
     enabled: !!projectId,
-    placeholderData: (prev) => prev,
+    placeholderData: (prev, prevQuery) => (prevQuery?.queryKey[2] === projectId ? prev : undefined),
   });
 }
 

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -65,6 +65,7 @@ const STATUS_VARIANT: Record<EvalRunStatus, "success" | "danger" | "warning" | "
   completed_with_errors: "warning",
   failed: "danger",
   incomplete: "warning",
+  cancelled: "default",
 };
 
 export function RunStatusBadge({ status }: { status: EvalRunStatus }) {


### PR DESCRIPTION
## Summary

Fixes: #1669

The React Query hooks each evaluation surface uses to read the derived read models and the comparison result from the APIs, plus the shared types — so the UI renders what the server derived and never recomputes comparison or registry math itself. Keeping this in one place keeps the views in sync with the read APIs and gives every surface one loading / error contract to render against.

## What's included

### Hooks / data
- `frontend/ui/src/features/evaluations/hooks.ts` — the per-surface query and mutation hooks over the project-scoped read APIs:
  - Datasets: `useDatasets`, `useDataset`, `useCreateDataset`, `useUpdateDataset`, `useDeleteDataset`, `useSaveTestCase`, `useUpdateTestCase`, `useTestCaseRuns`.
  - Evaluations and runs: `useEvaluations`, `useEvaluationRuns`, `useEvaluationRun`, `useDeleteRuns`, `useCreateHumanScore`.
  - Comparison: `useCompareRuns` — returns the server's derived candidate/baseline payload unchanged, shared by the run-detail compare-with and the shareable comparison view so the two can't disagree.
  - Scorers: `useScorers` and `useScorer` — the catalog and the per-scorer family, both over the same registry read model.
  - Trace links: `useTraceEvaluationResults`, `useTraceTestCases` — the trace → evaluation-run and span → dataset-case links, warmed when a trace opens.
  - Every hook is enabled on and keyed by `projectId`; a `getJson` / `sendJson` pair gives one uniform loading / error contract, and mutations invalidate the relevant caches. Query keys are aligned with the trace viewer's `["trace", projectId, traceId]` key so a trace already opened from the run detail is reused when the same case opens in diff mode.

### Shared types

### Frontend
- `frontend/ui/src/features/evaluations/views/evaluations-view.tsx` — provides `RunStatusBadge`, `EvaluationsView`, `formatElapsed`, `ScoreValue`.

## Test plan

- [ ] Confirm every surface reads through a typed hook over the derived APIs (no ad-hoc fetches in views).
- [ ] Confirm the UI does no comparison / registry math — hooks return the server payload unchanged.
- [ ] Confirm a change to a read-model field surfaces as a type error in the consuming views.
- [ ] Confirm query keys are project-scoped so switching projects doesn't serve another project's cached rows.
- [ ] Confirm a trace opened from the run detail is reused (not refetched) when the same case opens in diff mode.
- [ ] Confirm each hook exposes a uniform loading / error shape the surfaces render against.
