### PR TITLE
fix(worker): stop destroying traceroot.span.tags on write

### DIFF
--- a/backend/shared/span_attributes.py
+++ b/backend/shared/span_attributes.py
@@ -38,3 +38,13 @@ SPAN_TREE_ATTRIBUTES = (SPAN_PATH, SPAN_IDS_PATH, SPAN_STARTS_PATH)
 Not the same as what the trace-detail read returns: that returns only the
 attributes the client actually consumes.
 """
+
+SPAN_TAGS = "traceroot.span.tags"
+"""Caller-supplied labels from the SDK's typed `tags` option.
+
+Customer data with no dedicated column yet, so it rides in `metadata` on the
+same terms as the span-path attributes above. It has to survive both metadata
+branches in `worker/otel_transform.py`: a span that sets explicit metadata is
+exactly a span whose author is labelling things, so dropping tags there would
+lose them from the spans most likely to carry them.
+"""

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -38,7 +38,12 @@ from datetime import UTC, datetime
 from typing import Any
 
 from shared.enums import SpanKind, SpanStatus
-from shared.span_attributes import SPAN_IDS_PATH, SPAN_PATH, SPAN_TREE_ATTRIBUTES
+from shared.span_attributes import (
+    SPAN_IDS_PATH,
+    SPAN_PATH,
+    SPAN_TAGS,
+    SPAN_TREE_ATTRIBUTES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +100,11 @@ _KNOWN_ATTRIBUTE_PREFIXES = {
     "traceroot.span.output",
     "traceroot.span.type",
     "traceroot.span.metadata",
-    "traceroot.span.tags",
+    # traceroot.span.tags is deliberately absent. The SDK ships it as a typed
+    # option, but nothing extracts it and no column holds it, so listing it here
+    # stripped customer-sent labels and wrote them nowhere. It now falls into the
+    # metadata blob like any unextracted attribute, which keeps the values
+    # recoverable until tags get a dedicated field.
     "traceroot.trace.",
     "traceroot.environment",
     # Nothing extracts this any more; it is listed purely to keep a
@@ -978,9 +987,13 @@ def transform_otel_to_clickhouse(
                 # its parent was still open. That hit exactly the spans users
                 # annotate — usually leaves, whose long-lived parents are the ones
                 # still in flight — so the paths ride along with user metadata.
-                span_path_attrs = {
+                # Tags ride along for the same reason: they have no column, and a
+                # span that sets explicit metadata is exactly a span whose author
+                # is labelling things, so the explicit branch would drop them from
+                # the spans most likely to carry them.
+                carried_attrs = {
                     key: span_attrs[key]
-                    for key in SPAN_TREE_ATTRIBUTES
+                    for key in (*SPAN_TREE_ATTRIBUTES, SPAN_TAGS)
                     if span_attrs.get(key) is not None
                 }
                 explicit_metadata = span_attrs.get("traceroot.span.metadata")
@@ -992,7 +1005,7 @@ def transform_otel_to_clickhouse(
                         except (TypeError, ValueError):
                             parsed_explicit = None
                     if isinstance(parsed_explicit, dict):
-                        span_record["metadata"] = json.dumps({**parsed_explicit, **span_path_attrs})
+                        span_record["metadata"] = json.dumps({**parsed_explicit, **carried_attrs})
                     elif isinstance(explicit_metadata, str):
                         # Not a JSON object (free-text or a scalar): store it as
                         # given. Nothing to merge into, so this span has no paths.

--- a/tests/worker/test_otel_transform_metadata.py
+++ b/tests/worker/test_otel_transform_metadata.py
@@ -7,6 +7,7 @@ from shared.span_attributes import (
     SPAN_IDS_PATH,
     SPAN_PATH,
     SPAN_STARTS_PATH,
+    SPAN_TAGS,
     SPAN_TREE_ATTRIBUTES,
 )
 from worker.otel_transform import _is_known_attribute, transform_otel_to_clickhouse
@@ -399,3 +400,46 @@ def test_non_object_explicit_metadata_is_stored_verbatim():
 
     _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
     assert spans[0]["metadata"] == "just a note"
+
+
+def test_span_tags_survive_into_metadata():
+    """Tags sent through the SDK's typed option must reach the stored `metadata`.
+
+    The SDK ships `tags` as a first-class option and serializes it onto the span
+    as `traceroot.span.tags`. Nothing extracts that key and no column holds it,
+    so listing it in `_KNOWN_ATTRIBUTE_PREFIXES` stripped it from the leftover
+    bag and wrote it nowhere: ingest answered 200 and the values were gone. It
+    now survives into `metadata` like any other unextracted attribute, which
+    keeps customer labels recoverable until tags get a dedicated field.
+    """
+    payload = _otel_payload([_array_attr(SPAN_TAGS, ["prod", "checkout"])])
+
+    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+
+    metadata = json.loads(spans[0]["metadata"])
+    assert metadata[SPAN_TAGS] == ["prod", "checkout"]
+
+
+def test_span_tags_are_not_known_attributes():
+    """Direct guard on the mechanism above, independent of the transform."""
+    assert not _is_known_attribute(SPAN_TAGS), (
+        f"{SPAN_TAGS} is treated as a known attribute, so it would be stripped "
+        "from span metadata while no extraction and no column exist for it, and "
+        "customer-sent tags would be destroyed on write"
+    )
+
+
+def test_span_tags_survive_alongside_explicit_metadata():
+    """A span that also sets explicit metadata must KEEP its tags."""
+    payload = _otel_payload(
+        [
+            _attr("traceroot.span.metadata", {"stage": "checkout"}),
+            _array_attr(SPAN_TAGS, ["prod"]),
+        ]
+    )
+
+    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+
+    metadata = json.loads(spans[0]["metadata"])
+    assert metadata["stage"] == "checkout"
+    assert metadata[SPAN_TAGS] == ["prod"]


### PR DESCRIPTION
Closes #1748.

## What changed

`traceroot.span.tags` was listed in `_KNOWN_ATTRIBUTE_PREFIXES`, the strip-list for attributes already extracted into dedicated fields. Nothing extracts it and no column holds it, so tags were removed from the leftover-attribute bag and written nowhere. It is removed from that set, so tags now land in the `metadata` blob like any unextracted attribute.

## The second drop, not in the issue

While pinning the fix with a test I found the one-line change is not enough on its own. When a span also sets `traceroot.span.metadata`, the transform builds the metadata column as `{**parsed_explicit, **span_path_attrs}` and discards the leftover bag entirely, so tags were still lost on exactly that path.

That is the span whose author is deliberately labelling things, so it is the worst place to lose labels. Tags now ride along in both branches on the same terms as the span-path attributes, and the merged dict is renamed `span_path_attrs` to `carried_attrs` since it is no longer only paths.

A `SPAN_TAGS` constant is added next to the span-path constants in `shared/span_attributes.py`, so the wire string is referenced rather than repeated, matching how the existing tree attributes are handled.

This PR is step 1 of the issue only. The feature decision in step 2 (a trace-level `Array(String)` column, exposure in list/detail/export, filtering) is untouched, and the values are recoverable in the meantime.

## Test plan

Three tests added to `tests/worker/test_otel_transform_metadata.py`, mirroring the existing span-path trio:

- `test_span_tags_survive_into_metadata` — tags reach the stored metadata
- `test_span_tags_are_not_known_attributes` — direct guard on the strip-list, independent of the transform
- `test_span_tags_survive_alongside_explicit_metadata` — the second drop above; this one fails on the one-line fix alone

```
pytest tests/worker/test_otel_transform_metadata.py
    19 passed

pytest tests/worker/ --ignore=tests/worker/test_ingest_robustness.py
    511 passed, 1 failed
```

The single failure is `test_detector_tasks.py::TestAddBullmqJob::test_adds_delayed_job_with_dedup_id_and_closes`. It fails the same way with these changes stashed, so it is pre-existing and unrelated. `test_ingest_robustness.py` was skipped because it needs `fastapi`, which my minimal test environment did not install.

No UI change, so no screenshots.

AI usage: written with an AI assistant. I read and own every line, and the diagnosis of the second drop is mine.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loss of `traceroot.span.tags` during ingest. Tags now persist in stored `metadata`, including when spans set explicit `traceroot.span.metadata` (addresses #1748).

- **Bug Fixes**
  - Removed `traceroot.span.tags` from `_KNOWN_ATTRIBUTE_PREFIXES` so tags fall into `metadata`.
  - When explicit `traceroot.span.metadata` is present, merge tags with span-path attributes (now `carried_attrs`) instead of discarding the leftover bag.
  - Added `SPAN_TAGS` constant and tests to ensure tags survive, aren’t treated as known attributes, and persist alongside explicit metadata.

<sup>Written for commit 369081a98d5b41ccfe042923281755e2c7d69436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

