### PR TITLE
fix(worker): guard internal trace ingest against rootless batch overwrite (#1749)

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -1024,6 +1024,44 @@ async def ingest_internal_traces(
         record["source"] = "detector"
 
     ch = get_clickhouse_client()
+
+    # Root-span guard (mirror of the public ingest path's guard, keyed per
+    # project because a detector batch can carry several projects): only
+    # insert a trace record if this batch contains the trace's root span
+    # (parent_span_id is None) OR the trace is genuinely new (no existing
+    # ClickHouse record). A rootless batch landing after the root-bearing
+    # batch must not overwrite a correctly-named trace record with a shallow
+    # one — traces is a ReplacingMergeTree, so the later write wins. The
+    # worker's BatchSpanProcessor exports chunks concurrently on shutdown, so
+    # a rootless chunk can land after the root's chunk.
+    root_bearing_trace_ids = {s["trace_id"] for s in spans if s.get("parent_span_id") is None}
+    if traces:
+        trace_records_missing_root = [
+            t for t in traces if t["trace_id"] not in root_bearing_trace_ids
+        ]
+        if trace_records_missing_root:
+            existing_ids: set[str] = set()
+            by_project: dict[str, list[dict]] = {}
+            for t in trace_records_missing_root:
+                by_project.setdefault(t["project_id"], []).append(t)
+            for project_id, records in by_project.items():
+                ids = [t["trace_id"] for t in records]
+                # project_id is the sort-key prefix and trace_id carries no skip
+                # index — without this predicate the probe cannot prune and becomes
+                # a FINAL scan of every project in the table.
+                result = ch.query(
+                    "SELECT DISTINCT trace_id FROM traces FINAL"
+                    " WHERE project_id = {project_id:String}"
+                    " AND trace_id IN {ids:Array(String)}",
+                    parameters={"ids": ids, "project_id": project_id},
+                )
+                existing_ids.update(row[0] for row in result.result_rows)
+            traces = [
+                t
+                for t in traces
+                if t["trace_id"] in root_bearing_trace_ids or t["trace_id"] not in existing_ids
+            ]
+
     ch.insert_spans_batch(spans)
     ch.insert_traces_batch(traces)
     return {"ok": True}

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -754,11 +754,15 @@ def _otlp_body(
     span_id: bytes = b"\x01" * 8,
     parent_span_id: bytes | None = None,
     span_project_ids: tuple[str | None, ...] = (),
+    parent_span_ids: tuple[bytes | None, ...] = (),
 ) -> bytes:
     """Serialize an OTLP ExportTraceServiceRequest with one span per trace id.
 
     ``span_project_ids`` optionally stamps the Nth span with a per-span
     ``traceroot.project_id`` attribute (None leaves that span unattributed).
+    ``parent_span_id`` sets the parent on the first span only (legacy); give
+    ``parent_span_ids`` a tuple to set the parent on each span individually
+    (None marks that span a root).
     """
     request = ExportTraceServiceRequest()
     resource_spans = request.resource_spans.add()
@@ -768,7 +772,10 @@ def _otlp_body(
         span = scope_spans.spans.add()
         span.trace_id = tid
         span.span_id = span_id if index == 0 else bytes([index + 1]) * 8
-        if index == 0 and parent_span_id is not None:
+        if index < len(parent_span_ids):
+            if parent_span_ids[index] is not None:
+                span.parent_span_id = parent_span_ids[index]
+        elif index == 0 and parent_span_id is not None:
             span.parent_span_id = parent_span_id
         if index < len(span_project_ids) and span_project_ids[index]:
             attr = span.attributes.add()
@@ -1049,6 +1056,81 @@ class TestPerSpanProjectAttribution:
         assert resp.status_code == 400
         mock_ch.insert_spans_batch.assert_not_called()
         mock_ch.insert_traces_batch.assert_not_called()
+
+
+class TestInternalTraceIngestRootGuard:
+    """The internal route must not overwrite a populated trace row with a
+    shallow one from a rootless batch (issue #1749): the worker's
+    BatchSpanProcessor exports chunks concurrently on shutdown, so a rootless
+    chunk can land after the root-bearing chunk, and traces is a
+    ReplacingMergeTree where the later write wins."""
+
+    URL = "/api/v1/internal/traces?project_id=proj-1"
+
+    def test_root_bearing_batch_inserts_trace_without_probe(self, client, secret, mock_ch):
+        """A batch that carries the root span inserts the trace row directly —
+        no existence probe needed."""
+        resp = client.post(
+            self.URL,
+            content=_otlp_body(parent_span_id=None),
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        assert mock_ch.insert_traces_batch.called
+        mock_ch.query.assert_not_called()
+
+    def test_rootless_batch_new_trace_inserts_after_probe(self, client, secret, mock_ch):
+        """A rootless batch whose trace has no existing row is genuinely new —
+        the probe returns nothing, so the shallow trace row is still inserted."""
+        mock_ch.query.return_value = _make_query_result([], ["trace_id"])
+        resp = client.post(
+            self.URL,
+            content=_otlp_body(parent_span_id=b"\x02" * 8),
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        traces = mock_ch.insert_traces_batch.call_args[0][0]
+        assert len(traces) == 1
+        assert traces[0]["trace_id"] == "ab" * 16
+
+    def test_rootless_batch_existing_trace_is_skipped(self, client, secret, mock_ch):
+        """The #1749 case: a rootless batch landing after the root-bearing one
+        must not overwrite the populated trace row — the probe finds the trace
+        already present, so the shallow row is withheld. Spans still insert."""
+        mock_ch.query.return_value = _make_query_result([("ab" * 16,)], ["trace_id"])
+        resp = client.post(
+            self.URL,
+            content=_otlp_body(parent_span_id=b"\x02" * 8),
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        assert mock_ch.insert_traces_batch.call_args[0][0] == []
+        spans = mock_ch.insert_spans_batch.call_args[0][0]
+        assert spans and all(s["trace_id"] == "ab" * 16 for s in spans)
+
+    def test_multi_project_rootless_probe_keyed_per_project(self, client, secret, mock_ch):
+        """A detector batch can carry several projects: the existence probe must
+        be scoped to each trace's own project (sort-key prefix) so it prunes
+        correctly and never queries a row under the wrong project."""
+        mock_ch.query.return_value = _make_query_result([], ["trace_id"])
+        body = _otlp_body(
+            extra_trace_ids=(b"\xcd" * 16,),
+            parent_span_ids=(b"\x02" * 8, b"\x03" * 8),
+            span_project_ids=("proj-a", "proj-b"),
+        )
+        resp = client.post(self.URL, content=body, headers={"X-Internal-Secret": secret})
+        assert resp.status_code == 200
+        assert mock_ch.query.call_count == 2
+        probe_sql = mock_ch.query.call_args_list[0].args[0]
+        assert "FROM traces FINAL" in probe_sql
+        assert "WHERE project_id = {project_id:String}" in probe_sql
+        assert "AND trace_id IN {ids:Array(String)}" in probe_sql
+        assert {
+            call.kwargs["parameters"]["project_id"] for call in mock_ch.query.call_args_list
+        } == {
+            "proj-a",
+            "proj-b",
+        }
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

    The internal trace-ingest route (`backend/rest/routers/internal.py`, `ingest_internal_traces`) writes a `traces` row from
  every batch it receives, with no root-span guard. `traces` is a `ReplacingMergeTree` whose sort key ends in the trace id, so
  the later write wins.

    During worker shutdown (SIGTERM/SIGINT), the OTel `BatchSpanProcessor._flushAll()` splits the buffer into
  `maxExportBatchSize` (100) chunks and exports them **concurrently** via `Promise.all`. With >100 self-trace spans buffered, a
   rootless chunk can land after the root-bearing chunk — and since a rootless batch carries none of the root-derived fields
  (name, user/session, input, metadata), it replaces a fully-populated trace row with a blank one.

    The affected self-trace then renders as perpetually "still being recorded" in the runs tab. Detector telemetry only;
  customer traffic goes through the public path, which has had this guard since April.

    ## Fix

    Mirror the public ingest path's root-span guard (`backend/worker/ingest_tasks.py`) on the internal route, keyed
  appropriately for a multi-project batch:

    - Only insert a trace row when the batch contains that trace's root span (`parent_span_id` is `None`), **or** when the
  trace is genuinely new (no existing ClickHouse record).
    - Rootless traces trigger an existence probe (`SELECT DISTINCT trace_id FROM traces FINAL WHERE project_id = … AND trace_id
   IN …`), grouped **per project** so a multi-project detector batch probes each project once and the `project_id` sort-key
  predicate keeps the probe pruned.
    - Spans are still always inserted; only the trace row is guarded.

    This is the same ordering fix the public path relies on, applied at the boundary that writes the bad row — no SDK or schema
   changes.

    ## Tests

    Added `TestInternalTraceIngestRootGuard` (`tests/rest/test_detector_endpoints.py`):

    - Root-bearing batch inserts the trace row without a probe.
    - Rootless batch whose trace has no existing row inserts after an empty probe (genuinely new).
    - **The #1749 case:** rootless batch whose trace already exists is withheld (`insert_traces_batch([])`) while spans still
  insert.
    - Multi-project rootless batch probes each project once, keyed per trace's own project.

    Also extended the `_otlp_body` test helper with a backward-compatible `parent_span_ids` tuple to set each span's parent
  individually.

    ## Verification

    - `tests/rest/test_detector_endpoints.py` — 68 passed (incl. 4 new)
    - Detector/transform/ingest/db suites — 166 passed
    - `ruff check .` — clean
    - `ruff format --check` — my two files conform
    - Full `tests/` run: 1101 passed, 26 failed — all 26 verified as pre-existing on `origin/main` (local
  `localhost:3000`/`:3001` port mismatch in auth/whoami/public-trace tests); this change introduces no new failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded internal trace ingest against rootless batch overwrites during worker shutdown, preventing populated trace rows from being replaced and stuck in “recording” state.

- **Bug Fixes**
  - Added a root-span guard in `ingest_internal_traces`: insert trace rows only when the batch contains the root span or when no existing row is found. Spans still always insert.
  - Probed for existing traces per project (`project_id + trace_id`), grouping IDs per project for efficient, pruned queries.
  - Added tests covering root-bearing batches, rootless new/existing traces, and per-project probe behavior.

<sup>Written for commit 9dc4ba39b4d4759711222d69f66ca070cedcaff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

