### PR TITLE
fix(ui): prevent stale AI session history

### DIFF
--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AISession } from "../types";
+import { useAiChat } from "./use-ai-chat";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function session(id: string): AISession {
+  return {
+    id,
+    projectId: "project-1",
+    title: id,
+    status: "active",
+    createTime: "2026-08-03T00:00:00.000Z",
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useAiChat session history", () => {
+  it("keeps the latest selection when message requests resolve out of order", async () => {
+    const first = deferred<Response>();
+    const second = deferred<Response>();
+    const fetchMock = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useAiChat({ projectId: "project-1" }));
+
+    let firstSelection!: Promise<void>;
+    let secondSelection!: Promise<void>;
+    act(() => {
+      firstSelection = result.current.handleSelectSession(session("session-a"));
+    });
+    act(() => {
+      secondSelection = result.current.handleSelectSession(session("session-b"));
+    });
+
+    second.resolve(
+      new Response(
+        JSON.stringify({
+          messages: [
+            {
+              id: "message-b",
+              role: "assistant",
+              content: "Session B",
+              createTime: "2026-08-03T00:00:02.000Z",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    await act(async () => secondSelection);
+
+    expect(result.current.currentSessionId).toBe("session-b");
+    expect(result.current.messages.map((message) => message.content)).toEqual(["Session B"]);
+
+    first.resolve(
+      new Response(
+        JSON.stringify({
+          messages: [
+            {
+              id: "message-a",
+              role: "assistant",
+              content: "Session A",
+              createTime: "2026-08-03T00:00:01.000Z",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    await act(async () => firstSelection);
+
+    expect(result.current.currentSessionId).toBe("session-b");
+    expect(result.current.messages.map((message) => message.content)).toEqual(["Session B"]);
+  });
+});

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
@@ -25,7 +25,24 @@ function session(id: string): AISession {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
+
+function mockAbortableFetch() {
+  let signal: AbortSignal | undefined;
+  const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+    signal = init?.signal ?? undefined;
+    return new Promise<Response>((_resolve, reject) => {
+      signal?.addEventListener(
+        "abort",
+        () => reject(new DOMException("The operation was aborted", "AbortError")),
+        { once: true },
+      );
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { fetchMock, getSignal: () => signal };
+}
 
 describe("useAiChat session history", () => {
   it("keeps the latest selection when message requests resolve out of order", async () => {
@@ -87,5 +104,62 @@ describe("useAiChat session history", () => {
 
     expect(result.current.currentSessionId).toBe("session-b");
     expect(result.current.messages.map((message) => message.content)).toEqual(["Session B"]);
+  });
+
+  it("cancels a pending history load when starting a new session", async () => {
+    const { getSignal } = mockAbortableFetch();
+    const { result } = renderHook(() => useAiChat({ projectId: "project-1" }));
+
+    let selection!: Promise<void>;
+    act(() => {
+      selection = result.current.handleSelectSession(session("session-a"));
+    });
+    act(() => result.current.handleNewSession());
+    await act(async () => selection);
+
+    expect(getSignal()?.aborted).toBe(true);
+    expect(result.current.currentSessionId).toBeNull();
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("cancels a pending history load when closing the chat", async () => {
+    const { getSignal } = mockAbortableFetch();
+    const { result } = renderHook(() => useAiChat({ projectId: "project-1" }));
+
+    let selection!: Promise<void>;
+    act(() => {
+      selection = result.current.handleSelectSession(session("session-a"));
+    });
+    act(() => result.current.handleClose());
+    await act(async () => selection);
+
+    expect(getSignal()?.aborted).toBe(true);
+    expect(result.current.currentSessionId).toBeNull();
+  });
+
+  it("cancels a pending history load when deleting the active session", async () => {
+    const { getSignal } = mockAbortableFetch();
+    const { result } = renderHook(() => useAiChat({ projectId: "project-1" }));
+
+    let selection!: Promise<void>;
+    act(() => {
+      selection = result.current.handleSelectSession(session("session-a"));
+    });
+    act(() => result.current.handleDeleteSession("session-a"));
+    await act(async () => selection);
+
+    expect(getSignal()?.aborted).toBe(true);
+    expect(result.current.currentSessionId).toBeNull();
+  });
+
+  it("logs non-abort failures while loading session history", async () => {
+    const error = new Error("network unavailable");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(error));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { result } = renderHook(() => useAiChat({ projectId: "project-1" }));
+
+    await act(async () => result.current.handleSelectSession(session("session-a")));
+
+    expect(consoleError).toHaveBeenCalledWith("[AI Chat] Failed to load session messages:", error);
   });
 });

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -18,6 +18,7 @@ export function useAiChat({
 }: UseAiChatOptions) {
   const { messages, isStreaming, sendMessage, abort, setMessages } = useAIStream();
   const sessionIdRef = useRef<string | null>(null);
+  const selectSessionAborterRef = useRef<AbortController | null>(null);
   // Set so concurrent ensureSession calls don't cancel each other; handleClose
   // aborts all in-flight POST /sessions to prevent post-close resurrection.
   const ensureSessionAbortersRef = useRef<Set<AbortController>>(new Set());
@@ -38,6 +39,8 @@ export function useAiChat({
   // When initialSessionId is set, the loading useEffect below owns session
   // ownership, so we bail here to avoid clobbering its fetched messages.
   useEffect(() => {
+    selectSessionAborterRef.current?.abort();
+    selectSessionAborterRef.current = null;
     if (initialSessionId) return;
     sessionIdRef.current = null;
     setMessages([]);
@@ -132,6 +135,8 @@ export function useAiChat({
     // in the background. Its SSE deltas may briefly bleed into this fresh
     // chat view until the backend turn completes — tracked separately as a
     // follow-up (see the linked discussion / issue on #784).
+    selectSessionAborterRef.current?.abort();
+    selectSessionAborterRef.current = null;
     sessionIdRef.current = null;
     setMessages([]);
   }, [setMessages]);
@@ -144,6 +149,8 @@ export function useAiChat({
   const handleClose = useCallback(() => {
     for (const ac of ensureSessionAbortersRef.current) ac.abort();
     ensureSessionAbortersRef.current.clear();
+    selectSessionAborterRef.current?.abort();
+    selectSessionAborterRef.current = null;
     abort();
     sessionIdRef.current = null;
     setMessages([]);
@@ -163,25 +170,39 @@ export function useAiChat({
 
   const handleSelectSession = useCallback(
     async (session: AISession) => {
+      if (!projectId) return;
+      selectSessionAborterRef.current?.abort();
+      const ac = new AbortController();
+      selectSessionAborterRef.current = ac;
       sessionIdRef.current = session.id;
       setMessages([]);
       setHistoryOpen(false);
 
-      if (!projectId) return;
       try {
-        const res = await fetch(`/api/projects/${projectId}/ai/sessions/${session.id}/messages`);
+        const res = await fetch(`/api/projects/${projectId}/ai/sessions/${session.id}/messages`, {
+          signal: ac.signal,
+        });
         if (res.ok) {
           const data = await res.json();
-          const loaded = (data.messages || []).map((m: any) => ({
-            id: m.id,
-            role: m.role as "user" | "assistant",
-            content: m.content,
-            timestamp: m.createTime,
-          }));
+          if (ac.signal.aborted) return;
+          const loaded = (data.messages || []).map(
+            (m: { id: string; role: string; content: string; createTime: string }): AIMessage => ({
+              id: m.id,
+              role: m.role as "user" | "assistant",
+              content: m.content,
+              timestamp: m.createTime,
+            }),
+          );
           setMessages(loaded);
         }
       } catch (err) {
-        console.error("[AI Chat] Failed to load session messages:", err);
+        if ((err as Error).name !== "AbortError") {
+          console.error("[AI Chat] Failed to load session messages:", err);
+        }
+      } finally {
+        if (selectSessionAborterRef.current === ac) {
+          selectSessionAborterRef.current = null;
+        }
       }
     },
     [projectId, setMessages],
@@ -191,6 +212,8 @@ export function useAiChat({
     (sessionId: string) => {
       setSessions((prev) => prev.filter((s) => s.id !== sessionId));
       if (sessionIdRef.current === sessionId) {
+        selectSessionAborterRef.current?.abort();
+        selectSessionAborterRef.current = null;
         sessionIdRef.current = null;
         setMessages([]);
       }


### PR DESCRIPTION
Closes #1801

## Summary

- cancel stale AI session-history requests
- ignore aborted responses during session switches
- add an out-of-order response regression test

## Validation

- focused regression test passes
- ESLint and Prettier pass
- UI suite: 1,044 pass; one existing locale-sensitive billing test fails under `en-IN`

No visual changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale session history from overwriting the active chat when switching or managing sessions. Fixes the race condition in #1801 by canceling prior fetches and ignoring aborted responses.

- **Bug Fixes**
  - Cancel in-flight message fetches on switch, new session, close, and delete using `AbortController` with `fetch` signals.
  - Skip state updates for aborted requests and log only non-abort failures.
  - Expand tests to cover out-of-order loads and cleanup paths (new session, close, delete).

<sup>Written for commit 7903abd38b43496ff55e1e31dec9197ef7cbe642. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

