### PR TITLE
perf(db): carry source in the spans no-I/O projection so source-filtered reads can use it

### DIFF
--- a/backend/db/clickhouse/migrations/008_add_source_to_spans_projection.sql
+++ b/backend/db/clickhouse/migrations/008_add_source_to_spans_projection.sql
@@ -1,0 +1,101 @@
+-- +goose Up
+
+-- Carry `source` in the spans no-I/O projection so source-filtered reads can use
+-- it again.
+--
+-- Migration 005 built `spans_no_io_by_start_time` for exactly one query shape:
+-- one project, a `span_start_time` window, none of the input/output/metadata
+-- blobs. Migration 006 then added `source` as a metadata-only ALTER — cheap
+-- because `source` sits outside every sort and partition key, which 006's
+-- comment notes as the advantage. What it does not note: a column outside the
+-- projection's SELECT list is not merely unsorted there, it is absent. A
+-- ClickHouse projection can only serve a query whose every referenced column it
+-- carries, so from 006 onward every read that filters `source = 'user'` — which
+-- is every customer-facing span read, via `customer_traffic_only()` — was
+-- refused the projection and fell back to the base table, whose sort key buries
+-- `span_start_time` behind `trace_id`. The projection built to fix that time
+-- pruning has been unreachable for the queries it was built for.
+--
+-- `source` is added to the SELECT list only, NOT to the projection's ORDER BY.
+-- Carrying the column is what restores eligibility; the sort key stays
+-- `(project_id, span_start_time, trace_id, span_id)` so the time-window pruning
+-- the projection exists for is unchanged, and `source = 'user'` stays a
+-- PREWHERE-evaluated predicate over a LowCardinality column. Keeping `source`
+-- out of every ORDER BY also preserves the invariant that makes 006 replayable
+-- as a metadata-only ALTER on a fresh database (asserted by
+-- tests/db/test_source_migration_is_metadata_only.py).
+--
+-- ClickHouse cannot rename a projection and cannot alter one in place, so the
+-- new column list arrives under a new name and the old projection is retired
+-- afterwards. The order matters and is the reason this is not a
+-- DROP-then-ADD of the same name: dropping first would leave a window, as long
+-- as the rematerialization takes, in which the table has NO no-I/O projection at
+-- all. That window is not harmless — the trace-list filter semi-joins
+-- (`_membership_semijoin` / `_aggregate_semijoin` in rest/services/filters/
+-- translate.py) scan spans with a project id and a `span_start_time` bound and
+-- no `source` predicate, so they are the reads the projection serves *today*,
+-- and dropping it first would regress them for the duration of the migration.
+-- Adding first costs a temporary second copy of the projection's parts instead,
+-- for the length of Step 2 only, and that copy is bounded by the projection's
+-- own size: input/output/metadata are in neither projection, so the overlap
+-- never duplicates the blob columns.
+--
+-- Unlike 005 this does not need ingestion paused: there is no table rebuild and
+-- no rename, new parts pick up the new projection from the moment it is
+-- declared, and MATERIALIZE only backfills the parts that already exist.
+
+-- Idempotent cleanup: if a prior run died between ADD and DROP, the new
+-- projection may already be declared with an unusable partial materialization.
+ALTER TABLE spans DROP PROJECTION IF EXISTS spans_no_io_by_start_time_v2;
+
+-- Step 1 — declare the replacement. Metadata-only: parts written from here on
+-- carry both projections, existing parts carry neither the new one yet.
+ALTER TABLE spans ADD PROJECTION spans_no_io_by_start_time_v2
+(
+    SELECT
+        span_id, trace_id, parent_span_id, project_id,
+        span_start_time, span_end_time, name, span_kind,
+        status, status_message, model_name, cost,
+        input_tokens, output_tokens, total_tokens,
+        git_source_file, git_source_line, git_source_function,
+        ch_create_time, ch_update_time, environment, usage_details,
+        source
+    ORDER BY (project_id, span_start_time, trace_id, span_id)
+);
+
+-- Step 2 — backfill the existing parts. `mutations_sync = 2` makes this block
+-- until every replica has finished, deliberately: Step 3 must not race an
+-- asynchronous mutation, or the drop lands while the replacement is still
+-- half-built and the table is left with no usable no-I/O projection — the exact
+-- regression this ordering exists to avoid. On a single node this behaves as
+-- mutations_sync = 1.
+ALTER TABLE spans MATERIALIZE PROJECTION spans_no_io_by_start_time_v2
+SETTINGS mutations_sync = 2;
+
+-- Step 3 — retire the projection that is missing `source`. Dropped here rather
+-- than left as a backstop (the way 005 keeps `spans_old`): a stale table costs
+-- disk once, but a redundant projection is rewritten on every insert and every
+-- merge for as long as it exists.
+ALTER TABLE spans DROP PROJECTION IF EXISTS spans_no_io_by_start_time;
+
+-- +goose Down
+
+-- Reverse: restore the projection without `source`, same ordering discipline.
+ALTER TABLE spans DROP PROJECTION IF EXISTS spans_no_io_by_start_time;
+
+ALTER TABLE spans ADD PROJECTION spans_no_io_by_start_time
+(
+    SELECT
+        span_id, trace_id, parent_span_id, project_id,
+        span_start_time, span_end_time, name, span_kind,
+        status, status_message, model_name, cost,
+        input_tokens, output_tokens, total_tokens,
+        git_source_file, git_source_line, git_source_function,
+        ch_create_time, ch_update_time, environment, usage_details
+    ORDER BY (project_id, span_start_time, trace_id, span_id)
+);
+
+ALTER TABLE spans MATERIALIZE PROJECTION spans_no_io_by_start_time
+SETTINGS mutations_sync = 2;
+
+ALTER TABLE spans DROP PROJECTION IF EXISTS spans_no_io_by_start_time_v2;

