### PR TITLE
feat: store unrecognized usage keys as display-only extra entries in `usage_details`

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -34,6 +34,7 @@ OTEL JSON structure (camelCase - standard OTLP format):
 import base64
 import json
 import logging
+import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -41,6 +42,62 @@ from shared.enums import SpanKind, SpanStatus
 from shared.span_attributes import SPAN_IDS_PATH, SPAN_PATH, SPAN_TREE_ATTRIBUTES
 
 logger = logging.getLogger(__name__)
+
+_CAMEL_RE = re.compile(r"(?<=[a-z0-9])([A-Z])")
+
+
+def _camel_to_snake(name: str) -> str:
+    return _CAMEL_RE.sub(r"_\1", name).lower()
+
+
+# Keys that are already extracted into dedicated usage_details entries and
+# feed the cost calculation. These are EXCLUDED from the extra-usage scan.
+_PRICED_USAGE_ATTRS: frozenset[str] = frozenset(
+    {
+        # input_tokens / output_tokens (top-level columns, not usage_details)
+        "llm.token_count.prompt",
+        "gen_ai.usage.input_tokens",
+        "gen_ai.usage.prompt_tokens",
+        "ai.usage.inputTokens",
+        "ai.usage.promptTokens",
+        "llm.token_count.completion",
+        "gen_ai.usage.output_tokens",
+        "gen_ai.usage.completion_tokens",
+        "ai.usage.outputTokens",
+        "ai.usage.completionTokens",
+        # cache_read_tokens
+        "llm.token_count.prompt_details.cache_read",
+        "gen_ai.usage.cache_read.input_tokens",
+        "gen_ai.usage.cache_read_input_tokens",
+        "gen_ai.usage.input_cached_tokens",
+        "gen_ai.usage.details.cache_read_tokens",
+        "gen_ai.usage.cache_read_tokens",
+        "gen_ai.usage.details.cache_read_input_tokens",
+        "ai.usage.cachedInputTokens",
+        "ai.usage.inputTokenDetails.cacheReadTokens",
+        # cache_write_tokens
+        "llm.token_count.prompt_details.cache_write",
+        "gen_ai.usage.cache_creation.input_tokens",
+        "gen_ai.usage.cache_creation_input_tokens",
+        "gen_ai.usage.details.cache_write_tokens",
+        "gen_ai.usage.details.cache_creation_input_tokens",
+        "ai.usage.inputTokenDetails.cacheWriteTokens",
+        # cache_write_1h_tokens
+        "llm.token_count.prompt_details.cache_write_1h",
+        "gen_ai.usage.cache_creation.ephemeral_1h_input_tokens",
+        "gen_ai.usage.cache_creation_ephemeral_1h_input_tokens",
+        # reasoning_tokens
+        "llm.token_count.completion_details.reasoning",
+        "gen_ai.usage.reasoning_tokens",
+        "gen_ai.usage.output_details.reasoning_tokens",
+        "gen_ai.usage.details.reasoning_tokens",
+        "ai.usage.outputTokenDetails.reasoningTokens",
+        "ai.usage.reasoningTokens",
+        # total_tokens (top-level)
+        "gen_ai.usage.total_tokens",
+        "llm.token_count.total",
+    }
+)
 
 # Scopes whose LLM spans intentionally leave per-turn token counts unset (usage is
 # aggregated onto a few result spans). Skip text-based estimation for them, else the
@@ -321,6 +378,31 @@ _MANUAL_USAGE_KEYS = (
 )
 
 
+def _parse_manual_value(key: str, value: Any) -> int | None:
+    """Validate one manual-usage field, returning its non-negative int or None.
+
+    A dropped field is silent data loss from the user's point of view: they
+    reported a count and it is priced as if absent. Warn as int_or_zero does
+    for the same input class, so the discard is diagnosable from the logs.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        logger.warning("Manual usage field %s is a bool (%r); ignoring it", key, value)
+        return None
+    try:
+        parsed = max(int(value), 0)
+    except (TypeError, ValueError, OverflowError):
+        logger.warning("Manual usage field %s is not a usable number (%r); ignoring it", key, value)
+        return None
+    if parsed > _MAX_PLAUSIBLE_TOKENS:
+        logger.warning(
+            "Manual usage field %s exceeds the sanity bound (%r); ignoring it", key, value
+        )
+        return None
+    return parsed
+
+
 def parse_manual_usage(raw: Any) -> dict[str, int]:
     """Parse the manual usage dict reported via the SDKs' update-span API.
 
@@ -333,13 +415,21 @@ def parse_manual_usage(raw: Any) -> dict[str, int]:
     its valid fields (and an entirely unusable one to the text-estimation
     fallback), never to an error.
 
+    Fields outside the recognized set (e.g. ``audio_tokens``, ``image_tokens``,
+    a new cache variant) are NOT discarded: they are returned as display-only
+    entries keyed ``extra:<name>`` so the ingest path can surface them in
+    ``usage_details`` without pricing them. The ``extra:`` prefix keeps them
+    visibly separate from the priced buckets, preserving the property that the
+    priced keys reconcile with the stored ``input_tokens``/``output_tokens``.
+
     Args:
         raw (Any): The raw attribute value (a JSON string as the SDK writes it,
             or an already-decoded dict).
 
     Returns:
         dict[str, int]: The recognized usage fields with non-negative int
