### PR TITLE
Surface detector write errors in the UI

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
@@ -6,14 +6,10 @@ import { getTemplate } from "@/features/detectors/templates";
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
-<<<<<<< HEAD
   mutate: vi.fn((_input: unknown, options?: { onSuccess?: () => void }) => {
     options?.onSuccess?.();
   }),
-=======
-  mutateAsync: vi.fn().mockResolvedValue({ id: "det-1" }),
   selectorProps: null as Record<string, unknown> | null,
->>>>>>> c630f5dba178e4184b0c3db5111ee62f69932171
 }));
 
 vi.mock("next/navigation", () => ({

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
@@ -5,7 +5,9 @@ import { getTemplate } from "@/features/detectors/templates";
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
-  mutateAsync: vi.fn().mockResolvedValue({ id: "det-1" }),
+  mutate: vi.fn((_input: unknown, options?: { onSuccess?: () => void }) => {
+    options?.onSuccess?.();
+  }),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -13,7 +15,12 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mocks.push }),
 }));
 vi.mock("@/features/detectors/hooks/use-detectors", () => ({
-  useCreateDetector: () => ({ mutateAsync: mocks.mutateAsync, isPending: false }),
+  useCreateDetector: () => ({
+    mutate: mocks.mutate,
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
 }));
 vi.mock("@/features/projects/hooks", () => ({
   useProject: () => ({ data: undefined }),
@@ -38,7 +45,7 @@ import NewDetectorPage from "./page";
 
 afterEach(() => {
   cleanup();
-  mocks.mutateAsync.mockClear();
+  mocks.mutate.mockClear();
   mocks.push.mockClear();
 });
 
@@ -47,21 +54,24 @@ describe("NewDetectorPage", () => {
     render(<NewDetectorPage />);
     fireEvent.click(screen.getByRole("button", { name: "Create Detector" }));
 
-    await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mocks.mutate).toHaveBeenCalledTimes(1));
     const failure = getTemplate("failure")!;
-    expect(mocks.mutateAsync).toHaveBeenCalledWith({
-      name: "Failure Detector",
-      template: "failure",
-      prompt: failure.prompt,
-      outputSchema: failure.outputSchema,
-      triggerConditions: failure.defaultConditions,
-      sampleRate: 25,
-      enabled: true,
-      enableRca: true,
-      detectionModel: undefined,
-      detectionProvider: undefined,
-      detectionSource: "system",
-    });
+    expect(mocks.mutate).toHaveBeenCalledWith(
+      {
+        name: "Failure Detector",
+        template: "failure",
+        prompt: failure.prompt,
+        outputSchema: failure.outputSchema,
+        triggerConditions: failure.defaultConditions,
+        sampleRate: 25,
+        enabled: true,
+        enableRca: true,
+        detectionModel: undefined,
+        detectionProvider: undefined,
+        detectionSource: "system",
+      },
+      expect.any(Object),
+    );
     expect(mocks.push).toHaveBeenCalledWith("/projects/proj-1/detectors");
   });
 
@@ -75,8 +85,8 @@ describe("NewDetectorPage", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Create Detector" }));
 
-    await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(1));
-    expect(mocks.mutateAsync.mock.calls[0][0]).toMatchObject({
+    await waitFor(() => expect(mocks.mutate).toHaveBeenCalledTimes(1));
+    expect(mocks.mutate.mock.calls[0][0]).toMatchObject({
       name: "My detector",
       prompt: "my prompt",
       template: "failure",

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -61,7 +61,7 @@ export default function NewDetectorPage() {
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const template = DETECTOR_TEMPLATES.find((t) => t.id === selectedTemplate)!;
     const input: CreateDetectorInput = {
@@ -76,8 +76,11 @@ export default function NewDetectorPage() {
       detectionProvider: modelSelection.provider || undefined,
       detectionSource: modelSelection.source === "byok" ? "byok" : "system",
     };
-    await createMutation.mutateAsync(input);
-    router.push(`/projects/${projectId}/detectors`);
+    createMutation.mutate(input, {
+      onSuccess: () => {
+        router.push(`/projects/${projectId}/detectors`);
+      },
+    });
   };
 
   const selectedTemplateDef = DETECTOR_TEMPLATES.find((t) => t.id === selectedTemplate);
@@ -223,6 +226,10 @@ export default function NewDetectorPage() {
                 </span>
               </div>
             </div>
+
+            {createMutation.isError && (
+              <p className="text-[12px] text-destructive">{createMutation.error.message}</p>
+            )}
 
             {/* Footer */}
             <div className="flex justify-end gap-2 pt-1">

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -6,11 +6,17 @@ import type { Detector } from "../hooks/use-detectors";
 const mocks = vi.hoisted(() => ({
   detector: undefined as Detector | undefined,
   mutate: vi.fn(),
+  mutationError: null as Error | null,
 }));
 
 vi.mock("../hooks/use-detectors", () => ({
   useDetector: () => ({ data: mocks.detector }),
-  useUpdateDetector: () => ({ mutate: mocks.mutate, isPending: false }),
+  useUpdateDetector: () => ({
+    mutate: mocks.mutate,
+    isPending: false,
+    isError: mocks.mutationError !== null,
+    error: mocks.mutationError,
+  }),
 }));
 vi.mock("@/features/projects/hooks", () => ({
   useProject: () => ({ data: undefined }),
@@ -81,6 +87,7 @@ afterEach(() => {
   cleanup();
   mocks.detector = undefined;
   mocks.mutate.mockReset();
+  mocks.mutationError = null;
 });
 
 describe("DetectorPanel", () => {
@@ -131,5 +138,15 @@ describe("DetectorPanel", () => {
     renderPanel("det-2");
     expect(promptBox().value).toBe("");
     expect((saveButton() as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("renders an update error and keeps the panel open", () => {
+    mocks.detector = baseDetector;
+    mocks.mutationError = new Error("Detector not found");
+
+    const { onClose } = renderPanel();
+
+    expect(screen.getByText("Detector not found")).toBeDefined();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -302,6 +302,10 @@ export function DetectorPanel({
           </div>
         </div>
 
+        {updateMutation.isError && (
+          <p className="text-[12px] text-destructive">{updateMutation.error.message}</p>
+        )}
+
         {/* Save / Cancel */}
         <div className="flex justify-end gap-2 pt-1">
           <Button variant="outline" size="sm" onClick={onClose} className="h-7 text-[12px]">

--- a/frontend/ui/src/features/detectors/hooks/use-detectors.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-detectors.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { broadcastQueryInvalidation } from "@/lib/cross-tab-sync";
+import { fetchNextApi } from "@/lib/api/client";
 
 export interface Detector {
   id: string;
@@ -59,27 +60,25 @@ async function fetchDetectorList(
   if (query.search_query) params.set("search_query", query.search_query);
 
   const qs = params.toString();
-  const url = `/api/projects/${projectId}/detectors${qs ? `?${qs}` : ""}`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Failed to fetch detectors: ${res.status}`);
-  return res.json() as Promise<DetectorListResponse>;
+  const endpoint = `/projects/${projectId}/detectors${qs ? `?${qs}` : ""}`;
+
+  return fetchNextApi<DetectorListResponse>(endpoint);
 }
 
 async function fetchDetector(projectId: string, detectorId: string): Promise<Detector> {
-  const res = await fetch(`/api/projects/${projectId}/detectors/${detectorId}`);
-  if (!res.ok) throw new Error(`Failed to fetch detector: ${res.status}`);
-  const data = (await res.json()) as { detector: Detector };
+  const data = await fetchNextApi<{ detector: Detector }>(
+    `/projects/${projectId}/detectors/${detectorId}`,
+  );
+
   return data.detector;
 }
 
 async function createDetector(projectId: string, input: CreateDetectorInput): Promise<Detector> {
-  const res = await fetch(`/api/projects/${projectId}/detectors`, {
+  const data = await fetchNextApi<{ detector: Detector }>(`/projects/${projectId}/detectors`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
   });
-  if (!res.ok) throw new Error(`Failed to create detector: ${res.status}`);
-  const data = (await res.json()) as { detector: Detector };
+
   return data.detector;
 }
 
@@ -100,21 +99,21 @@ async function updateDetector(
   detectorId: string,
   input: UpdateDetectorInput,
 ): Promise<Detector> {
-  const res = await fetch(`/api/projects/${projectId}/detectors/${detectorId}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  if (!res.ok) throw new Error(`Failed to update detector: ${res.status}`);
-  const data = (await res.json()) as { detector: Detector };
+  const data = await fetchNextApi<{ detector: Detector }>(
+    `/projects/${projectId}/detectors/${detectorId}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(input),
+    },
+  );
+
   return data.detector;
 }
 
 async function deleteDetector(projectId: string, detectorId: string): Promise<void> {
-  const res = await fetch(`/api/projects/${projectId}/detectors/${detectorId}`, {
+  await fetchNextApi<void>(`/projects/${projectId}/detectors/${detectorId}`, {
     method: "DELETE",
   });
-  if (!res.ok) throw new Error(`Failed to delete detector: ${res.status}`);
 }
 
 /** List detectors for the list page (paginated, optional search). */
@@ -155,9 +154,10 @@ async function fetchDetectorCounts(
 ): Promise<Record<string, DetectorCountsItem>> {
   const params = new URLSearchParams({ start_after: startAfter });
   if (endBefore) params.set("end_before", endBefore);
-  const res = await fetch(`/api/projects/${projectId}/detector-counts?${params.toString()}`);
-  if (!res.ok) throw new Error(`Failed to fetch detector counts: ${res.status}`);
-  const body = (await res.json()) as { data: Record<string, DetectorCountsItem> };
+  const body = await fetchNextApi<{ data: Record<string, DetectorCountsItem> }>(
+    `/projects/${projectId}/detector-counts?${params.toString()}`,
+  );
+
   return body.data;
 }
 

--- a/frontend/ui/src/lib/api/client.error.test.ts
+++ b/frontend/ui/src/lib/api/client.error.test.ts
@@ -2,11 +2,55 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/auth-client", () => ({ authClient: { getSession: vi.fn() } }));
 
-import { fetchTraceApi } from "./client";
+import { fetchNextApi, fetchTraceApi } from "./client";
 import { ApiError } from "./errors";
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+describe("fetchNextApi error classification", () => {
+  it("preserves Next.js { error } responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ error: "Detector not found" }),
+      }),
+    );
+
+    const err = await fetchNextApi("/projects/p1/detectors/d1").catch((e) => e);
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(404);
+    expect((err as ApiError).message).toBe("Detector not found");
+    expect((err as ApiError).detail).toBe("Detector not found");
+  });
+
+  it("preserves proxied Python { detail } responses", async () => {
+    const detail = {
+      message: "Data outside retention window",
+      retention_days: 15,
+      plan: "free",
+      cutoff: "x",
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ detail }),
+      }),
+    );
+
+    const err = await fetchNextApi("/projects/p1/detector-counts").catch((e) => e);
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(403);
+    expect((err as ApiError).detail).toEqual(detail);
+  });
 });
 
 describe("fetchTraceApi error classification", () => {

--- a/frontend/ui/src/lib/api/client.ts
+++ b/frontend/ui/src/lib/api/client.ts
@@ -26,8 +26,19 @@ export async function fetchNextApi<T>(endpoint: string, options: RequestInit = {
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: "Unknown error" }));
-    throw new ApiError(response.status, error.error || `API error: ${response.status}`);
+    const body = await response.json().catch(() => null);
+
+    const error =
+      body && typeof body === "object" && "error" in body
+        ? (body as { error?: unknown }).error
+        : undefined;
+
+    const detail =
+      body && typeof body === "object" && "detail" in body
+        ? (body as { detail?: unknown }).detail
+        : undefined;
+
+    throw new ApiError(response.status, error ?? detail ?? `API error: ${response.status}`);
   }
 
   if (response.status === 204) {


### PR DESCRIPTION
Fixes #1634

## Summary
- Route detector API calls through `fetchNextApi` to preserve server errors.
- Render create and update failures in the detector UI.
- Keep forms open after failed writes and update related tests.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)
<img width="1504" height="801" alt="trace2" src="https://github.com/user-attachments/assets/740b6101-920b-474c-9e97-bcbf1c381447" />


## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface server write errors for detectors in the UI so users see clear create/update failure messages. Switched detector API calls to `fetchNextApi`, which now preserves both `error` and `detail` responses; forms stay open until success.

- **Bug Fixes**
  - Show create/update error messages in the new detector page and detector panel.
  - Keep forms open on failure; navigate only on mutation success.
  - Use `fetchNextApi` across detector hooks and improve error handling to pass through Next.js `error` and backend `detail`; update tests to cover this.

<sup>Written for commit d0074413fe0b48114e5c3a789d122c96606334a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