--- a/tests/db/test_spans_projection_column_coverage.py
+++ b/tests/db/test_spans_projection_column_coverage.py
@@ -1,0 +1,254 @@
+"""The spans no-I/O projection must carry every column its readers touch.
+
+Migration 005 built `spans_no_io_by_start_time` to serve time-ranged span
+reads that never open the input/output/metadata blobs: its
+`ORDER BY (project_id, span_start_time, ...)` repairs the weak time pruning of
+the base table, whose sort key buries `span_start_time` behind `trace_id`.
+
+ClickHouse will only use a projection for a query whose every referenced
+column the projection carries. So a column added to `spans` after 005 does not
+merely miss the projection's sort key — it disqualifies the projection for
+every read that then references the new column, and those reads silently fall
+back to the base table's slow path.
+
+That is what migration 006 did with `source`. Its ALTER is metadata-only
+because `source` sits outside every sort and partition key (guarded by
+test_source_migration_is_metadata_only) — but sitting outside the projection's
+*column list* is a different fact with a cost, and nothing caught it.
+
+These assertions replay the migration files, so the next ALTER ADD COLUMN that
+forgets the projection fails here instead of quietly buying a base-table scan.
+"""
+
+import re
+from pathlib import Path
+
+MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[2] / "backend" / "db" / "clickhouse" / "migrations"
+)
+
+# The blobs the no-I/O projection exists to avoid reading. Everything else on
+# `spans` belongs in it; these three deliberately do not.
+IO_COLUMNS = frozenset({"input", "output", "metadata"})
+
+# Entries in a CREATE TABLE body that declare something other than a column.
+_NON_COLUMN_KEYWORDS = frozenset({"PROJECTION", "INDEX", "CONSTRAINT", "PRIMARY"})
+
+
+def _migration_files() -> list[Path]:
+    """Every migration, in the order goose applies them (numeric filename prefix)."""
+    files = sorted(MIGRATIONS_DIR.glob("*.sql"))
+    assert files, f"no migrations found in {MIGRATIONS_DIR}"
+    return files
+
+
+def _up_section(sql: str) -> str:
+    """The goose Up half of a migration, with `--` comments stripped.
+
+    Down sections are excluded deliberately: 005's Down re-creates `spans_v2`
+    without a projection, and counting it would model a schema that never
+    exists on a migrated database.
+    """
+    up, _, _down = sql.partition("-- +goose Down")
+    assert "-- +goose Up" in up, "migration must declare a goose Up section"
+    return re.sub(r"--[^\n]*", "", up)
+
+
+def _paren_body(text: str, open_idx: int) -> str:
+    """Contents of the parenthesis group that opens at `open_idx`, nesting included."""
+    assert text[open_idx] == "(", "expected an opening parenthesis"
+    depth = 0
+    for i in range(open_idx, len(text)):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return text[open_idx + 1 : i]
+    raise AssertionError("unbalanced parentheses in migration SQL")
+
+
+def _split_top_level(body: str) -> list[str]:
+    """Split on commas that are not inside a nested parenthesis group."""
+    parts, depth, current = [], 0, []
+    for char in body:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        if char == "," and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    parts.append("".join(current))
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _create_table_columns(up_sql: str, table: str) -> list[str] | None:
+    """Column names declared by `CREATE TABLE <table>` in `up_sql`, or None.
+
+    Non-column entries (a PROJECTION, INDEX, CONSTRAINT or PRIMARY KEY clause)
+    are skipped; a projection body carries commas of its own, which is why the
+    split is depth-aware.
+    """
+    match = re.search(rf"CREATE TABLE (?:IF NOT EXISTS )?{table}\b", up_sql)
+    if not match:
+        return None
+    open_idx = up_sql.index("(", match.end())
+    entries = _split_top_level(_paren_body(up_sql, open_idx))
+    return [
+        entry.split()[0]
+        for entry in entries
+        if entry.split()[0].upper() not in _NON_COLUMN_KEYWORDS
+    ]
+
+
+def _projection_events(up_sql: str) -> list[tuple[int, str, set[str] | None]]:
+    """Projection declarations and drops in `up_sql`, in statement order.
+
+    Each event is `(position, name, columns)` — `columns` is the SELECT list for
+    a declaration and None for a drop. Order within a file matters: a migration
+    that drops a leftover name before declaring it under the same name would
+    otherwise replay as a net removal.
+
+    Declarations cover both forms: a `PROJECTION name (...)` inside a CREATE
+    TABLE body and a standalone `ALTER TABLE ... ADD PROJECTION name (...)`. The
+    `(?=\\()` lookahead is what separates them from a drop, which names a
+    projection with no body following.
+    """
+    events: list[tuple[int, str, set[str] | None]] = []
+
+    for match in re.finditer(r"\bPROJECTION\s+(\w+)\s*(?=\()", up_sql):
+        body = _paren_body(up_sql, up_sql.index("(", match.end(1)))
+        select_list = re.search(r"SELECT(.*?)ORDER BY", body, re.DOTALL)
+        assert select_list, f"projection {match.group(1)} must SELECT columns and ORDER BY"
+        events.append((match.start(), match.group(1), set(_split_top_level(select_list.group(1)))))
+
+    for match in re.finditer(r"DROP PROJECTION(?: IF EXISTS)? (\w+)", up_sql):
+        events.append((match.start(), match.group(1), None))
+
+    return sorted(events, key=lambda event: event[0])
+
+
+def live_spans_columns() -> set[str]:
+    """Columns on `spans` after every migration has been applied.
+
+    Starts from the last CREATE that becomes the live table (005 creates
+    `spans_v2` and renames it over `spans`, so the rebuild's column list is the
+    baseline, not 002's) and replays the ADD/DROP COLUMN statements that follow.
+    """
+    columns: list[str] = []
+    for path in _migration_files():
+        up = _up_section(path.read_text())
+        created = _create_table_columns(up, "spans_v2") or _create_table_columns(up, "spans")
+        if created is not None:
+            columns = created
+            continue
+        for name in re.findall(r"ALTER TABLE spans\s+ADD COLUMN(?: IF NOT EXISTS)? (\w+)", up):
+            if name not in columns:
+                columns.append(name)
+        for name in re.findall(r"ALTER TABLE spans\s+DROP COLUMN(?: IF EXISTS)? (\w+)", up):
+            if name in columns:
+                columns.remove(name)
+    assert columns, "expected a CREATE TABLE for spans in the migrations"
+    return set(columns)
+
+
+def live_spans_projections() -> dict[str, set[str]]:
+    """Projections on `spans` after every migration, mapped to their columns.
+
+    Replayed in migration order: a CREATE seeds the table's projections, an ADD
+    PROJECTION installs one, a DROP PROJECTION removes it. ClickHouse cannot
+    rename a projection, so a rebuild that changes the column list arrives under
+    a new name and retires the old one here.
+    """
+    projections: dict[str, set[str]] = {}
+    for path in _migration_files():
+        up = _up_section(path.read_text())
+        if _create_table_columns(up, "spans_v2") is not None:
+            projections = {}
+        for _position, name, columns in _projection_events(up):
+            if columns is None:
+                projections.pop(name, None)
+            else:
+                projections[name] = columns
+    return projections
+
+
+def test_spans_has_exactly_one_no_io_projection():
+    """One projection serves the no-I/O reads; a rebuild retires its predecessor.
+
+    Two live projections carrying the same columns would double the write and
+    storage cost of every part for no read benefit, which is the failure mode of
+    adding a `_v2` and forgetting to drop the original.
+    """
+    projections = live_spans_projections()
+    assert len(projections) == 1, (
+        f"expected exactly one projection on spans, found {sorted(projections)}"
+    )
+
+
+def test_no_io_projection_carries_every_non_blob_column():
+    """The projection's column list is the whole table minus the I/O blobs.
+
+    A column missing here cannot be read through the projection, so ClickHouse
+    refuses the projection outright for any query naming that column — the
+    read falls back to the base table and its buried `span_start_time`.
+    """
+    columns = live_spans_columns()
+    (projected,) = live_spans_projections().values()
+
+    expected = columns - IO_COLUMNS
+    missing = expected - projected
+    assert not missing, (
+        "columns on spans are absent from the no-I/O projection, disabling it for "
+        f"every read that references them: {sorted(missing)}"
+    )
+
+    unexpected = projected - columns
+    assert not unexpected, (
+        f"projection carries columns that spans does not have: {sorted(unexpected)}"
+    )
+
+    carried_blobs = projected & IO_COLUMNS
+    assert not carried_blobs, (
+        "the projection exists to keep the I/O blobs off the read path; carrying "
+        f"them defeats it: {sorted(carried_blobs)}"
+    )
+
+
+def test_widget_spans_base_reads_only_projection_columns():
+    """The dashboard's spans scan must stay eligible for the projection.
+
+    `_SPANS_BASE` is the exact shape the projection was built for — one project,
+    a `span_start_time` window, no blob columns. It also filters
+    `source = 'user'`, so every column it names has to be one the projection
+    carries or the whole widget path pays a base-table scan.
+    """
+    from rest.services.widget_registry import _SPANS_BASE
+
+    columns = live_spans_columns()
+    (projected,) = live_spans_projections().values()
+
+    referenced = {name for name in columns if re.search(rf"\b{name}\b", _SPANS_BASE)}
+    assert "span_start_time" in referenced, "sanity: the base query is time-windowed"
+
+    missing = referenced - projected
+    assert not missing, (
+        "the widget spans scan references columns the projection does not carry, so "
+        f"ClickHouse cannot use it: {sorted(missing)}"
+    )
+
+
+def test_paren_body_handles_nesting():
+    """A projection body inside a CREATE is returned whole, inner parens included."""
+    text = "CREATE TABLE t (a String, PROJECTION p (SELECT a ORDER BY (a)))"
+    body = _paren_body(text, text.index("("))
+    assert body.startswith("a String")
+    assert body.endswith("ORDER BY (a))")
+
+
+def test_split_top_level_ignores_commas_inside_parens():
+    """Only depth-zero commas separate entries."""
+    assert _split_top_level("a, f(b, c), d") == ["a", "f(b, c)", "d"]


