### PR TITLE
fix(api): add keyset pagination to trace list so trace_start_time ties never drop rows (#1747)

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1687,6 +1687,24 @@
               "description": "Only traces that started before this time (exclusive, ISO 8601)",
               "title": "End Before"
             }
+          },
+          {
+            "description": "Trace id cursor for keyset pagination. Use the last item's trace_start_time as end_before and its trace_id as end_before_id to walk through traces that share the same start time without dropping rows.",
+            "in": "query",
+            "name": "end_before_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Trace id cursor for keyset pagination. Use the last item's trace_start_time as end_before and its trace_id as end_before_id to walk through traces that share the same start time without dropping rows.",
+              "title": "End Before Id"
+            }
           }
         ],
         "responses": {

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -62,8 +62,21 @@ async def list_traces(
         None,
         description="Only traces that started before this time (exclusive, ISO 8601)",
     ),
+    end_before_id: str | None = Query(
+        None,
+        description=(
+            "Trace id cursor for keyset pagination. Use the last item's trace_start_time "
+            "as end_before and its trace_id as end_before_id to walk through traces that "
+            "share the same start time without dropping rows."
+        ),
+    ),
 ):
     """List recent traces for the API key's project (newest first)."""
+    if end_before_id is not None and end_before is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="end_before_id requires end_before",
+        )
     start_after, end_before = clamp_retention_window(auth.billing_plan, start_after, end_before)
     try:
         service = get_trace_reader_service()
@@ -72,6 +85,7 @@ async def list_traces(
             limit=limit,
             start_after=start_after,
             end_before=end_before,
+            end_before_id=end_before_id,
         )
     except Exception as e:
         logger.exception(f"Error listing traces: {e}")

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -389,6 +389,7 @@ class TraceReaderService:
         user_id: str | None = None,
         start_after: datetime | None = None,
         end_before: datetime | None = None,
+        end_before_id: str | None = None,
         search_query: str | None = None,
         filters: list[Predicate] | None = None,
     ) -> dict:
@@ -417,8 +418,21 @@ class TraceReaderService:
 
         normalized_end = to_utc_naive(end_before) if end_before is not None else None
         if normalized_end is not None:
-            conditions.append("t.trace_start_time < {end_before:DateTime64(3)}")
-            params["end_before"] = normalized_end
+            if end_before_id is not None:
+                # Keyset pagination on (trace_start_time DESC, trace_id DESC): the
+                # exclusive time bound alone cannot advance past a millisecond tie
+                # group (excluding the timestamp skips never-returned rows, #1747).
+                # With end_before_id the bound becomes the full ordering pair.
+                conditions.append(
+                    "(t.trace_start_time < {end_before:DateTime64(3)} "
+                    "OR (t.trace_start_time = {end_before:DateTime64(3)} "
+                    "AND t.trace_id < {end_before_id:String}))"
+                )
+                params["end_before"] = normalized_end
+                params["end_before_id"] = end_before_id
+            else:
+                conditions.append("t.trace_start_time < {end_before:DateTime64(3)}")
+                params["end_before"] = normalized_end
 
         # Multi-field keyword search (trace_id, name, session_id, user_id)
         if search_query:
@@ -465,7 +479,7 @@ class TraceReaderService:
                     ORDER BY t.ch_update_time DESC
                     LIMIT 1 BY t.project_id, t.trace_id
                 )
