### PR TITLE
feat(api): typed public trace filters generated from the filter registry

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -119,6 +119,47 @@
         "title": "ExportManifest",
         "type": "object"
       },
+      "FilterValueCount": {
+        "description": "A distinct categorical value and how often it occurs.",
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "value": {
+            "title": "Value",
+            "type": "string"
+          }
+        },
+        "required": [
+          "value",
+          "count"
+        ],
+        "title": "FilterValueCount",
+        "type": "object"
+      },
+      "FilterValuesResponse": {
+        "description": "Distinct values for one categorical filter field, by frequency.",
+        "properties": {
+          "field": {
+            "title": "Field",
+            "type": "string"
+          },
+          "values": {
+            "items": {
+              "$ref": "#/components/schemas/FilterValueCount"
+            },
+            "title": "Values",
+            "type": "array"
+          }
+        },
+        "required": [
+          "field",
+          "values"
+        ],
+        "title": "FilterValuesResponse",
+        "type": "object"
+      },
       "FindingDetail": {
         "description": "A finding plus its per-detector results and optional free-text RCA.",
         "properties": {
@@ -2410,6 +2451,255 @@
               "description": "Search across trace_id, name, session_id, user_id",
               "title": "Search Query"
             }
+          },
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "field": {
+                            "const": "trace_id",
+                            "title": "Trace ID"
+                          },
+                          "op": {
+                            "enum": [
+                              "eq",
+                              "contains"
+                            ]
+                          },
+                          "value": {
+                            "maxLength": 1024,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "field",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "field": {
+                            "const": "model_name",
+                            "title": "Model"
+                          },
+                          "op": {
+                            "enum": [
+                              "in"
+                            ]
+                          },
+                          "value": {
+                            "items": {
+                              "maxLength": 1024,
+                              "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "field",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "field": {
+                            "const": "environment",
+                            "title": "Environment"
+                          },
+                          "op": {
+                            "enum": [
+                              "in"
+                            ]
+                          },
+                          "value": {
+                            "items": {
+                              "maxLength": 1024,
+                              "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "field",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "field": {
+                            "const": "cost",
+                            "title": "Cost"
+                          },
+                          "op": {
+                            "enum": [
+                              "eq",
+                              "gt",
+                              "gte",
+                              "lt",
+                              "lte"
+                            ]
+                          },
+                          "value": {
+                            "maximum": 999999999,
+                            "minimum": 0,
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "field",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "field": {
+                            "const": "total_tokens",
+                            "title": "Tokens"
+                          },
+                          "op": {
+                            "enum": [
+                              "eq",
+                              "gt",
+                              "gte",
+                              "lt",
+                              "lte"
+                            ]
+                          },
+                          "value": {
+                            "maximum": 9223372036854775807,
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "field",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "field": {
+                            "const": "duration_ms",
+                            "title": "Latency"
+                          },
+                          "op": {
+                            "enum": [
+                              "eq",
+                              "gt",
+                              "gte",
+                              "lt",
+                              "lte"
+                            ]
+                          },
+                          "value": {
+                            "maximum": 9223372036854775807,
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "field",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "field": {
+                            "const": "errors",
+                            "title": "Errors"
+                          },
+                          "op": {
+                            "enum": [
+                              "eq",
+                              "gt",
+                              "gte",
+                              "lt",
+                              "lte"
+                            ]
+                          },
+                          "value": {
+                            "maximum": 18446744073709551615,
+                            "minimum": 0,
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "field",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "field": {
+                            "const": "metadata",
+                            "title": "Metadata"
+                          },
+                          "key": {
+                            "description": "Which metadata key the value is compared against",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "op": {
+                            "enum": [
+                              "eq",
+                              "contains"
+                            ]
+                          },
+                          "value": {
+                            "maxLength": 1024,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "field",
+                          "key",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "maxItems": 20,
+                  "type": "array"
+                }
+              }
+            },
+            "description": "JSON array of typed filter predicates ({field, op, value}); the field catalog and per-field operators are defined in the schema",
+            "in": "query",
+            "name": "filters",
+            "required": false
           }
         ],
         "responses": {
@@ -2422,6 +2712,21 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Invalid filters parameter"
           },
           "401": {
             "content": {
@@ -2489,7 +2794,7 @@
           "Traces (Public)"
         ],
         "x-tool": {
-          "description": "List recent traces for the project (newest first). Filter by time range, trace name, user id, or a free-text search across trace/session/user ids and names. Use this for discovery before fetching a specific trace.",
+          "description": "List recent traces for the project (newest first). Filter by time range, trace name, user id, or a free-text search across trace/session/user ids and names. Use this for discovery before fetching a specific trace. Structured filters (model, environment, cost, tokens, latency, error count, keyed metadata) are available via the typed filters parameter.",
           "enabled": true,
           "name": "list_traces"
         }
@@ -2631,6 +2936,157 @@
         ],
         "x-tool": {
           "enabled": false
+        }
+      }
+    },
+    "/api/v1/public/traces/filter-values/{field}": {
+      "get": {
+        "description": "Distinct values for an open-ended categorical filter field.\n\nThe values-discovery companion to the typed ``filters`` parameter on the\ntrace list: the filterable field catalog lives in the generated schema,\nwhile a field's current values are dynamic per project. Only fields the\nregistry marks as distinct-query (model_name, environment) are listable;\nthe field is resolved through the registry before it reaches SQL, so it can\nnever be a raw client-supplied column name.\n\nArgs:\n    auth (StampedAuth): Resolved API-key context; scopes the read to its\n        project and stamps the rate-limit identity.\n    field (str): The categorical field to enumerate.\n    start_after (datetime | None): Lower bound on span start time (active\n        window).\n    end_before (datetime | None): Upper bound on span start time (active\n        window), symmetric with ``start_after`` so options match the list's\n        window.\n\nReturns:\n    FilterValuesResponse: Distinct values ordered by descending frequency.\n\nRaises:\n    HTTPException: 400 if the field is unknown or not a distinct-query\n        categorical, 500 on a reader failure.",
+        "operationId": "list_trace_filter_values",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "field",
+            "required": true,
+            "schema": {
+              "title": "Field",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only consider spans starting at or after this timestamp",
+            "in": "query",
+            "name": "start_after",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only consider spans starting at or after this timestamp",
+              "title": "Start After"
+            }
+          },
+          {
+            "description": "Only consider spans starting before this timestamp",
+            "in": "query",
+            "name": "end_before",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only consider spans starting before this timestamp",
+              "title": "End Before"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterValuesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Field is not filterable by distinct values"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to list filter values"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List Trace Filter Values",
+        "tags": [
+          "Traces (Public)"
+        ],
+        "x-tool": {
+          "description": "Discover the current values of a categorical trace filter field (e.g. model_name, environment) for the project \u2014 use before filtering the trace list by that field.",
+          "enabled": true,
+          "name": "list_trace_filter_values"
         }
       }
     },

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -11,6 +11,14 @@ import copy
 import json
 from typing import Any
 
+from rest.services.filters.columns import FILTER_COLUMNS, FilterType
+from rest.services.filters.translate import (
+    MAX_FILTERS,
+    MAX_KEY_LENGTH,
+    MAX_VALUE_LENGTH,
+    NUMERIC_TYPE_MAX,
+)
+
 PUBLIC_PREFIX = "/api/v1/public/"
 TITLE = "TraceRoot Public API"
 
@@ -76,6 +84,7 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
     # Trace read/export error contract (matches the route code).
     list_op = schema["paths"].get("/api/v1/public/traces", {}).get("get")
     if list_op is not None:
+        list_op["responses"].setdefault("400", _error_response("Invalid filters parameter"))
         list_op["responses"].setdefault("500", _error_response("Failed to list traces"))
     for path in ("/api/v1/public/traces/{trace_id}", "/api/v1/public/traces/{trace_id}/export"):
         op = schema["paths"].get(path, {}).get("get")
@@ -83,6 +92,18 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
             op["responses"].setdefault("400", _error_response("Invalid fields parameter"))
             op["responses"].setdefault("404", _error_response("Trace not found"))
             op["responses"].setdefault("500", _error_response("Failed to get trace"))
+
+    # Filter-values discovery error contract (matches the route code).
+    filter_values_op = (
+        schema["paths"].get("/api/v1/public/traces/filter-values/{field}", {}).get("get")
+    )
+    if filter_values_op is not None:
+        filter_values_op["responses"].setdefault(
+            "400", _error_response("Field is not filterable by distinct values")
+        )
+        filter_values_op["responses"].setdefault(
+            "500", _error_response("Failed to list filter values")
+        )
 
     # Detector catalog list error contract (matches the route code).
     detectors_list_op = schema["paths"].get("/api/v1/public/detectors", {}).get("get")
@@ -114,6 +135,103 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
         session_get_op["responses"].setdefault("500", _error_response("Failed to get session"))
 
 
+def _filter_predicate_variants() -> list[dict[str, Any]]:
+    """One JSON-Schema variant per filterable field, generated from the registry.
+
+    The field registry (``rest.services.filters.columns``) is the single source
+    of truth; this builder mirrors each column's operator whitelist and value
+    shape into the public contract, so adding a filter field remains one
+    registry entry and a schema regeneration.
+
+    Returns:
+        list[dict[str, Any]]: ``anyOf`` variants for the ``filters`` parameter.
+    """
+    variants: list[dict[str, Any]] = []
+    for col in FILTER_COLUMNS:
+        if col.type == FilterType.CATEGORICAL:
+            # Per-element length cap, mirroring the runtime validator; the list
+            # itself is unbounded (each element binds into one Array parameter).
+            value_schema: dict[str, Any] = {
+                "type": "array",
+                "items": {"type": "string", "maxLength": MAX_VALUE_LENGTH},
+                "minItems": 1,
+            }
+        elif col.type == FilterType.NUMERIC:
+            # Mirror the runtime validator: metrics are non-negative, integer
+            # columns reject fractional values, and each column type has an
+            # inclusive maximum (shared map with the validator).
+            if col.is_integer:
+                value_schema = {"type": "integer", "minimum": 0}
+            else:
+                value_schema = {"type": "number", "minimum": 0}
+            max_val = NUMERIC_TYPE_MAX.get(col.ch_type)
+            if max_val is not None:
+                value_schema["maximum"] = max_val
+        elif col.type == FilterType.TEXT:
+            # The validator rejects empty strings and caps the length.
+            value_schema = {"type": "string", "minLength": 1, "maxLength": MAX_VALUE_LENGTH}
+        else:
+            # A new FilterType member must get an explicit value schema here;
+            # failing the build beats silently typing it as free text.
+            raise ValueError(f"unhandled filter type for schema generation: {col.type!r}")
+        properties: dict[str, Any] = {
+            "field": {"const": col.name, "title": col.label},
+            "op": {"enum": [str(o) for o in col.operators]},
+            "value": value_schema,
+        }
+        required = ["field", "op", "value"]
+        if col.requires_key:
+            # Mirror the runtime validator: a keyed field (e.g. metadata) carries
+            # which map key the value is compared against, as a bounded string.
+            properties["key"] = {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": MAX_KEY_LENGTH,
+                "description": f"Which {col.name} key the value is compared against",
+            }
+            required = ["field", "key", "op", "value"]
+        variants.append(
+            {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+                "additionalProperties": False,
+            }
+        )
+    return variants
+
+
+def _apply_filters_param_schema(schema: dict[str, Any]) -> None:
+    """Replace the string-typed ``filters`` query param with its JSON-content form.
+
+    FastAPI declares the route param as a plain string; the real contract is a
+    JSON array of typed predicates. OpenAPI models JSON-in-query as a parameter
+    with ``content`` instead of ``schema`` — downstream generators read
+    ``content["application/json"].schema``.
+
+    Args:
+        schema (dict[str, Any]): The public-only OpenAPI document; mutated in
+            place. No-op if the operation or parameter is absent.
+    """
+    op = schema["paths"].get("/api/v1/public/traces", {}).get("get")
+    if op is None:
+        return
+    for param in op.get("parameters", []):
+        if param.get("name") == "filters" and param.get("in") == "query":
+            param.pop("schema", None)
+            param["content"] = {
+                "application/json": {
+                    "schema": {
+                        "type": "array",
+                        "items": {"anyOf": _filter_predicate_variants()},
+                        # Mirror the runtime cap: each span-level predicate costs
+                        # its own scan in the page AND count queries.
+                        "maxItems": MAX_FILTERS,
+                    }
+                }
+            }
+
+
 # Agent/CLI-facing tool curation, keyed by operationId. Reviewed in the same PR
 # as any endpoint change so tool naming can't drift from the API. Every public
 # operation MUST have an entry: enabled tools carry the agent-facing
@@ -132,7 +250,18 @@ _TOOL_CURATION: dict[str, dict[str, Any]] = {
         "description": (
             "List recent traces for the project (newest first). Filter by time range, "
             "trace name, user id, or a free-text search across trace/session/user ids "
-            "and names. Use this for discovery before fetching a specific trace."
+            "and names. Use this for discovery before fetching a specific trace. "
+            "Structured filters (model, environment, cost, tokens, latency, error "
+            "count, keyed metadata) are available via the typed filters parameter."
+        ),
+        "enabled": True,
+    },
+    "list_trace_filter_values": {
+        "name": "list_trace_filter_values",
+        "description": (
+            "Discover the current values of a categorical trace filter field "
+            "(e.g. model_name, environment) for the project — use before "
+            "filtering the trace list by that field."
         ),
         "enabled": True,
     },
@@ -287,6 +416,7 @@ def build_public_schema(app: Any) -> dict[str, Any]:
         "components": components,
     }
     _apply_public_contract(schema)
+    _apply_filters_param_schema(schema)
     _apply_tool_curation(schema)
     return schema
 

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -36,6 +36,9 @@ from rest.schemas.public import (
     PublicTraceExportResponse,
     PublicTraceListResponse,
 )
+from rest.schemas.traces import FilterValuesResponse
+from rest.services.filters import columns as filter_columns
+from rest.services.filters.translate import parse_filters_param
 from rest.services.trace_reader import get_trace_reader_service
 from rest.url_utils import build_trace_url
 from shared.config import settings
@@ -67,8 +70,21 @@ async def list_traces(
     search_query: str | None = Query(
         None, description="Search across trace_id, name, session_id, user_id"
     ),
+    filters: str | None = Query(
+        None,
+        description=(
+            "JSON array of typed filter predicates ({field, op, value}); the "
+            "field catalog and per-field operators are defined in the schema"
+        ),
+    ),
 ):
     """List recent traces for the API key's project (newest first)."""
+    # Parse + validate filters before the DB try-block so a bad predicate
+    # surfaces as a 400 with an actionable message, not a 500.
+    try:
+        parsed_filters = parse_filters_param(filters)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     start_after, end_before = clamp_retention_window(auth.billing_plan, start_after, end_before)
     try:
         service = get_trace_reader_service()
@@ -80,6 +96,7 @@ async def list_traces(
             name=name,
             user_id=user_id,
             search_query=search_query,
+            filters=parsed_filters,
         )
     except Exception as e:
         logger.exception(f"Error listing traces: {e}")
@@ -93,6 +110,83 @@ async def list_traces(
             settings.traceroot_public_ui_url, auth.project_id, item["trace_id"]
         )
     return result
+
+
+# Declared above the /{trace_id} route so the literal `filter-values` segment
+# is matched here and never captured as a trace id.
+@router.get(
+    "/filter-values/{field}",
+    response_model=FilterValuesResponse,
+    operation_id="list_trace_filter_values",
+)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def list_trace_filter_values(
+    request: Request,
+    response: Response,
+    auth: StampedAuth,
+    field: str,
+    start_after: datetime | None = Query(
+        None, description="Only consider spans starting at or after this timestamp"
+    ),
+    end_before: datetime | None = Query(
+        None, description="Only consider spans starting before this timestamp"
+    ),
+):
+    """Distinct values for an open-ended categorical filter field.
+
+    The values-discovery companion to the typed ``filters`` parameter on the
+    trace list: the filterable field catalog lives in the generated schema,
+    while a field's current values are dynamic per project. Only fields the
+    registry marks as distinct-query (model_name, environment) are listable;
+    the field is resolved through the registry before it reaches SQL, so it can
+    never be a raw client-supplied column name.
+
+    Args:
+        auth (StampedAuth): Resolved API-key context; scopes the read to its
+            project and stamps the rate-limit identity.
+        field (str): The categorical field to enumerate.
+        start_after (datetime | None): Lower bound on span start time (active
+            window).
+        end_before (datetime | None): Upper bound on span start time (active
+            window), symmetric with ``start_after`` so options match the list's
+            window.
+
+    Returns:
+        FilterValuesResponse: Distinct values ordered by descending frequency.
+
+    Raises:
+        HTTPException: 400 if the field is unknown or not a distinct-query
+            categorical, 500 on a reader failure.
+    """
+    start_after, end_before = clamp_retention_window(auth.billing_plan, start_after, end_before)
+    column = filter_columns.get_column(field)
+    if column is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown filter field: {field}",
+        )
+    if column.value_source != filter_columns.ValueSource.DISTINCT_QUERY:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Field '{field}' does not support distinct-value listing",
+        )
+    try:
+        service = get_trace_reader_service()
+        values = service.get_distinct_span_values(
+            project_id=auth.project_id,
+            column=column.name,
+            start_after=start_after,
+            end_before=end_before,
+        )
+    except Exception as e:
+        logger.exception(f"Error listing filter values: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list filter values",
+        ) from e
+    return {"field": field, "values": values}
 
 
 @router.get("/{trace_id}", response_model=PublicTraceDetailResponse, operation_id="get_trace")