### PR DESCRIPTION
Fixes #1751

## Summary

`spans_no_io_by_start_time` (migration 005) exists to repair the weak time pruning of the base table, whose sort key `(project_id, trace_id, span_start_time, span_id)` buries `span_start_time` behind a random `trace_id`. Migration 006 then added `source` as a metadata-only `ALTER`, which left the column outside the projection's SELECT list. ClickHouse only uses a projection for a query whose every referenced column the projection carries, so from 006 onward every read going through `customer_traffic_only()` was refused the projection and fell back to the base table.

This adds migration 008, which carries `source` in the projection, plus tests that replay the migration files so the next `ALTER ADD COLUMN` that forgets the projection fails a test rather than quietly buying a base-table scan.

## Type of Change

- [x] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests

## Details

### Measured, not inferred

The issue notes that the column-list rule makes an `EXPLAIN` unnecessary. It is unnecessary to establish the rule, but it does put a number on the cost, so I ran it. ClickHouse 26.8.1, 16M spans over 6 monthly partitions, 4 projects, 2M traces, `trace_id` uncorrelated with time (real ingest shape), querying one project over one day:

| query | plan node | marks | rows read | rows returned |
|---|---|---|---|---|
| widget spans scan, `source = 'user'` — **before** | `ReadFromMergeTree (spans)` | 85 | 696,320 | 17,448 |
| identical query, `source` predicate removed | `ReadFromMergeTree (spans_no_io_by_start_time)` | 4 | 32,768 | 17,448 |
| widget spans scan, `source = 'user'` — **after 008** | `ReadFromMergeTree (spans_no_io_by_start_time_v2)` | 4 | 32,768 | 17,448 |

