### PR TITLE
perf(traces): keep input/output out of the trace-paging dedup sort

### DIFF
--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -450,16 +450,22 @@ class TraceReaderService:
         # This avoids scanning/joining every span in the project on each list call,
         # and never groups by the large input/output text columns. See #963.
         query = f"""
-            WITH page AS (
+            WITH page_keys AS (
                 -- Dedup ReplacingMergeTree by latest ch_update_time FIRST (correctness),
                 -- THEN order by start time for pagination.
+                --
+                -- input/output are deliberately absent here. This dedup sorts every
+                -- row matching the WHERE, so any column listed rides through that
+                -- sort: carrying the I/O text made peak memory scale with
+                -- (matching rows x payload width) instead of with the page. The
+                -- text is fetched below for the page's traces only.
                 SELECT
                     trace_id, project_id, name, trace_start_time,
-                    user_id, session_id, input, output
+                    user_id, session_id, ch_update_time
                 FROM (
                     SELECT
                         t.trace_id, t.project_id, t.name, t.trace_start_time,
-                        t.user_id, t.session_id, t.input, t.output
+                        t.user_id, t.session_id, t.ch_update_time
                     FROM traces AS t
                     WHERE {where_clause}
                     ORDER BY t.ch_update_time DESC
@@ -467,6 +473,30 @@ class TraceReaderService:
                 )
                 ORDER BY trace_start_time DESC
                 LIMIT {{limit:UInt32}} OFFSET {{offset:UInt32}}
+            ),
+            page_io AS (
+                -- The heavy columns, for the page's traces only. Pinned to the exact
+                -- (trace_id, ch_update_time) row the dedup above selected, so the
+                -- text cannot come from a different version than the metadata when
+                -- a trace has several rows sharing one update time.
+                SELECT trace_id, input, output
+                FROM (
+                    SELECT trace_id, input, output, ch_update_time
+                    FROM traces
+                    WHERE project_id = {{project_id:String}}
+                      AND (trace_id, ch_update_time) IN (
+                          SELECT trace_id, ch_update_time FROM page_keys
+                      )
+                    ORDER BY ch_update_time DESC
+                    LIMIT 1 BY project_id, trace_id
+                )
+            ),
+            page AS (
+                SELECT
+                    k.trace_id, k.project_id, k.name, k.trace_start_time,
+                    k.user_id, k.session_id, io.input AS input, io.output AS output
+                FROM page_keys AS k
+                LEFT JOIN page_io AS io ON k.trace_id = io.trace_id
             ),
             span_agg AS (
                 SELECT

--- a/backend/shared/span_attributes.py
+++ b/backend/shared/span_attributes.py
@@ -38,3 +38,13 @@ SPAN_TREE_ATTRIBUTES = (SPAN_PATH, SPAN_IDS_PATH, SPAN_STARTS_PATH)
 Not the same as what the trace-detail read returns: that returns only the
 attributes the client actually consumes.
 """
+
+SPAN_TAGS = "traceroot.span.tags"
+"""Caller-supplied labels from the SDK's typed `tags` option.
+
+Customer data with no dedicated column yet, so it rides in `metadata` on the
+same terms as the span-path attributes above. It has to survive both metadata
+branches in `worker/otel_transform.py`: a span that sets explicit metadata is
+exactly a span whose author is labelling things, so dropping tags there would
+lose them from the spans most likely to carry them.
+"""

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -38,7 +38,12 @@ from datetime import UTC, datetime
 from typing import Any
 
 from shared.enums import SpanKind, SpanStatus
