### PR TITLE
fix(integrations): add parity check for BYOK provider display drift

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -173,11 +173,17 @@
           {
             "group": "Model Providers",
             "pages": [
+              "integrations/amazon-bedrock",
               "integrations/anthropic",
+              "integrations/azure",
+              "integrations/deepseek",
               "integrations/gemini",
               "integrations/mistral",
+              "integrations/moonshot",
               "integrations/openai",
-              "integrations/openrouter"
+              "integrations/openrouter",
+              "integrations/xai",
+              "integrations/zai"
             ]
           },
           {

--- a/docs/integrations/amazon-bedrock.mdx
+++ b/docs/integrations/amazon-bedrock.mdx
@@ -7,9 +7,11 @@ AWS Bedrock is supported as a bring-your-own-key (BYOK) model provider — confi
 
 <Note>
   Bedrock is accessed through the AWS SDK (`boto3` / `@aws-sdk/client-bedrock-runtime`) rather
-  than the OpenAI-compatible pattern used by the other model providers listed in the
-  [integrations overview](/integrations/overview), so its auto-instrumentation setup is
-  different from a simple `base_url` override. This page
+  than the OpenAI-compatible pattern used by [Azure OpenAI](/integrations/azure),
+  [DeepSeek](/integrations/deepseek), [Moonshot](/integrations/moonshot),
+  [OpenRouter](/integrations/openrouter), [xAI](/integrations/xai), and
+  [Z.AI](/integrations/zai), so its auto-instrumentation setup is different from a simple
+  `base_url` override. This page
   intentionally does not show a specific `traceroot.initialize(integrations=[...])` snippet —
   check the [Python SDK](/tracing/python-sdk) or [TypeScript SDK](/tracing/typescript-sdk) docs,
   or the SDK's own changelog, for the current Bedrock instrumentation entry point before wiring

--- a/docs/integrations/amazon-bedrock.mdx
+++ b/docs/integrations/amazon-bedrock.mdx
@@ -1,0 +1,26 @@
+---
+title: AWS Bedrock
+description: Configure AWS Bedrock as a BYOK model provider
+---
+
+AWS Bedrock is supported as a bring-your-own-key (BYOK) model provider — configure it in **Workspace Settings → Model Providers** using your AWS credentials (access key, secret key, and region).
+
+<Note>
+  Bedrock is accessed through the AWS SDK (`boto3` / `@aws-sdk/client-bedrock-runtime`) rather
+  than the OpenAI-compatible pattern used by the other model providers on this page, so its
+  auto-instrumentation setup is different from a simple `base_url` override. This page
+  intentionally does not show a specific `traceroot.initialize(integrations=[...])` snippet —
+  check the [Python SDK](/tracing/python-sdk) or [TypeScript SDK](/tracing/typescript-sdk) docs,
+  or the SDK's own changelog, for the current Bedrock instrumentation entry point before wiring
+  this up.
+</Note>
+
+## BYOK Setup
+
+1. Go to **Workspace Settings → Model Providers**.
+2. Select **AWS Bedrock** and enter your AWS access key, secret key, and region.
+3. Once configured, Bedrock becomes available as a model source for TraceRoot's AI features (trace analysis, root cause analysis, and automated fix PR generation).
+
+## Tracing Your Own Bedrock Calls
+
+If you want TraceRoot to trace calls your own application makes to Bedrock (separate from the BYOK configuration above), consult the SDK documentation directly for the current instrumentation approach — the auto-instrumentation code path for the AWS SDK is not yet documented on this page.

--- a/docs/integrations/amazon-bedrock.mdx
+++ b/docs/integrations/amazon-bedrock.mdx
@@ -7,8 +7,9 @@ AWS Bedrock is supported as a bring-your-own-key (BYOK) model provider — confi
 
 <Note>
   Bedrock is accessed through the AWS SDK (`boto3` / `@aws-sdk/client-bedrock-runtime`) rather
-  than the OpenAI-compatible pattern used by the other model providers on this page, so its
-  auto-instrumentation setup is different from a simple `base_url` override. This page
+  than the OpenAI-compatible pattern used by the other model providers listed in the
+  [integrations overview](/integrations/overview), so its auto-instrumentation setup is
+  different from a simple `base_url` override. This page
   intentionally does not show a specific `traceroot.initialize(integrations=[...])` snippet —
   check the [Python SDK](/tracing/python-sdk) or [TypeScript SDK](/tracing/typescript-sdk) docs,
   or the SDK's own changelog, for the current Bedrock instrumentation entry point before wiring

--- a/docs/integrations/azure.mdx
+++ b/docs/integrations/azure.mdx
@@ -1,0 +1,108 @@
+---
+title: Azure OpenAI
+description: Trace Azure OpenAI calls through the OpenAI-compatible SDK
+---
+
+Azure OpenAI is accessed through the same `openai` SDK as OpenAI itself, via the dedicated `AzureOpenAI` client. TraceRoot captures these calls through the existing OpenAI instrumentation — no new Azure-specific instrumentor or enum is required.
+
+## Setup
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    from openai import AzureOpenAI
+    import traceroot
+    from traceroot import Integration
+
+    traceroot.initialize(integrations=[Integration.OPENAI])
+
+    client = AzureOpenAI(
+        api_key=os.environ["AZURE_OPENAI_API_KEY"],
+        azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+        api_version="2024-10-21",
+    )
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import { AzureOpenAI } from 'openai';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { openAI: AzureOpenAI },
+    });
+
+    const client = new AzureOpenAI({
+      apiKey: process.env.AZURE_OPENAI_API_KEY,
+      endpoint: process.env.AZURE_OPENAI_ENDPOINT,
+      apiVersion: '2024-10-21',
+    });
+    ```
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    from openai import AzureOpenAI
+
+    client = AzureOpenAI(
+        api_key=os.environ["AZURE_OPENAI_API_KEY"],
+        azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+        api_version="2024-10-21",
+    )
+
+    # This Azure OpenAI call is traced by TraceRoot's OpenAI integration
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",  # Your Azure deployment name
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ],
+    )
+
+    print(response.choices[0].message.content)
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import { AzureOpenAI } from 'openai';
+
+    const client = new AzureOpenAI({
+      apiKey: process.env.AZURE_OPENAI_API_KEY,
+      endpoint: process.env.AZURE_OPENAI_ENDPOINT,
+      apiVersion: '2024-10-21',
+    });
+
+    // This Azure OpenAI call is traced by TraceRoot's OpenAI integration
+    const response = await client.chat.completions.create({
+      model: 'gpt-4o-mini', // Your Azure deployment name
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'What is the capital of France?' },
+      ],
+    });
+
+    console.log(response.choices[0].message.content);
+    ```
+
+  </Tab>
+</Tabs>
+
+## What Gets Captured
+
+| Attribute  | Description                                                                       |
+| ---------- | ---------------------------------------------------------------------------------- |
+| Model      | Your Azure deployment name                                                        |
+| Messages   | Input messages array                                                              |
+| Response   | Completion content                                                                |
+| Tool calls | Function/tool call inputs and outputs when using the OpenAI SDK tool-calling API   |
+| Tokens     | Prompt, completion, and total tokens when returned by the provider                |
+| Latency    | Request duration                                                                  |