40x read amplification before, 1.9x after — the base table has to read the project's whole month because `trace_id` scatters `span_start_time` across every granule in the project's range. Same query, same window, `optimize_use_projections` on versus off, identical `cityHash64` row checksum (`2642194346874165985`), so the projection path returns the same rows.

Wall clock did not move at this scale (~0.30s either way): the dataset fits in page cache on a local SSD and process startup dominates. The reduction is in read amplification, which is what scales on a cold, shared cluster. I do not have a production instance, so I am not claiming a latency number.

### The second finding — the projection is not dead today, and the obvious fix order would kill it

The issue proposes `DROP PROJECTION` / `ADD PROJECTION` / `MATERIALIZE`. That order has a cost the issue does not mention, because the projection is only disqualified for queries that *name* `source`, and not every spans read does. `_membership_semijoin` and `_aggregate_semijoin` in `rest/services/filters/translate.py` scan spans with a project id and a `span_start_time` bound and no `source` predicate — the middle row of the table above is literally their shape, and it uses the projection today. Dropping first would leave those trace-list filter reads with no projection for the entire length of the rematerialization.

So 008 goes the other way, which is also the shape 005 already uses for the table rebuild: declare the replacement under a new name, materialize it, then retire the old one. `MATERIALIZE` runs with `mutations_sync = 2` deliberately, so the drop cannot race a still-running mutation and leave the table with no usable projection. The overlap costs a temporary second copy of the projection's parts, bounded by the projection's own size — `input`/`output`/`metadata` are in neither projection, so the blobs are never duplicated. It ran in 11.4s on the 16M-row set.