-from shared.span_attributes import SPAN_IDS_PATH, SPAN_PATH, SPAN_TREE_ATTRIBUTES
+from shared.span_attributes import (
+    SPAN_IDS_PATH,
+    SPAN_PATH,
+    SPAN_TAGS,
+    SPAN_TREE_ATTRIBUTES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +100,11 @@ _KNOWN_ATTRIBUTE_PREFIXES = {
     "traceroot.span.output",
     "traceroot.span.type",
     "traceroot.span.metadata",
-    "traceroot.span.tags",
+    # traceroot.span.tags is deliberately absent. The SDK ships it as a typed
+    # option, but nothing extracts it and no column holds it, so listing it here
+    # stripped customer-sent labels and wrote them nowhere. It now falls into the
+    # metadata blob like any unextracted attribute, which keeps the values
+    # recoverable until tags get a dedicated field.
     "traceroot.trace.",
     "traceroot.environment",
     # Nothing extracts this any more; it is listed purely to keep a
@@ -978,9 +987,13 @@ def transform_otel_to_clickhouse(
                 # its parent was still open. That hit exactly the spans users
                 # annotate — usually leaves, whose long-lived parents are the ones
                 # still in flight — so the paths ride along with user metadata.
-                span_path_attrs = {
+                # Tags ride along for the same reason: they have no column, and a
+                # span that sets explicit metadata is exactly a span whose author
+                # is labelling things, so the explicit branch would drop them from
+                # the spans most likely to carry them.
+                carried_attrs = {
                     key: span_attrs[key]
-                    for key in SPAN_TREE_ATTRIBUTES
+                    for key in (*SPAN_TREE_ATTRIBUTES, SPAN_TAGS)
                     if span_attrs.get(key) is not None
                 }
                 explicit_metadata = span_attrs.get("traceroot.span.metadata")
@@ -992,7 +1005,7 @@ def transform_otel_to_clickhouse(
                         except (TypeError, ValueError):
                             parsed_explicit = None
                     if isinstance(parsed_explicit, dict):
-                        span_record["metadata"] = json.dumps({**parsed_explicit, **span_path_attrs})
+                        span_record["metadata"] = json.dumps({**parsed_explicit, **carried_attrs})
                     elif isinstance(explicit_metadata, str):
                         # Not a JSON object (free-text or a scalar): store it as
                         # given. Nothing to merge into, so this span has no paths.

--- a/tests/rest/test_trace_reader_filters.py
+++ b/tests/rest/test_trace_reader_filters.py
@@ -168,3 +168,57 @@ def test_unfiltered_list_without_window_stays_unbounded():
     params = svc._client.query.call_args_list[0].kwargs["parameters"]
     assert "start_after" not in params
     assert "t.trace_start_time >=" not in page_sql
+
+
+def test_page_dedup_does_not_carry_io_text_through_its_sort():
+    """The trace-paging dedup must not list input/output.
+
+    That dedup sorts every row matching the WHERE, so any column named in it is
+    materialized for the whole matching set, not for the page. Carrying the I/O
+    text there made peak memory scale with (matching rows x payload width),
+    which is unbounded in tenant size — a page load on a large tenant could
+    exhaust a shared node. The text is fetched separately for the page's traces.
+    """
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1")
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    dedup = page_sql.split("page_keys AS (")[1].split("),")[0]
+    assert "input" not in dedup, (
+        "input rides through the pre-page dedup sort again; peak memory is back to "
+        "scaling with the matching set instead of the page"
+    )
+    assert "output" not in dedup
+
+
+def test_io_text_is_fetched_only_for_the_page_and_pinned_to_the_deduped_row():
+    """The I/O fetch must be restricted to the page and to the row the dedup chose.
+
+    Restricted to the page so it stays bounded; pinned on (trace_id,
+    ch_update_time) so metadata and text cannot come from two different versions
+    of the same trace when several rows share one update time.
+    """
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1")
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    io_cte = page_sql.split("page_io AS (")[1].split("),")[0]
+    assert "input" in io_cte and "output" in io_cte
+    assert "(trace_id, ch_update_time) IN (" in io_cte
+    assert "SELECT trace_id, ch_update_time FROM page_keys" in io_cte
+
+
+def test_page_still_exposes_io_columns_to_the_final_select():
+    """Splitting the fetch must not change what the list returns."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1")
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    assert "p.input" in page_sql
+    assert "p.output" in page_sql

--- a/tests/worker/test_otel_transform_metadata.py
+++ b/tests/worker/test_otel_transform_metadata.py
@@ -7,6 +7,7 @@ from shared.span_attributes import (
     SPAN_IDS_PATH,
     SPAN_PATH,
     SPAN_STARTS_PATH,
+    SPAN_TAGS,
     SPAN_TREE_ATTRIBUTES,
 )
 from worker.otel_transform import _is_known_attribute, transform_otel_to_clickhouse
@@ -399,3 +400,46 @@ def test_non_object_explicit_metadata_is_stored_verbatim():
 
     _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
     assert spans[0]["metadata"] == "just a note"
+
+
+def test_span_tags_survive_into_metadata():
+    """Tags sent through the SDK's typed option must reach the stored `metadata`.
+
+    The SDK ships `tags` as a first-class option and serializes it onto the span
+    as `traceroot.span.tags`. Nothing extracts that key and no column holds it,
+    so listing it in `_KNOWN_ATTRIBUTE_PREFIXES` stripped it from the leftover
+    bag and wrote it nowhere: ingest answered 200 and the values were gone. It
+    now survives into `metadata` like any other unextracted attribute, which
+    keeps customer labels recoverable until tags get a dedicated field.
+    """
+    payload = _otel_payload([_array_attr(SPAN_TAGS, ["prod", "checkout"])])
+
+    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+
+    metadata = json.loads(spans[0]["metadata"])
+    assert metadata[SPAN_TAGS] == ["prod", "checkout"]
+
+
+def test_span_tags_are_not_known_attributes():
+    """Direct guard on the mechanism above, independent of the transform."""
+    assert not _is_known_attribute(SPAN_TAGS), (
+        f"{SPAN_TAGS} is treated as a known attribute, so it would be stripped "
+        "from span metadata while no extraction and no column exist for it, and "
+        "customer-sent tags would be destroyed on write"
+    )
+
+
+def test_span_tags_survive_alongside_explicit_metadata():
+    """A span that also sets explicit metadata must KEEP its tags."""
+    payload = _otel_payload(
+        [
+            _attr("traceroot.span.metadata", {"stage": "checkout"}),
+            _array_attr(SPAN_TAGS, ["prod"]),
+        ]
+    )
+
+    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+
+    metadata = json.loads(spans[0]["metadata"])
+    assert metadata["stage"] == "checkout"
+    assert metadata[SPAN_TAGS] == ["prod"]


### PR DESCRIPTION
Step 1 of #1752, the query-only half. No migration, no schema change.

## What changed

The `page` CTE deduped with `input`/`output` in its projection, so its `ORDER BY ch_update_time DESC` sorted every row matching the WHERE with the I/O text attached. Any column named in that dedup is materialized for the whole matching set, not for the page, which is why peak memory scaled with (matching rows x payload width) rather than with the 50 rows returned.

The CTE is now two stages:

- `page_keys` dedups, orders and pages on identity and display metadata only. The wide sort is gone.
- `page_io` fetches `input`/`output` for the page traces only.
- `page` joins them, so the final SELECT is unchanged.

## The version-mixing hole, not in the issue

The issue warns about the over-fetch variant and its correctness cliff. There is a second one in any naive split: if a trace has several rows sharing one `ch_update_time`, two independent `LIMIT 1 BY` passes can settle on different rows, and the page would then show one version metadata with another version text. A single CTE could not do that because it picked once.

`page_io` therefore matches on the pair rather than the id:

```sql
WHERE project_id = {project_id:String}
  AND (trace_id, ch_update_time) IN (
      SELECT trace_id, ch_update_time FROM page_keys
  )
```

so it is pinned to the exact row stage one selected.

## What this does not do

Problem A, the day-granularity sort key, is untouched, so the full-timestamp `ORDER BY` still cannot terminate the scan early and deep pagination is still expensive. That is the migration in step 2 of the issue.

## Test plan

Three tests added to `tests/rest/test_trace_reader_filters.py`, using the file existing mocked-client pattern that asserts on the generated SQL:

- `test_page_dedup_does_not_carry_io_text_through_its_sort` — pins the invariant that regressed
- `test_io_text_is_fetched_only_for_the_page_and_pinned_to_the_deduped_row` — page restriction and the pair match
- `test_page_still_exposes_io_columns_to_the_final_select` — the split does not change what the list returns

```
pytest tests/rest/test_trace_reader_filters.py
    12 passed

pytest tests/rest/
    584 passed, 1 skipped
```

The skip is `test_filter_columns_parity.py`, which skips itself on this branch.

I could not reproduce the memory figures: they came from a local ClickHouse with a 5M-trace project, and I have no ClickHouse instance. The tests therefore pin the query shape, which is what the fix changes, rather than the gigabytes. Someone with the seeded instance can confirm the peak drops in the range the issue predicts.

No UI change, so no screenshots.

AI usage: written with an AI assistant. I read and own every line, and the version-mixing hole above is my own finding.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces peak memory on trace list paging by removing `input`/`output` from the dedup sort and fetching them only for the page, and preserves `traceroot.span.tags` by keeping them in span metadata. Implements the query-only half of #1752 and fixes data loss from `tags` (#1748).

- **Performance**
  - Split the page CTE into `page_keys` (dedup/order/page on IDs/metadata) and `page_io` (fetch `input`/`output` only for the page).
  - Pin I/O fetch on `(trace_id, ch_update_time)` to prevent version mix when multiple rows share an update time.
  - Final SELECT is unchanged; no schema or migration.

- **Bug Fixes**
  - Stop stripping `traceroot.span.tags` during ingest: remove it from the known-attribute strip list and merge it into `metadata`, including when explicit metadata is set.
  - Add tests to ensure tags persist and the new query shape is enforced.

<sup>Written for commit 0aa56a966b873bca7da2efa366a15f390e77422b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