-                ORDER BY trace_start_time DESC
+                ORDER BY trace_start_time DESC, trace_id DESC
                 LIMIT {{limit:UInt32}} OFFSET {{offset:UInt32}}
             ),
             span_agg AS (
@@ -509,7 +523,7 @@ class TraceReaderService:
                 sa.total_cost
             FROM page AS p
             LEFT JOIN span_agg AS sa ON p.trace_id = sa.trace_id
-            ORDER BY p.trace_start_time DESC
+            ORDER BY p.trace_start_time DESC, p.trace_id DESC
         """
 
         result = self._client.query(query, parameters=params)

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -187,6 +187,35 @@ class TestPublicListTraces:
         assert kwargs["start_after"] == datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
         assert kwargs["end_before"] == datetime(2024, 1, 31, 23, 59, 59, tzinfo=UTC)
 
+    def test_forwards_end_before_id_keyset_cursor(self, client, mock_reader):
+        mock_reader.list_traces.return_value = {
+            "data": [],
+            "meta": {"page": 0, "limit": 50, "total": 0},
+        }
+        resp = client.get(
+            "/api/v1/public/traces?end_before=2024-01-31T23:59:59Z&end_before_id=trace-abc",
+            headers=AUTH_HEADER,
+        )
+        assert resp.status_code == 200
+        kwargs = mock_reader.list_traces.call_args.kwargs
+        assert kwargs["end_before"] == datetime(2024, 1, 31, 23, 59, 59, tzinfo=UTC)
+        assert kwargs["end_before_id"] == "trace-abc"
+
+    def test_end_before_id_defaults_to_none_when_absent(self, client, mock_reader):
+        mock_reader.list_traces.return_value = {
+            "data": [],
+            "meta": {"page": 0, "limit": 50, "total": 0},
+        }
+        resp = client.get("/api/v1/public/traces", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        assert mock_reader.list_traces.call_args.kwargs["end_before_id"] is None
+
+    def test_end_before_id_without_end_before_rejected(self, client, mock_reader):
+        """A keyset cursor without its time half is meaningless — reject with 422."""
+        resp = client.get("/api/v1/public/traces?end_before_id=trace-abc", headers=AUTH_HEADER)
+        assert resp.status_code == 422
+        assert mock_reader.list_traces.call_args is None
+
     def test_time_range_defaults_to_none_when_absent(self, client, mock_reader):
         mock_reader.list_traces.return_value = {
             "data": [],

--- a/tests/rest/test_trace_reader_filters.py
+++ b/tests/rest/test_trace_reader_filters.py
@@ -168,3 +168,51 @@ def test_unfiltered_list_without_window_stays_unbounded():
     params = svc._client.query.call_args_list[0].kwargs["parameters"]
     assert "start_after" not in params
     assert "t.trace_start_time >=" not in page_sql
+
+
+def test_keyset_end_before_id_lands_in_both_page_and_count_queries():
+    """#1747: end_before_id (keyset on trace_start_time + trace_id) must reach BOTH
+    queries so the page stays consistent with the total — the whole tie group at the
+    bound timestamp is walkable, never silently dropped."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+    end = datetime(2026, 6, 2, 12, 0, 0)
+
+    svc.list_traces(project_id="p1", end_before=end, end_before_id="trace-abc")
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    count_sql = svc._client.query.call_args_list[1].args[0]
+    keyset = (
+        "t.trace_start_time = {end_before:DateTime64(3)} AND t.trace_id < {end_before_id:String}"
+    )
+    assert keyset in page_sql
+    assert keyset in count_sql  # the invariant — cursor reaches the total too
+    params = svc._client.query.call_args_list[0].kwargs["parameters"]
+    assert params["end_before_id"] == "trace-abc"
+    assert params["end_before"] == end
+
+
+def test_plain_end_before_keeps_exclusive_time_bound():
+    """Without end_before_id the bound is the legacy exclusive time predicate."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+    end = datetime(2026, 6, 2, 12, 0, 0)
+
+    svc.list_traces(project_id="p1", end_before=end)
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    assert "t.trace_start_time < {end_before:DateTime64(3)}" in page_sql
+    assert "end_before_id" not in svc._client.query.call_args_list[0].kwargs["parameters"]
+
+
+def test_list_traces_orders_by_trace_id_tiebreaker():
+    """#1747: the page and final ORDER BY must tie-break ties on trace_id so
+    OFFSET pagination (dashboard) is stable and keyset cursoring is well-defined."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1")
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    assert "ORDER BY trace_start_time DESC, trace_id DESC" in page_sql
+    assert "ORDER BY p.trace_start_time DESC, p.trace_id DESC" in page_sql