--- a/docs/integrations/deepseek.mdx
+++ b/docs/integrations/deepseek.mdx
@@ -1,0 +1,104 @@
+---
+title: DeepSeek
+description: Trace DeepSeek calls through the OpenAI-compatible SDK
+---
+
+DeepSeek is OpenAI-compatible: use the standard `openai` SDK with the DeepSeek base URL (`https://api.deepseek.com`). TraceRoot captures these calls through the existing OpenAI instrumentation — no new DeepSeek-specific instrumentor or enum is required.
+
+## Setup
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+    import traceroot
+    from traceroot import Integration
+
+    traceroot.initialize(integrations=[Integration.OPENAI])
+
+    client = openai.OpenAI(
+        api_key=os.environ["DEEPSEEK_API_KEY"],
+        base_url="https://api.deepseek.com",
+    )
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { openAI: OpenAI },
+    });
+
+    const openai = new OpenAI({
+      apiKey: process.env.DEEPSEEK_API_KEY,
+      baseURL: 'https://api.deepseek.com',
+    });
+    ```
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+
+    client = openai.OpenAI(
+        api_key=os.environ["DEEPSEEK_API_KEY"],
+        base_url="https://api.deepseek.com",
+    )
+
+    # This DeepSeek call is traced by TraceRoot's OpenAI integration
+    response = client.chat.completions.create(
+        model="deepseek-chat",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ],
+    )
+
+    print(response.choices[0].message.content)
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+
+    const openai = new OpenAI({
+      apiKey: process.env.DEEPSEEK_API_KEY,
+      baseURL: 'https://api.deepseek.com',
+    });
+
+    // This DeepSeek call is traced by TraceRoot's OpenAI integration
+    const response = await openai.chat.completions.create({
+      model: 'deepseek-chat',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'What is the capital of France?' },
+      ],
+    });
+
+    console.log(response.choices[0].message.content);
+    ```
+
+  </Tab>
+</Tabs>
+
+## What Gets Captured
+
+| Attribute  | Description                                                                       |
+| ---------- | ---------------------------------------------------------------------------------- |
+| Model      | Any DeepSeek model string, such as `deepseek-chat` or `deepseek-reasoner`          |
+| Messages   | Input messages array                                                              |
+| Response   | Completion content                                                                |
+| Tool calls | Function/tool call inputs and outputs when using the OpenAI SDK tool-calling API   |
+| Tokens     | Prompt, completion, and total tokens when returned by the provider                |
+| Latency    | Request duration                                                                  |

