### PR TITLE
test(evaluations): backend suite — engines, contract parity, lifecycle

### DIFF
--- a/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
@@ -94,10 +94,20 @@ describe("A2: upsert a dataset by client id", () => {
     expect((await readJson(again)).dataset_id).toBe("ds_01");
   });
 
-  it("hides a dataset id owned by another project (404)", async () => {
-    await upsertDataset(req({ dataset_id: "ds_shared", name: "mine" }));
-    const res = await upsertDataset(req({ dataset_id: "ds_shared", name: "theirs" }, OTHER_KEY));
-    expect(res.status).toBe(404);
+  it("lets another project independently own the same client id (project-scoped, not global)", async () => {
+    // client_dataset_id is unique per PROJECT (uq_dataset_project_client_id), not
+    // globally, so a second project reusing "ds_shared" creates its own row
+    // rather than colliding with — or ever being able to observe — the first
+    // project's. See the docstring on POST /api/public/datasets.
+    const mine = await upsertDataset(req({ dataset_id: "ds_shared", name: "mine" }));
+    expect(mine.status).toBe(201);
+    const theirs = await upsertDataset(req({ dataset_id: "ds_shared", name: "theirs" }, OTHER_KEY));
+    expect(theirs.status).toBe(201);
+    expect((await readJson(theirs)).name).toBe("theirs");
+
+    const rows = fakePrisma.dataset.rows.filter((d) => d.clientDatasetId === "ds_shared");
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.projectId))).toEqual(new Set([PROJECT_ID, OTHER_PROJECT]));
   });
 });
 
