### PR TITLE
fix: prevent rootless internal trace overwrite

### DIFF
--- a/backend/db/clickhouse/client.py
+++ b/backend/db/clickhouse/client.py
@@ -1,5 +1,6 @@
 """ClickHouse client using clickhouse-connect."""
 
+from collections.abc import Set
 from datetime import UTC, datetime
 from typing import Any
 
@@ -8,6 +9,19 @@ from clickhouse_connect.driver.client import Client
 from clickhouse_connect.driver.query import QueryResult
 
 from shared.config import settings
+
+_TRACE_AUTHORITY_SHIFT = 63
+
+
+def _make_trace_version(written_at: datetime, *, authoritative: bool) -> int:
+    """Build the trace-summary winner value used by ReplacingMergeTree.
+
+    The highest UInt64 bit stores authority, while the lower bits store Unix
+    milliseconds. Therefore, an authoritative row always beats an internal
+    rootless placeholder; when authority is equal, the newer row wins.
+    """
+    unix_milliseconds = int(written_at.timestamp() * 1_000)
+    return (int(authoritative) << _TRACE_AUTHORITY_SHIFT) | unix_milliseconds
 
 
 class ClickHouseClient:
@@ -37,13 +51,22 @@ class ClickHouseClient:
         )
         return cls(client)
 
-    def insert_traces_batch(self, traces: list[dict[str, Any]]) -> None:
+    def insert_traces_batch(
+        self,
+        traces: list[dict[str, Any]],
+        *,
+        root_bearing_keys: Set[tuple[str, str]] | None = None,
+    ) -> None:
         """Insert multiple trace records.
 
         Args:
             traces (list[dict[str, Any]]): Trace records; an optional
                 "source" field distinguishes detector self-traces from
                 customer traffic and defaults to "user".
+            root_bearing_keys: For internal ingest, exact ``(project_id,
+                trace_id)`` pairs whose batch contained the root span. ``None``
+                preserves existing public behavior by treating every public
+                row as authoritative.
         """
         if not traces:
             return
@@ -51,6 +74,8 @@ class ClickHouseClient:
         now = datetime.now(UTC)
         rows = []
         for t in traces:
+            trace_key = (t["project_id"], t["trace_id"])
+            authoritative = True if root_bearing_keys is None else trace_key in root_bearing_keys
             rows.append(
                 [
                     t["trace_id"],
@@ -68,6 +93,8 @@ class ClickHouseClient:
                     now,  # ch_create_time
                     now,  # ch_update_time
                     t.get("environment"),
+                    int(authoritative),
+                    _make_trace_version(now, authoritative=authoritative),
                 ]
             )
 
@@ -90,6 +117,8 @@ class ClickHouseClient:
                 "ch_create_time",
                 "ch_update_time",
                 "environment",
+                "trace_authority",
+                "trace_version",
             ],
         )
 

--- a/backend/db/clickhouse/migrations/008_prioritize_internal_trace_rows.sql
+++ b/backend/db/clickhouse/migrations/008_prioritize_internal_trace_rows.sql
@@ -10,10 +10,11 @@
 --   1. trace_authority (authoritative rows beat internal placeholders)
 --   2. ch_update_time (newer rows win when authority is equal)
 --
--- As with migration 005, ingestion must be paused for the copy-and-swap
--- window because ClickHouse cannot change the engine's version column in
--- place and this migration has no concurrent-write catch-up step.
+-- A temporary materialized view mirrors writes that arrive during the
+-- copy-and-swap window, so active ingestion cannot strand new rows in the
+-- renamed backup table.
 
+DROP TABLE IF EXISTS traces_authority_write_mirror;
 DROP TABLE IF EXISTS traces_with_authority;
 DROP TABLE IF EXISTS traces_before_authority;
 
@@ -50,6 +51,47 @@ ENGINE = ReplacingMergeTree(trace_version)
 PARTITION BY toYYYYMM(trace_start_time)
 ORDER BY (project_id, toDate(trace_start_time), trace_id);
 