The new name carries a `_v2` suffix only because ClickHouse can neither rename a projection nor alter one in place.

Unlike 005 this does not need ingestion paused: no table rebuild, no rename. New parts pick up the projection the moment it is declared; `MATERIALIZE` only backfills the parts that already exist.

### Why `source` is not in the projection's ORDER BY

The issue suggests considering it. I left it out. Carrying the column is what restores eligibility, and the projection's whole purpose is the `(project_id, span_start_time, ...)` sort — `source = 'user'` stays a PREWHERE-evaluated predicate over a `LowCardinality` column. Putting `source` in a key would also break the invariant `tests/db/test_source_migration_is_metadata_only.py` guards, which is what keeps 006 a metadata-only `ALTER` when the migrations are replayed on a fresh database.

### Tests

`tests/db/test_spans_projection_column_coverage.py` replays the migration files to derive two things: the columns `spans` has after every migration, and the projections it has after every migration (statement-ordered, so an idempotent `DROP ... IF EXISTS` before an `ADD` of the same name does not replay as a removal). Then it asserts the projection's column list equals the table minus `input`/`output`/`metadata`, that exactly one no-I/O projection is live (a `_v2` added and the original left behind would be paid for on every insert and merge), and that every column the widget's `_SPANS_BASE` references is one the projection carries.

Both of the substantive assertions fail on `main` with `['source']`, which is how the fix was driven. I also checked they fail for the right reasons: removing `source` from 008's SELECT list reproduces both failures, and removing 008's final `DROP PROJECTION` trips the single-projection assertion.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

## Verification

- Full backend suite: **1128 passed, 1 skipped, 0 failed** (the skip is the pre-existing SQL Gateway `PUBLIC_TABLES` snapshot).
- `ruff check` and `ruff format --check` clean on the new file.
- Migration 008 applied for real against ClickHouse 26.8.1 on the 16M-row set — the `SETTINGS mutations_sync = 2` clause, the `ADD PROJECTION`, and the drop all executed, leaving `spans_no_io_by_start_time_v2` as the only projection.

## AI disclosure

This change was written with AI assistance (Claude). I reviewed and ran everything reported above myself; the numbers are from my own local ClickHouse instance, not generated text.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `source` to the spans no-I/O projection and materialized it as `spans_no_io_by_start_time_v2` so source-filtered reads use the projection again. This restores fast time-pruned scans for the dashboard spans query, cutting read amplification on source-filtered queries.

- **Migration**
  - Adds migration 008: `ADD PROJECTION ... SELECT ... source` with `ORDER BY (project_id, span_start_time, trace_id, span_id)`.
  - Synchronously materializes the new projection (`mutations_sync = 2`), then drops the old projection to avoid a window with no projection.
  - Leaves `source` out of the ORDER BY to keep migration 006 metadata-only.

- **Tests**
  - Replays migrations to assert the projection carries all non-blob columns and that only one no-I/O projection is live.
  - Ensures the dashboard’s `_SPANS_BASE` query only references columns present in the projection.

<sup>Written for commit 60db50c51fee90ca51def61954a7af22375d3e6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