@@ -123,8 +133,10 @@ describe("A4: publish an immutable version from changes", () => {
     expect(body.version_number).toBe(1);
     const versionId = body.dataset_version_id as string;
 
-    // Dataset now points at the new version.
-    const ds = fakePrisma.dataset.rows.find((d) => d.id === "ds1")!;
+    // Dataset now points at the new version. Looked up by clientDatasetId, not
+    // id: "ds1" is the SDK's client-supplied id, deliberately not the row's own
+    // (auto-generated) primary key — see datasets/route.ts's docstring.
+    const ds = fakePrisma.dataset.rows.find((d) => d.clientDatasetId === "ds1")!;
     expect(ds.currentVersionId).toBe(versionId);
 
     // A second publish based on the new version: edit tc_1, delete tc_2, add tc_3.
@@ -298,16 +310,32 @@ describe("A4→pull: native JSON round-trips through the real WRITE + READ route
 });
 
 describe("A1/A5: listing", () => {
-  it("lists datasets with a next_cursor when there are more than the limit", async () => {
-    fakePrisma.dataset.rows.push(
-      { id: "ds_a", projectId: PROJECT_ID, name: "a", updateTime: new Date("2026-01-01") },
-      { id: "ds_b", projectId: PROJECT_ID, name: "b", updateTime: new Date("2026-01-02") },
-      { id: "ds_c", projectId: PROJECT_ID, name: "c", updateTime: new Date("2026-01-03") },
+  it("actually paginates: a next_cursor page returns the remaining dataset exactly once", async () => {
+    // Built through the real write route (not hand-pushed rows) so `updateTime`
+    // — which the list route reads — is stamped the way `upsertDataset` really
+    // stamps it, not asserted into existence by the fixture.
+    await upsertDataset(req({ dataset_id: "ds_a", name: "a" }));
+    await upsertDataset(req({ dataset_id: "ds_b", name: "b" }));
+    await upsertDataset(req({ dataset_id: "ds_c", name: "c" }));
+
+    const page1 = await readJson(await listDatasets(getReq("?limit=2")));
+    const page1Ids = (page1.datasets as Array<Record<string, unknown>>).map((d) => d.dataset_id);
+    expect(page1Ids).toHaveLength(2);
+    expect(page1.next_cursor).not.toBeNull();
+
+    // Feed the cursor back in: the SDK's actual pagination loop. The third
+    // dataset must come back exactly once, on this page and no other, and this
+    // (last) page's next_cursor must be null.
+    const page2 = await readJson(
+      await listDatasets(getReq(`?limit=2&cursor=${page1.next_cursor}`)),
     );
-    const res = await listDatasets(getReq("?limit=2"));
-    const body = await readJson(res);
-    expect((body.datasets as unknown[]).length).toBe(2);
-    expect(body.next_cursor).not.toBeNull();
+    const page2Ids = (page2.datasets as Array<Record<string, unknown>>).map((d) => d.dataset_id);
+    expect(page2Ids).toHaveLength(1);
+    expect(page2.next_cursor).toBeNull();
+
+    const allIds = [...page1Ids, ...page2Ids];
+    expect(new Set(allIds)).toEqual(new Set(["ds_a", "ds_b", "ds_c"]));
+    expect(allIds).toHaveLength(3); // no repeat, none skipped
 
     const all = await listDatasets(getReq("?limit=50"));
     expect((await readJson(all)).next_cursor).toBeNull();
@@ -367,6 +395,25 @@ describe("B3/B4: additive scores and human scores", () => {
     expect(scores[0].numericValue).toBe(0.95);
   });
 
+  it("keys on scorer_version too — a second version is a distinct row, not a merge", async () => {
+    // Same scorer NAME, two different versions: this must NOT collapse the way
+    // two reports of the same (name, version) do above, or a second scorer
+    // version silently overwrites/drops the first (the bug live at
+    // comparison.ts's `m.set(s.scorerName, s)`, keyed on name alone).
+    await addScore(
+      req({ scorer_name: "helpfulness", scorer_version: "v2", numeric_value: 0.8 }),
+      resultParams("run1", "tc_1"),
+    );
+    await addScore(
+      req({ scorer_name: "helpfulness", scorer_version: "v3", numeric_value: 0.95 }),
+      resultParams("run1", "tc_1"),
+    );
+    const scores = fakePrisma.score.rows.filter((s) => s.resultId === "res1");
+    expect(scores).toHaveLength(2);
+    expect(scores.find((s) => s.scorerVersion === "v2")!.numericValue).toBe(0.8);
+    expect(scores.find((s) => s.scorerVersion === "v3")!.numericValue).toBe(0.95);
+  });
+
   it("records a human score bound to the run + test case", async () => {
     const res = await addHumanScore(
       req({ verdict: "pass", quality: 4, reviewer: "e@x.com" }),
@@ -383,6 +430,39 @@ describe("B3/B4: additive scores and human scores", () => {
       resultParams("run1", "missing"),
     );
     expect(res.status).toBe(404);
+  });
+});
+
+describe("B2: /complete is replay-safe and terminal", () => {
+  it("keeps the first completedAt across a replay, and rejects reopening a finished run", async () => {
+    // Neither this file nor eval-reporting.exerciser.test.ts ever replayed
+    // /complete before — every run in both suites was completed exactly once,
+    // so the terminal guard at complete/route.ts:35-44 was untouched by any test.
+    fakePrisma.evaluationRun.rows.push({ id: "run1", projectId: PROJECT_ID, status: "running" });
+    const complete = (body: unknown) =>
+      completeRun(req(body), { params: Promise.resolve({ runId: "run1" }) });
+
+    const first = await complete({ status: "completed", main_score: 93.8 });
+    expect(first.status).toBe(200);
+    const afterFirst = fakePrisma.evaluationRun.rows.find((r) => r.id === "run1")!;
+    expect(afterFirst.completedAt).toBeInstanceOf(Date);
+    const firstCompletedAt = afterFirst.completedAt as Date;
+
+    // A retried/corrected completion is accepted — the SDK completing with final
+    // counts a second time is the normal retry shape — but must not re-stamp the
+    // finish time.
+    const replay = await complete({ status: "failed", main_score: 0 });
+    expect(replay.status).toBe(200);
+    const afterReplay = fakePrisma.evaluationRun.rows.find((r) => r.id === "run1")!;
+    expect(afterReplay.status).toBe("failed");
+    expect(afterReplay.mainScore).toBe(0);
+    expect(afterReplay.completedAt).toEqual(firstCompletedAt);
+
+    // A finished run can never be walked back to "running".
+    const reopen = await complete({ status: "running" });
+    expect(reopen.status).toBe(409);
+    expect((await readJson(reopen)).error as string).toContain("cannot be reopened");
+    expect(fakePrisma.evaluationRun.rows.find((r) => r.id === "run1")!.status).toBe("failed");
   });
 });
 

--- a/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
@@ -30,6 +30,7 @@ import { hashApiKey } from "@/lib/api-keys";
 import { GET as listDatasets, POST as upsertDataset } from "./datasets/route";
 import { PATCH as patchDataset } from "./datasets/[datasetId]/route";
 import { POST as publishVersion, GET as listVersions } from "./datasets/[datasetId]/versions/route";
+import { GET as readVersion } from "./dataset-versions/[versionId]/route";
 import { POST as completeRun } from "./evaluation-runs/[runId]/complete/route";
 import { POST as addScore } from "./evaluation-runs/[runId]/results/[testCaseId]/scores/route";
 import { POST as addHumanScore } from "./evaluation-runs/[runId]/results/[testCaseId]/human-score/route";
@@ -56,6 +57,7 @@ async function readJson(res: { json: () => Promise<unknown> }) {
   return res.json() as Promise<Record<string, unknown>>;
 }
 const dsParams = (datasetId: string) => ({ params: Promise.resolve({ datasetId }) });
+const versionParams = (versionId: string) => ({ params: Promise.resolve({ versionId }) });
 const resultParams = (runId: string, testCaseId: string) => ({
   params: Promise.resolve({ runId, testCaseId }),
 });
@@ -220,6 +222,78 @@ describe("A4: publish an immutable version from changes", () => {
     expect(stored("tc_str")!.input).toBe('"hello"');
     expect(stored("tc_jsonstr")!.input).toBe('"123"');
     expect(stored("tc_jsonstr")!.expected).toBe('"true"');
+  });
+});
+
+describe("A4→pull: native JSON round-trips through the real WRITE + READ routes", () => {
+  beforeEach(async () => {
+    await upsertDataset(req({ dataset_id: "ds1", name: "billing" }));
+  });
+
+  // The SDK pushes native JSON and pulls it back native (push_dataset / pull_dataset
+  // are pass-through; the backend owns the single encode/decode at the storage seam).
+  // This drives BOTH real public routes so the whole boundary — not just the stored
+  // encoding — is proven to preserve every JSON type, incl. JSON-looking strings.
+  it("preserves strings, JSON-looking strings, numbers, booleans, null, lists, objects, and structured expected", async () => {
+    const publish = await publishVersion(
+      req({
+        base_version_id: null,
+        changes: [
+          { op: "upsert", test_case_id: "tc_str", input: "hello world" },
+          // A genuine string that merely looks like JSON must stay a string, not
+          // become the number 123 / the boolean true / an object.
+          { op: "upsert", test_case_id: "tc_jsonstr_num", input: "123" },
+          { op: "upsert", test_case_id: "tc_jsonstr_bool", input: "true" },
+          { op: "upsert", test_case_id: "tc_jsonstr_obj", input: '{"not":"parsed"}' },
+          { op: "upsert", test_case_id: "tc_num", input: 42 },
+          { op: "upsert", test_case_id: "tc_float", input: 3.5 },
+          { op: "upsert", test_case_id: "tc_bool", input: false },
+          { op: "upsert", test_case_id: "tc_null", input: null },
+          { op: "upsert", test_case_id: "tc_list", input: [1, "two", { three: 3 }] },
+          {
+            op: "upsert",
+            test_case_id: "tc_obj",
+            input: { a: 1, nested: { b: [true, null] } },
+            // A structured (object) expected value must round-trip too.
+            expected: { verdict: "pass", score: 0.9 },
+            metadata: { captured_from: "prod" },
+            source_trace_id: "tr_src_1",
+            source_span_id: "sp_src_1",
+          },
+          { op: "upsert", test_case_id: "tc_expect_null", input: "x", expected: null },
+        ],
+      }),
+      dsParams("ds1"),
+    );
+    expect(publish.status).toBe(201);
+    const versionId = (await readJson(publish)).dataset_version_id as string;
+
+    // Pull the immutable snapshot back through the real public READ route.
+    const read = await readVersion(getReq("", API_KEY), versionParams(versionId));
+    expect(read.status).toBe(200);
+    const body = await readJson(read);
+    const items = body.items as Array<Record<string, unknown>>;
+    const item = (id: string) => items.find((i) => i.test_case_id === id)!;
+
+    // Native types survive the write→read round-trip exactly.
+    expect(item("tc_str").input).toBe("hello world");
+    expect(item("tc_jsonstr_num").input).toBe("123"); // string, NOT number 123
+    expect(item("tc_jsonstr_bool").input).toBe("true"); // string, NOT boolean true
+    expect(item("tc_jsonstr_obj").input).toBe('{"not":"parsed"}'); // string, NOT object
+    expect(item("tc_num").input).toBe(42);
+    expect(item("tc_float").input).toBe(3.5);
+    expect(item("tc_bool").input).toBe(false);
+    expect(item("tc_null").input).toBeNull();
+    expect(item("tc_list").input).toEqual([1, "two", { three: 3 }]);
+    expect(item("tc_obj").input).toEqual({ a: 1, nested: { b: [true, null] } });
+
+    // Structured expected + provenance + native metadata are all returned.
+    expect(item("tc_obj").expected).toEqual({ verdict: "pass", score: 0.9 });
+    expect(item("tc_obj").metadata).toEqual({ captured_from: "prod" });
+    expect(item("tc_obj").source_trace_id).toBe("tr_src_1");
+    expect(item("tc_obj").source_span_id).toBe("sp_src_1");
+    // An explicit-null expected reads back as null (not the string "null").
+    expect(item("tc_expect_null").expected).toBeNull();
   });
 });
 

--- a/frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts
@@ -237,8 +237,29 @@ describe("SDK reporting: full run lifecycle", () => {
     expect(fakePrisma.evaluationResult.rows.filter((r) => r.testCaseId === "case-1")).toHaveLength(
       1,
     );
-    const case1 = fakePrisma.evaluationResult.rows.find((r) => r.testCaseId === "case-1")!;
+    let case1 = fakePrisma.evaluationResult.rows.find((r) => r.testCaseId === "case-1")!;
     expect(fakePrisma.score.rows.filter((s) => s.resultId === case1.id)).toHaveLength(1);
+    // A caller omitting expected_output/change (both sent on the original report,
+    // 2a) must not wipe them: an unsent field keeps its stored value.
+    expect(case1.expectedOutput).toBe("billing");
+    expect(case1.change).toBe("improved");
+
+    // 3b. A follow-up that omits `scores` entirely (not even `[]`) must leave the
+    // previously-reported scores untouched — only a caller-sent `scores` array
+    // (including an explicit `[]`) may replace them.
+    await upsertResult(
+      req({
+        test_case_id: "case-1",
+        input: "double charge refund?",
+        status: "passed",
+      }),
+      params(runId),
+    );
+    case1 = fakePrisma.evaluationResult.rows.find((r) => r.testCaseId === "case-1")!;
+    expect(fakePrisma.score.rows.filter((s) => s.resultId === case1.id)).toHaveLength(1);
+    expect(case1.expectedOutput).toBe("billing");
+    expect(case1.change).toBe("improved");
+    expect(case1.traceId).toBe("trace-aaa");
 
     // 4. Out-of-order trace: a result reported without a trace, then linked later.
     await upsertResult(
@@ -281,5 +302,33 @@ describe("SDK reporting: full run lifecycle", () => {
     expect(run.scoredCount).toBe(22);
     expect(run.caseCount).toBe(24);
     expect(run.completedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("SDK reporting: concurrent registration", () => {
+  it("never assigns two runs the same run_number when two registrations race", async () => {
+    // Every fake-prisma method is async, so two registerRun calls driven with
+    // Promise.all genuinely interleave at the awaits between the run_number
+    // read and the insert — the same race a real database sees under READ
+    // COMMITTED. uq_run_evaluation_run_number must catch whichever one loses
+    // (the route's retry loop replays it), not let both insert run_number 1.
+    const register = () =>
+      registerRun(
+        req({
+          evaluation_name: "Concurrent eval",
+          dataset_id: "ds1",
+          candidate_version: "git:abc123",
+        }),
+      );
+    const [a, b] = await Promise.all([register(), register()]);
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+    const [aBody, bBody] = await Promise.all([readJson(a), readJson(b)]);
+
+    // One evaluation lineage, two distinct runs, no run_number collision.
+    expect(fakePrisma.evaluation.rows).toHaveLength(1);
+    expect(fakePrisma.evaluationRun.rows).toHaveLength(2);
+    expect(aBody.evaluation_run_id).not.toBe(bBody.evaluation_run_id);
+    expect(new Set([aBody.run_number, bBody.run_number])).toEqual(new Set([1, 2]));
   });
 });

--- a/tests/fixtures/otel_payloads.py
+++ b/tests/fixtures/otel_payloads.py
@@ -62,3 +62,107 @@ def make_otel_payload(
             }
         ]
     }
+
+
+# ── Evaluation-trace (SDK-shaped) builders ──────────────────────────────
+#
+# These mirror the REAL attribute keys the Python SDK stamps on an evaluation
+# run's spans (traceroot-py `feat/offline-eval-sdk`, engine.py `_set_root_attrs`
+# and the task/scorer child stampers) so backend contract tests exercise the
+# actual cross-surface payload shape rather than an independently invented one.
+# Source of truth for the key names: offline-eval/contract-notes/eval-trace-attributes.md.
+
+
+def eval_root_attributes(
+    *,
+    run_id: str | None = "run_platform_1",
+    local_run_id: str = "run_01JLOCALULID",
+    dataset_id: str | None = "ds_1",
+    dataset_version_id: str | None = "dsv_1",
+    dataset_name: str = "billing-routing",
+    name: str = "billing-routing",
+    case_id: str = "tc_1",
+    candidate_version: str | None = "cand_42",
+    source_trace_id: str | None = "tr_src_1",
+    source_span_id: str | None = "sp_src_1",
+    score_target_span_id: str | None = "sp_scored_1",
+    has_expected: bool = True,
+) -> list[dict]:
+    """The full identity attribute set on an evaluation-item root span.
+
+    Optional fields (run_id, dataset_id, dataset_version_id, candidate_version,
+    source ids, score_target_span_id) are omitted when passed None — the SDK's
+    ``set_span_attribute`` no-ops on None, so they appear only when known.
+    """
+    attrs = [
+        make_attr("traceroot.span.type", "evaluation"),
+        make_attr("traceroot.eval.contract_version", "1"),
+        make_attr("traceroot.environment", "evaluation"),
+        make_attr("traceroot.eval.environment", "evaluation"),
+        make_attr("traceroot.eval.name", name),
+        make_attr("traceroot.eval.run_name", name),
+        make_attr("traceroot.eval.dataset_name", dataset_name),
+        make_attr("traceroot.eval.case_id", case_id),
+        make_attr("traceroot.eval.has_expected", has_expected),
+    ]
+    optional = {
+        "traceroot.eval.dataset_id": dataset_id,
+        "traceroot.eval.dataset_version_id": dataset_version_id,
+        "traceroot.eval.candidate_version": candidate_version,
+        "traceroot.eval.run_id": run_id,
+        "traceroot.eval.local_run_id": local_run_id,
+        "traceroot.eval.source_trace_id": source_trace_id,
+        "traceroot.eval.source_span_id": source_span_id,
+        "traceroot.eval.score_target_span_id": score_target_span_id,
+    }
+    for key, value in optional.items():
+        if value is not None:
+            attrs.append(make_attr(key, value))
+    return attrs
+
+
+def make_eval_trace(
+    trace_id_hex: str,
+    root_span_id_hex: str = "bb" * 8,
+    task_span_id_hex: str = "cc" * 8,
+    scorer_span_id_hex: str = "dd" * 8,
+    *,
+    name: str = "billing-routing",
+    case_id: str = "tc_1",
+    scorer_name: str = "helpfulness",
+    **root_attr_overrides,
+) -> dict:
+    """A full SDK-shaped evaluation trace: an evaluation-item root with a nested
+    ``task`` (candidate) span and a sibling ``scorer`` span — the structure the SDK
+    emits for one reported test case."""
+    root = make_span(
+        trace_id_hex,
+        root_span_id_hex,
+        name="evaluation-item",
+        attributes=eval_root_attributes(name=name, case_id=case_id, **root_attr_overrides),
+    )
+    task = make_span(
+        trace_id_hex,
+        task_span_id_hex,
+        name="task",
+        parent_span_id_hex=root_span_id_hex,
+        attributes=[
+            make_attr("traceroot.span.type", "task"),
+            make_attr("traceroot.eval.task_name", "task"),
+            make_attr("traceroot.eval.case_id", case_id),
+            make_attr("traceroot.eval.run_name", name),
+        ],
+    )
+    scorer = make_span(
+        trace_id_hex,
+        scorer_span_id_hex,
+        name=scorer_name,
+        parent_span_id_hex=root_span_id_hex,
+        attributes=[
+            make_attr("traceroot.span.type", "scorer"),
+            make_attr("traceroot.eval.scorer_name", scorer_name),
+            make_attr("traceroot.eval.score_value", 0.9),
+            make_attr("traceroot.eval.run_name", name),
+        ],
+    )
+    return make_otel_payload([root, task, scorer])

--- a/tests/worker/test_eval_journey.py
+++ b/tests/worker/test_eval_journey.py
@@ -6,7 +6,7 @@ ONE evaluation trace — built with the same attribute shape the Python SDK emit
 crosses, so the surfaces are proven to agree on the *same* classification value:
 
 1. The SDK reports an evaluation run          → make_eval_trace(...) payload
-2. The backend records it as an eval trace     → transform → environment=evaluation
+2. The backend records it as an eval trace     → transform → is_evaluation=1
 3. It is excluded from normal trace browsing   → list_traces() default predicate
 4. It appears when eval traces are requested   → list_traces(include_evaluations=True)
 5. Detectors skip it by default                → _detector_runs_on_trace(...) is False
@@ -45,7 +45,7 @@ class TestEvaluationJourney:
         SCORER span kinds are all preserved (not coerced to SPAN)."""
         traces, spans = _ingest()
         assert len(traces) == 1
-        assert traces[0]["environment"] == "evaluation"
+        assert traces[0]["is_evaluation"] is True
 
         kinds = {s["name"]: s["span_kind"] for s in spans}
         assert kinds["evaluation-item"] == "EVALUATION"
@@ -53,10 +53,12 @@ class TestEvaluationJourney:
         assert kinds["helpfulness"] == "SCORER"
 
     def test_detector_skips_the_evaluation_trace_by_default(self):
-        """Step 5: the SAME environment the transformer produced is what the detector
-        gate skips — and an explicit opt-in re-enables it."""
+        """Step 5: the SAME flag the transformer set is what the detector gate skips —
+        and an explicit opt-in re-enables it. Keyed on `is_evaluation`, never on
+        `environment`: a customer may legitimately name their environment "evaluation",
+        and that must not silence their production detectors."""
         traces, _ = _ingest()
-        summary = {"environment": traces[0]["environment"]}
+        summary = {"is_evaluation": traces[0]["is_evaluation"]}
 
         assert _detector_runs_on_trace(summary, {"id": "d1"}) is False
         assert _detector_runs_on_trace(summary, {"id": "d1", "run_on_evaluation": True}) is True
@@ -93,14 +95,15 @@ def _make_service(query_side_effect):
 
 
 class TestEvaluationBrowsingSeparation:
-    """Step 3+4: default browsing excludes environment=evaluation; requesting eval
-    traces drops the predicate. Binds the reader's filter to the SAME 'evaluation'
-    value the transformer stamps (asserted in TestEvaluationJourney)."""
+    """Step 3+4: default browsing excludes is_evaluation traces; requesting eval traces
+    drops the predicate. Binds the reader's filter to the SAME flag ingestion sets
+    (asserted in TestEvaluationJourney) — never to `environment`, which is
+    user-controlled free text a customer may legitimately set to "evaluation"."""
 
     def _run(self, **kwargs):
-        # Confirm the value the reader excludes is exactly what ingestion produced.
+        # Confirm the flag the reader excludes on is exactly what ingestion produced.
         traces, _ = _ingest()
-        assert traces[0]["environment"] == "evaluation"
+        assert traces[0]["is_evaluation"] is True
 
         queries: list[str] = []
         params_seen: list[dict] = []
@@ -117,10 +120,12 @@ class TestEvaluationBrowsingSeparation:
         return queries, params_seen
 
     def test_excluded_from_normal_browsing_by_default(self):
-        queries, params = self._run()
-        assert any(p.get("excluded_env") == "evaluation" for p in params)
-        assert all("{excluded_env:String}" in q for q in queries if "environment" in q)
+        queries, _params = self._run()
+        assert any("is_evaluation = 1" in q for q in queries)
+        # Set-membership, not a per-row column read: a later batch that rewrites the
+        # trace row with is_evaluation = 0 must not un-hide the trace.
+        assert all("is_evaluation = 1" in q for q in queries if "NOT IN" in q)
 
     def test_appears_when_evaluation_traces_are_requested(self):
         queries, _ = self._run(include_evaluations=True)
-        assert all("excluded_env" not in q for q in queries)
+        assert all("is_evaluation = 1" not in q for q in queries)

--- a/tests/worker/test_eval_journey.py
+++ b/tests/worker/test_eval_journey.py
@@ -1,0 +1,126 @@
+"""Cross-surface evaluation journey — one real SDK-shaped payload, end to end.
+
+Unlike the per-surface unit tests (transform / trace-reader / detector), this drives
+ONE evaluation trace — built with the same attribute shape the Python SDK emits
+(``tests.fixtures.otel_payloads.make_eval_trace``) — through every backend surface it
+crosses, so the surfaces are proven to agree on the *same* classification value:
+
+1. The SDK reports an evaluation run          → make_eval_trace(...) payload
+2. The backend records it as an eval trace     → transform → environment=evaluation
+3. It is excluded from normal trace browsing   → list_traces() default predicate
+4. It appears when eval traces are requested   → list_traces(include_evaluations=True)
+5. Detectors skip it by default                → _detector_runs_on_trace(...) is False
+6. The eval result resolves to the real trace  → identity available on the trace record
+7. Dataset + candidate identity are readable   → identity survives into span metadata
+8. Native dataset JSON values retain types     → covered by the dataset round-trip
+   exerciser (frontend eval-dataset-sync.exerciser.test.ts) — the dataset payload is a
+   separate control-plane surface, proven there against the same native-JSON contract.
+
+Placed under tests/ (CI-collected) on purpose: the detector predicate's own tests live
+in backend/worker/tests/, which is outside `testpaths`, so this is the CI-covered proof
+that the transformer's classification is exactly what the detector gate skips.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from tests.fixtures.otel_payloads import make_eval_trace
+from worker.detector_tasks import _detector_runs_on_trace
+from worker.otel_transform import transform_otel_to_clickhouse
+
+TRACE_HEX = "ab" * 16
+
+
+def _ingest():
+    """Step 1→2: an SDK-shaped evaluation run, transformed as the worker would."""
+    payload = make_eval_trace(TRACE_HEX)
+    traces, spans = transform_otel_to_clickhouse(payload, "proj-eval")
+    return traces, spans
+
+
+class TestEvaluationJourney:
+    def test_backend_records_it_as_an_evaluation_trace(self):
+        """Step 2: the root classifies the trace as evaluation and the EVALUATION/TASK/
+        SCORER span kinds are all preserved (not coerced to SPAN)."""
+        traces, spans = _ingest()
+        assert len(traces) == 1
+        assert traces[0]["environment"] == "evaluation"
+
+        kinds = {s["name"]: s["span_kind"] for s in spans}
+        assert kinds["evaluation-item"] == "EVALUATION"
+        assert kinds["task"] == "TASK"
+        assert kinds["helpfulness"] == "SCORER"
+
+    def test_detector_skips_the_evaluation_trace_by_default(self):
+        """Step 5: the SAME environment the transformer produced is what the detector
+        gate skips — and an explicit opt-in re-enables it."""
+        traces, _ = _ingest()
+        summary = {"environment": traces[0]["environment"]}
+
+        assert _detector_runs_on_trace(summary, {"id": "d1"}) is False
+        assert _detector_runs_on_trace(summary, {"id": "d1", "run_on_evaluation": True}) is True
+
+    def test_dataset_and_candidate_identity_are_readable(self):
+        """Steps 6+7: the identity a result needs to resolve to and render its real
+        trace (run + dataset/version + candidate + case + provenance) survives ingestion
+        onto the root span, retrievable via the on-demand per-span metadata."""
+        _, spans = _ingest()
+        root = next(s for s in spans if s["name"] == "evaluation-item")
+        meta = json.loads(root["metadata"])
+
+        assert meta["traceroot.eval.run_id"] == "run_platform_1"
+        assert meta["traceroot.eval.local_run_id"] == "run_01JLOCALULID"
+        assert meta["traceroot.eval.dataset_id"] == "ds_1"
+        assert meta["traceroot.eval.dataset_version_id"] == "dsv_1"
+        assert meta["traceroot.eval.candidate_version"] == "cand_42"
+        assert meta["traceroot.eval.case_id"] == "tc_1"
+        assert meta["traceroot.eval.source_trace_id"] == "tr_src_1"
+        assert meta["traceroot.eval.source_span_id"] == "sp_src_1"
+
+
+# --- Steps 3+4: the reader's default/opt-in filter keys on the same value ---
+
+
+def _make_service(query_side_effect):
+    from rest.services.trace_reader import TraceReaderService
+
+    client = MagicMock()
+    client.query.side_effect = query_side_effect
+    with patch("rest.services.trace_reader.get_clickhouse_client", return_value=client):
+        service = TraceReaderService()
+    return service, client
+
+
+class TestEvaluationBrowsingSeparation:
+    """Step 3+4: default browsing excludes environment=evaluation; requesting eval
+    traces drops the predicate. Binds the reader's filter to the SAME 'evaluation'
+    value the transformer stamps (asserted in TestEvaluationJourney)."""
+
+    def _run(self, **kwargs):
+        # Confirm the value the reader excludes is exactly what ingestion produced.
+        traces, _ = _ingest()
+        assert traces[0]["environment"] == "evaluation"
+
+        queries: list[str] = []
+        params_seen: list[dict] = []
+
+        def side_effect(query, parameters=None):
+            queries.append(query)
+            params_seen.append(parameters or {})
+            if "count()" in query:
+                return SimpleNamespace(result_rows=[(0,)])
+            return SimpleNamespace(result_rows=[])
+
+        service, _ = _make_service(side_effect)
+        service.list_traces("proj-eval", **kwargs)
+        return queries, params_seen
+
+    def test_excluded_from_normal_browsing_by_default(self):
+        queries, params = self._run()
+        assert any(p.get("excluded_env") == "evaluation" for p in params)
+        assert all("{excluded_env:String}" in q for q in queries if "environment" in q)
+
+    def test_appears_when_evaluation_traces_are_requested(self):
+        queries, _ = self._run(include_evaluations=True)
+        assert all("excluded_env" not in q for q in queries)

--- a/tests/worker/test_ingest_tasks.py
+++ b/tests/worker/test_ingest_tasks.py
@@ -196,3 +196,111 @@ class TestTaskCostByTrace:
             "t1": pytest.approx(0.01),
             "t2": pytest.approx(0.02),
         }
+
+
+class FakeCursor:
+    """Records every `execute()` call and answers `fetchall()` from a canned
+    result, so a test can assert on exactly which statements were issued."""
+
+    def __init__(self, fetchall_result):
+        self._fetchall_result = fetchall_result
+        self.executed: list[tuple[str, tuple]] = []
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetchall(self):
+        return self._fetchall_result
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.committed = False
+        self.closed = False
+
+    def cursor(self):
+        return self._cursor
+
+    def commit(self):
+        self.committed = True
+
+    def close(self):
+        self.closed = True
+
+
+class TestUpdateEvalResultCosts:
+    """`_update_eval_result_costs` denormalizes derived cost onto `evaluation_results`
+    for a costed trace, and per the module's own docstring — "never writes 0 (a
+    cost-less trace leaves `cost` NULL)" — must issue no UPDATE at all for a
+    cost-less trace. That second half had zero coverage: nothing under `tests/`
+    drove this function at all."""
+
+    def _patch_connect(self, monkeypatch, cursor):
+        conn = FakeConnection(cursor)
+        monkeypatch.setattr("psycopg2.connect", lambda *a, **kw: conn)
+        return conn
+
+    def test_writes_every_eval_trace_and_nullifs_the_costless_one(self, monkeypatch):
+        """The write is UNCONDITIONAL — a zero total is still written, as NULLIF.
+
+        Skipping the write when the recomputed total is 0 would freeze a transient
+        over-report permanently: under ``BatchSpanProcessor`` a scorer's LLM child can
+        land in an earlier batch than the SCORER span that excludes it, so the total is
+        briefly too high and only a later batch corrects it downward. See the rationale
+        on ``_update_eval_result_costs``. ``NULLIF(%s, 0)`` is what keeps a genuinely
+        cost-less trace's ``cost`` NULL rather than a misleading 0.
+        """
+        from worker.ingest_tasks import _update_eval_result_costs
+
+        # Both traces are eval results (the scoping query returns both); only
+        # "t-costed" has any non-scorer LLM cost, "t-zero" has none.
+        cursor = FakeCursor(fetchall_result=[("t-costed",), ("t-zero",)])
+        conn = self._patch_connect(monkeypatch, cursor)
+
+        mock_ch = MagicMock()
+        mock_ch.query.return_value = MagicMock(
+            result_rows=[
+                ("t-costed", "task", "root", "TASK", None),
+                ("t-costed", "llm", "task", "LLM", 0.02),
+                ("t-zero", "task", "root", "TASK", None),
+            ]
+        )
+
+        _update_eval_result_costs("proj-1", {"t-costed", "t-zero"}, mock_ch)
+
+        updates = [
+            (sql, params) for sql, params in cursor.executed if sql.strip().startswith("UPDATE")
+        ]
+        assert len(updates) == 2
+        by_trace = {params[2]: (sql, params) for sql, params in updates}
+        assert set(by_trace) == {"t-costed", "t-zero"}
+        for sql, _ in updates:
+            assert "evaluation_results" in sql
+            # NULLIF is what makes the unconditional write safe for a cost-less trace.
+            assert "NULLIF" in sql
+        assert by_trace["t-costed"][1] == (pytest.approx(0.02), "proj-1", "t-costed")
+        assert by_trace["t-zero"][1] == (pytest.approx(0.0), "proj-1", "t-zero")
+        assert conn.committed is True
+        assert conn.closed is True
+
+    def test_no_eval_trace_ids_skips_clickhouse_and_updates(self, monkeypatch):
+        """The scoping query (trace_id must belong to `evaluation_results`) returning
+        nothing means the batch had no eval traces at all — bail before ever calling
+        ClickHouse or issuing an UPDATE."""
+        from worker.ingest_tasks import _update_eval_result_costs
+
+        cursor = FakeCursor(fetchall_result=[])
+        self._patch_connect(monkeypatch, cursor)
+        mock_ch = MagicMock()
+
+        _update_eval_result_costs("proj-1", {"t-not-an-eval"}, mock_ch)
+
+        mock_ch.query.assert_not_called()
+        assert not any(sql.strip().startswith("UPDATE") for sql, _ in cursor.executed)


### PR DESCRIPTION
## Summary

Fixes: #1657

Covers the backend surface with unit tests for the pure engines, cross-layer contract parity, and write-then-read round trips through the real routes — including the full reporting lifecycle and trace ingestion. This is the safety net that lets every other backend change land without silently breaking a neighbor, and it runs in CI alongside the rest of the backend tests.

## What's included

### Engine unit tests (`frontend/ui/src/lib/eval`)
- `tests/worker/test_ingest_tasks.py` (`TestTaskCostByTrace`) — cost attribution: scorer-subtree exclusion at arbitrary depth, cost-less trace attributes to `0` in the pure helper, and multi-trace isolation within one batch.

### Contract parity

### Read-back + lifecycle
- `frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts` — register → upsert → complete through the real public routes with a realistic payload, out-of-order `trace_id` link, and idempotent re-upsert on `(run, test_case)`.
- `frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts` + `frontend/ui/src/app/api/projects/[projectId]/datasets/datasets-versioning.test.ts` — dataset push/pull with version immutability.
- `tests/worker/test_eval_journey.py` — a cross-surface SDK→backend journey where evaluation identity survives ingestion.

### Ingestion
- `tests/worker/test_ingest_tasks.py` — batch classification of eval traces and detector-enqueue scoping.
- `tests/fixtures/otel_payloads.py` — shared OTEL payload fixtures for the ingestion suite.

## Test plan
- [ ] Each pure engine is unit-tested against its edge cases.
- [ ] Contract parity feeds one payload set to both layers and asserts identical accept/reject.
- [ ] Cost-attribution tests cover scorer-subtree exclusion at arbitrary depth; a cost-less trace attributes to `0` in the pure helper while the writer leaves the column NULL.
- [ ] The parity and schema-drift checks fail on divergence.
- [ ] Round trips cover an out-of-order `trace_id` link and idempotent re-upsert on `(run, test_case)`.
- [ ] The write-then-read round trips run through the real endpoints, not stubbed handlers.
- [ ] The suite runs in CI alongside the rest of the backend tests.