+-- Existing REST/worker pods may keep inserting into `traces` while the
+-- historical copy below runs. This temporary materialized view forwards every
+-- newly inserted block into the replacement table so those rows participate in
+-- the atomic table swap instead of being stranded in the backup table.
+CREATE MATERIALIZED VIEW traces_authority_write_mirror
+TO traces_with_authority
+AS
+SELECT
+    trace_id,
+    project_id,
+    trace_start_time,
+    name,
+    user_id,
+    session_id,
+    git_ref,
+    git_repo,
+    input,
+    output,
+    metadata,
+    ch_create_time,
+    ch_update_time,
+    environment,
+    source,
+
+    -- The currently deployed writers do not provide authority information.
+    -- Preserve their previous/public behavior by treating those rows as
+    -- authoritative. New application pods explicitly mark internal rootless
+    -- rows after the migration finishes.
+    toUInt8(1) AS trace_authority,
+
+    -- Authority occupies the high bit. The timestamp continues deciding
+    -- between two rows that have the same authority.
+    bitShiftLeft(toUInt64(1), 63)
+        + toUInt64(toUnixTimestamp64Milli(ch_update_time))
+        AS trace_version
+FROM traces;
+
+-- Copy all rows that existed before the migration. A concurrently inserted
+-- row may occasionally arrive through both this copy and the materialized
+-- view. That is safe: both copies have the same ReplacingMergeTree key and
+-- version and therefore collapse to one winner.
 INSERT INTO traces_with_authority
 (
     trace_id,
@@ -101,11 +143,16 @@ RENAME TABLE
     traces TO traces_before_authority,
     traces_with_authority TO traces;
 
+-- New writes now resolve `traces` directly to the replacement table, so the
+-- temporary forwarding rule is no longer necessary.
+DROP TABLE traces_authority_write_mirror;
+
 
 -- +goose Down
 
 -- Rebuild the pre-version schema from the current table so rows written after
 -- the Up migration survive rollback.
+DROP TABLE IF EXISTS traces_without_authority_write_mirror;
 DROP TABLE IF EXISTS traces_without_authority;
 
 CREATE TABLE traces_without_authority
@@ -129,6 +176,28 @@ CREATE TABLE traces_without_authority
 ENGINE = ReplacingMergeTree(ch_update_time)
 PARTITION BY toYYYYMM(trace_start_time)
 ORDER BY (project_id, toDate(trace_start_time), trace_id);
+
+-- Keep forwarding new writes while the rollback table is populated.
+CREATE MATERIALIZED VIEW traces_without_authority_write_mirror
+TO traces_without_authority
+AS
+SELECT
+    trace_id,
+    project_id,
+    trace_start_time,
+    name,
+    user_id,
+    session_id,
+    git_ref,
+    git_repo,
+    input,
+    output,
+    metadata,
+    ch_create_time,
+    ch_update_time,
+    environment,
+    source
+FROM traces;
 
 INSERT INTO traces_without_authority
 (
@@ -172,3 +241,5 @@ DROP TABLE IF EXISTS traces_before_authority;
 RENAME TABLE
     traces TO traces_before_authority,
     traces_without_authority TO traces;
+
+DROP TABLE traces_without_authority_write_mirror;

--- a/backend/db/clickhouse/migrations/008_prioritize_internal_trace_rows.sql
+++ b/backend/db/clickhouse/migrations/008_prioritize_internal_trace_rows.sql
@@ -1,0 +1,174 @@
+-- +goose Up
+
+-- The internal detector exporter can send one trace in several concurrent
+-- batches during shutdown. A root-bearing batch has the authoritative trace
+-- summary; a rootless batch contains only a temporary placeholder. The old
+-- ReplacingMergeTree(ch_update_time) rule could keep the placeholder merely
+-- because it was inserted later.
+--
+-- Rebuild the table with a version that compares:
+--   1. trace_authority (authoritative rows beat internal placeholders)
+--   2. ch_update_time (newer rows win when authority is equal)
+--
+-- As with migration 005, ingestion must be paused for the copy-and-swap
+-- window because ClickHouse cannot change the engine's version column in
+-- place and this migration has no concurrent-write catch-up step.
+
+DROP TABLE IF EXISTS traces_with_authority;
+DROP TABLE IF EXISTS traces_before_authority;
+
+CREATE TABLE traces_with_authority
+(
+    trace_id            String,
+    project_id          String,
+    trace_start_time    DateTime64(3),
+    name                String,
+    user_id             Nullable(String),
+    session_id          Nullable(String),
+    git_ref             Nullable(String),
+    git_repo            Nullable(String),
+    input               Nullable(String) CODEC(ZSTD(3)),
+    output              Nullable(String) CODEC(ZSTD(3)),
+    metadata            Nullable(String) CODEC(ZSTD(3)),
+    ch_create_time      DateTime64(3) DEFAULT now64(3),
+    ch_update_time      DateTime64(3) DEFAULT now64(3),
+    environment         Nullable(String),
+    source              LowCardinality(String) DEFAULT 'user',
+
+    -- 0 = internal batch did not contain this trace's root span.
+    -- 1 = internal root-bearing row, public row, or historical row.
+    trace_authority     UInt8 DEFAULT 1,
+
+    -- The high bit stores authority; the lower bits store Unix milliseconds.
+    -- Defaulting to authority 1 preserves public/legacy writer behavior during
+    -- a rolling deployment if a writer omits the two new columns.
+    trace_version       UInt64 DEFAULT
+        bitShiftLeft(toUInt64(1), 63)
+        + toUInt64(toUnixTimestamp64Milli(ch_update_time))
+)
+ENGINE = ReplacingMergeTree(trace_version)
+PARTITION BY toYYYYMM(trace_start_time)
+ORDER BY (project_id, toDate(trace_start_time), trace_id);
+
+INSERT INTO traces_with_authority
+(
+    trace_id,
+    project_id,
+    trace_start_time,
+    name,
+    user_id,
+    session_id,
+    git_ref,
+    git_repo,
+    input,
+    output,
+    metadata,
+    ch_create_time,
+    ch_update_time,
+    environment,
+    source,
+    trace_authority,
+    trace_version
+)
+SELECT
+    trace_id,
+    project_id,
+    trace_start_time,
+    name,
+    user_id,
+    session_id,
+    git_ref,
+    git_repo,
+    input,
+    output,
+    metadata,
+    ch_create_time,
+    ch_update_time,
+    environment,
+    source,
+
+    -- Historical rows cannot be classified reliably after the fact. Treat
+    -- them as authoritative so a new internal placeholder cannot replace
+    -- existing data; newer authority-1 rows still win by timestamp.
+    1,
+    bitShiftLeft(toUInt64(1), 63)
+        + toUInt64(toUnixTimestamp64Milli(ch_update_time))
+FROM traces;
+
+-- Atomic on a single ClickHouse node. Keep the previous table as a backstop
+-- until row counts and winner selection have been verified after deployment.
+RENAME TABLE
+    traces TO traces_before_authority,
+    traces_with_authority TO traces;
+
+
+-- +goose Down
+
+-- Rebuild the pre-version schema from the current table so rows written after
+-- the Up migration survive rollback.
+DROP TABLE IF EXISTS traces_without_authority;
+
+CREATE TABLE traces_without_authority
+(
+    trace_id            String,
+    project_id          String,
+    trace_start_time    DateTime64(3),
+    name                String,
+    user_id             Nullable(String),
+    session_id          Nullable(String),
+    git_ref             Nullable(String),
+    git_repo            Nullable(String),
+    input               Nullable(String) CODEC(ZSTD(3)),
+    output              Nullable(String) CODEC(ZSTD(3)),
+    metadata            Nullable(String) CODEC(ZSTD(3)),
+    ch_create_time      DateTime64(3) DEFAULT now64(3),
+    ch_update_time      DateTime64(3) DEFAULT now64(3),
+    environment         Nullable(String),
+    source              LowCardinality(String) DEFAULT 'user'
+)
+ENGINE = ReplacingMergeTree(ch_update_time)
+PARTITION BY toYYYYMM(trace_start_time)
+ORDER BY (project_id, toDate(trace_start_time), trace_id);
+
+INSERT INTO traces_without_authority
+(
+    trace_id,
+    project_id,
+    trace_start_time,
+    name,
+    user_id,
+    session_id,
+    git_ref,
+    git_repo,
+    input,
+    output,
+    metadata,
+    ch_create_time,
+    ch_update_time,
+    environment,
+    source
+)
+SELECT
+    trace_id,
+    project_id,
+    trace_start_time,
+    name,
+    user_id,
+    session_id,
+    git_ref,
+    git_repo,
+    input,
+    output,
+    metadata,
+    ch_create_time,
+    ch_update_time,
+    environment,
+    source
+FROM traces;
+
+-- Replace the old backup with the freshest versioned table.
+DROP TABLE IF EXISTS traces_before_authority;
+
+RENAME TABLE
+    traces TO traces_before_authority,
+    traces_without_authority TO traces;

--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -1025,5 +1025,46 @@ async def ingest_internal_traces(
 
     ch = get_clickhouse_client()
     ch.insert_spans_batch(spans)
-    ch.insert_traces_batch(traces)
+    had_trace_records = bool(traces)
+
+    # Unlike public ingest, one internal batch can carry several projects.
+    # Therefore, a trace is identified by the exact (project_id, trace_id) pair.
+    root_bearing_keys = {
+        (span["project_id"], span["trace_id"])
+        for span in spans
+        if span.get("parent_span_id") is None
+    }
+
+    trace_records_missing_root = [
+        trace
+        for trace in traces
+        if (trace["project_id"], trace["trace_id"]) not in root_bearing_keys
+    ]
+
+    if trace_records_missing_root:
+        project_ids = sorted({trace["project_id"] for trace in trace_records_missing_root})
+        trace_ids = sorted({trace["trace_id"] for trace in trace_records_missing_root})
+
+        result = ch.query(
+            "SELECT DISTINCT project_id, trace_id FROM traces FINAL"
+            " WHERE project_id IN {project_ids:Array(String)}"
+            " AND trace_id IN {trace_ids:Array(String)}",
+            parameters={
+                "project_ids": project_ids,
+                "trace_ids": trace_ids,
+            },
+        )
+        existing_keys = {(row[0], row[1]) for row in result.result_rows}
+
+        traces = [
+            trace
+            for trace in traces
+            if (trace["project_id"], trace["trace_id"]) in root_bearing_keys
+            or (trace["project_id"], trace["trace_id"]) not in existing_keys
+        ]
+
+    # Preserve the existing empty-payload no-op call, but avoid invoking the
+    # trace writer when a real rootless batch was entirely filtered out.
+    if traces or not had_trace_records:
+        ch.insert_traces_batch(traces)
     return {"ok": True}

--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -1066,5 +1066,5 @@ async def ingest_internal_traces(
     # Preserve the existing empty-payload no-op call, but avoid invoking the
     # trace writer when a real rootless batch was entirely filtered out.
     if traces or not had_trace_records:
-        ch.insert_traces_batch(traces)
+        ch.insert_traces_batch(traces, root_bearing_keys=root_bearing_keys)
     return {"ok": True}

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -605,8 +605,10 @@ class TraceReaderService:
         source_predicate = f"AND {source_condition}"
 
         # Fetch trace
-        # Dedup the ReplacingMergeTree row without FINAL: keep the latest version
-        # of this trace_id.
+        # Dedup the ReplacingMergeTree row without FINAL using the same winner
+        # rule as the table engine. This matters for detector self-traces:
+        # background merging may not have removed a later rootless placeholder
+        # yet, but its lower trace_version must not hide the root-bearing row.
         trace_query = f"""
             SELECT
                 trace_id, project_id, name, trace_start_time,
@@ -614,7 +616,7 @@ class TraceReaderService:
             FROM traces
             WHERE project_id = {{project_id:String}} AND trace_id = {{trace_id:String}}
             {source_predicate}
-            ORDER BY ch_update_time DESC
+            ORDER BY trace_version DESC
             LIMIT 1 BY trace_id
         """
         trace_result = self._client.query(

--- a/tests/db/test_client.py
+++ b/tests/db/test_client.py
@@ -3,10 +3,33 @@
 Tests row construction without a real ClickHouse connection.
 """
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
-from db.clickhouse.client import ClickHouseClient
+from db.clickhouse.client import ClickHouseClient, _make_trace_version
+
+
+def test_authoritative_trace_beats_a_newer_internal_placeholder():
+    """Authority, not request completion order, decides the winner."""
+    root_time = datetime(2026, 1, 1, tzinfo=UTC)
+    later_placeholder_time = root_time + timedelta(days=1)
+
+    assert _make_trace_version(root_time, authoritative=True) > _make_trace_version(
+        later_placeholder_time, authoritative=False
+    )
+
+
+def test_newer_trace_wins_when_authority_is_equal():
+    """The old timestamp ordering is preserved within each authority class."""
+    older_time = datetime(2026, 1, 1, tzinfo=UTC)
+    newer_time = older_time + timedelta(seconds=1)
+
+    assert _make_trace_version(newer_time, authoritative=True) > _make_trace_version(
+        older_time, authoritative=True
+    )
+    assert _make_trace_version(newer_time, authoritative=False) > _make_trace_version(
+        older_time, authoritative=False
+    )
 
 
 class TestInsertTracesBatch:
@@ -55,9 +78,16 @@ class TestInsertTracesBatch:
         # ch_create_time and ch_update_time are auto-set
         assert isinstance(row[12], datetime)
         assert isinstance(row[13], datetime)
-        assert len(columns) == 15
+        assert len(columns) == 17
         assert "environment" in columns
         assert row[columns.index("environment")] == "production"
+        # Omitting root_bearing_keys is the public/legacy path: preserve its
+        # existing timestamp-only behavior by treating the row as authority 1.
+        assert row[columns.index("trace_authority")] == 1
+        assert row[columns.index("trace_version")] == _make_trace_version(
+            row[columns.index("ch_update_time")],
+            authoritative=True,
+        )
 
     def test_empty_batch_no_insert(self):
         """Empty list -> no _client.insert() call."""
@@ -115,6 +145,40 @@ class TestInsertTracesBatch:
         columns = mock_internal.insert.call_args[1]["column_names"]
         row = mock_internal.insert.call_args[0][1][0]
         assert row[columns.index("environment")] is None
+
+    def test_internal_root_keys_classify_root_and_placeholder_rows(self):
+        """An empty/internal root set differs from the public None default."""
+        mock_internal = MagicMock()
+        client = ClickHouseClient(mock_internal)
+
+        traces = [
+            {
+                "trace_id": "root-trace",
+                "project_id": "proj-1",
+                "trace_start_time": datetime(2024, 1, 15, 12, 0, 0),
+                "name": "root",
+            },
+            {
+                "trace_id": "child-only-trace",
+                "project_id": "proj-1",
+                "trace_start_time": datetime(2024, 1, 15, 12, 0, 0),
+                "name": "placeholder",
+            },
+        ]
+
+        client.insert_traces_batch(
+            traces,
+            root_bearing_keys={("proj-1", "root-trace")},
+        )
+
+        columns = mock_internal.insert.call_args.kwargs["column_names"]
+        rows = mock_internal.insert.call_args.args[1]
+        authority_index = columns.index("trace_authority")
+        version_index = columns.index("trace_version")
+
+        assert rows[0][authority_index] == 1
+        assert rows[1][authority_index] == 0
+        assert rows[0][version_index] > rows[1][version_index]
 
 
 class TestInsertSpansBatch:

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -1000,6 +1000,9 @@ class TestInternalTraceIngest:
         assert len(inserted_traces) == 1
         assert inserted_traces[0]["trace_id"] == trace_id_hex
         assert inserted_traces[0]["project_id"] == "proj-1"
+        assert mock_ch.insert_traces_batch.call_args.kwargs["root_bearing_keys"] == {
+            ("proj-1", trace_id_hex)
+        }
 
         # A root-bearing trace is authoritative, so the route should write it
         # directly without asking ClickHouse whether it already exists.
@@ -1089,6 +1092,10 @@ class TestInternalTraceIngest:
         assert len(inserted_traces) == 1
         assert inserted_traces[0]["project_id"] == "proj-1"
         assert inserted_traces[0]["trace_id"] == trace_id_hex
+        # An empty set means this internal batch was inspected and contained
+        # no root; the client therefore writes authority 0, not the public
+        # authority-1 default represented by root_bearing_keys=None.
+        assert mock_ch.insert_traces_batch.call_args.kwargs["root_bearing_keys"] == set()
 
     def test_existing_pair_does_not_suppress_same_trace_id_in_another_project(
         self,
@@ -1179,6 +1186,9 @@ class TestInternalTraceIngest:
         assert [(trace["project_id"], trace["trace_id"]) for trace in inserted_traces] == [
             ("proj-a", root_trace_id_hex)
         ]
+        assert mock_ch.insert_traces_batch.call_args.kwargs["root_bearing_keys"] == {
+            ("proj-a", root_trace_id_hex)
+        }
 
         # Only rootless candidates should be sent to the existence query.
         # The authoritative root-bearing trace must not be queried.

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -754,11 +754,20 @@ def _otlp_body(
     span_id: bytes = b"\x01" * 8,
     parent_span_id: bytes | None = None,
     span_project_ids: tuple[str | None, ...] = (),
+    parent_span_ids: tuple[bytes | None, ...] = (),
 ) -> bytes:
     """Serialize an OTLP ExportTraceServiceRequest with one span per trace id.
 
     ``span_project_ids`` optionally stamps the Nth span with a per-span
     ``traceroot.project_id`` attribute (None leaves that span unattributed).
+
+    ``parent_span_ids`` optionally controls whether each generated span is
+    a root or child:
+    - None means the span is a root.
+    - bytes means the span is a child of that parent.
+
+    The existing ``parent_span_id`` argument remains supported for tests that
+    generate only one span.
     """
     request = ExportTraceServiceRequest()
     resource_spans = request.resource_spans.add()
@@ -768,8 +777,18 @@ def _otlp_body(
         span = scope_spans.spans.add()
         span.trace_id = tid
         span.span_id = span_id if index == 0 else bytes([index + 1]) * 8
-        if index == 0 and parent_span_id is not None:
-            span.parent_span_id = parent_span_id
+
+        selected_parent_span_id = (
+            parent_span_ids[index]
+            if index < len(parent_span_ids)
+            else parent_span_id
+            if index == 0
+            else None
+        )
+
+        # In OTLP, an absent parent_span_id means this is a root span.
+        if selected_parent_span_id is not None:
+            span.parent_span_id = selected_parent_span_id
         if index < len(span_project_ids) and span_project_ids[index]:
             attr = span.attributes.add()
             attr.key = "traceroot.project_id"
@@ -947,6 +966,227 @@ class TestInternalTraceIngest:
         import rest.routers.internal as internal_module
 
         assert "enqueue_detector_runs" not in inspect.getsource(internal_module)
+
+    def test_rootless_batch_does_not_overwrite_existing_trace(
+        self,
+        client,
+        secret,
+        mock_ch,
+    ):
+        trace_id = b"\xab" * 16
+        trace_id_hex = "ab" * 16
+        headers = {"X-Internal-Secret": secret}
+
+        # ---------------------------------------------------------
+        # Request 1: send the root span.
+        #
+        # parent_span_id=None means this span is the trace root.
+        # This should create the complete trace row.
+        # ---------------------------------------------------------
+        first_response = client.post(
+            self.URL,
+            content=_otlp_body(
+                trace_id=trace_id,
+                span_id=b"\x01" * 8,
+                parent_span_id=None,
+            ),
+            headers=headers,
+        )
+
+        assert first_response.status_code == 200
+
+        inserted_traces = mock_ch.insert_traces_batch.call_args.args[0]
+
+        assert len(inserted_traces) == 1
+        assert inserted_traces[0]["trace_id"] == trace_id_hex
+        assert inserted_traces[0]["project_id"] == "proj-1"
+
+        # A root-bearing trace is authoritative, so the route should write it
+        # directly without asking ClickHouse whether it already exists.
+        mock_ch.query.assert_not_called()
+
+        mock_ch.reset_mock()
+
+        # Simulate ClickHouse reporting that this exact project/trace pair
+        # already has a summary row.
+        mock_ch.query.return_value = _make_query_result(
+            rows=[("proj-1", trace_id_hex)],
+            column_names=["project_id", "trace_id"],
+        )
+
+        # ---------------------------------------------------------
+        # Request 2: send only a child span for the same trace.
+        #
+        # A non-null parent_span_id means this is not the root.
+        # ---------------------------------------------------------
+        second_response = client.post(
+            self.URL,
+            content=_otlp_body(
+                trace_id=trace_id,
+                span_id=b"\x02" * 8,
+                parent_span_id=b"\x01" * 8,
+            ),
+            headers=headers,
+        )
+
+        assert second_response.status_code == 200
+
+        # The child span must still be stored.
+        mock_ch.insert_spans_batch.assert_called_once()
+
+        # But no new trace summary row should be written, because the
+        # complete trace row already exists.
+        mock_ch.insert_traces_batch.assert_not_called()
+
+        # Verify the existence check uses ClickHouse's deduplicated FINAL view
+        # and both parts of the internal trace identity.
+        query_sql = mock_ch.query.call_args.args[0]
+        query_parameters = mock_ch.query.call_args.kwargs["parameters"]
+
+        assert "FROM traces FINAL" in query_sql
+        assert "project_id IN" in query_sql
+        assert "trace_id IN" in query_sql
+        assert query_parameters == {
+            "project_ids": ["proj-1"],
+            "trace_ids": [trace_id_hex],
+        }
+
+    def test_new_rootless_trace_writes_first_placeholder(
+        self,
+        client,
+        secret,
+        mock_ch,
+    ):
+        trace_id = b"\xbc" * 16
+        trace_id_hex = "bc" * 16
+
+        # ClickHouse has no row for this project/trace pair.
+        #
+        # Even though the batch lacks its root, we need one initial placeholder
+        # so the trace exists until its authoritative root-bearing batch arrives.
+        mock_ch.query.return_value = _make_query_result(
+            rows=[],
+            column_names=["project_id", "trace_id"],
+        )
+
+        response = client.post(
+            self.URL,
+            content=_otlp_body(
+                trace_id=trace_id,
+                parent_span_id=b"\x01" * 8,
+            ),
+            headers={"X-Internal-Secret": secret},
+        )
+
+        assert response.status_code == 200
+
+        # The individual child span must always be stored.
+        mock_ch.insert_spans_batch.assert_called_once()
+
+        # Because no trace row exists yet, the rootless placeholder remains
+        # in ``traces`` and therefore reaches insert_traces_batch().
+        inserted_traces = mock_ch.insert_traces_batch.call_args.args[0]
+        assert len(inserted_traces) == 1
+        assert inserted_traces[0]["project_id"] == "proj-1"
+        assert inserted_traces[0]["trace_id"] == trace_id_hex
+
+    def test_existing_pair_does_not_suppress_same_trace_id_in_another_project(
+        self,
+        client,
+        secret,
+        mock_ch,
+    ):
+        trace_id = b"\xcd" * 16
+        trace_id_hex = "cd" * 16
+
+        # Both incoming spans use the same trace_id, but belong to different
+        # projects. Therefore they represent two different trace records:
+        #
+        #     ("proj-a", trace_id)
+        #     ("proj-b", trace_id)
+        #
+        # ClickHouse reports that only proj-a's record already exists.
+        mock_ch.query.return_value = _make_query_result(
+            rows=[("proj-a", trace_id_hex)],
+            column_names=["project_id", "trace_id"],
+        )
+
+        response = client.post(
+            "/api/v1/internal/traces",
+            content=_otlp_body(
+                trace_id=trace_id,
+                extra_trace_ids=(trace_id,),
+                span_project_ids=("proj-a", "proj-b"),
+                # Both spans are children, so both generated trace records
+                # are candidates for the existence check.
+                parent_span_ids=(b"\x10" * 8, b"\x20" * 8),
+            ),
+            headers={"X-Internal-Secret": secret},
+        )
+
+        assert response.status_code == 200
+
+        # Filtering trace summaries must never remove the actual spans.
+        inserted_spans = mock_ch.insert_spans_batch.call_args.args[0]
+        assert len(inserted_spans) == 2
+
+        # proj-a is suppressed because that exact pair exists.
+        # proj-b remains even though it has the same trace_id.
+        inserted_traces = mock_ch.insert_traces_batch.call_args.args[0]
+        assert [(trace["project_id"], trace["trace_id"]) for trace in inserted_traces] == [
+            ("proj-b", trace_id_hex)
+        ]
+
+    def test_mixed_batch_keeps_root_and_queries_only_rootless_candidates(
+        self,
+        client,
+        secret,
+        mock_ch,
+    ):
+        root_trace_id = b"\xde" * 16
+        root_trace_id_hex = "de" * 16
+        rootless_trace_id = b"\xef" * 16
+        rootless_trace_id_hex = "ef" * 16
+
+        # Only the rootless trace already exists.
+        mock_ch.query.return_value = _make_query_result(
+            rows=[("proj-b", rootless_trace_id_hex)],
+            column_names=["project_id", "trace_id"],
+        )
+
+        response = client.post(
+            "/api/v1/internal/traces",
+            content=_otlp_body(
+                trace_id=root_trace_id,
+                extra_trace_ids=(rootless_trace_id,),
+                span_project_ids=("proj-a", "proj-b"),
+                # First span: root.
+                # Second span: child/rootless.
+                parent_span_ids=(None, b"\x30" * 8),
+            ),
+            headers={"X-Internal-Secret": secret},
+        )
+
+        assert response.status_code == 200
+
+        # Both actual spans are stored, regardless of trace-summary filtering.
+        inserted_spans = mock_ch.insert_spans_batch.call_args.args[0]
+        assert len(inserted_spans) == 2
+
+        # The existing rootless summary is filtered out, while the
+        # authoritative root-bearing summary remains.
+        inserted_traces = mock_ch.insert_traces_batch.call_args.args[0]
+        assert [(trace["project_id"], trace["trace_id"]) for trace in inserted_traces] == [
+            ("proj-a", root_trace_id_hex)
+        ]
+
+        # Only rootless candidates should be sent to the existence query.
+        # The authoritative root-bearing trace must not be queried.
+        query_parameters = mock_ch.query.call_args.kwargs["parameters"]
+        assert query_parameters == {
+            "project_ids": ["proj-b"],
+            "trace_ids": [rootless_trace_id_hex],
+        }
 
 
 class TestPerSpanProjectAttribution:

--- a/tests/rest/test_trace_reader_source.py
+++ b/tests/rest/test_trace_reader_source.py
@@ -50,6 +50,9 @@ class TestGetTraceSourceFilter:
         trace_sql, spans_sql = self._sqls("detector")
         assert "source = 'detector'" in trace_sql
         assert "source = 'detector'" in spans_sql
+        # A detector root must be selected immediately even while an
+        # authority-0 placeholder still exists before background merging.
+        assert "ORDER BY trace_version DESC" in trace_sql
 
     def test_user_source_excludes_detector_in_both_queries(self):
         trace_sql, spans_sql = self._sqls("user")


### PR DESCRIPTION
Fixes #1749 

## Summary

Prevent rootless internal ingest batches from overwriting existing trace rows while continuing to store their spans.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
- Mirror the public ingest guard on the internal route.
- Match traces by `(project_id, trace_id)` for multi-project batches.
- Preserve all span writes.
- Add coverage for rootless, root-bearing, mixed, and multi-project batches.

## Screenshots / Recordings (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents rootless internal trace batches from overwriting complete trace summaries and makes winner selection deterministic in ClickHouse. Spans are always stored; trace summaries are written only when safe.

- **Bug Fixes**
  - Add `trace_authority` and `trace_version` (high-bit authority + milliseconds) and switch to `ReplacingMergeTree(trace_version)` so authoritative rows always beat later internal placeholders.
  - Internal ingest filters rootless records by exact `(project_id, trace_id)` against `traces FINAL`, passes root-bearing keys to the writer, and skips `insert_traces_batch` when a rootless batch is fully filtered; spans are always inserted.
  - Public/legacy writes default to authoritative; the trace reader now orders by `trace_version` to select the same winner without `FINAL`.

- **Migration**
  - Migration 008 rebuilds `traces` with authority/version and `ReplacingMergeTree(trace_version)`; a temporary materialized view mirrors concurrent writes during the swap (no ingest pause), then the tables are atomically renamed; `traces_before_authority` is kept as a backup.
  - The Down path rebuilds the pre-version schema and forwards new writes so rows created after Up survive rollback.

<sup>Written for commit 58c9903a602f156b865b10471bb99b98996281a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