--- a/backend/rest/services/filters/translate.py
+++ b/backend/rest/services/filters/translate.py
@@ -73,9 +73,9 @@ def parse_filters_param(raw: str | None) -> list[Predicate]:
         list[Predicate]: The parsed, registry-validated predicates.
 
     Raises:
-        ValueError: If the value is not a JSON array of valid predicate objects, carries
-            more than ``MAX_FILTERS`` of them, or names an unknown field or a
-            non-whitelisted operator.
+        ValueError: If the value is not a JSON array of valid predicate objects,
+            carries more than ``MAX_FILTERS`` of them, names an unknown field or
+            a non-whitelisted operator, or is nested too deeply to parse.
     """
     if not raw:
         return []
@@ -83,6 +83,11 @@ def parse_filters_param(raw: str | None) -> list[Predicate]:
         data = json.loads(raw)
     except json.JSONDecodeError as e:
         raise ValueError(f"filters is not valid JSON: {e}") from e
+    except RecursionError as e:
+        # Past the parser's depth limit json.loads raises RecursionError
+        # rather than JSONDecodeError; normalize it so callers keep their
+        # 400-on-malformed-input contract instead of a 500.
+        raise ValueError("filters is nested too deeply") from e
     if not isinstance(data, list):
         raise ValueError("filters must be a JSON array of predicate objects")
     # Bound the array before validating a single item, so an oversized one costs one
@@ -135,7 +140,7 @@ def _is_number(x: object) -> bool:
 # Decimal64(9) is Decimal(18, 9) — 9 integer digits — so its largest value is < 10**9; the
 # whole-number cap is deliberately conservative (rejects the absurd top fractional cent
 # too) to guarantee no overflow rather than track the exact per-scale maximum.
-_NUMERIC_TYPE_MAX = {"Int64": 2**63 - 1, "UInt64": 2**64 - 1, "Decimal64(9)": 10**9 - 1}
+NUMERIC_TYPE_MAX = {"Int64": 2**63 - 1, "UInt64": 2**64 - 1, "Decimal64(9)": 10**9 - 1}
 
 
 # Inclusive cap on a keyed field's key length. The key is free text the user may type
@@ -245,7 +250,7 @@ def _validate_numeric(x: object, pred: Predicate, col: FilterColumn) -> None:
         raise ValueError(
             f"{pred.op!r} filter on {pred.field!r} takes whole numbers only (got {x!r})"
         )
-    max_val = _NUMERIC_TYPE_MAX.get(col.ch_type)
+    max_val = NUMERIC_TYPE_MAX.get(col.ch_type)
     if max_val is not None and x > max_val:
         raise ValueError(f"{pred.op!r} filter on {pred.field!r} exceeds its maximum value")
 

--- a/tests/rest/test_filter_translate.py
+++ b/tests/rest/test_filter_translate.py
@@ -12,6 +12,7 @@ separately throughout, its span half through the one shared span-scan builder.
 """
 
 import json