--- a/docs/integrations/moonshot.mdx
+++ b/docs/integrations/moonshot.mdx
@@ -1,0 +1,104 @@
+---
+title: Moonshot (Kimi)
+description: Trace Moonshot AI (Kimi) calls through the OpenAI-compatible SDK
+---
+
+Moonshot AI (Kimi) is OpenAI-compatible: use the standard `openai` SDK with the Moonshot base URL (`https://api.moonshot.ai/v1`). TraceRoot captures these calls through the existing OpenAI instrumentation — no new Moonshot-specific instrumentor or enum is required.
+
+## Setup
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+    import traceroot
+    from traceroot import Integration
+
+    traceroot.initialize(integrations=[Integration.OPENAI])
+
+    client = openai.OpenAI(
+        api_key=os.environ["MOONSHOT_API_KEY"],
+        base_url="https://api.moonshot.ai/v1",
+    )
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { openAI: OpenAI },
+    });
+
+    const openai = new OpenAI({
+      apiKey: process.env.MOONSHOT_API_KEY,
+      baseURL: 'https://api.moonshot.ai/v1',
+    });
+    ```
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+
+    client = openai.OpenAI(
+        api_key=os.environ["MOONSHOT_API_KEY"],
+        base_url="https://api.moonshot.ai/v1",
+    )
+
+    # This Moonshot call is traced by TraceRoot's OpenAI integration
+    response = client.chat.completions.create(
+        model="kimi-k2-0905-preview",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ],
+    )
+
+    print(response.choices[0].message.content)
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+
+    const openai = new OpenAI({
+      apiKey: process.env.MOONSHOT_API_KEY,
+      baseURL: 'https://api.moonshot.ai/v1',
+    });
+
+    // This Moonshot call is traced by TraceRoot's OpenAI integration
+    const response = await openai.chat.completions.create({
+      model: 'kimi-k2-0905-preview',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'What is the capital of France?' },
+      ],
+    });
+
+    console.log(response.choices[0].message.content);
+    ```
+
+  </Tab>
+</Tabs>
+
+## What Gets Captured
+
+| Attribute  | Description                                                                       |
+| ---------- | ---------------------------------------------------------------------------------- |
+| Model      | Any Moonshot model string, such as `kimi-k2-0905-preview`                          |
+| Messages   | Input messages array                                                              |
+| Response   | Completion content                                                                |
+| Tool calls | Function/tool call inputs and outputs when using the OpenAI SDK tool-calling API   |
+| Tokens     | Prompt, completion, and total tokens when returned by the provider                |
+| Latency    | Request duration                                                                  |

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -155,10 +155,25 @@ Trace direct calls to LLM providers.
 
 <IntegrationGrid cols={3}>
   <IntegrationCard
+    logo="../logo/integrations/amazon-bedrock.svg"
+    title="AWS Bedrock"
+    href="/integrations/amazon-bedrock"
+  />
+  <IntegrationCard
     logo="../logo/integrations/anthropic.svg"
     logoDark="../logo/integrations/anthropic-dark.svg"
     title="Anthropic"
     href="/integrations/anthropic"
+  />
+  <IntegrationCard
+    logo="../logo/integrations/azure.svg"
+    title="Azure OpenAI"
+    href="/integrations/azure"
+  />
+  <IntegrationCard
+    logo="../logo/integrations/deepseek.svg"
+    title="DeepSeek"
+    href="/integrations/deepseek"
   />
   <IntegrationCard
     logo="../logo/integrations/gemini.svg"
@@ -171,6 +186,11 @@ Trace direct calls to LLM providers.
     href="/integrations/mistral"
   />
   <IntegrationCard
+    logo="../logo/integrations/moonshot.svg"
+    title="Moonshot (Kimi)"
+    href="/integrations/moonshot"
+  />
+  <IntegrationCard
     logo="../logo/integrations/openai.svg"
     logoDark="../logo/integrations/openai-dark.svg"
     title="OpenAI"
@@ -181,6 +201,16 @@ Trace direct calls to LLM providers.
     logoDark="../logo/integrations/openrouter-dark.svg"
     title="OpenRouter"
     href="/integrations/openrouter"
+  />
+  <IntegrationCard
+    logo="../logo/integrations/xai.svg"
+    title="xAI"
+    href="/integrations/xai"
+  />
+  <IntegrationCard
+    logo="../logo/integrations/zai.svg"
+    title="Z.AI (GLM)"
+    href="/integrations/zai"
   />
 </IntegrationGrid>
 

