### PR TITLE
perf(db): partition detector_runs/detector_findings by month, the recommended skip index prunes nothing

### DIFF
--- a/backend/db/clickhouse/migrations/009_partition_detector_tables_by_month.sql
+++ b/backend/db/clickhouse/migrations/009_partition_detector_tables_by_month.sql
@@ -1,0 +1,174 @@
+-- +goose Up
+
+-- Rebuild `detector_runs` and `detector_findings` with a monthly partition key
+-- so the time-bounded reads can prune instead of scanning a tenant's whole
+-- history.
+--
+-- Both tables were created (003) with no PARTITION BY, and `timestamp` is in
+-- neither sort key (`(project_id, detector_id, run_id)` /
+-- `(project_id, trace_id, finding_id)`). Four reads filter on `timestamp` and
+-- none of them can prune: billing metering and the digest sample
+-- (`/usage/details`, `/detector-window-summary` in rest/routers/internal.py),
+-- the paginated runs list, and the findings list
+-- (rest/services/detector_reader.py). Each reads the project's entire run or
+-- finding history and discards everything outside the window, and the discarded
+-- share grows every month the project stays alive.
+--
+-- WHY NOT THE MINMAX SKIP INDEX. `ALTER TABLE ... ADD INDEX ts TYPE minmax` is
+-- the cheap in-place option, and it does nothing here. A minmax index prunes a
+-- granule only when the granule's value range is narrow, which requires the
+-- indexed column to be correlated with the sort order. `run_id` and
+-- `finding_id` are sha256-derived, so within one (project, detector) group the
+-- rows are in effectively random time order and every granule spans the whole
+-- retained history. Measured on ClickHouse 26.8.1 with 8M runs over 180 days,
+-- one project, one month asked for: the skip index pruned 245 granules to 245.
+-- Not a smaller win than partitioning, no win at all. The same table with
+-- PARTITION BY toYYYYMM(timestamp) read 43 granules for the identical answer.
+--
+-- ClickHouse cannot add a partition key in place, so this is the create-new +
+-- backfill + atomic-rename rebuild that migration 005 established for `spans`,
+-- with the same constraints: the multi-table RENAME is atomic on a single node,
+-- there is deliberately NO concurrent-write catch-up step, and the pre-migration
+-- tables are kept aside as a backstop rather than dropped here.
+--
+-- DEDUP BOUNDARY, CHECKED. Both tables are ReplacingMergeTree(timestamp) whose
+-- duplicates are idempotent BullMQ retries sharing a deterministic id, and the
+-- partition key is now derived from `timestamp`, which is also the version
+-- column. A retry therefore carries a different timestamp and a retry that lands
+-- on the far side of a month boundary goes to a different partition, where the
+-- engine will never physically collapse it, because merges do not cross
+-- partitions.
+--
+-- Reads are unaffected, and this was measured rather than assumed. On ClickHouse
+-- 26.8.1 the same run_id written either side of a month boundary produces two
+-- parts and two raw rows, and `SELECT ... FINAL` returns one row from the
+-- partitioned table exactly as it does from the unpartitioned one, because FINAL
+-- merges across partitions unless
+-- `do_not_merge_across_partitions_select_final` is turned on. The reads that do
+-- not use FINAL dedup by `uniqExact(run_id)` (billing), `GROUP BY detector_id,
+-- run_id` (window summary) or `LIMIT 1 BY finding_id` (findings list), none of
+-- which is partition-local either. What remains is storage, one uncollapsed row
+-- per retry that happened to cross a month boundary.
+--
+-- The sort keys stay exactly as 003 wrote them. Putting `timestamp` into a sort
+-- key would prune beautifully and destroy the dedup, because a retry's newer
+-- version would then sort as a different row and never collapse at all.
+
+-- Idempotent cleanup: if a prior run died between RENAME and DROP, these may
+-- still exist. A successful run leaves neither behind.
+DROP TABLE IF EXISTS detector_runs_v2;
+DROP TABLE IF EXISTS detector_runs_old;
+DROP TABLE IF EXISTS detector_findings_v2;
+DROP TABLE IF EXISTS detector_findings_old;
+
+-- Step 1 — replacement tables. Column lists are the EXACT live schema (003 base
+-- + `self_traced` from 007) and are spelled out in every INSERT, never
+-- `SELECT *`, so a future ALTER ADD COLUMN cannot silently mis-map a column the
+-- way a positional copy would. Sort keys are unchanged: the dedup key must stay
+-- free of `timestamp`, or a retry's newer version would sort as a new row and
+-- never collapse at all.
+CREATE TABLE detector_runs_v2
+(
+    run_id      String DEFAULT toString(generateUUIDv4()),
+    detector_id String,
+    project_id  String,
+    trace_id    String,
+    finding_id  Nullable(String),
+    status      String DEFAULT 'completed',
+    timestamp   DateTime64(3) DEFAULT now64(3),
+    self_traced Bool DEFAULT false
+)
+ENGINE = ReplacingMergeTree(timestamp)
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (project_id, detector_id, run_id);
+
+CREATE TABLE detector_findings_v2
+(
+    finding_id  String DEFAULT toString(generateUUIDv4()),
+    project_id  String,
+    trace_id    String,
+    summary     String,
+    payload     String,
+    timestamp   DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(timestamp)
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (project_id, trace_id, finding_id);
+
+-- Step 2 — backfill (explicit column lists, never SELECT *).
+INSERT INTO detector_runs_v2
+(run_id, detector_id, project_id, trace_id, finding_id, status, timestamp, self_traced)
+SELECT run_id, detector_id, project_id, trace_id, finding_id, status, timestamp, self_traced
+FROM detector_runs;
+
+INSERT INTO detector_findings_v2
+(finding_id, project_id, trace_id, summary, payload, timestamp)
+SELECT finding_id, project_id, trace_id, summary, payload, timestamp
+FROM detector_findings;
+
+-- Step 3 — atomic swap. One statement, atomic on a single node.
+RENAME TABLE
+    detector_runs     TO detector_runs_old,     detector_runs_v2     TO detector_runs,
+    detector_findings TO detector_findings_old, detector_findings_v2 TO detector_findings;
+
+-- Step 4 — KEEP the *_old tables as a backstop; they are intentionally NOT
+-- dropped here. After confirming row parity in the target environment, drop them
+-- explicitly (manually or in a follow-up migration):
+--   DROP TABLE IF EXISTS detector_runs_old;
+--   DROP TABLE IF EXISTS detector_findings_old;
+--
+-- REQUIRED PROCEDURE — as in 005, run this with detector ingestion paused (scale
+-- traceroot-detector to 0) for the backfill+swap window, then resume. There is
+-- deliberately no concurrent-write catch-up step; the *_old tables hold anything
+-- nonetheless written mid-rebuild.
+
+-- +goose Down
+
+-- Reverse: rebuild both tables without a partition key.
+DROP TABLE IF EXISTS detector_runs_v2;
+DROP TABLE IF EXISTS detector_runs_old;
+DROP TABLE IF EXISTS detector_findings_v2;
+DROP TABLE IF EXISTS detector_findings_old;
+
+CREATE TABLE detector_runs_v2
+(
+    run_id      String DEFAULT toString(generateUUIDv4()),
+    detector_id String,
+    project_id  String,
+    trace_id    String,
+    finding_id  Nullable(String),
+    status      String DEFAULT 'completed',
+    timestamp   DateTime64(3) DEFAULT now64(3),
+    self_traced Bool DEFAULT false
+)
+ENGINE = ReplacingMergeTree(timestamp)
+ORDER BY (project_id, detector_id, run_id);
+
+CREATE TABLE detector_findings_v2
+(
+    finding_id  String DEFAULT toString(generateUUIDv4()),
+    project_id  String,
+    trace_id    String,
+    summary     String,
+    payload     String,
+    timestamp   DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(timestamp)
+ORDER BY (project_id, trace_id, finding_id);
+
+INSERT INTO detector_runs_v2
+(run_id, detector_id, project_id, trace_id, finding_id, status, timestamp, self_traced)
+SELECT run_id, detector_id, project_id, trace_id, finding_id, status, timestamp, self_traced
+FROM detector_runs;
+
+INSERT INTO detector_findings_v2
+(finding_id, project_id, trace_id, summary, payload, timestamp)
+SELECT finding_id, project_id, trace_id, summary, payload, timestamp
+FROM detector_findings;
+
+RENAME TABLE
+    detector_runs     TO detector_runs_old,     detector_runs_v2     TO detector_runs,
+    detector_findings TO detector_findings_old, detector_findings_v2 TO detector_findings;
+
+-- As in the Up section: run with ingestion paused, keep the *_old tables as a
+-- backstop, and drop them manually after verifying parity.

--- a/tests/db/test_detector_tables_are_time_partitioned.py
+++ b/tests/db/test_detector_tables_are_time_partitioned.py
@@ -1,0 +1,165 @@
+"""The detector tables must prune by time, and must keep their dedup key.
+
+`detector_runs` and `detector_findings` are read through a `timestamp` window by
+billing metering, the detector-window summary, the paginated runs list and the
+findings list. A ClickHouse table can only prune such a window with a partition
+key built from that column, because `timestamp` is deliberately absent from both
+sort keys.
+
+That absence is not an oversight. Both tables are `ReplacingMergeTree(timestamp)`
+and the version column cannot also sit in the sort key: a retry writes the same
+deterministic id with a newer timestamp, so a timestamp-bearing sort key would
+make the retry a different row and stop it collapsing. The partition key is the
+only place the time can go.
+
+These are string assertions over the migration files, replayed in goose order, so
+a future rebuild that quietly drops the partition key, or "fixes" pruning by
+moving `timestamp` into a sort key, fails here instead of in production.
+"""
+
+import re
+from pathlib import Path
+
+MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[2] / "backend" / "db" / "clickhouse" / "migrations"
+)
+
+DETECTOR_TABLES = ("detector_runs", "detector_findings")
+
+# Sort keys as migration 003 wrote them, and as they must stay.
+EXPECTED_SORT_KEYS = {
+    "detector_runs": ("project_id", "detector_id", "run_id"),
+    "detector_findings": ("project_id", "trace_id", "finding_id"),
+}
+
+
+def _migration_files() -> list[Path]:
+    """Every migration, in the order goose applies them."""
+    files = sorted(MIGRATIONS_DIR.glob("*.sql"))
+    assert files, f"no migrations found in {MIGRATIONS_DIR}"
+    return files
+
+
+def _up_section(sql: str) -> str:
+    """The goose Up half of a migration, with `--` comments stripped and flattened.
+
+    Down sections are excluded: a rebuild's Down re-creates the pre-migration
+    shape, which is never the live schema of a migrated database.
+    """
+    up, _, _down = sql.partition("-- +goose Down")
+    assert "-- +goose Up" in up, "migration must declare a goose Up section"
+    return re.sub(r"\s+", " ", re.sub(r"--[^\n]*", "", up))
+
+
+def _create_statement(up_sql: str, table: str) -> str | None:
+    """The `CREATE TABLE <table>` statement in `up_sql`, or None if absent."""
+    match = re.search(
+        rf"CREATE TABLE (?:IF NOT EXISTS )?{table}\b.*?(?=;)",
+        up_sql,
+    )
+    return match.group(0) if match else None
+
+
+def live_create_statement(table: str) -> str:
+    """The CREATE that defines `table` after every migration has been applied.
+
+    A rebuild creates `<table>_v2` and renames it over `<table>`, so the newest
+    such CREATE wins over the original. Later migrations that only ALTER the
+    table do not replace it.
+    """
+    statement = None
+    for path in _migration_files():
+        up = _up_section(path.read_text())
+        rebuilt = _create_statement(up, f"{table}_v2")
+        if rebuilt is not None:
+            renamed = re.search(rf"RENAME TABLE .*?{table}_v2 TO {table}\b", up)
+            assert renamed, f"{path.name} creates {table}_v2 without renaming it over {table}"
+            statement = rebuilt
+            continue
+        created = _create_statement(up, table)
+        if created is not None:
+            statement = created
+    assert statement, f"no CREATE TABLE found for {table}"
+    return statement
+
+
+def _clause(statement: str, keyword: str) -> str | None:
+    """The `keyword` clause of a CREATE, up to the next clause keyword or the end."""
+    match = re.search(
+        rf"\b{keyword}\s+(.*?)"
+        r"(?=\bORDER BY\b|\bPARTITION BY\b|\bPRIMARY KEY\b|\bSETTINGS\b|\bTTL\b|\bSAMPLE BY\b|$)",
+        statement,
+    )
+    return match.group(1).strip() if match else None
+
+
+def test_detector_tables_partition_by_month_of_timestamp():
+    """Both tables carry a monthly partition key derived from `timestamp`.
+
+    Without it the window predicates in billing metering, the window summary and
+    the two list endpoints cannot prune, because `timestamp` is in neither sort
+    key and a minmax skip index cannot help a column that is uncorrelated with
+    the sort order.
+    """
+    for table in DETECTOR_TABLES:
+        partition = _clause(live_create_statement(table), "PARTITION BY")
+        assert partition, f"{table} has no PARTITION BY, so no timestamp window can prune"
+        assert re.fullmatch(r"toYYYYMM\(timestamp\)", partition), (
+            f"{table} must partition by toYYYYMM(timestamp), found {partition!r}"
+        )
+
+
+def test_detector_sort_keys_stay_free_of_timestamp():
+    """`timestamp` must never enter a sort key of a ReplacingMergeTree keyed on it.
+
+    It is the version column. In the sort key, a retry's newer version becomes a
+    distinct row and the deterministic-id dedup stops working entirely, which is
+    a correctness regression traded for the pruning the partition key already
+    provides.
+    """
+    for table in DETECTOR_TABLES:
+        statement = live_create_statement(table)
+        order_by = _clause(statement, "ORDER BY")
+        assert order_by, f"{table} must declare an ORDER BY"
+        assert "timestamp" not in order_by, (
+            f"{table} sort key contains timestamp, which breaks ReplacingMergeTree "
+            f"dedup for retries: {order_by}"
+        )
+
+
+def test_detector_sort_keys_are_unchanged():
+    """The rebuild keeps 003's sort keys exactly, so dedup identity is untouched."""
+    for table, expected in EXPECTED_SORT_KEYS.items():
+        order_by = _clause(live_create_statement(table), "ORDER BY")
+        columns = tuple(part.strip() for part in order_by.strip("()").split(","))
+        assert columns == expected, f"{table} sort key changed: {columns} != {expected}"
+
+
+def test_detector_tables_stay_replacing_merge_tree_versioned_by_timestamp():
+    """The engine and its version column are what make retries idempotent."""
+    for table in DETECTOR_TABLES:
+        statement = live_create_statement(table)
+        assert re.search(r"ENGINE = ReplacingMergeTree\(timestamp\)", statement), (
+            f"{table} must stay ReplacingMergeTree(timestamp): {statement}"
+        )
+
+
+def test_rebuild_lists_every_column_explicitly():
+    """A rebuild copies columns by name, never `SELECT *`.
+
+    A positional copy silently mis-maps the day someone adds a column between the
+    CREATE and the backfill, and the wrongness is invisible until a read returns
+    a value from the neighbouring column.
+    """
+    for path in _migration_files():
+        up = _up_section(path.read_text())
+        for table in DETECTOR_TABLES:
+            if _create_statement(up, f"{table}_v2") is None:
+                continue
+            backfill = re.search(rf"INSERT INTO {table}_v2 \((.*?)\) SELECT (.*?) FROM", up)
+            assert backfill, f"{path.name} rebuilds {table} without an explicit backfill"
+            target = [c.strip() for c in backfill.group(1).split(",")]
+            source = [c.strip() for c in backfill.group(2).split(",")]
+            assert target == source, (
+                f"{path.name}: {table} backfill column lists differ, {target} != {source}"
+            )


### PR DESCRIPTION
Fixes #1750

## Summary

`detector_runs` and `detector_findings` were created (migration 003) with no `PARTITION BY`, and `timestamp` is in neither sort key. Four reads filter on `timestamp` and none of them can prune: billing metering (`/usage/details`) and the digest window summary (`/detector-window-summary`) in `rest/routers/internal.py`, the paginated runs list, and the findings list in `rest/services/detector_reader.py`. Each reads the project's entire run or finding history and discards everything outside the window, and the discarded share grows every month a project stays alive.

Migration 009 rebuilds both tables with `PARTITION BY toYYYYMM(timestamp)`.

## Type of Change

- [x] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests

## Details

### The recommended fix does not work, and that is measurable

The issue recommends the minmax skip index first, as "most of the benefit at a fraction of the cost", with the repartition rebuild reserved for if the index proves insufficient. I built the table and tried it. ClickHouse 26.8.1, 8M runs over 180 days, 4 projects, 3 detectors, `run_id` sha256-shaped as the worker generates it. Asking one project for one month:

```
Skip
  Name: idx_ts
  Description: minmax GRANULARITY 1
  Condition: and((timestamp in (-Inf, '1780261200')), (timestamp in ['1777582800', +Inf)))
  Parts: 1/1
  Granules: 245/245
```

245 granules in, 245 out. The index pruned nothing, and it cannot: a minmax index skips a granule only when that granule's value range is narrow, which requires the indexed column to be correlated with the sort order. The sort key is `(project_id, detector_id, run_id)` and `run_id` is `sha256(project:trace:detector)`, so inside a `(project, detector)` group the rows sit in random time order and every granule spans the whole retained history.

There is a second reason not to trust it. On the same table before merges consolidated it, the plan did prune, through part-level `Statistics` on `timestamp` rather than through the skip index, because young parts are still time-local. That pruning disappeared once the parts merged into one. An index whose benefit decays as the table grows is the wrong shape for a problem that only exists because the table grows.

| variant | marks | rows read | answer |
|---|---|---|---|
| unpartitioned, mature table, with the minmax index | 245 | 2,007,040 | 344,441 |
| `PARTITION BY toYYYYMM(timestamp)` | 43 | 352,256 | 344,441 |

5.7x fewer rows on six months of history, and the ratio is roughly retention divided by window, so it grows with retention rather than staying put.

### Why the sort keys are untouched

The cheaper-looking move is to put `timestamp` into the sort key and prune on the primary index. That would prune well and break dedup. Both tables are `ReplacingMergeTree(timestamp)` and their duplicates are idempotent BullMQ retries sharing a deterministic id; with `timestamp` in the sort key a retry's newer version sorts as a different row and never collapses onto the original. The partition key is the only place the time can go. There is a test asserting this so the trade cannot be quietly reversed later.

### The dedup boundary, checked rather than assumed

Deriving the partition key from the version column means a retry that lands on the far side of a month boundary goes to a different partition, and merges do not cross partitions, so it is never physically collapsed. I expected this to break the `FINAL` reads and it does not. Writing the same `run_id` either side of the boundary gives two parts and two raw rows, and `SELECT ... FINAL` returns one row from the partitioned table exactly as from the unpartitioned one, because `FINAL` merges across partitions unless `do_not_merge_across_partitions_select_final` is switched on. The reads that avoid `FINAL` dedup by `uniqExact(run_id)`, `GROUP BY detector_id, run_id` or `LIMIT 1 BY finding_id`, none of which is partition-local either. What remains is storage, one uncollapsed row per retry that happened to cross a month boundary.

### Migration shape

Create-new, backfill by explicit column list, atomic multi-table rename, keep the pre-migration tables aside as a backstop. That is migration 005's pattern for `spans`, including its constraint: run with detector ingestion paused, since there is deliberately no concurrent-write catch-up step. Both tables move in one `RENAME`.

I ran the migration itself against ClickHouse 26.8.1 on 50,000 runs and 20,000 findings. Both tables come out with identical row counts, the backstops hold the same counts, `system.tables` reports `toYYYYMM(timestamp)` as the partition key with the sort keys unchanged, and the data lands in 4 monthly partitions.

### Tests

`tests/db/test_detector_tables_are_time_partitioned.py` replays the migrations in goose order to derive the live `CREATE` for each table, following the `_v2` + `RENAME` rebuild the way a migrated database would. It asserts the monthly partition key is present, that `timestamp` never enters a sort key, that the sort keys still match 003 exactly, that the engine stays `ReplacingMergeTree(timestamp)`, and that a rebuild's backfill names its columns rather than positionally copying them.

Checked for the right reasons: without migration 009 the partition assertion fails; with `timestamp` inserted into a sort key, the two dedup guards fail.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

## Verification

- Full backend suite: **1128 passed, 1 skipped, 0 failed** (the skip is the pre-existing SQL Gateway `PUBLIC_TABLES` snapshot).
- `ruff check` and `ruff format --check` clean on the new file.
- All numbers above are from my own local ClickHouse 26.8.1 on synthetic data, not a production cluster. The structural conclusions hold regardless of environment; absolute coefficients would differ on prod hardware.

## AI disclosure

This change was written with AI assistance (Claude). I reviewed and ran everything reported above myself; the measurements come from my own ClickHouse instance.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Partitions `detector_runs` and `detector_findings` by month of `timestamp` so time-window queries prune instead of scanning full history, cutting scanned rows ~5–6x on 6 months of data. Keeps dedup correct by leaving sort keys unchanged; the recommended minmax skip index does not prune in this schema.

- **Migration**
  - Rebuilds both tables as `ReplacingMergeTree(timestamp)` with `PARTITION BY toYYYYMM(timestamp)`, keeping the original sort keys.
  - Uses create-new, explicit-column backfill, atomic multi-table rename; retains `*_old` tables as a backstop.
  - Run with detector ingestion paused during backfill+swap. Reads remain correct (FINAL spans partitions); only storage grows for retries crossing month boundaries.

- **Tests**
  - Assert monthly partition key exists, `timestamp` is not in sort keys, sort keys match the original, engine stays `ReplacingMergeTree(timestamp)`, and backfill lists columns explicitly.

<sup>Written for commit 8cdcfb4c3e3122ca0c22ef6eac4b72cfb1a88804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