-            values; empty when the payload is missing or unusable.
+            values, plus unrecognized fields as ``extra:*`` display-only keys;
+            empty when the payload is missing or unusable.
     """
     if isinstance(raw, str):
         try:
@@ -353,41 +443,31 @@ def parse_manual_usage(raw: Any) -> dict[str, int]:
         if raw is not None:
             logger.warning("Manual usage attribute is not an object; ignoring it")
         return {}
-    # Fields outside the recognized set are never examined below, so without this
-    # they vanish without any signal at all — a provider token type we don't model
-    # yet (audio, image, a new cache variant) reads as if it was never reported.
-    # Bounded because the payload is client-controlled.
-    unrecognized = sorted(k for k in raw if k not in _MANUAL_USAGE_KEYS)
+    # Fields outside the recognized set are stored as display-only extra keys, so
+    # a provider token type we don't model yet (audio, image, a new cache
+    # variant) is surfaced rather than vanishing. Bounded because the payload is
+    # client-controlled. JSON object keys are strings, but a directly-decoded
+    # dict is untrusted too, so non-string keys are skipped rather than sorted.
+    unrecognized = sorted(k for k in raw if isinstance(k, str) and k not in _MANUAL_USAGE_KEYS)
     if unrecognized:
         logger.warning(
-            "Manual usage fields %s are not recognized and were ignored; recognized fields are %s",
+            "Manual usage fields %s are not recognized and are stored as display-only "
+            "extra keys (unpriced); recognized fields are %s",
             unrecognized[:10],
             list(_MANUAL_USAGE_KEYS),
         )
     usage: dict[str, int] = {}
     for key in _MANUAL_USAGE_KEYS:
-        value = raw.get(key)
-        if value is None:
-            continue
-        # A dropped field is silent data loss from the user's point of view: they
-        # reported a count and it is priced as if absent. Warn as int_or_zero does
-        # for the same input class, so the discard is diagnosable from the logs.
-        if isinstance(value, bool):
-            logger.warning("Manual usage field %s is a bool (%r); ignoring it", key, value)
-            continue
-        try:
-            parsed = max(int(value), 0)
-        except (TypeError, ValueError, OverflowError):
-            logger.warning(
-                "Manual usage field %s is not a usable number (%r); ignoring it", key, value
-            )
-            continue
-        if parsed > _MAX_PLAUSIBLE_TOKENS:
-            logger.warning(
-                "Manual usage field %s exceeds the sanity bound (%r); ignoring it", key, value
-            )
-            continue
-        usage[key] = parsed
+        parsed = _parse_manual_value(key, raw.get(key))
+        if parsed is not None:
+            usage[key] = parsed
+    # Unrecognized fields use the same validation as the recognized ones; the
+    # normalized snake_case name keeps the stored key consistent across the
+    # OTEL-attribute path (gen_ai.usage.audio_tokens -> extra:audio_tokens).
+    for key in unrecognized:
+        parsed = _parse_manual_value(key, raw[key])
+        if parsed is not None:
+            usage[f"extra:{_camel_to_snake(key)}"] = parsed
     return usage
 
 
@@ -850,12 +930,21 @@ def transform_otel_to_clickhouse(
                     # it states the invariant where the dict is read — manual usage
                     # must never resurrect counts on a span we suppressed — and skips
                     # a needless parse.
+                    manual_extra_usage: dict[str, int] = {}
                     if (
                         not aggregate_wrapper
                         and api_input_tokens is None
                         and api_output_tokens is None
                     ):
                         manual_usage = parse_manual_usage(span_attrs.get("traceroot.llm.usage"))
+                        # Unrecognized fields come back as display-only extra:* keys.
+                        # They must not feed pricing, but should surface in
+                        # usage_details so the reported counts are visible.
+                        manual_extra_usage = {
+                            key: val
+                            for key, val in manual_usage.items()
+                            if key.startswith("extra:")
+                        }
                         if "input_tokens" in manual_usage or "output_tokens" in manual_usage:
                             api_input_tokens = manual_usage.get("input_tokens")
                             api_output_tokens = manual_usage.get("output_tokens")
@@ -933,6 +1022,33 @@ def transform_otel_to_clickhouse(
                             span_record["usage_details"]["cache_write_1h_tokens"] = (
                                 buckets.cache_write_1h
                             )
+
+                        # Capture unrecognized usage attributes as display-only extra keys.
+                        # These are NOT priced — they appear in usage_details for visibility
+                        # only, prefixed with "extra:" to separate them from priced buckets.
+                        for attr_key, attr_val in span_attrs.items():
+                            if attr_key in _PRICED_USAGE_ATTRS:
+                                continue
+                            # Match usage attribute namespaces
+                            extra_key = None
+                            if attr_key.startswith("gen_ai.usage."):
+                                extra_key = attr_key[len("gen_ai.usage.") :]
+                            elif attr_key.startswith("llm.token_count."):
+                                extra_key = attr_key[len("llm.token_count.") :]
+                            elif attr_key.startswith("ai.usage."):
+                                extra_key = attr_key[len("ai.usage.") :]
+                            if extra_key is not None:
+                                val = int_or_zero(attr_val)
+                                if val > 0:
+                                    # Convert camelCase to snake_case for consistency
+                                    normalized = _camel_to_snake(extra_key)
+                                    span_record["usage_details"][f"extra:{normalized}"] = val
+
+                        # Same display-only treatment for unrecognized keys reported
+                        # through the manual usage dict (traceroot.llm.usage).
+                        for extra_key, val in manual_extra_usage.items():
+                            span_record["usage_details"][extra_key] = val
+
                         cost = cost_from_buckets(get_model_price(model_name), buckets)
                         if cost is not None:
                             span_record["cost"] = cost

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -238,7 +238,7 @@ def _usable_token_value(value: Any) -> bool:
         return False
     try:
         parsed = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return False
     return 0 <= parsed <= _MAX_PLAUSIBLE_TOKENS
 
@@ -283,7 +283,10 @@ def int_or_zero(value: Any) -> int:
         return 0
     try:
         parsed = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError: int(float('inf')) / int(1e400) raise it, and OTEL
+        # double attributes can legitimately carry Infinity/NaN — a single
+        # non-finite attribute must not abort ingestion of the whole batch.
         logger.warning("Non-numeric OTEL token attribute %r; treating as 0", value)
         return 0
     if parsed < 0:
@@ -403,6 +406,28 @@ def _parse_manual_value(key: str, value: Any) -> int | None:
     return parsed
 
 
+def _add_extra_value(usage: dict[str, int], key: str, value: int, source: str) -> None:
+    """Add a display-only extra usage value to a dict, bounded like the priced paths.
+
+    Individual extra values are validated against ``_MAX_PLAUSIBLE_TOKENS`` before
+    they reach this helper, but colliding spellings that normalize to the same key
+    are summed — and the SUM is not individually bounded. Cap it here: a merged
+    value that would exceed the plausible bound drops the incoming contribution, so
+    no unbounded Int64 usage entry is persisted (later rollups would amplify it).
+    """
+    merged = usage.get(key, 0) + value
+    if merged > _MAX_PLAUSIBLE_TOKENS:
+        logger.warning(
+            "Extra usage field %s from %s would exceed the sanity bound (%d); "
+            "dropping the contribution",
+            key,
+            source,
+            _MAX_PLAUSIBLE_TOKENS,
+        )
+        return
+    usage[key] = merged
+
+
 def parse_manual_usage(raw: Any) -> dict[str, int]:
     """Parse the manual usage dict reported via the SDKs' update-span API.
 
@@ -470,8 +495,7 @@ def parse_manual_usage(raw: Any) -> dict[str, int]:
     for key in unrecognized:
         parsed = _parse_manual_value(key, raw[key])
         if parsed is not None:
-            extra_key = f"extra:{_camel_to_snake(key)}"
-            usage[extra_key] = usage.get(extra_key, 0) + parsed
+            _add_extra_value(usage, f"extra:{_camel_to_snake(key)}", parsed, "manual usage")
     return usage
 
 