--- a/docs/integrations/xai.mdx
+++ b/docs/integrations/xai.mdx
@@ -1,0 +1,104 @@
+---
+title: xAI
+description: Trace xAI (Grok) calls through the OpenAI-compatible SDK
+---
+
+xAI is OpenAI-compatible: use the standard `openai` SDK with the xAI base URL (`https://api.x.ai/v1`). TraceRoot captures these calls through the existing OpenAI instrumentation — no new xAI-specific instrumentor or enum is required.
+
+## Setup
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+    import traceroot
+    from traceroot import Integration
+
+    traceroot.initialize(integrations=[Integration.OPENAI])
+
+    client = openai.OpenAI(
+        api_key=os.environ["XAI_API_KEY"],
+        base_url="https://api.x.ai/v1",
+    )
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { openAI: OpenAI },
+    });
+
+    const openai = new OpenAI({
+      apiKey: process.env.XAI_API_KEY,
+      baseURL: 'https://api.x.ai/v1',
+    });
+    ```
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+
+    client = openai.OpenAI(
+        api_key=os.environ["XAI_API_KEY"],
+        base_url="https://api.x.ai/v1",
+    )
+
+    # This xAI call is traced by TraceRoot's OpenAI integration
+    response = client.chat.completions.create(
+        model="grok-4",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ],
+    )
+
+    print(response.choices[0].message.content)
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+
+    const openai = new OpenAI({
+      apiKey: process.env.XAI_API_KEY,
+      baseURL: 'https://api.x.ai/v1',
+    });
+
+    // This xAI call is traced by TraceRoot's OpenAI integration
+    const response = await openai.chat.completions.create({
+      model: 'grok-4',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'What is the capital of France?' },
+      ],
+    });
+
+    console.log(response.choices[0].message.content);
+    ```
+
+  </Tab>
+</Tabs>
+
+## What Gets Captured
+
+| Attribute  | Description                                                                       |
+| ---------- | ---------------------------------------------------------------------------------- |
+| Model      | Any xAI model string, such as `grok-4` or `grok-4-fast`                           |
+| Messages   | Input messages array                                                              |
+| Response   | Completion content                                                                |
+| Tool calls | Function/tool call inputs and outputs when using the OpenAI SDK tool-calling API   |
+| Tokens     | Prompt, completion, and total tokens when returned by the provider                |
+| Latency    | Request duration                                                                  |

--- a/docs/integrations/zai.mdx
+++ b/docs/integrations/zai.mdx
@@ -1,0 +1,104 @@
+---
+title: Z.AI (GLM)
+description: Trace Z.AI (GLM) calls through the OpenAI-compatible SDK
+---
+
+Z.AI (GLM) is OpenAI-compatible: use the standard `openai` SDK with the Z.AI base URL (`https://api.z.ai/api/paas/v4`). TraceRoot captures these calls through the existing OpenAI instrumentation — no new Z.AI-specific instrumentor or enum is required.
+
+## Setup
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+    import traceroot
+    from traceroot import Integration
+
+    traceroot.initialize(integrations=[Integration.OPENAI])
+
+    client = openai.OpenAI(
+        api_key=os.environ["ZAI_API_KEY"],
+        base_url="https://api.z.ai/api/paas/v4",
+    )
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { openAI: OpenAI },
+    });
+
+    const openai = new OpenAI({
+      apiKey: process.env.ZAI_API_KEY,
+      baseURL: 'https://api.z.ai/api/paas/v4',
+    });
+    ```
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+
+    client = openai.OpenAI(
+        api_key=os.environ["ZAI_API_KEY"],
+        base_url="https://api.z.ai/api/paas/v4",
+    )
+
+    # This Z.AI call is traced by TraceRoot's OpenAI integration
+    response = client.chat.completions.create(
+        model="glm-4.6",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ],
+    )
+
+    print(response.choices[0].message.content)
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+
+    const openai = new OpenAI({
+      apiKey: process.env.ZAI_API_KEY,
+      baseURL: 'https://api.z.ai/api/paas/v4',
+    });
+
+    // This Z.AI call is traced by TraceRoot's OpenAI integration
+    const response = await openai.chat.completions.create({
+      model: 'glm-4.6',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'What is the capital of France?' },
+      ],
+    });
+
+    console.log(response.choices[0].message.content);
+    ```
+
+  </Tab>
+</Tabs>
+
+## What Gets Captured
+
+| Attribute  | Description                                                                       |
+| ---------- | ---------------------------------------------------------------------------------- |
+| Model      | Any Z.AI model string, such as `glm-4.6`                                          |
+| Messages   | Input messages array                                                              |
+| Response   | Completion content                                                                |
+| Tool calls | Function/tool call inputs and outputs when using the OpenAI SDK tool-calling API   |
+| Tokens     | Prompt, completion, and total tokens when returned by the provider                |
+| Latency    | Request duration                                                                  |