--- a/tests/rest/test_trace_reader_filters.py
+++ b/tests/rest/test_trace_reader_filters.py
@@ -182,8 +182,15 @@ def test_keyset_end_before_id_lands_in_both_page_and_count_queries():
 
     page_sql = svc._client.query.call_args_list[0].args[0]
     count_sql = svc._client.query.call_args_list[1].args[0]
+    # Guard the FULL keyset predicate — both halves of the OR. The exclusive branch
+    # (trace_start_time < end_before) is what lets pagination advance across
+    # timestamps; the tie branch (trace_start_time = end_before AND trace_id <
+    # end_before_id) walks through the tied group. Dropping either half would
+    # re-introduce the #1747 data loss while a partial assertion would miss it.
     keyset = (
-        "t.trace_start_time = {end_before:DateTime64(3)} AND t.trace_id < {end_before_id:String}"
+        "(t.trace_start_time < {end_before:DateTime64(3)} "
+        "OR (t.trace_start_time = {end_before:DateTime64(3)} "
+        "AND t.trace_id < {end_before_id:String}))"
     )
     assert keyset in page_sql
     assert keyset in count_sql  # the invariant — cursor reaches the total too


### PR DESCRIPTION
 Fixes #1749.

    ## Problem

    The internal trace-ingest route (`backend/rest/routers/internal.py`, `ingest_internal_traces`) writes a `traces` row from
  every batch it receives, with no root-span guard. `traces` is a `ReplacingMergeTree` whose sort key ends in the trace id, so
  the later write wins.

    During worker shutdown (SIGTERM/SIGINT), the OTel `BatchSpanProcessor._flushAll()` splits the buffer into
  `maxExportBatchSize` (100) chunks and exports them concurrently via `Promise.all`. With >100 self-trace spans buffered, a
  rootless chunk can land after the root-bearing chunk — and since a rootless batch carries none of the root-derived fields
  (name, user/session, input, metadata), it replaces a fully-populated trace row with a blank one.

    The affected self-trace then renders as perpetually "still being recorded" in the runs tab. Detector telemetry only;
  customer traffic goes through the public path, which has had this guard since April.

    ## Fix

    Mirror the public ingest path's root-span guard (`backend/worker/ingest_tasks.py`) on the internal route, keyed
  appropriately for a multi-project batch:

    - Only insert a trace row when the batch contains that trace's root span (`parent_span_id` is `None`), or when the trace is
   genuinely new (no existing ClickHouse record).
    - Rootless traces trigger an existence probe (`SELECT DISTINCT trace_id FROM traces FINAL WHERE project_id = … AND trace_id
   IN …`), grouped per project so a multi-project detector batch probes each project once and the `project_id` sort-key
  predicate keeps the probe pruned.
    - Spans are still always inserted; only the trace row is guarded.

    This is the same ordering fix the public path relies on, applied at the boundary that writes the bad row — no SDK or schema
   changes.

    ## Tests

    Added `TestInternalTraceIngestRootGuard` (`tests/rest/test_detector_endpoints.py`):

    - Root-bearing batch inserts the trace row without a probe.
    - Rootless batch whose trace has no existing row inserts after an empty probe (genuinely new).
    - The #1749 case: rootless batch whose trace already exists is withheld (`insert_traces_batch([])`) while spans still
  insert.
    - Multi-project rootless batch probes each project once, keyed per trace's own project.

    Also extended the `_otlp_body` test helper with a backward-compatible `parent_span_ids` tuple to set each span's parent
  individually.

    ## Verification

    - `tests/rest/test_detector_endpoints.py` — 68 passed (incl. 4 new)
    - Detector/transform/ingest/db suites — 166 passed
    - `ruff check .` — clean
    - `ruff format --check` — my two files conform
    - Full `tests/` run: 1101 passed, 26 failed — all 26 verified as pre-existing on `origin/main` (local
  `localhost:3000`/`:3001` port mismatch in auth/whoami/public-trace tests); this change introduces no new failures.


<sup>Written for commit be236f357f28a1bb457b4ce531c232d389c37612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