+from unittest import mock
 
 import pytest
 
@@ -49,6 +50,21 @@ def test_parse_valid_json_array_yields_predicates():
 def test_parse_rejects_non_json():
     with pytest.raises(ValueError):
         parse_filters_param("not json")
+
+
+def test_parse_rejects_pathological_nesting():
+    # json.loads raises RecursionError (not JSONDecodeError) past the
+    # interpreter's parser depth; it must surface as ValueError so endpoints
+    # keep their 400-on-malformed-input contract. The trigger depth varies by
+    # platform, so simulate the parser overflow instead of provoking it.
+    with (
+        mock.patch(
+            "rest.services.filters.translate.json.loads",
+            side_effect=RecursionError("maximum recursion depth exceeded"),
+        ),
+        pytest.raises(ValueError, match="nested too deeply"),
+    ):
+        parse_filters_param("[[[]]]")
 
 
 def test_parse_rejects_non_array():

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -181,6 +181,7 @@ EXPECTED_OPERATION_IDS = {
     "/api/v1/public/sessions": {"get": "list_sessions"},
     "/api/v1/public/sessions/{session_id}": {"get": "get_session"},
     "/api/v1/public/traces": {"get": "list_traces", "post": "ingest_traces"},
+    "/api/v1/public/traces/filter-values/{field}": {"get": "list_trace_filter_values"},
     "/api/v1/public/traces/{trace_id}": {"get": "get_trace"},
     "/api/v1/public/traces/{trace_id}/export": {"get": "export_trace"},
     "/api/v1/public/whoami": {"get": "whoami"},
@@ -235,6 +236,7 @@ def test_x_tool_enabled_set_and_shape():
     assert set(enabled) == {
         "whoami",
         "list_traces",
+        "list_trace_filter_values",
         "get_trace",
         "export_trace",
         "list_sessions",
@@ -246,6 +248,89 @@ def test_x_tool_enabled_set_and_shape():
     }
     for name, tool in enabled.items():
         assert tool["description"], f"{name} needs an agent-facing description"
+
+
+def _filters_param(schema):
+    params = schema["paths"]["/api/v1/public/traces"]["get"]["parameters"]
+    matches = [p for p in params if p["name"] == "filters"]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def test_filters_param_is_json_content_with_registry_variants():
+    """The filters param schema is generated from the filter-field registry."""
+    from rest.services.filters.columns import FILTER_COLUMNS
+
+    param = _filters_param(_schema())
+    assert param["in"] == "query"
+    assert param.get("required") is not True
+    inner = param["content"]["application/json"]["schema"]
+    assert inner["type"] == "array"
+    from rest.services.filters.translate import MAX_FILTERS
+
+    # The runtime bounds the predicate count; the contract declares the same cap.
+    assert inner["maxItems"] == MAX_FILTERS
+    variants = inner["items"]["anyOf"]
+    assert len(variants) == len(FILTER_COLUMNS)
+    by_field = {v["properties"]["field"]["const"]: v for v in variants}
+    assert set(by_field) == {c.name for c in FILTER_COLUMNS}
+    from rest.services.filters.translate import MAX_KEY_LENGTH
+
+    for col in FILTER_COLUMNS:
+        v = by_field[col.name]
+        assert v["properties"]["op"]["enum"] == [str(o) for o in col.operators]
+        assert v["additionalProperties"] is False
+        if col.requires_key:
+            # A keyed field carries the map key, mirroring the runtime validator.
+            assert v["required"] == ["field", "key", "op", "value"]
+            key_schema = v["properties"]["key"]
+            assert key_schema["type"] == "string"
+            assert key_schema["minLength"] == 1
+            assert key_schema["maxLength"] == MAX_KEY_LENGTH
+        else:
+            assert v["required"] == ["field", "op", "value"]
+            assert "key" not in v["properties"]
+
+
+def test_filters_param_value_types_match_field_kinds():
+    from rest.services.filters.translate import MAX_VALUE_LENGTH
+
+    param = _filters_param(_schema())
+    variants = param["content"]["application/json"]["schema"]["items"]["anyOf"]
+    by_field = {v["properties"]["field"]["const"]: v for v in variants}
+    # categorical: non-empty array of strings, each element length-capped
+    assert by_field["model_name"]["properties"]["value"] == {
+        "type": "array",
+        "items": {"type": "string", "maxLength": MAX_VALUE_LENGTH},
+        "minItems": 1,
+    }
+    # numeric: number
+    # numeric: non-negative, per-column-type inclusive maximum; integer
+    # columns additionally reject fractions
+    assert by_field["duration_ms"]["properties"]["value"] == {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 2**63 - 1,
+    }
+    assert by_field["errors"]["properties"]["value"] == {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 2**64 - 1,
+    }
+    assert by_field["cost"]["properties"]["value"] == {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 10**9 - 1,
+    }
+    # text: the validator rejects empty strings and caps the length
+    assert by_field["trace_id"]["properties"]["value"] == {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": MAX_VALUE_LENGTH,
+    }
+    # categorical items carry no minLength: the runtime validator permits empty
+    # strings inside an 'in' list, and the schema must mirror, not exceed, it
+    assert "minLength" not in by_field["model_name"]["properties"]["value"]["items"]
 
 
 def test_uncurated_public_op_fails_build():

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -225,6 +225,86 @@ class TestPublicListTraces:
         assert resp.json()["detail"] == "Failed to list traces"
 
 
+class TestPublicListTracesFilters:
+    def test_forwards_parsed_predicates(self, client, mock_reader):
+        mock_reader.list_traces.return_value = {
+            "data": [],
+            "meta": {"page": 0, "limit": 50, "total": 0},
+        }
+        filters = '[{"field":"model_name","op":"in","value":["gpt-4o"]}]'
+        resp = client.get(f"/api/v1/public/traces?filters={filters}", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        sent = mock_reader.list_traces.call_args.kwargs["filters"]
+        assert len(sent) == 1
+        assert sent[0].field == "model_name"
+        assert sent[0].op == "in"
+        assert sent[0].value == ["gpt-4o"]
+
+    def test_no_filters_forwards_empty(self, client, mock_reader):
+        mock_reader.list_traces.return_value = {
+            "data": [],
+            "meta": {"page": 0, "limit": 50, "total": 0},
+        }
+        resp = client.get("/api/v1/public/traces", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        assert mock_reader.list_traces.call_args.kwargs["filters"] == []
+
+    def test_unknown_field_is_400_naming_the_field(self, client, mock_reader):
+        filters = '[{"field":"nope","op":"eq","value":1}]'
+        resp = client.get(f"/api/v1/public/traces?filters={filters}", headers=AUTH_HEADER)
+        assert resp.status_code == 400
+        assert "nope" in resp.json()["detail"]
+        mock_reader.list_traces.assert_not_called()
+
+    def test_bad_operator_is_400(self, client, mock_reader):
+        filters = '[{"field":"model_name","op":"contains","value":["x"]}]'
+        resp = client.get(f"/api/v1/public/traces?filters={filters}", headers=AUTH_HEADER)
+        assert resp.status_code == 400
+        mock_reader.list_traces.assert_not_called()
+
+    def test_malformed_json_is_400(self, client, mock_reader):
+        resp = client.get("/api/v1/public/traces?filters=not-json", headers=AUTH_HEADER)
+        assert resp.status_code == 400
+        mock_reader.list_traces.assert_not_called()
+
+
+class TestPublicListTraceFilterValues:
+    def test_returns_distinct_values_scoped_to_project(self, client, mock_reader):
+        mock_reader.get_distinct_span_values.return_value = [
+            {"value": "gpt-4o", "count": 3},
+            {"value": "claude", "count": 1},
+        ]
+        resp = client.get("/api/v1/public/traces/filter-values/model_name", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        assert resp.json()["values"] == [
+            {"value": "gpt-4o", "count": 3},
+            {"value": "claude", "count": 1},
+        ]
+        assert mock_reader.get_distinct_span_values.call_args.kwargs["project_id"] == "proj-A"
+
+    def test_non_enumerable_field_is_400(self, client, mock_reader):
+        resp = client.get("/api/v1/public/traces/filter-values/duration_ms", headers=AUTH_HEADER)
+        assert resp.status_code == 400
+
+    def test_unknown_field_is_400(self, client, mock_reader):
+        resp = client.get("/api/v1/public/traces/filter-values/nope", headers=AUTH_HEADER)
+        assert resp.status_code == 400
+
+    def test_literal_segment_not_captured_as_trace_id(self, client, mock_reader):
+        # Guards the route-declaration order: /filter-values/{field} must win
+        # over /{trace_id}. If ordering regresses, this 404s via get_trace.
+        mock_reader.get_distinct_span_values.return_value = []
+        resp = client.get("/api/v1/public/traces/filter-values/model_name", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        mock_reader.get_trace.assert_not_called()
+
+    def test_500_on_reader_failure(self, client, mock_reader):
+        mock_reader.get_distinct_span_values.side_effect = RuntimeError("boom")
+        resp = client.get("/api/v1/public/traces/filter-values/model_name", headers=AUTH_HEADER)
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Failed to list filter values"
+
+
 class TestPublicGetTrace:
     def test_scopes_to_auth_project_id(self, client, mock_reader):
         mock_reader.get_trace.return_value = dict(TRACE_DETAIL)


### PR DESCRIPTION
Exposes the trace-list predicate filtering on the public API with the field catalog embedded in the generated schema, plus a public values-discovery endpoint — so registry-generated tools gain fully-typed filtering with no hand-maintained field list anywhere.

**Stacked PR** — layer 4 of the stack; base is `feat/public-sessions-read`.

## What

- **Typed `filters` param on public `list_traces`**: a JSON array of `{field, op, value}` predicates, validated through the existing `parse_filters_param` before the DB try-block (unknown field / bad operator / malformed value → 400 with an actionable message). Same `trace_reader.list_traces(filters=…)` path the internal route uses.
- **Schema generated from the field registry** (`services/filters/columns.py` — the single source of truth): `openapi_public.py` emits one `anyOf` variant per registry column — field const, that field's exact operator whitelist as an enum, and the value typed to match the runtime validator (categorical → non-empty string array; integer metrics → non-negative integer; decimal metrics → non-negative number; text → string). Modeled OpenAPI-correctly as a JSON-content query parameter. Adding a filter field remains one registry entry + regeneration; a new `FilterType` fails the build loudly instead of silently degrading to free text.
- **Values discovery**: `GET /api/v1/public/traces/filter-values/{field}` (`list_trace_filter_values`), key-scoped with the retention clamp, mirroring the internal route's service invocation; declared above `/{trace_id}` with a regression test pinning the route order.
- Curation entry for the new tool; the `list_traces` tool description now mentions structured filters; error contracts (including the list route's new 400) stamped and regenerated.

## Design notes

- Unknown filter-values field returns **400** publicly (the internal route returns 404 for the same condition): on the public surface 404 is reserved for missing project resources, and a filter field is static catalog, not project data. The internal route's alignment is a candidate follow-up.
- The generated value schemas intentionally mirror `_validate_numeric` (non-negative everywhere; integer-only on integer columns) so schema-valid predicates can't fail runtime validation.

Closes #1807

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed, registry-driven filters to `GET /api/v1/public/traces` and a values-discovery endpoint so clients can filter traces with generated types and no hand-kept field lists. The list route previously had no structured filters; it now accepts JSON-in-query predicates and returns 400 on unknown fields/ops, bad values, or pathological nesting (was 500 on deep JSON).

- Typed `filters` on `GET /api/v1/public/traces`: JSON array of `{field, op, value}` validated by `parse_filters_param` and forwarded to `trace_reader.list_traces(filters=…)`; defaults to `[]`. Public OpenAPI now models this as JSON-in-query with one `anyOf` variant per registry field, operator enums, and value schemas that mirror runtime validators (categorical → non-empty string array with per-item length cap; numeric → non-negative with per-type max via `NUMERIC_TYPE_MAX`, integers reject fractions; text → non-empty string). Adds a documented 400.
- `GET /api/v1/public/traces/filter-values/{field}`: lists distinct values for registry-backed categorical fields (e.g., `model_name`, `environment`) within the retention window; 400 for unknown or non-enumerable fields. Declared above `/{trace_id}` and curated as a tool; the `list_traces` tool description now mentions structured filters.

<sup>Written for commit 07a4f3ba67c5d576935716c97aed604a05fc01a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