--- a/docs/logo/integrations/amazon-bedrock.svg
+++ b/docs/logo/integrations/amazon-bedrock.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>AWS Bedrock</title><circle cx="12" cy="12" r="12" fill="#FF9900"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">AB</text></svg>

--- a/docs/logo/integrations/azure.svg
+++ b/docs/logo/integrations/azure.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Azure OpenAI</title><circle cx="12" cy="12" r="12" fill="#0078D4"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">AZ</text></svg>

--- a/docs/logo/integrations/deepseek.svg
+++ b/docs/logo/integrations/deepseek.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>DeepSeek</title><circle cx="12" cy="12" r="12" fill="#4D6BFE"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">DS</text></svg>

--- a/docs/logo/integrations/moonshot.svg
+++ b/docs/logo/integrations/moonshot.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Moonshot (Kimi)</title><circle cx="12" cy="12" r="12" fill="#7C3AED"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">MS</text></svg>

--- a/docs/logo/integrations/xai.svg
+++ b/docs/logo/integrations/xai.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>xAI</title><circle cx="12" cy="12" r="12" fill="#1A1A1A"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">X</text></svg>

--- a/docs/logo/integrations/zai.svg
+++ b/docs/logo/integrations/zai.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Z.AI (GLM)</title><circle cx="12" cy="12" r="12" fill="#14B8A6"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">Z</text></svg>

--- a/frontend/ui/public/logo/integrations/azure.svg
+++ b/frontend/ui/public/logo/integrations/azure.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Azure OpenAI</title><circle cx="12" cy="12" r="12" fill="#0078D4"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">AZ</text></svg>

--- a/frontend/ui/public/logo/integrations/deepseek.svg
+++ b/frontend/ui/public/logo/integrations/deepseek.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>DeepSeek</title><circle cx="12" cy="12" r="12" fill="#4D6BFE"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">DS</text></svg>

--- a/frontend/ui/public/logo/integrations/moonshot.svg
+++ b/frontend/ui/public/logo/integrations/moonshot.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Moonshot (Kimi)</title><circle cx="12" cy="12" r="12" fill="#7C3AED"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">MS</text></svg>

--- a/frontend/ui/public/logo/integrations/xai.svg
+++ b/frontend/ui/public/logo/integrations/xai.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>xAI</title><circle cx="12" cy="12" r="12" fill="#1A1A1A"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">X</text></svg>

--- a/frontend/ui/public/logo/integrations/zai.svg
+++ b/frontend/ui/public/logo/integrations/zai.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Z.AI (GLM)</title><circle cx="12" cy="12" r="12" fill="#14B8A6"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">Z</text></svg>

