### PR TITLE
fail RCA when unknown  detector model

### DIFF
--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const fetchProviderConfigMock = vi.fn();
 const resolvePiModelMock = vi.fn();
+const isSystemModelIdMock = vi.fn();
 const modelProviderFindMany = vi.fn().mockResolvedValue([]);
 const digestAddMock = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("@traceroot/core/model-resolver", async () => ({
   fetchProviderConfig: (...args: any[]) => fetchProviderConfigMock(...args),
   resolvePiModel: (...args: any[]) => resolvePiModelMock(...args),
+  isSystemModelId: (...args: any[]) => isSystemModelIdMock(...args),
 }));
 
 vi.mock("../../queues/digest-queue.js", async (importOriginal) => {
@@ -32,6 +34,7 @@ vi.mock("@traceroot/core", async (importOriginal) => {
 afterEach(() => {
   fetchProviderConfigMock.mockReset();
   resolvePiModelMock.mockReset();
+  isSystemModelIdMock.mockReset();
   modelProviderFindMany.mockReset();
   modelProviderFindMany.mockResolvedValue([]);
   digestAddMock.mockReset().mockResolvedValue(undefined);
@@ -66,11 +69,13 @@ describe("resolveProjectModel", () => {
   });
 
   it("resolves a system model via resolvePiModel", async () => {
+    isSystemModelIdMock.mockReturnValue(true);
     resolvePiModelMock.mockReturnValue({ id: "claude-sonnet-4-5", provider: "anthropic" });
 
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
     const res = await resolveProjectModel("claude-sonnet-4-5", null, null, "ws-123");
 
+    expect(isSystemModelIdMock).toHaveBeenCalledWith("claude-sonnet-4-5");
     expect(resolvePiModelMock).toHaveBeenCalledWith("claude-sonnet-4-5", null);
     expect(res).toEqual({
       model: "claude-sonnet-4-5",
@@ -99,11 +104,17 @@ describe("resolveProjectModel", () => {
     expect(res).toEqual({ model: "deepseek-chat", providerName: "my-deepseek", source: "byok" });
   });
 
-  it("returns null for unknown models not in system catalog", async () => {
-    const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("unknown-model", null, null, "ws-123");
+  it("rejects a configured model that has left the system catalog", async () => {
+    isSystemModelIdMock.mockReturnValue(false);
 
-    expect(res).toBeNull();
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+
+    //   requires an exception containing the invalid stored model ID.
+    await expect(resolveProjectModel("retired-rca-test", null, "system", "ws-123")).rejects.toThrow(
+      'RCA model "retired-rca-test" is not a known system model',
+    );
+
+    expect(resolvePiModelMock).not.toHaveBeenCalled();
     expect(fetchProviderConfigMock).not.toHaveBeenCalled();
   });
 
@@ -113,14 +124,18 @@ describe("resolveProjectModel", () => {
     expect(await resolveProjectModel(undefined, null, null, "ws-123")).toBeNull();
   });
 
-  it("handles errors in legacy BYOK provider lookup gracefully", async () => {
+  it("rejects the unknown model when legacy BYOK lookup cannot resolve it", async () => {
+    isSystemModelIdMock.mockReturnValue(false);
     modelProviderFindMany.mockRejectedValue(new Error("DB down"));
 
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("unknown-custom-model", null, null, "ws-123");
 
-    expect(res).toBeNull();
+    await expect(resolveProjectModel("unknown-custom-model", null, null, "ws-123")).rejects.toThrow(
+      'RCA model "unknown-custom-model" is not a known system model',
+    );
+
     expect(modelProviderFindMany).toHaveBeenCalled();
+    expect(resolvePiModelMock).not.toHaveBeenCalled();
   });
 });
 
@@ -172,6 +187,36 @@ const textDeltaFrame = {
 };
 
 describe("runRcaSession", () => {
+  it("does not send an RCA message when the configured model is retired", async () => {
+    isSystemModelIdMock.mockReturnValue(false);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "s1" }),
+    });
+
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+
+    const { runRcaSession } = await import("../detector-rca-processor.js");
+
+    await expect(
+      runRcaSession({
+        findingId: "f1",
+        projectId: "p1",
+        workspaceId: "ws1",
+        traceId: "t1",
+        findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+        hasGitHub: false,
+        rcaModel: "retired-rca-test",
+        rcaProvider: null,
+        rcaSource: "system",
+      }),
+    ).rejects.toThrow(/retired-rca-test/);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
   it("calls resolveProjectModel and builds message body", async () => {
     fetchProviderConfigMock.mockResolvedValue({
       adapter: "openai",

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -1,14 +1,17 @@
 import { Queue, Worker, type Job } from "bullmq";
 import {
   prisma,
-  SYSTEM_MODELS,
   PlanType,
   ModelSource,
   ALERT_WINDOWS,
   DEFAULT_ALERT_WINDOW,
   isAlertWindow,
 } from "@traceroot/core";
-import { fetchProviderConfig, resolvePiModel } from "@traceroot/core/model-resolver";
+import {
+  fetchProviderConfig,
+  isSystemModelId,
+  resolvePiModel,
+} from "@traceroot/core/model-resolver";
 import type { DetectorRcaJob } from "../queues/detector-run-queue.js";
 import { DETECTOR_RCA_QUEUE, createRedisConnection } from "../queues/detector-run-queue.js";
 import {
@@ -36,16 +39,22 @@ function getDigestQueue(): Queue<DigestFlushJob> {
 // Uses the same pattern as sandbox-eval.ts: reads the provider from saved
 // config (BYOK) or the shared system-model resolver — no fragile prefix
 // matching or adapter guessing.
-// Returns null when the model is unset or unknown (caller should omit fields).
+//
+// An unset model may return null because no specific model was requested.
+//
+// An unknown stored model must throw. Returning null for an unknown model
+// incorrectly tells the caller that no model was selected. The caller then
+// omits model/provider/source from the Agent Service request, which makes the
+// Agent Service silently choose its default model.
 export async function resolveProjectModel(
   rcaModel: string | null | undefined,
   rcaProvider: string | null | undefined,
   rcaSource: string | null | undefined,
   workspaceId: string,
 ): Promise<{ model: string; providerName: string; source: ModelSource } | null> {
+  // null/undefined means the project genuinely has no saved model choice.
   if (!rcaModel) return null;
 
-  // 1. BYOK: read provider from saved config (same pattern as sandbox-eval.ts L126-136)
   if (rcaSource === "byok" && rcaProvider) {
     const providerConfig = await fetchProviderConfig(workspaceId, rcaProvider);
     if (!providerConfig) {
@@ -61,25 +70,21 @@ export async function resolveProjectModel(
     return { model: model.id, providerName: rcaProvider, source: ModelSource.BYOK };
   }
 
-  // 2. System model: validate against catalog, then use shared resolver
-  for (const group of SYSTEM_MODELS) {
-    if (group.models.some((m) => m.id === rcaModel)) {
-      const model = resolvePiModel(rcaModel, null);
-      return { model: model.id, providerName: model.provider, source: ModelSource.SYSTEM };
-    }
+  if (isSystemModelId(rcaModel)) {
+    const model = resolvePiModel(rcaModel, null);
+    return {
+      model: model.id,
+      providerName: model.provider,
+      source: ModelSource.SYSTEM,
+    };
   }
 
-  // 3. Legacy BYOK fallback for pre-existing configs
   const legacy = await resolveLegacyByok(rcaModel, workspaceId);
   if (legacy) return legacy;
 
-  console.warn(`[detector-rca] Unknown rca_model "${rcaModel}", falling back to default`);
-  return null;
+  throw new Error(`RCA model "${rcaModel}" is not a known system model`);
 }
 
-// 3. Legacy BYOK fallback: projects that saved a BYOK model before
-//    rcaSource and rcaProvider fields existed have both set to NULL.
-//    Try to resolve the model from the workspace's enabled providers.
 async function resolveLegacyByok(
   rcaModel: string,
   workspaceId: string,


### PR DESCRIPTION
Fixes #1639

## Summary
Make detector RCA fail when the stored `rca_model` no longer exists instead of silently falling back to the default system model.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

Before this change:
- `resolveProjectModel()` manually checked `SYSTEM_MODELS`
- if the stored `rca_model` was unknown, it logged a warning and returned `null`
- `runRcaSession()` then sent no `model`, `providerName`, or `source`
- the Agent Service treated that as "pick the default model" and RCA still succeeded

That was the bug. A detector configured with a retired model should not quietly run on some other model.

After this change:
- `resolveProjectModel()` uses `isSystemModelId` from `@traceroot/core/model-resolver`
- if the stored `rca_model` is unknown and not recoverable through the legacy project-model path, it throws an error instead of returning `null`
- that error is caught by the existing RCA job failure path, so the RCA run fails visibly instead of degrading to a default model

Tests were updated to cover:
- valid system model resolution through `isSystemModelId`
- unknown/retired `rca_model` rejecting instead of returning `null`
- `run

## Screenshots / Recordings (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail RCA when a detector’s saved `rca_model` is unknown or retired instead of silently using the default system model. This makes misconfigurations visible and prevents runs on the wrong model.

- **Bug Fixes**
  - `resolveProjectModel()` now uses `isSystemModelId` from `@traceroot/core/model-resolver`; throws when the stored model isn’t in the system catalog and legacy BYOK lookup can’t recover it.
  - Removed manual `SYSTEM_MODELS` checks; use shared resolver and ID guard instead.
  - RCA job failure path surfaces the error; `runRcaSession` skips sending an RCA message when the model is invalid.
  - Tests cover valid system model resolution, rejection of unknown/retired models, and legacy BYOK fallback.

<sup>Written for commit 705367e232e70943fd0e760ca2844981ced4e9b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