@@ -1089,17 +1113,21 @@ def transform_otel_to_clickhouse(
                                     # ai.usage.audioTokens vs gen_ai.usage.audio_tokens)
                                     # so neither reported value is silently dropped.
                                     stored_key = f"extra:{_camel_to_snake(extra_key)}"
-                                    span_record.setdefault("usage_details", {})
-                                    span_record["usage_details"][stored_key] = (
-                                        span_record["usage_details"].get(stored_key, 0) + val
+                                    _add_extra_value(
+                                        span_record.setdefault("usage_details", {}),
+                                        stored_key,
+                                        val,
+                                        attr_key,
                                     )
 
                         # Same display-only treatment for unrecognized keys reported
                         # through the manual usage dict (traceroot.llm.usage).
                         for extra_key, val in manual_extra_usage.items():
-                            span_record.setdefault("usage_details", {})
-                            span_record["usage_details"][extra_key] = (
-                                span_record["usage_details"].get(extra_key, 0) + val
+                            _add_extra_value(
+                                span_record.setdefault("usage_details", {}),
+                                extra_key,
+                                val,
+                                "manual usage",
                             )
 
                 # Extract metadata

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -955,11 +955,11 @@ def transform_otel_to_clickhouse(
                         elif manual_usage:
                             # Recognized fields, but nothing to price against: a
                             # cache or reasoning count alone does not describe a
-                            # call. Dropping it silently is the same data loss the
-                            # field-level warnings above exist to surface.
+                            # call. Extras (extra:*) still surface in usage_details
+                            # for display; only the unpriced fields are dropped.
                             logger.warning(
                                 "Manual usage reported only %s with no input_tokens or "
-                                "output_tokens; ignoring it",
+                                "output_tokens; only unpriced display-only fields are kept",
                                 sorted(manual_usage),
                             )
 
@@ -1023,32 +1023,6 @@ def transform_otel_to_clickhouse(
                                 buckets.cache_write_1h
                             )
 
-                        # Capture unrecognized usage attributes as display-only extra keys.
-                        # These are NOT priced — they appear in usage_details for visibility
-                        # only, prefixed with "extra:" to separate them from priced buckets.
-                        for attr_key, attr_val in span_attrs.items():
-                            if attr_key in _PRICED_USAGE_ATTRS:
-                                continue
-                            # Match usage attribute namespaces
-                            extra_key = None
-                            if attr_key.startswith("gen_ai.usage."):
-                                extra_key = attr_key[len("gen_ai.usage.") :]
-                            elif attr_key.startswith("llm.token_count."):
-                                extra_key = attr_key[len("llm.token_count.") :]
-                            elif attr_key.startswith("ai.usage."):
-                                extra_key = attr_key[len("ai.usage.") :]
-                            if extra_key is not None:
-                                val = int_or_zero(attr_val)
-                                if val > 0:
-                                    # Convert camelCase to snake_case for consistency
-                                    normalized = _camel_to_snake(extra_key)
-                                    span_record["usage_details"][f"extra:{normalized}"] = val
-
-                        # Same display-only treatment for unrecognized keys reported
-                        # through the manual usage dict (traceroot.llm.usage).
-                        for extra_key, val in manual_extra_usage.items():
-                            span_record["usage_details"][extra_key] = val
-
                         cost = cost_from_buckets(get_model_price(model_name), buckets)
                         if cost is not None:
                             span_record["cost"] = cost
@@ -1083,6 +1057,39 @@ def transform_otel_to_clickhouse(
                             span_record["total_tokens"] = usage["total_tokens"]
                         if usage["cost"] is not None:
                             span_record["cost"] = usage["cost"]
+
+                    # Capture unrecognized usage attributes as display-only extra keys.
+                    # These are NOT priced — they appear in usage_details for visibility
+                    # only, prefixed with "extra:" to separate them from priced buckets.
+                    # This runs independent of whether priced input/output tokens were
+                    # present, so an audio/image-only span (no input/output counts) still
+                    # surfaces its extra usage instead of vanishing. Aggregate wrappers
+                    # restate their children's usage, so their extras are suppressed too.
+                    if not aggregate_wrapper:
+                        for attr_key, attr_val in span_attrs.items():
+                            if attr_key in _PRICED_USAGE_ATTRS:
+                                continue
+                            # Match usage attribute namespaces
+                            extra_key = None
+                            if attr_key.startswith("gen_ai.usage."):
+                                extra_key = attr_key[len("gen_ai.usage.") :]
+                            elif attr_key.startswith("llm.token_count."):
+                                extra_key = attr_key[len("llm.token_count.") :]
+                            elif attr_key.startswith("ai.usage."):
+                                extra_key = attr_key[len("ai.usage.") :]
+                            if extra_key is not None:
+                                val = int_or_zero(attr_val)
+                                if val > 0:
+                                    # Convert camelCase to snake_case for consistency
+                                    normalized = _camel_to_snake(extra_key)
+                                    span_record.setdefault("usage_details", {})[
+                                        f"extra:{normalized}"
+                                    ] = val
+
+                        # Same display-only treatment for unrecognized keys reported
+                        # through the manual usage dict (traceroot.llm.usage).
+                        for extra_key, val in manual_extra_usage.items():
+                            span_record.setdefault("usage_details", {})[extra_key] = val
 
                 # Extract metadata
                 # Priority: explicit traceroot.span.metadata > remaining attributes.

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -464,10 +464,14 @@ def parse_manual_usage(raw: Any) -> dict[str, int]:
     # Unrecognized fields use the same validation as the recognized ones; the
     # normalized snake_case name keeps the stored key consistent across the
     # OTEL-attribute path (gen_ai.usage.audio_tokens -> extra:audio_tokens).
+    # Distinct spellings that normalize alike (audioTokens vs audio_tokens) are
+    # summed rather than overwriting each other, so neither reported value is
+    # silently lost from the display-only breakdown.
     for key in unrecognized:
         parsed = _parse_manual_value(key, raw[key])
         if parsed is not None:
-            usage[f"extra:{_camel_to_snake(key)}"] = parsed
+            extra_key = f"extra:{_camel_to_snake(key)}"
+            usage[extra_key] = usage.get(extra_key, 0) + parsed
     return usage
 
 
@@ -1080,16 +1084,23 @@ def transform_otel_to_clickhouse(
                             if extra_key is not None:
                                 val = int_or_zero(attr_val)
                                 if val > 0:
-                                    # Convert camelCase to snake_case for consistency
-                                    normalized = _camel_to_snake(extra_key)
-                                    span_record.setdefault("usage_details", {})[
-                                        f"extra:{normalized}"
-                                    ] = val
+                                    # Convert camelCase to snake_case for consistency,
+                                    # summing spellings that normalize alike (e.g.
+                                    # ai.usage.audioTokens vs gen_ai.usage.audio_tokens)
+                                    # so neither reported value is silently dropped.
+                                    stored_key = f"extra:{_camel_to_snake(extra_key)}"
+                                    span_record.setdefault("usage_details", {})
+                                    span_record["usage_details"][stored_key] = (
+                                        span_record["usage_details"].get(stored_key, 0) + val
+                                    )
 
                         # Same display-only treatment for unrecognized keys reported
                         # through the manual usage dict (traceroot.llm.usage).
                         for extra_key, val in manual_extra_usage.items():
-                            span_record.setdefault("usage_details", {})[extra_key] = val
+                            span_record.setdefault("usage_details", {})
+                            span_record["usage_details"][extra_key] = (
+                                span_record["usage_details"].get(extra_key, 0) + val
+                            )
 
                 # Extract metadata
                 # Priority: explicit traceroot.span.metadata > remaining attributes.

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
@@ -213,4 +213,47 @@ describe("SpanInfoPanel - Error box source location badges", () => {
     expect(screen.getByText("Session:")).toBeTruthy();
     expect(screen.getByText("session-7")).toBeTruthy();
   });
+
+  it("renders the trace-level TokenChip with aggregated extra usage details", () => {
+    // Trace branch: spans with total tokens and extra:* usage keys must flow
+    // through getTraceTokenUsage -> TokenChip -> TokenUsageBreakdown.
+    const traceWithTokens: TraceDetail = {
+      ...mockTrace,
+      spans: [
+        {
+          span_id: "s1",
+          trace_id: "trace-123",
+          parent_span_id: null,
+          name: "llm-1",
+          span_kind: "LLM",
+          span_start_time: "2026-07-12T12:00:00Z",
+          span_end_time: "2026-07-12T12:00:01Z",
+          status: SpanStatus.OK,
+          status_message: null,
+          model_name: "gpt-4o",
+          cost: 0.005,
+          input_tokens: 1000,
+          output_tokens: 200,
+          total_tokens: 1200,
+          git_source_file: null,
+          git_source_line: null,
+          git_source_function: null,
+          usage_details: {
+            cache_read_tokens: 300,
+            "extra:audio_tokens": 30,
+          },
+        },
+      ],
+    };
+    const mockTraceSelection: TraceSelection = { type: "trace" };
+
+    render(
+      <SpanInfoPanel projectId="proj-123" trace={traceWithTokens} selection={mockTraceSelection} />,
+    );
+
+    // The token chip renders with the input → output (total) flow.
+    const tokenChip = screen.getByText((content) => content.includes("→"));
+    expect(tokenChip).toBeTruthy();
+    expect(tokenChip.textContent).toContain("1.2K");
+  });
 });

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -153,6 +153,7 @@ export function SpanInfoPanel({
               cacheReadTokens={traceTokenUsage.cacheReadTokens}
               cacheWriteTokens={traceTokenUsage.cacheWriteTokens}
               reasoningTokens={traceTokenUsage.reasoningTokens}
+              usageDetails={traceTokenUsage.usageDetails}
             />
           )}
           {isTrace && traceTotalCost != null && (
@@ -172,6 +173,7 @@ export function SpanInfoPanel({
               cacheReadTokens={selection.span.usage_details?.cache_read_tokens}
               cacheWriteTokens={selection.span.usage_details?.cache_write_tokens}
               reasoningTokens={selection.span.usage_details?.reasoning_tokens}
+              usageDetails={selection.span.usage_details}
             />
           )}
           {!isTrace && (

--- a/frontend/ui/src/features/traces/components/TokenChip.tsx
+++ b/frontend/ui/src/features/traces/components/TokenChip.tsx
@@ -10,6 +10,7 @@ interface TokenChipProps {
   cacheReadTokens?: number | null;
   cacheWriteTokens?: number | null;
   reasoningTokens?: number | null;
+  usageDetails?: Record<string, number> | null;
 }
 
 /**
@@ -23,6 +24,7 @@ export function TokenChip({
   cacheReadTokens,
   cacheWriteTokens,
   reasoningTokens,
+  usageDetails,
 }: TokenChipProps) {
   return (
     <TooltipProvider delayDuration={150}>
@@ -43,6 +45,7 @@ export function TokenChip({
             cacheReadTokens={cacheReadTokens}
             cacheWriteTokens={cacheWriteTokens}
             reasoningTokens={reasoningTokens}
+            usageDetails={usageDetails}
           />
         </TooltipContent>
       </Tooltip>

--- a/frontend/ui/src/features/traces/components/TokenUsageBreakdown.tsx
+++ b/frontend/ui/src/features/traces/components/TokenUsageBreakdown.tsx
@@ -7,6 +7,7 @@ interface TokenUsageBreakdownProps {
   cacheReadTokens?: number | null;
   cacheWriteTokens?: number | null;
   reasoningTokens?: number | null;
+  usageDetails?: Record<string, number> | null;
 }
 
 function Row({ label, value }: { label: string; value: number }) {
@@ -36,6 +37,7 @@ export function TokenUsageBreakdown({
   cacheReadTokens,
   cacheWriteTokens,
   reasoningTokens,
+  usageDetails,
 }: TokenUsageBreakdownProps) {
   const input = inputTokens ?? 0;
   const output = outputTokens ?? 0;
@@ -46,6 +48,16 @@ export function TokenUsageBreakdown({
   // Disjoint remainders so each section's rows sum to its total.
   const uncachedInput = Math.max(input - cacheRead - cacheWrite, 0);
   const plainOutput = Math.max(output - reasoning, 0);
+
+  // Extract extra unpriced usage fields (e.g. extra:audio_tokens)
+  const extraRows = usageDetails
+    ? Object.entries(usageDetails)
+        .filter(([key, val]) => key.startsWith("extra:") && val > 0)
+        .map(([key, val]) => {
+          const label = key.substring(6).replace(/_/g, " ");
+          return { label, value: val };
+        })
+    : [];
 
   return (
     <div className="min-w-[220px] text-xs">
@@ -71,6 +83,19 @@ export function TokenUsageBreakdown({
         {reasoning > 0 && <Row label="reasoning" value={reasoning} />}
         <Row label="output" value={plainOutput} />
       </div>
+
+      {extraRows.length > 0 && (
+        <>
+          <div className="mt-2 flex justify-between gap-8 border-b border-border/60 pb-1 font-medium">
+            <span>Other usage</span>
+          </div>
+          <div className="mt-1 space-y-0.5">
+            {extraRows.map((row) => (
+              <Row key={row.label} label={row.label} value={row.value} />
+            ))}
+          </div>
+        </>
+      )}
 
       <div className="mt-2 flex justify-between gap-8 border-t border-border/60 pt-1 font-semibold">
         <span>Total usage</span>

--- a/frontend/ui/src/features/traces/components/TokenUsageBreakdown.tsx
+++ b/frontend/ui/src/features/traces/components/TokenUsageBreakdown.tsx
@@ -10,6 +10,41 @@ interface TokenUsageBreakdownProps {
   usageDetails?: Record<string, number> | null;
 }
 
+interface ExtraRow {
+  /** Original map key (e.g. "extra:audio_tokens") — unique, used as the React key. */
+  key: string;
+  label: string;
+  value: number;
+}
+
+/**
+ * Build display rows for the unpriced `extra:*` usage keys in `usage_details`.
+ *
+ * The raw `extra:*` key is preserved as the row identity so distinct keys can
+ * never collapse onto the same React key. The display label humanizes the suffix
+ * (underscores → spaces); when two distinct keys humanize identically (e.g.
+ * `extra:some_key` vs `extra:some key`), each is disambiguated by its raw key so
+ * the rows stay distinguishable during live-trace updates.
+ */
+export function buildExtraRows(
+  usageDetails: Record<string, number> | null | undefined,
+): ExtraRow[] {
+  const rows: ExtraRow[] = Object.entries(usageDetails ?? {})
+    .filter(([key, val]) => key.startsWith("extra:") && val > 0)
+    .map(([key, val]) => ({
+      key,
+      label: key.substring(6).replace(/_/g, " "),
+      value: val,
+    }));
+  const labelCounts = new Map<string, number>();
+  for (const row of rows) {
+    labelCounts.set(row.label, (labelCounts.get(row.label) ?? 0) + 1);
+  }
+  return rows.map((row) =>
+    labelCounts.get(row.label)! > 1 ? { ...row, label: `${row.label} (${row.key})` } : row,
+  );
+}
+
 function Row({ label, value }: { label: string; value: number }) {
   return (
     <div className="flex justify-between gap-8 text-muted-foreground">
@@ -49,15 +84,10 @@ export function TokenUsageBreakdown({
   const uncachedInput = Math.max(input - cacheRead - cacheWrite, 0);
   const plainOutput = Math.max(output - reasoning, 0);
 
-  // Extract extra unpriced usage fields (e.g. extra:audio_tokens)
-  const extraRows = usageDetails
-    ? Object.entries(usageDetails)
-        .filter(([key, val]) => key.startsWith("extra:") && val > 0)
-        .map(([key, val]) => {
-          const label = key.substring(6).replace(/_/g, " ");
-          return { label, value: val };
-        })
-    : [];
+  // Extract extra unpriced usage fields (e.g. extra:audio_tokens). Each row keeps
+  // its raw extra:* key as identity so colliding display labels cannot produce
+  // duplicate React keys or unstable row reconciliation on live updates.
+  const extraRows = buildExtraRows(usageDetails);
 
   return (
     <div className="min-w-[220px] text-xs">
@@ -91,7 +121,7 @@ export function TokenUsageBreakdown({
           </div>
           <div className="mt-1 space-y-0.5">
             {extraRows.map((row) => (
-              <Row key={row.label} label={row.label} value={row.value} />
+              <Row key={row.key} label={row.label} value={row.value} />
             ))}
           </div>
         </>

--- a/frontend/ui/src/features/traces/components/breakdown-ordering.test.ts
+++ b/frontend/ui/src/features/traces/components/breakdown-ordering.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { TokenUsageBreakdown } from "./TokenUsageBreakdown";
+import { TokenUsageBreakdown, buildExtraRows } from "./TokenUsageBreakdown";
 import { CostBreakdown } from "./CostBreakdown";
 
 // Both panels split input into the same three categories; they must render
@@ -65,5 +65,39 @@ describe("breakdown row ordering", () => {
     expect(markup).toContain("image tokens");
     expect(markup).toContain("150");
     expect(markup).toContain("75");
+  });
+
+  it("disambiguates extra keys whose humanized labels collide", () => {
+    // Distinct keys that humanize to the same label must keep unique identities
+    // and distinct labels — otherwise React sees duplicate keys and row
+    // reconciliation breaks on live-trace updates.
+    const rows = buildExtraRows({
+      "extra:some_key": 1,
+      "extra:some key": 2,
+      "extra:audio_tokens": 3,
+    });
+    const keys = rows.map((r) => r.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    const labels = rows.map((r) => r.label);
+    expect(new Set(labels).size).toBe(labels.length);
+    expect(labels).toContain("some key (extra:some_key)");
+    expect(labels).toContain("some key (extra:some key)");
+    expect(labels).toContain("audio tokens");
+  });
+
+  it("renders colliding extra keys as distinct rows", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TokenUsageBreakdown, {
+        inputTokens: 100,
+        outputTokens: 0,
+        totalTokens: 100,
+        usageDetails: {
+          "extra:some_key": 1,
+          "extra:some key": 2,
+        },
+      }),
+    );
+    expect(markup).toContain("some key (extra:some_key)");
+    expect(markup).toContain("some key (extra:some key)");
   });
 });

--- a/frontend/ui/src/features/traces/components/breakdown-ordering.test.ts
+++ b/frontend/ui/src/features/traces/components/breakdown-ordering.test.ts
@@ -45,4 +45,25 @@ describe("breakdown row ordering", () => {
     expect(read).toBeGreaterThan(uncached);
     expect(write).toBeGreaterThan(read);
   });
+
+  it("renders extra/unrecognized usage keys in Other usage section", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TokenUsageBreakdown, {
+        inputTokens: 1000,
+        outputTokens: 200,
+        totalTokens: 1200,
+        cacheReadTokens: 300,
+        cacheWriteTokens: 100,
+        usageDetails: {
+          "extra:audio_tokens": 150,
+          "extra:image_tokens": 75,
+        },
+      }),
+    );
+    expect(markup).toContain("Other usage");
+    expect(markup).toContain("audio tokens");
+    expect(markup).toContain("image tokens");
+    expect(markup).toContain("150");
+    expect(markup).toContain("75");
+  });
 });

--- a/frontend/ui/src/features/traces/utils/index.test.ts
+++ b/frontend/ui/src/features/traces/utils/index.test.ts
@@ -359,7 +359,7 @@ describe("summarizeCostDetails", () => {
 });
 
 describe("getTraceTokenUsage", () => {
-  it("aggregates extra unpriced usage keys across spans into usageDetails", () => {
+  it("aggregates extra unpriced usage keys across all spans into usageDetails", () => {
     const trace = {
       spans: [
         makeSpan({
@@ -383,6 +383,14 @@ describe("getTraceTokenUsage", () => {
             "extra:video_tokens": 12,
           },
         }),
+        // Extras-only span: no total_tokens, so it must not feed priced totals
+        // but still contributes its extra usage to the breakdown.
+        makeSpan({
+          span_id: "c",
+          usage_details: {
+            "extra:audio_tokens": 100,
+          },
+        }),
       ],
     } as unknown as TraceDetail;
 
@@ -392,7 +400,7 @@ describe("getTraceTokenUsage", () => {
     expect(result.outputTokens).toBe(300);
     expect(result.cacheReadTokens).toBe(300);
     expect(result.usageDetails).toEqual({
-      "extra:audio_tokens": 100,
+      "extra:audio_tokens": 200,
       "extra:image_tokens": 45,
       "extra:video_tokens": 12,
     });
@@ -420,7 +428,31 @@ describe("getTraceTokenUsage", () => {
     expect(result.usageDetails).toEqual({ "extra:image_tokens": 5 });
   });
 
-  it("returns null when no span reports total tokens", () => {
+  it("returns extras-only usage when no span reports total tokens", () => {
+    const trace = {
+      spans: [
+        makeSpan({
+          span_id: "a",
+          usage_details: {
+            "extra:audio_tokens": 30,
+            "extra:image_tokens": 45,
+          },
+        }),
+      ],
+    } as unknown as TraceDetail;
+
+    const result = getTraceTokenUsage(trace)!;
+    expect(result).not.toBeNull();
+    expect(result.inputTokens).toBeNull();
+    expect(result.outputTokens).toBeNull();
+    expect(result.totalTokens).toBe(0);
+    expect(result.usageDetails).toEqual({
+      "extra:audio_tokens": 30,
+      "extra:image_tokens": 45,
+    });
+  });
+
+  it("returns null when no span reports total tokens or extra usage", () => {
     const trace = { spans: [makeSpan({ span_id: "a" })] } as unknown as TraceDetail;
     expect(getTraceTokenUsage(trace)).toBeNull();
   });

--- a/frontend/ui/src/features/traces/utils/index.test.ts
+++ b/frontend/ui/src/features/traces/utils/index.test.ts
@@ -6,6 +6,7 @@ import {
   enrichSpansWithPending,
   getSpanDuration,
   getTraceDuration,
+  getTraceTokenUsage,
   summarizeCostDetails,
   getTraceCostBreakdown,
 } from "./index";
@@ -354,6 +355,74 @@ describe("summarizeCostDetails", () => {
     expect(s.inputCost).toBe(0);
     expect(s.outputCost).toBe(0);
     expect(s.total).toBe(0);
+  });
+});
+
+describe("getTraceTokenUsage", () => {
+  it("aggregates extra unpriced usage keys across spans into usageDetails", () => {
+    const trace = {
+      spans: [
+        makeSpan({
+          span_id: "a",
+          total_tokens: 1200,
+          input_tokens: 1000,
+          output_tokens: 200,
+          usage_details: {
+            cache_read_tokens: 300,
+            "extra:audio_tokens": 30,
+            "extra:image_tokens": 45,
+          },
+        }),
+        makeSpan({
+          span_id: "b",
+          total_tokens: 500,
+          input_tokens: 400,
+          output_tokens: 100,
+          usage_details: {
+            "extra:audio_tokens": 70,
+            "extra:video_tokens": 12,
+          },
+        }),
+      ],
+    } as unknown as TraceDetail;
+
+    const result = getTraceTokenUsage(trace)!;
+    expect(result.totalTokens).toBe(1700);
+    expect(result.inputTokens).toBe(1400);
+    expect(result.outputTokens).toBe(300);
+    expect(result.cacheReadTokens).toBe(300);
+    expect(result.usageDetails).toEqual({
+      "extra:audio_tokens": 100,
+      "extra:image_tokens": 45,
+      "extra:video_tokens": 12,
+    });
+  });
+
+  it("excludes non-extra and non-positive usage_details keys", () => {
+    const trace = {
+      spans: [
+        makeSpan({
+          span_id: "a",
+          total_tokens: 100,
+          input_tokens: 100,
+          output_tokens: 0,
+          usage_details: {
+            cache_read_tokens: 0,
+            reasoning_tokens: 10,
+            "extra:audio_tokens": 0,
+            "extra:image_tokens": 5,
+          },
+        }),
+      ],
+    } as unknown as TraceDetail;
+
+    const result = getTraceTokenUsage(trace)!;
+    expect(result.usageDetails).toEqual({ "extra:image_tokens": 5 });
+  });
+
+  it("returns null when no span reports total tokens", () => {
+    const trace = { spans: [makeSpan({ span_id: "a" })] } as unknown as TraceDetail;
+    expect(getTraceTokenUsage(trace)).toBeNull();
   });
 });
 

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -314,14 +314,39 @@ export function getTraceTokenUsage(trace: TraceDetail): {
   reasoningTokens: number;
   usageDetails: Record<string, number>;
 } | null {
+  // Aggregate display-only extra:* usage across ALL spans — including
+  // audio/image-only spans that report extras but no input/output/total
+  // tokens — so the trace-level "Other usage" breakdown is complete.
+  const usageDetails: Record<string, number> = {};
+  for (const span of trace.spans) {
+    if (!span.usage_details) continue;
+    for (const [key, val] of Object.entries(span.usage_details)) {
+      if (key.startsWith("extra:") && val > 0) {
+        usageDetails[key] = (usageDetails[key] ?? 0) + val;
+      }
+    }
+  }
+
   const spansWithTokens = trace.spans.filter((s) => s.total_tokens !== null);
-  if (spansWithTokens.length === 0) return null;
+  if (spansWithTokens.length === 0) {
+    // No priced tokens anywhere: surface extras if any were reported (so
+    // audio/image-only traces still show their "Other usage"), else null.
+    if (Object.keys(usageDetails).length === 0) return null;
+    return {
+      inputTokens: null,
+      outputTokens: null,
+      totalTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningTokens: 0,
+      usageDetails,
+    };
+  }
   // Preserve the unknown-vs-zero distinction: only coerce input/output to a
   // number when at least one span actually reports it, so a total-only trace
   // renders "-" (via formatTokenFlow) instead of a misleading 0.
   const hasInput = spansWithTokens.some((s) => s.input_tokens !== null);
   const hasOutput = spansWithTokens.some((s) => s.output_tokens !== null);
-  const usageDetails: Record<string, number> = {};
   const acc = spansWithTokens.reduce(
     (acc, s) => {
       acc.inputTokens += s.input_tokens ?? 0;
@@ -330,15 +355,6 @@ export function getTraceTokenUsage(trace: TraceDetail): {
       acc.cacheReadTokens += s.usage_details?.cache_read_tokens ?? 0;
       acc.cacheWriteTokens += s.usage_details?.cache_write_tokens ?? 0;
       acc.reasoningTokens += s.usage_details?.reasoning_tokens ?? 0;
-
-      if (s.usage_details) {
-        Object.entries(s.usage_details).forEach(([key, val]) => {
-          if (key.startsWith("extra:") && val > 0) {
-            usageDetails[key] = (usageDetails[key] ?? 0) + val;
-          }
-        });
-      }
-
       return acc;
     },
     {

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -312,6 +312,7 @@ export function getTraceTokenUsage(trace: TraceDetail): {
   cacheReadTokens: number;
   cacheWriteTokens: number;
   reasoningTokens: number;
+  usageDetails: Record<string, number>;
 } | null {
   const spansWithTokens = trace.spans.filter((s) => s.total_tokens !== null);
   if (spansWithTokens.length === 0) return null;
@@ -320,6 +321,7 @@ export function getTraceTokenUsage(trace: TraceDetail): {
   // renders "-" (via formatTokenFlow) instead of a misleading 0.
   const hasInput = spansWithTokens.some((s) => s.input_tokens !== null);
   const hasOutput = spansWithTokens.some((s) => s.output_tokens !== null);
+  const usageDetails: Record<string, number> = {};
   const acc = spansWithTokens.reduce(
     (acc, s) => {
       acc.inputTokens += s.input_tokens ?? 0;
@@ -328,6 +330,15 @@ export function getTraceTokenUsage(trace: TraceDetail): {
       acc.cacheReadTokens += s.usage_details?.cache_read_tokens ?? 0;
       acc.cacheWriteTokens += s.usage_details?.cache_write_tokens ?? 0;
       acc.reasoningTokens += s.usage_details?.reasoning_tokens ?? 0;
+
+      if (s.usage_details) {
+        Object.entries(s.usage_details).forEach(([key, val]) => {
+          if (key.startsWith("extra:") && val > 0) {
+            usageDetails[key] = (usageDetails[key] ?? 0) + val;
+          }
+        });
+      }
+
       return acc;
     },
     {
@@ -343,6 +354,7 @@ export function getTraceTokenUsage(trace: TraceDetail): {
     ...acc,
     inputTokens: hasInput ? acc.inputTokens : null,
     outputTokens: hasOutput ? acc.outputTokens : null,
+    usageDetails,
   };
 }
 

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -2052,6 +2052,15 @@ class TestManualUsageAttribute:
         assert "image_tokens" in warning
         assert "display-only" in warning
 
+    def test_manual_extra_key_spelling_collisions_are_summed(self):
+        from worker.otel_transform import parse_manual_usage
+
+        # Distinct spellings of the same token type normalize to the same extra:
+        # key; both values must survive (summed), not silently overwrite each other.
+        assert parse_manual_usage('{"audioTokens": 10, "audio_tokens": 20}') == {
+            "extra:audio_tokens": 30
+        }
+
     def test_fully_recognized_usage_logs_no_warning(self, caplog):
         import logging
 

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -1947,6 +1947,26 @@ class TestManualUsageAttribute:
         )
         assert span["cost"] == pytest.approx(expected)
 
+    def test_manual_extras_only_usage_is_persisted_without_priced_tokens(self):
+        from unittest.mock import patch
+
+        # A manual dict with only unrecognized fields (no input/output) must still
+        # surface its extra usage in usage_details, independent of the priced guard.
+        payload = make_otel_payload(
+            [self._manual_span({"audio_tokens": 30, "image_tokens": 45})],
+            scope_name="traceroot",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=MANUAL_USAGE_PRICES):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        span = spans[0]
+        assert span["usage_details"]["extra:audio_tokens"] == 30
+        assert span["usage_details"]["extra:image_tokens"] == 45
+        # No priced buckets are fabricated from extras alone.
+        assert "cache_read_tokens" not in span["usage_details"]
+        assert "cache_write_tokens" not in span["usage_details"]
+        assert "reasoning_tokens" not in span["usage_details"]
+
     def test_lone_instrumentor_total_also_suppresses_manual_dict(self):
         from unittest.mock import patch
 

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -1906,6 +1906,47 @@ class TestManualUsageAttribute:
         assert span["output_tokens"] == 50
         assert span["usage_details"]["cache_read_tokens"] == 0
 
+    def test_manual_extra_keys_are_stored_display_only_and_unpriced(self):
+        from unittest.mock import patch
+
+        # Unrecognized fields (audio, image) reported via the manual dict must
+        # surface in usage_details as display-only extra keys and must NOT change
+        # the cost — the priced buckets reconcile with input/output as before.
+        payload = make_otel_payload(
+            [
+                self._manual_span(
+                    {
+                        "input_tokens": 1000,
+                        "output_tokens": 200,
+                        "cache_read_tokens": 900,
+                        "audio_tokens": 30,
+                        "image_tokens": 45,
+                        "videoTokens": 12,
+                    }
+                )
+            ],
+            scope_name="traceroot",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=MANUAL_USAGE_PRICES):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        span = spans[0]
+        # Priced buckets are unchanged
+        assert span["input_tokens"] == 1000
+        assert span["output_tokens"] == 200
+        assert span["usage_details"]["cache_read_tokens"] == 900
+        # Unrecognized keys land with the extra: prefix and snake_case normalization
+        assert span["usage_details"]["extra:audio_tokens"] == 30
+        assert span["usage_details"]["extra:image_tokens"] == 45
+        assert span["usage_details"]["extra:video_tokens"] == 12
+        # Cost matches a span without extra keys exactly
+        expected = (
+            100 * MANUAL_USAGE_PRICES["input"]
+            + 900 * MANUAL_USAGE_PRICES["cacheRead"]
+            + 200 * MANUAL_USAGE_PRICES["output"]
+        )
+        assert span["cost"] == pytest.approx(expected)
+
     def test_lone_instrumentor_total_also_suppresses_manual_dict(self):
         from unittest.mock import patch
 
@@ -1957,7 +1998,7 @@ class TestManualUsageAttribute:
         assert parse_manual_usage(
             '{"input_tokens": "abc", "output_tokens": -5, "cache_read_tokens": 900, '
             '"unknown_key": 7, "reasoning_tokens": true}'
-        ) == {"output_tokens": 0, "cache_read_tokens": 900}
+        ) == {"output_tokens": 0, "cache_read_tokens": 900, "extra:unknown_key": 7}
         # json.loads accepts literal Infinity/NaN; int(inf) raises OverflowError
         # (not ValueError), so non-finite fields must drop rather than crash.
         assert parse_manual_usage(
@@ -1976,18 +2017,20 @@ class TestManualUsageAttribute:
 
     def test_unrecognized_usage_fields_are_reported(self, caplog):
         """A provider token type we do not model yet (audio, image, a new cache
-        variant) is never examined by the parser, so without a warning it vanishes
-        with no signal anywhere. The recognized fields must still parse."""
+        variant) is surfaced as a display-only extra key instead of vanishing, and
+        the recognized fields still parse. The warning stays so the unpriced nature
+        of the stored keys is diagnosable from the logs."""
         import logging
 
         from worker.otel_transform import parse_manual_usage
 
         with caplog.at_level(logging.WARNING):
             usage = parse_manual_usage('{"input_tokens": 10, "audio_tokens": 7, "image_tokens": 3}')
-        assert usage == {"input_tokens": 10}
+        assert usage == {"input_tokens": 10, "extra:audio_tokens": 7, "extra:image_tokens": 3}
         warning = "\n".join(r.getMessage() for r in caplog.records)
         assert "audio_tokens" in warning
         assert "image_tokens" in warning
+        assert "display-only" in warning
 
     def test_fully_recognized_usage_logs_no_warning(self, caplog):
         import logging

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -2060,6 +2060,13 @@ class TestManualUsageAttribute:
         assert parse_manual_usage('{"audioTokens": 10, "audio_tokens": 20}') == {
             "extra:audio_tokens": 30
         }
+        # A merged sum that would exceed the plausible bound drops the incoming
+        # contribution instead of storing an unbounded Int64.
+        assert parse_manual_usage('{"audioTokens": 900000000, "audio_tokens": 900000000}') == {
+            "extra:audio_tokens": 900000000
+        }
+        # Non-finite unrecognized fields are dropped, never fatal.
+        assert parse_manual_usage('{"audio_tokens": Infinity}') == {}
 
     def test_fully_recognized_usage_logs_no_warning(self, caplog):
         import logging

--- a/tests/worker/test_otel_transform_metadata.py
+++ b/tests/worker/test_otel_transform_metadata.py
@@ -474,3 +474,22 @@ def test_extras_only_usage_is_persisted_without_priced_tokens():
     assert "cache_write_tokens" not in span["usage_details"]
     assert "reasoning_tokens" not in span["usage_details"]
     assert span["input_tokens"] == 0
+
+
+def test_extra_attr_spelling_collisions_are_summed():
+    """Spellings that normalize to the same extra: key (ai.usage.audioTokens vs
+    gen_ai.usage.audio_tokens) are summed, not overwritten."""
+    payload = _otel_payload(
+        [
+            _attr("llm.model_name", "claude-3-5-sonnet-20241022"),
+            _attr("gen_ai.usage.input_tokens", 1000),
+            _attr("gen_ai.usage.output_tokens", 200),
+            _attr("ai.usage.audioTokens", 10),
+            _attr("gen_ai.usage.audio_tokens", 20),
+        ]
+    )
+
+    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+
+    assert len(spans) == 1
+    assert spans[0]["usage_details"]["extra:audio_tokens"] == 30

--- a/tests/worker/test_otel_transform_metadata.py
+++ b/tests/worker/test_otel_transform_metadata.py
@@ -447,3 +447,30 @@ def test_extra_unrecognized_usage_keys_are_stored():
     )
     _t, spans_no_extra = transform_otel_to_clickhouse(payload_no_extra, project_id="proj-1")
     assert span.get("cost") == spans_no_extra[0].get("cost")
+
+
+def test_extras_only_usage_is_persisted_without_priced_tokens():
+    """An audio/image-only span (no input/output counts) still surfaces its extra
+    usage in usage_details — extras must persist independently of the priced guard."""
+    payload = _otel_payload(
+        [
+            _attr("llm.model_name", "claude-3-5-sonnet-20241022"),
+            _attr("gen_ai.usage.audio_tokens", 30),
+            _attr("gen_ai.usage.image_tokens", 45),
+        ]
+    )
+
+    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+
+    assert len(spans) == 1
+    span = spans[0]
+    # Extras persist without any priced input/output tokens present.
+    assert span["usage_details"]["extra:audio_tokens"] == 30
+    assert span["usage_details"]["extra:image_tokens"] == 45
+    # No priced buckets are fabricated — only the display-only extras land in
+    # usage_details. The LLM span still gets its text-estimation zeros (no text),
+    # but nothing is priced from the extras themselves.
+    assert "cache_read_tokens" not in span["usage_details"]
+    assert "cache_write_tokens" not in span["usage_details"]
+    assert "reasoning_tokens" not in span["usage_details"]
+    assert span["input_tokens"] == 0

--- a/tests/worker/test_otel_transform_metadata.py
+++ b/tests/worker/test_otel_transform_metadata.py
@@ -493,3 +493,59 @@ def test_extra_attr_spelling_collisions_are_summed():
 
     assert len(spans) == 1
     assert spans[0]["usage_details"]["extra:audio_tokens"] == 30
+
+
+def test_non_finite_extra_attr_does_not_crash_ingestion():
+    """An Infinity/NaN extra usage attribute must not abort ingestion of the batch;
+    it resolves to 0 and is not persisted."""
+    payload = _otel_payload(
+        [
+            _attr("llm.model_name", "claude-3-5-sonnet-20241022"),
+            _attr("gen_ai.usage.audio_tokens", float("inf")),
+            _attr("gen_ai.usage.image_tokens", float("nan")),
+        ]
+    )
+
+    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+
+    assert len(spans) == 1
+    assert "extra:audio_tokens" not in spans[0].get("usage_details", {})
+    assert "extra:image_tokens" not in spans[0].get("usage_details", {})
+
+
+def test_non_finite_priced_attr_does_not_crash_ingestion():
+    """Infinity in a priced token attribute is dropped to 0, not fatal."""
+    payload = _otel_payload(
+        [
+            _attr("llm.model_name", "claude-3-5-sonnet-20241022"),
+            _attr("gen_ai.usage.input_tokens", float("inf")),
+            _attr("gen_ai.usage.output_tokens", 200),
+        ]
+    )
+
+    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+
+    assert len(spans) == 1
+    assert spans[0]["input_tokens"] == 0
+    assert spans[0]["output_tokens"] == 200
+
+
+def test_extra_attr_collision_sum_is_bounded():
+    """Colliding spellings whose merged value would exceed the plausible token
+    bound drop the incoming contribution instead of storing an unbounded Int64."""
+    payload = _otel_payload(
+        [
+            _attr("llm.model_name", "claude-3-5-sonnet-20241022"),
+            _attr("gen_ai.usage.input_tokens", 1000),
+            _attr("gen_ai.usage.output_tokens", 200),
+            _attr("ai.usage.audioTokens", 900_000_000),
+            _attr("gen_ai.usage.audio_tokens", 900_000_000),
+        ]
+    )
+
+    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+
+    assert len(spans) == 1
+    # First spelling lands; the second would push the sum past the bound and is
+    # dropped rather than stored unbounded.
+    assert spans[0]["usage_details"]["extra:audio_tokens"] == 900_000_000

--- a/tests/worker/test_otel_transform_metadata.py
+++ b/tests/worker/test_otel_transform_metadata.py
@@ -399,3 +399,51 @@ def test_non_object_explicit_metadata_is_stored_verbatim():
 
     _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
     assert spans[0]["metadata"] == "just a note"
+
+
+def test_extra_unrecognized_usage_keys_are_stored():
+    """Unrecognized usage attributes land in usage_details with extra: prefix, normalized and not priced."""
+    payload = _otel_payload(
+        [
+            _attr("llm.model_name", "claude-3-5-sonnet-20241022"),
+            _attr("gen_ai.usage.input_tokens", 1000),
+            _attr("gen_ai.usage.output_tokens", 200),
+            _attr("gen_ai.usage.cache_read_input_tokens", 800),
+            _attr("gen_ai.usage.audio_tokens", 30),
+            _attr("gen_ai.usage.image_tokens", 45),
+            _attr("ai.usage.videoTokens", 12),
+            _attr("llm.token_count.audio", 9),
+            _attr("gen_ai.usage.zero_tokens", 0),  # should be skipped
+        ]
+    )
+
+    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+
+    assert len(spans) == 1
+    span = spans[0]
+    # Gross columns are unchanged
+    assert span["input_tokens"] == 1000
+    assert span["output_tokens"] == 200
+    # Priced keys are normal in usage_details
+    assert span["usage_details"]["cache_read_tokens"] == 800
+    assert "extra:cache_read_tokens" not in span["usage_details"]
+    # Unrecognized keys land with extra: prefix and camelCase normalization
+    assert span["usage_details"]["extra:audio_tokens"] == 30
+    assert span["usage_details"]["extra:image_tokens"] == 45
+    assert span["usage_details"]["extra:video_tokens"] == 12
+    assert span["usage_details"]["extra:audio"] == 9
+    # Zero tokens are skipped
+    assert "extra:zero_tokens" not in span["usage_details"]
+
+    # Cost should not be changed by adding extra keys
+    # Let's compare with a span that does not have extra keys
+    payload_no_extra = _otel_payload(
+        [
+            _attr("llm.model_name", "claude-3-5-sonnet-20241022"),
+            _attr("gen_ai.usage.input_tokens", 1000),
+            _attr("gen_ai.usage.output_tokens", 200),
+            _attr("gen_ai.usage.cache_read_input_tokens", 800),
+        ]
+    )
+    _t, spans_no_extra = transform_otel_to_clickhouse(payload_no_extra, project_id="proj-1")
+    assert span.get("cost") == spans_no_extra[0].get("cost")


### PR DESCRIPTION
### Problem
Fixes #1631

Manually reported usage (`update_current_span(usage=...)` → `traceroot.llm.usage`) was
matched against a closed allowlist of six field names (`input_tokens`, `output_tokens`,
`cache_read_tokens`, `cache_write_tokens`, `cache_write_1h_tokens`, `reasoning_tokens`).
Any token type outside it was silently discarded. Real-world cases: `audio_tokens`,
`image_tokens`, and future Anthropic cache tiers. The same loss applied on the OTEL
attribute path for unrecognized `gen_ai.usage.*` / `llm.token_count.*` / `ai.usage.*` keys.

### Fix
Unrecognized keys are no longer dropped — they are stored in `usage_details` as
**display-only, explicitly unpriced** entries prefixed `extra:` (e.g. `extra:audio_tokens`):

- **`parse_manual_usage()`** returns unrecognized fields as `extra:<name>` keys, sharing
  the exact validation of recognized fields (bool / non-numeric / negative / over-bound
  rejection) via a new `_parse_manual_value()` helper, with camelCase normalized to
  snake_case.
- **Ingest path** merges manual `extra:*` keys into `usage_details` alongside the existing
  OTEL-attribute extra scan, so both reporting paths surface the same way.
- **Frontend** renders `extra:*` keys in a new "Other usage" section of the token
  breakdown tooltip, and the trace-level rollup aggregates them across spans.

### Why this is safe
- Cost is **unaffected**: priced buckets still reconcile with the stored
  `input_tokens` / `output_tokens`, and `extra:*` keys are visibly separate.
- No schema change: `usage_details` is already a `Map(LowCardinality(String), Int64)`
  column chosen exactly so new provider token types need no migration.
- Backward compatible: existing readers of `usage_details?.cache_read_tokens` etc. are
  unchanged.

### Tests
- Backend: unit + integration coverage of manual extra keys (`extra:audio_tokens`,
  `extra:image_tokens`, camelCase `videoTokens`), cost-unchanged assertion, and the
  `llm.token_count.*` attribute branch.
- Frontend: `getTraceTokenUsage` aggregation across spans, trace-level `TokenChip` with
  extra keys, and the "Other usage" render.

### Verification
- `ruff check` / `ruff format --check`: pass
- ESLint / Prettier: pass
- Backend `pytest` (worker ingest + pricing): pass
- Frontend vitest (traces suite): 166 passed
- Coverage gate (`diff-cover >= 80%` on changed lines): backend **100%**, frontend **100%**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unrecognized usage keys are stored as display‑only `extra:` entries in `usage_details` and shown in the UI, so audio/image/future token types are visible without changing cost. Extras surface on spans and traces even without input/output tokens; non‑finite values are dropped and colliding spellings sum safely. Addresses #1631.

- **New Features**
  - Capture unrecognized `gen_ai.usage.*` / `llm.token_count.*` / `ai.usage.*` and manual `traceroot.llm.usage` keys into `usage_details` as `extra:<name>` (e.g. `extra:audio_tokens`), camelCase normalized to snake_case and colliding spellings summed.
  - UI shows an “Other usage” section in the token breakdown tooltip; trace rollups aggregate `extra:*` across all spans, including extras‑only traces.

- **Bug Fixes**
  - Persist `extra:*` keys independent of priced input/output guards and on audio/image‑only spans; extras are unpriced and display‑only.
  - Make “Other usage” rows key‑stable by using the raw `extra:*` key and disambiguating colliding labels.
  - Harden OTEL parsing: non‑finite values (Infinity/NaN/overflow) resolve to 0 without aborting ingestion; merged `extra:*` sums are bounded and drop contributions that would exceed the plausible token limit.

<sup>Written for commit 8279b25d708da4ff30430b7bfe5fbc0fa66cec69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