--- a/frontend/ui/src/features/traces/components/GettingStarted/integrations-parity.test.ts
+++ b/frontend/ui/src/features/traces/components/GettingStarted/integrations-parity.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { ADAPTER_CONFIG } from "@traceroot/core";
+import { INTEGRATIONS } from "./integrations";
+
+// This suite is a drift guard for issue #1795: BYOK model providers
+// (ADAPTER_CONFIG, the source of truth) must stay in sync with every
+// display surface that's supposed to list them — the getting-started
+// picker and the docs. It intentionally does NOT cover "instrumentation
+// integrations" (agent frameworks) against the Python/TS SDK enums —
+// those enums live in the traceroot-py / traceroot-ts repos, which are
+// not part of this checkout, so there is no source-of-truth file here
+// to check against.
+
+// ADAPTER_CONFIG keys the same provider `google` where docs/picker call
+// it `gemini`. Every other key matches its docs/picker id verbatim.
+const ADAPTER_ID_TO_DOCS_ID: Record<string, string> = {
+  google: "gemini",
+};
+
+// AWS Bedrock needs boto3-based instrumentation with no verified
+// `Integration` enum member available to this repo (see its docs page) —
+// intentionally left out of the getting-started picker, which cannot
+// render an entry with zero code examples (see ManualTab.tsx's guard).
+const PICKER_EXCEPTIONS = new Set(["amazon-bedrock"]);
+
+const DOCS_ROOT = path.resolve(process.cwd(), "../../docs");
+const INTEGRATIONS_DIR = path.join(DOCS_ROOT, "integrations");
+const OVERVIEW_MDX_PATH = path.join(INTEGRATIONS_DIR, "overview.mdx");
+const DOCS_JSON_PATH = path.join(DOCS_ROOT, "docs.json");
+
+function readText(filePath: string): string {
+  return fs.readFileSync(filePath, "utf-8");
+}
+
+// Recursively collect every `docs.json` "pages" entry, repo-wide — not just
+// under the Integrations tab — so this doesn't silently stop working if the
+// nav gets reorganized.
+function collectDocsJsonPages(node: unknown, out: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (const item of node) collectDocsJsonPages(item, out);
+  } else if (node && typeof node === "object") {
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (key === "pages" && Array.isArray(value)) {
+        for (const page of value) {
+          if (typeof page === "string") out.push(page);
+        }
+      } else {
+        collectDocsJsonPages(value, out);
+      }
+    }
+  }
+  return out;
+}
+
+const byokIds = Object.keys(ADAPTER_CONFIG).map((key) => ADAPTER_ID_TO_DOCS_ID[key] ?? key);
+
+const pickerProviderIds = INTEGRATIONS.filter((i) => i.category === "provider").map((i) => i.id);
+
+const docsJsonPages = collectDocsJsonPages(JSON.parse(readText(DOCS_JSON_PATH)));
+const docsJsonIntegrationIds = docsJsonPages
+  .filter((p) => p.startsWith("integrations/"))
+  .map((p) => p.replace("integrations/", ""));
+
+const mdxFileIds = fs
+  .readdirSync(INTEGRATIONS_DIR)
+  .filter((f) => f.endsWith(".mdx"))
+  .map((f) => f.replace(/\.mdx$/, ""));
+
+const overviewMdx = readText(OVERVIEW_MDX_PATH);
+const overviewLinkedIds = Array.from(overviewMdx.matchAll(/\/integrations\/([a-z0-9-]+)"/g)).map(
+  (m) => m[1],
+);
+
+describe("BYOK model providers stay in sync with the picker and docs (#1795)", () => {
+  it("every ADAPTER_CONFIG provider has a docs.json nav entry", () => {
+    for (const id of byokIds) {
+      expect(docsJsonIntegrationIds, `${id} missing from docs.json nav`).toContain(id);
+    }
+  });
+
+  it("every ADAPTER_CONFIG provider has a docs/integrations/*.mdx page", () => {
+    for (const id of byokIds) {
+      expect(mdxFileIds, `${id} missing a docs/integrations/*.mdx page`).toContain(id);
+    }
+  });
+
+  it("every ADAPTER_CONFIG provider has an overview.mdx card", () => {
+    for (const id of byokIds) {
+      expect(overviewLinkedIds, `${id} missing an overview.mdx card`).toContain(id);
+    }
+  });
+
+  it("every ADAPTER_CONFIG provider (except documented exceptions) has a getting-started picker entry", () => {
+    for (const id of byokIds) {
+      if (PICKER_EXCEPTIONS.has(id)) continue;
+      expect(pickerProviderIds, `${id} missing from the getting-started picker`).toContain(id);
+    }
+  });
+
+  // Not tested in reverse: the picker's "provider" category means
+  // "instrumentable" (you can trace your own calls to it), which is a
+  // legitimately broader set than "BYOK-configurable" — e.g. Mistral is
+  // instrumentable but isn't in ADAPTER_CONFIG, and that's not drift.
+});
+
+describe("Docs stay in 1:1 correspondence: overview.mdx cards, docs.json nav, *.mdx files (#1795)", () => {
+  it("every docs/integrations/*.mdx file has a docs.json nav entry, and vice versa", () => {
+    expect([...mdxFileIds].sort()).toEqual([...docsJsonIntegrationIds].sort());
+  });
+
+  it("every docs/integrations/*.mdx file except overview.mdx itself is linked from overview.mdx", () => {
+    const expected = mdxFileIds.filter((id) => id !== "overview");
+    expect([...overviewLinkedIds].sort()).toEqual([...expected].sort());
+  });
+});

--- a/frontend/ui/src/features/traces/components/GettingStarted/integrations.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/integrations.tsx
@@ -364,6 +364,82 @@ const client = new Anthropic();`,
     },
   },
   {
+    id: "azure",
+    name: "Azure OpenAI",
+    href: "https://traceroot.ai/docs/integrations/azure",
+    category: "provider",
+    logo: "/logo/integrations/azure.svg",
+    languages: {
+      python: {
+        installCommand: "pip install traceroot openai",
+        initSnippet: `import os
+from openai import AzureOpenAI
+import traceroot
+from traceroot import Integration
+
+traceroot.initialize(integrations=[Integration.OPENAI])
+
+client = AzureOpenAI(
+    api_key=os.environ["AZURE_OPENAI_API_KEY"],
+    azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+    api_version="2024-10-21",
+)`,
+      },
+      typescript: {
+        installCommand: "npm install @traceroot-ai/traceroot openai",
+        initSnippet: `import { AzureOpenAI } from "openai";
+import { TraceRoot } from "@traceroot-ai/traceroot";
+
+TraceRoot.initialize({
+  instrumentModules: { openAI: AzureOpenAI },
+});
+
+const client = new AzureOpenAI({
+  apiKey: process.env.AZURE_OPENAI_API_KEY,
+  endpoint: process.env.AZURE_OPENAI_ENDPOINT,
+  apiVersion: "2024-10-21",
+});`,
+      },
+    },
+  },
+  {
+    id: "deepseek",
+    name: "DeepSeek",
+    href: "https://traceroot.ai/docs/integrations/deepseek",
+    category: "provider",
+    logo: "/logo/integrations/deepseek.svg",
+    languages: {
+      python: {
+        installCommand: "pip install traceroot openai",
+        initSnippet: `import os
+import openai
+import traceroot
+from traceroot import Integration
+
+traceroot.initialize(integrations=[Integration.OPENAI])
+
+client = openai.OpenAI(
+    api_key=os.environ["DEEPSEEK_API_KEY"],
+    base_url="https://api.deepseek.com",
+)`,
+      },
+      typescript: {
+        installCommand: "npm install @traceroot-ai/traceroot openai",
+        initSnippet: `import OpenAI from "openai";
+import { TraceRoot } from "@traceroot-ai/traceroot";
+
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+const client = new OpenAI({
+  apiKey: process.env.DEEPSEEK_API_KEY,
+  baseURL: "https://api.deepseek.com",
+});`,
+      },
+    },
+  },
+  {
     id: "gemini",
     name: "Google Gemini",
     href: "https://traceroot.ai/docs/integrations/gemini",
@@ -457,6 +533,117 @@ TraceRoot.initialize({
 const openai = new OpenAI({
   apiKey: process.env.OPENROUTER_API_KEY,
   baseURL: "https://openrouter.ai/api/v1",
+});`,
+      },
+    },
+  },
+  {
+    id: "xai",
+    name: "xAI",
+    href: "https://traceroot.ai/docs/integrations/xai",
+    category: "provider",
+    logo: "/logo/integrations/xai.svg",
+    languages: {
+      python: {
+        installCommand: "pip install traceroot openai",
+        initSnippet: `import os
+import openai
+import traceroot
+from traceroot import Integration
+
+traceroot.initialize(integrations=[Integration.OPENAI])
+
+client = openai.OpenAI(
+    api_key=os.environ["XAI_API_KEY"],
+    base_url="https://api.x.ai/v1",
+)`,
+      },
+      typescript: {
+        installCommand: "npm install @traceroot-ai/traceroot openai",
+        initSnippet: `import OpenAI from "openai";
+import { TraceRoot } from "@traceroot-ai/traceroot";
+
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+const client = new OpenAI({
+  apiKey: process.env.XAI_API_KEY,
+  baseURL: "https://api.x.ai/v1",
+});`,
+      },
+    },
+  },
+  {
+    id: "moonshot",
+    name: "Moonshot (Kimi)",
+    href: "https://traceroot.ai/docs/integrations/moonshot",
+    category: "provider",
+    logo: "/logo/integrations/moonshot.svg",
+    languages: {
+      python: {
+        installCommand: "pip install traceroot openai",
+        initSnippet: `import os
+import openai
+import traceroot
+from traceroot import Integration
+
+traceroot.initialize(integrations=[Integration.OPENAI])
+
+client = openai.OpenAI(
+    api_key=os.environ["MOONSHOT_API_KEY"],
+    base_url="https://api.moonshot.ai/v1",
+)`,
+      },
+      typescript: {
+        installCommand: "npm install @traceroot-ai/traceroot openai",
+        initSnippet: `import OpenAI from "openai";
+import { TraceRoot } from "@traceroot-ai/traceroot";
+
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+const client = new OpenAI({
+  apiKey: process.env.MOONSHOT_API_KEY,
+  baseURL: "https://api.moonshot.ai/v1",
+});`,
+      },
+    },
+  },
+  {
+    id: "zai",
+    name: "Z.AI (GLM)",
+    href: "https://traceroot.ai/docs/integrations/zai",
+    category: "provider",
+    logo: "/logo/integrations/zai.svg",
+    languages: {
+      python: {
+        installCommand: "pip install traceroot openai",
+        initSnippet: `import os
+import openai
+import traceroot
+from traceroot import Integration
+
+traceroot.initialize(integrations=[Integration.OPENAI])
+
+client = openai.OpenAI(
+    api_key=os.environ["ZAI_API_KEY"],
+    base_url="https://api.z.ai/api/paas/v4",
+)`,
+      },
+      typescript: {
+        installCommand: "npm install @traceroot-ai/traceroot openai",
+        initSnippet: `import OpenAI from "openai";
+import { TraceRoot } from "@traceroot-ai/traceroot";
+
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+const client = new OpenAI({
+  apiKey: process.env.ZAI_API_KEY,
+  baseURL: "https://api.z.ai/api/paas/v4",
 });`,
       },
     },


### PR DESCRIPTION
## Summary

Fixes #1795.

Six BYOK model providers configured in `ADAPTER_CONFIG` (`frontend/packages/core/src/llm-providers.ts`) — `azure`, `amazon-bedrock`, `deepseek`, `xai`, `moonshot`, `zai` — had zero presence in the getting-started picker, `docs/integrations/overview.mdx`, `docs.json` nav, or a `docs/integrations/*.mdx` page. Nothing enforced these staying in sync, which is exactly how the drift accumulated (matches the issue's "Groq/Bedrock/Azure hidden, xAI/Moonshot/Z.AI/DeepSeek missing" complaint precisely).

## Scope note (please read before reviewing)

This PR **only** covers "BYOK model providers vs `ADAPTER_CONFIG`" and "docs internal consistency" — both fully local to this repo. It does **not** cover the issue's other half: "instrumentation integrations vs the SDK's `Integration` enum." `traceroot-py` and `traceroot-ts` (referenced in the issue) are separate repos not present in this checkout — there's no source-of-truth file here to test against, so I can't honestly claim to enforce that half from this PR. That would need a companion change in those repos.

**Also worth flagging:** #1799 (open, by @somtri) independently adds `xai`/`moonshot`/`zai` docs+picker entries. This PR is self-contained and adds all six regardless of that PR's status — whichever of the two merges second will need a routine conflict resolution on `docs.json`/`overview.mdx`/`integrations.tsx`.

## Changes

- **`integrations-parity.test.ts`** (new): asserts every `ADAPTER_CONFIG` provider (with an explicit `google`→`gemini` alias, since the same provider is keyed differently on each side) has a `docs.json` nav entry, a `docs/integrations/*.mdx` page, an `overview.mdx` card, and a getting-started picker entry — and locks `overview.mdx` cards, `docs.json` nav, and `*.mdx` files into exact 1:1 correspondence (the issue's second acceptance criterion, confirmed already true today, now enforced).
- **Picker**: added `azure`, `deepseek`, `xai`, `moonshot`, `zai` (5 of 6), modeled on `openrouter`'s existing pattern — all five are OpenAI-API-compatible endpoints, so they reuse `Integration.OPENAI` with a custom `base_url` rather than needing an unverified SDK enum member I can't check against the actual (external) source.
- **`amazon-bedrock` is intentionally left out of the picker.** It needs AWS-SDK-based instrumentation with a different shape entirely, and `ManualTab.tsx` hard-errors (throws in dev) on any picker entry with zero code examples — so a "docs link only, no code" picker entry isn't actually possible. It gets a `docs.json` entry, an `overview.mdx` card, and its own docs page that says plainly it needs the real SDK snippet confirmed, instead of me guessing an `Integration` enum member name.
- **Logos**: all six are simple placeholder monogram badges (colored circle + initials), not official brand marks — flagging for a maintainer/designer to swap in real assets when convenient.

## Test plan

- [x] New parity test: 6/6 pass
- [x] Mutation-tested the parity test itself — temporarily removed `deepseek` from `docs.json`, confirmed both relevant assertions fail with a clear message, then restored it
- [x] `tsc --noEmit` and `eslint` clean on all touched files
- [x] Full frontend suite: 1052/1054 pass (2 pre-existing, unrelated environment flakes — a locale-dependent formatting test and a Slack OAuth timeout — confirmed to pass in isolation, unrelated to anything this PR touches)
- [x] Local diff-cover: 100% on this PR's diff

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep BYOK model providers in `ADAPTER_CONFIG` in sync with the docs and Getting Started picker, and add the missing providers. Adds a parity test to prevent provider display drift; fixes #1795.

- **Bug Fixes**
  - Parity test: `integrations-parity.test.ts` checks each `ADAPTER_CONFIG` provider (with `google`→`gemini` alias) has a `docs.json` nav entry, a `docs/integrations/*.mdx` page, an `overview.mdx` card, and a picker entry; enforces 1:1 between overview cards, docs nav, and MDX; excludes `amazon-bedrock` from the picker by design.
  - Picker: added `azure`, `deepseek`, `xai`, `moonshot`, `zai` via OpenAI-compatible `base_url`; `amazon-bedrock` intentionally excluded due to AWS SDK instrumentation and no code example path.
  - Docs: added pages for `amazon-bedrock`, `azure`, `deepseek`, `moonshot`, `xai`, `zai`; updated `docs.json` and the integrations overview; added placeholder logos; updated the Bedrock note to explicitly list the OpenAI-compatible providers (`azure`, `deepseek`, `moonshot`, `openrouter`, `xai`, `zai`) that use the `base_url` pattern.

<sup>Written for commit b9470a3ce22223244259c9d4fbe2d419fab2c4a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

