### PR TITLE
feat(ui): Home section rendering the assistant panel full-page

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/home/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/home/page.test.tsx
@@ -138,6 +138,29 @@ describe("Home page", () => {
     expect(column!.className).toContain("mx-auto");
   });
 
+  it("renders the greeting inside the panel, centered after the toolbar", () => {
+    render(<HomePage />);
+    const toolbarButton = screen.getByTitle("New session");
+    const heading = screen.getByText("How can I help?");
+    // The greeting follows the toolbar in DOM order (it lives in the message
+    // region, not above the panel) and sits in the margin-auto-centered child
+    // of the scrollable region, so short viewports scroll instead of clipping.
+    expect(
+      toolbarButton.compareDocumentPosition(heading) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    const centered = heading.closest('[class*="m-auto"]');
+    expect(centered).not.toBeNull();
+    const scrollRegion = centered!.parentElement!;
+    expect(scrollRegion.className).toContain("flex-1");
+    expect(scrollRegion.className).toContain("overflow-y-auto");
+  });
+
+  it("suppresses the greeting during a session handoff", () => {
+    mocks.aiInitialSessionId = "sess-9";
+    render(<HomePage />);
+    expect(screen.queryByText("How can I help?")).toBeNull();
+  });
+
   it("sends a starter prompt through the chat send path with the default model", () => {
     mocks.projectData = { workspace_id: "ws-1" };
     mocks.llmModels = {

--- a/frontend/ui/src/app/projects/[projectId]/home/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/home/page.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, screen } from "@testing-library/react";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => {
   const releaseAiHost = vi.fn();
@@ -127,5 +127,45 @@ describe("Home page", () => {
     const column = container.querySelector('[class*="max-w-[900px]"]');
     expect(column).not.toBeNull();
     expect(column!.className).toContain("mx-auto");
+  });
+
+  it("sends a starter prompt through the chat send path with the default model", () => {
+    mocks.projectData = { workspace_id: "ws-1" };
+    mocks.llmModels = {
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "model-a", label: "Model A" }],
+        },
+      ],
+      byokProviders: [],
+    };
+    render(<HomePage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Summarize today's sessions" }));
+    expect(mocks.handleSend).toHaveBeenCalledWith("Summarize today's sessions", {
+      model: "model-a",
+      provider: "anthropic",
+      source: "system",
+      adapter: "anthropic",
+    });
+  });
+
+  it("disables starter prompts until the model list has loaded", () => {
+    render(<HomePage />);
+    const chip = screen.getByRole("button", {
+      name: "Summarize today's sessions",
+    }) as HTMLButtonElement;
+    expect(chip.disabled).toBe(true);
+    fireEvent.click(chip);
+    expect(mocks.handleSend).not.toHaveBeenCalled();
+  });
+
+  it("hides the starter prompts once the conversation has messages", () => {
+    mocks.messages = [{ id: "m1", role: "user", content: "hi" }];
+    render(<HomePage />);
+    expect(screen.queryByRole("button", { name: "Summarize today's sessions" })).toBeNull();
   });
 });

--- a/frontend/ui/src/app/projects/[projectId]/home/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/home/page.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => {
+  const releaseAiHost = vi.fn();
+  const registerAiHost = vi.fn(() => releaseAiHost);
+  return {
+    registerAiHost,
+    releaseAiHost,
+    handleSend: vi.fn(),
+    messages: [] as Array<{ id: string; role: string; content: string }>,
+    projectData: undefined as { workspace_id: string } | undefined,
+    llmModels: undefined as
+      | {
+          systemModels: Array<{
+            provider: string;
+            adapter: string;
+            source: "system";
+            models: Array<{ id: string; label: string; supported?: boolean }>;
+          }>;
+          byokProviders: Array<{
+            provider: string;
+            adapter: string;
+            source: "byok";
+            models: Array<{ id: string; label: string; supported?: boolean }>;
+          }>;
+        }
+      | undefined,
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "proj-1" }),
+}));
+
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({
+    registerAiHost: mocks.registerAiHost,
+  }),
+}));
+
+vi.mock("@/features/projects/components", () => ({
+  ProjectBreadcrumb: ({ projectId }: { projectId: string }) => (
+    <div data-testid="breadcrumb" data-project-id={projectId} />
+  ),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryKey }: { queryKey: unknown[] }) => {
+    if (queryKey[0] === "project") return { data: mocks.projectData };
+    if (queryKey[0] === "llm-models") return { data: mocks.llmModels };
+    return { data: undefined };
+  },
+}));
+
+vi.mock("@/lib/api", () => ({
+  getProject: vi.fn(),
+  getAvailableLLMModels: vi.fn(),
+}));
+
+vi.mock("@/features/ai-assistant/components/ai-chat-context", () => ({
+  useAiChatContext: () => ({
+    messages: mocks.messages,
+    isStreaming: false,
+    sessions: [],
+    historyOpen: false,
+    currentSessionId: null,
+    setHistoryOpen: vi.fn(),
+    handleSend: mocks.handleSend,
+    handleAbort: vi.fn(),
+    handleNewSession: vi.fn(),
+    handleClose: vi.fn(),
+    handleOpenHistory: vi.fn(),
+    handleSelectSession: vi.fn(),
+    handleDeleteSession: vi.fn(),
+  }),
+}));
+
+// Heavy chat children are covered by their own tests
+vi.mock("@/features/ai-assistant/components/message-list", () => ({
+  MessageList: () => null,
+}));
+vi.mock("@/features/ai-assistant/components/message-input", () => ({
+  MessageInput: () => null,
+}));
+vi.mock("@/features/ai-assistant/components/session-history", () => ({
+  SessionHistory: () => null,
+}));
+
+import HomePage from "./page";
+
+afterEach(() => {
+  cleanup();
+  mocks.registerAiHost.mockClear();
+  mocks.releaseAiHost.mockClear();
+  mocks.handleSend.mockClear();
+  mocks.messages = [];
+  mocks.projectData = undefined;
+  mocks.llmModels = undefined;
+});
+
+describe("Home page", () => {
+  it("renders the assistant in page variant: New and History present, Close absent", () => {
+    render(<HomePage />);
+    expect(screen.getByTitle("New session")).not.toBeNull();
+    expect(screen.getByTitle("History")).not.toBeNull();
+    // The Close button is the only header control rendering an X icon.
+    expect(document.querySelector("svg.lucide-x")).toBeNull();
+  });
+
+  it("renders the project breadcrumb for the route's project", () => {
+    render(<HomePage />);
+    expect(screen.getByTestId("breadcrumb").getAttribute("data-project-id")).toBe("proj-1");
+  });
+
+  it("claims the AI slot on mount and releases it on unmount", () => {
+    const { unmount } = render(<HomePage />);
+    expect(mocks.registerAiHost).toHaveBeenCalledTimes(1);
+    expect(mocks.releaseAiHost).not.toHaveBeenCalled();
+    unmount();
+    expect(mocks.releaseAiHost).toHaveBeenCalledTimes(1);
+  });
+
+  it("centers the assistant in a max-width column", () => {
+    const { container } = render(<HomePage />);
+    const column = container.querySelector('[class*="max-w-[900px]"]');
+    expect(column).not.toBeNull();
+    expect(column!.className).toContain("mx-auto");
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/home/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/home/page.test.tsx
@@ -8,6 +8,9 @@ const mocks = vi.hoisted(() => {
   return {
     registerAiHost,
     releaseAiHost,
+    setAiContext: vi.fn(),
+    aiContext: null as { traceId?: string } | null,
+    aiInitialSessionId: undefined as string | undefined,
     handleSend: vi.fn(),
     messages: [] as Array<{ id: string; role: string; content: string }>,
     projectData: undefined as { workspace_id: string } | undefined,
@@ -37,6 +40,9 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/components/layout/app-layout", () => ({
   useLayout: () => ({
     registerAiHost: mocks.registerAiHost,
+    aiContext: mocks.aiContext,
+    setAiContext: mocks.setAiContext,
+    aiInitialSessionId: mocks.aiInitialSessionId,
   }),
 }));
 
@@ -94,7 +100,10 @@ afterEach(() => {
   cleanup();
   mocks.registerAiHost.mockClear();
   mocks.releaseAiHost.mockClear();
+  mocks.setAiContext.mockClear();
   mocks.handleSend.mockClear();
+  mocks.aiContext = null;
+  mocks.aiInitialSessionId = undefined;
   mocks.messages = [];
   mocks.projectData = undefined;
   mocks.llmModels = undefined;
@@ -167,5 +176,23 @@ describe("Home page", () => {
     mocks.messages = [{ id: "m1", role: "user", content: "hi" }];
     render(<HomePage />);
     expect(screen.queryByRole("button", { name: "Summarize today's sessions" })).toBeNull();
+  });
+
+  it("clears a stale trace context on mount", () => {
+    mocks.aiContext = { traceId: "trace-1" };
+    render(<HomePage />);
+    expect(mocks.setAiContext).toHaveBeenCalledWith(null);
+  });
+
+  it("preserves the context while a session handoff is in flight", () => {
+    mocks.aiContext = { traceId: "trace-1" };
+    mocks.aiInitialSessionId = "sess-9";
+    render(<HomePage />);
+    expect(mocks.setAiContext).not.toHaveBeenCalled();
+  });
+
+  it("leaves the context alone when there is nothing to clear", () => {
+    render(<HomePage />);
+    expect(mocks.setAiContext).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ui/src/app/projects/[projectId]/home/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/home/page.tsx
@@ -30,7 +30,7 @@ const STARTER_PROMPTS = [
 export default function HomePage() {
   const params = useParams();
   const projectId = params.projectId as string;
-  const { registerAiHost } = useLayout();
+  const { registerAiHost, aiContext, setAiContext, aiInitialSessionId } = useLayout();
   const { messages, handleSend } = useAiChatContext();
 
   // Claim the AI slot for this page so AppLayout's project rail can never
@@ -40,6 +40,18 @@ export default function HomePage() {
   useEffect(() => {
     return registerAiHost();
   }, [registerAiHost]);
+
+  // Home is project-scoped but trace-agnostic: a trace context inherited from
+  // a trace/session viewer would silently attribute new chats here to that
+  // trace. AppLayout's navigation effect already clears the context (and any
+  // session handoff id) on every pathname change, so in the integrated app
+  // this mount-time clear is defense-in-depth for direct mounts and effect
+  // ordering — not the primary mechanism, and no handoff-into-Home flow
+  // exists today. Mount-only by design.
+  useEffect(() => {
+    if (!aiInitialSessionId && aiContext) setAiContext(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Starter prompts bypass the message input, so they resolve the model the
   // same way the input's selector would auto-pick it: from the settled model

--- a/frontend/ui/src/app/projects/[projectId]/home/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/home/page.tsx
@@ -2,9 +2,24 @@
 
 import { useEffect } from "react";
 import { useParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
 import { useLayout } from "@/components/layout/app-layout";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
+import { useAiChatContext } from "@/features/ai-assistant/components/ai-chat-context";
+import {
+  flattenAvailableModels,
+  pickDefaultModel,
+} from "@/features/ai-assistant/lib/resolve-model";
+import { getProject, getAvailableLLMModels } from "@/lib/api";
+
+// Starter prompts shown while the current session has no messages. Clicking
+// one sends it immediately through the same send path as the message input.
+const STARTER_PROMPTS = [
+  "Investigate the most recent errored trace",
+  "Summarize today's sessions",
+  "What did detector findings flag this week?",
+];
 
 /**
  * Home — the AI assistant as a first-class project section. Renders the same
@@ -16,6 +31,7 @@ export default function HomePage() {
   const params = useParams();
   const projectId = params.projectId as string;
   const { registerAiHost } = useLayout();
+  const { messages, handleSend } = useAiChatContext();
 
   // Claim the AI slot for this page so AppLayout's project rail can never
   // double-render the assistant alongside it. `registerAiHost()` returns its
@@ -25,9 +41,60 @@ export default function HomePage() {
     return registerAiHost();
   }, [registerAiHost]);
 
+  // Starter prompts bypass the message input, so they resolve the model the
+  // same way the input's selector would auto-pick it: from the settled model
+  // list only (`isPending: false` keeps the compiled-in fallback list out, so
+  // a prompt can never run against a model the workspace doesn't have). This is
+  // the auto-pick default, not the selector's live state — the selector's
+  // selection lives inside MessageInput and isn't readable from here.
+  // These queries share keys with the panel's own, so react-query dedups them.
+  const { data: project } = useQuery({
+    queryKey: ["project", projectId],
+    queryFn: () => getProject(projectId),
+    enabled: !!projectId,
+  });
+  const workspaceId = project?.workspace_id;
+  const { data: llmModels } = useQuery({
+    queryKey: ["llm-models", workspaceId],
+    queryFn: () => getAvailableLLMModels(workspaceId!),
+    enabled: !!workspaceId,
+  });
+  const defaultModel = pickDefaultModel(flattenAvailableModels(llmModels, false));
+
   return (
     <div className="flex h-full flex-col text-[13px]">
       <ProjectBreadcrumb projectId={projectId} />
+      {/* Suppressed during a session handoff so the greeting can't flash while
+          the handed-off session's messages load. */}
+      {messages.length === 0 && !aiInitialSessionId && (
+        <div className="mx-auto w-full max-w-[900px] px-6 pb-2 pt-10 text-center">
+          <h1 className="text-[15px] font-medium">How can I help?</h1>
+          <p className="mt-1 text-[12px] text-muted-foreground">
+            Ask about this project&apos;s traces, sessions, errors, and detector findings.
+          </p>
+          <div className="mt-4 flex flex-wrap justify-center gap-2">
+            {STARTER_PROMPTS.map((prompt) => (
+              <button
+                key={prompt}
+                type="button"
+                disabled={!defaultModel}
+                onClick={() => {
+                  if (!defaultModel) return;
+                  void handleSend(prompt, {
+                    model: defaultModel.id,
+                    provider: defaultModel.provider,
+                    source: defaultModel.source,
+                    adapter: defaultModel.adapter,
+                  });
+                }}
+                className="rounded-md border border-border px-3 py-1.5 text-[12px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {prompt}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
       <div className="min-h-0 flex-1">
         <AiAssistantPanel projectId={projectId} variant="page" onClose={() => {}} />
       </div>

--- a/frontend/ui/src/app/projects/[projectId]/home/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/home/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from "react";
+import { useParams } from "next/navigation";
+import { useLayout } from "@/components/layout/app-layout";
+import { ProjectBreadcrumb } from "@/features/projects/components";
+import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
+
+/**
+ * Home — the AI assistant as a first-class project section. Renders the same
+ * assistant panel used by the right rail and viewer panels, as a centered
+ * full-page column. Chat state lives in the app-wide AiChatProvider, so a
+ * conversation started here survives navigating to other sections.
+ */
+export default function HomePage() {
+  const params = useParams();
+  const projectId = params.projectId as string;
+  const { registerAiHost } = useLayout();
+
+  // Claim the AI slot for this page so AppLayout's project rail can never
+  // double-render the assistant alongside it. `registerAiHost()` returns its
+  // own cleanup, which we return from the effect so React releases the slot
+  // on unmount and the rail behaves normally elsewhere.
+  useEffect(() => {
+    return registerAiHost();
+  }, [registerAiHost]);
+
+  return (
+    <div className="flex h-full flex-col text-[13px]">
+      <ProjectBreadcrumb projectId={projectId} />
+      <div className="min-h-0 flex-1">
+        <AiAssistantPanel projectId={projectId} variant="page" onClose={() => {}} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/app/projects/[projectId]/home/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/home/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
+import { MessagesSquare, Radar, TriangleAlert } from "lucide-react";
 import { useLayout } from "@/components/layout/app-layout";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
@@ -16,9 +17,9 @@ import { getProject, getAvailableLLMModels } from "@/lib/api";
 // Starter prompts shown while the current session has no messages. Clicking
 // one sends it immediately through the same send path as the message input.
 const STARTER_PROMPTS = [
-  "Investigate the most recent errored trace",
-  "Summarize today's sessions",
-  "What did detector findings flag this week?",
+  { icon: TriangleAlert, text: "Investigate the most recent errored trace" },
+  { icon: MessagesSquare, text: "Summarize today's sessions" },
+  { icon: Radar, text: "What did detector findings flag this week?" },
 ];
 
 /**
@@ -31,7 +32,7 @@ export default function HomePage() {
   const params = useParams();
   const projectId = params.projectId as string;
   const { registerAiHost, aiContext, setAiContext, aiInitialSessionId } = useLayout();
-  const { messages, handleSend } = useAiChatContext();
+  const { handleSend } = useAiChatContext();
 
   // Claim the AI slot for this page so AppLayout's project rail can never
   // double-render the assistant alongside it. `registerAiHost()` returns its
@@ -73,42 +74,51 @@ export default function HomePage() {
   });
   const defaultModel = pickDefaultModel(flattenAvailableModels(llmModels, false));
 
+  // Rendered by the panel, vertically centered in the empty message region
+  // (between the toolbar and the input). Suppressed during a session handoff
+  // so the greeting can't flash while the handed-off session's messages load;
+  // the panel itself hides it as soon as the conversation has messages.
+  const greeting = aiInitialSessionId ? undefined : (
+    <div className="text-center">
+      <h1 className="text-[15px] font-medium">How can I help?</h1>
+      <p className="mt-1 text-[12px] text-muted-foreground">
+        Ask about this project&apos;s traces, sessions, errors, and detector findings.
+      </p>
+      <div className="mt-4 flex flex-wrap justify-center gap-2">
+        {STARTER_PROMPTS.map(({ icon: Icon, text }) => (
+          <button
+            key={text}
+            type="button"
+            disabled={!defaultModel}
+            onClick={() => {
+              if (!defaultModel) return;
+              void handleSend(text, {
+                model: defaultModel.id,
+                provider: defaultModel.provider,
+                source: defaultModel.source,
+                adapter: defaultModel.adapter,
+              });
+            }}
+            className="flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-[12px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Icon className="h-3.5 w-3.5 shrink-0" />
+            {text}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+
   return (
     <div className="flex h-full flex-col text-[13px]">
       <ProjectBreadcrumb projectId={projectId} />
-      {/* Suppressed during a session handoff so the greeting can't flash while
-          the handed-off session's messages load. */}
-      {messages.length === 0 && !aiInitialSessionId && (
-        <div className="mx-auto w-full max-w-[900px] px-6 pb-2 pt-10 text-center">
-          <h1 className="text-[15px] font-medium">How can I help?</h1>
-          <p className="mt-1 text-[12px] text-muted-foreground">
-            Ask about this project&apos;s traces, sessions, errors, and detector findings.
-          </p>
-          <div className="mt-4 flex flex-wrap justify-center gap-2">
-            {STARTER_PROMPTS.map((prompt) => (
-              <button
-                key={prompt}
-                type="button"
-                disabled={!defaultModel}
-                onClick={() => {
-                  if (!defaultModel) return;
-                  void handleSend(prompt, {
-                    model: defaultModel.id,
-                    provider: defaultModel.provider,
-                    source: defaultModel.source,
-                    adapter: defaultModel.adapter,
-                  });
-                }}
-                className="rounded-md border border-border px-3 py-1.5 text-[12px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {prompt}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
       <div className="min-h-0 flex-1">
-        <AiAssistantPanel projectId={projectId} variant="page" onClose={() => {}} />
+        <AiAssistantPanel
+          projectId={projectId}
+          variant="page"
+          onClose={() => {}}
+          emptyState={greeting}
+        />
       </div>
     </div>
   );

--- a/frontend/ui/src/components/layout/sidebar.test.tsx
+++ b/frontend/ui/src/components/layout/sidebar.test.tsx
@@ -80,6 +80,21 @@ describe("Sidebar", () => {
     expect(container.querySelector('[data-testid="star-widget"]')).toBeNull();
   });
 
+  it("puts Home first among the project links, above Tracing", () => {
+    navigation.pathname = "/projects/p1/home";
+    navigation.params = { projectId: "p1" };
+    render();
+
+    const links = Array.from(container.querySelectorAll("nav a"));
+    expect(links.slice(0, 2).map((l) => l.textContent)).toEqual(["Home", "Tracing"]);
+
+    const home = links[0];
+    expect(home.getAttribute("href")).toBe("/projects/p1/home");
+    // Active state: the plain `bg-muted` token (not the `hover:` variant).
+    expect(home.className.split(" ")).toContain("bg-muted");
+    expect(links[1].className.split(" ")).not.toContain("bg-muted");
+  });
+
   it("shows the upgrade button only in a project or workspace context", () => {
     render();
     expect(container.querySelector('[data-testid="upgrade-button"]')).toBeNull();

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -9,6 +9,7 @@ import {
   LifeBuoy,
   ChevronRight,
   Github,
+  House,
   Sun,
   Moon,
   Monitor,
@@ -138,6 +139,26 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
           {projectId ? (
             // Project context navigation
             <>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Link
+                    href={`/projects/${projectId}/home`}
+                    className={cn(
+                      "flex items-center gap-2 py-2 text-[13px] transition-colors",
+                      collapsed ? "justify-center px-2" : "px-3",
+                      pathname.includes("/home") ? "bg-muted" : "hover:bg-muted/50",
+                    )}
+                  >
+                    <House className="h-3.5 w-3.5 shrink-0" />
+                    {!collapsed && "Home"}
+                  </Link>
+                </TooltipTrigger>
+                {collapsed && (
+                  <TooltipContent side="right" sideOffset={16}>
+                    Home
+                  </TooltipContent>
+                )}
+              </Tooltip>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Link

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.test.tsx
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => ({
       }
     | undefined,
   onClose: vi.fn(),
+  messages: [] as Array<{ id: string; role: string; content: string }>,
+  isStreaming: false,
 }));
 
 vi.mock("@tanstack/react-query", () => ({
@@ -38,8 +40,8 @@ vi.mock("@/lib/api", () => ({
 
 vi.mock("./ai-chat-context", () => ({
   useAiChatContext: () => ({
-    messages: [],
-    isStreaming: false,
+    messages: mocks.messages,
+    isStreaming: mocks.isStreaming,
     sessions: [],
     historyOpen: false,
     currentSessionId: null,
@@ -64,6 +66,8 @@ afterEach(() => {
   cleanup();
   mocks.projectData = undefined;
   mocks.llmModels = undefined;
+  mocks.messages = [];
+  mocks.isStreaming = false;
   mocks.onClose.mockReset();
 });
 
@@ -86,5 +90,49 @@ describe("AiAssistantPanel", () => {
     expect(closeButton).not.toBeNull();
     fireEvent.click(closeButton!);
     expect(mocks.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the emptyState once the conversation has messages", () => {
+    mocks.messages = [{ id: "m1", role: "user", content: "hi" }];
+
+    render(
+      <AiAssistantPanel
+        projectId="proj-1"
+        onClose={mocks.onClose}
+        emptyState={<div>greeting</div>}
+      />,
+    );
+
+    expect(screen.queryByText("greeting")).toBeNull();
+  });
+
+  it("hides the emptyState while a send is in flight so the waiting UI shows", () => {
+    mocks.isStreaming = true;
+
+    render(
+      <AiAssistantPanel
+        projectId="proj-1"
+        onClose={mocks.onClose}
+        emptyState={<div>greeting</div>}
+      />,
+    );
+
+    expect(screen.queryByText("greeting")).toBeNull();
+  });
+
+  it("lets the no-models gate win over the emptyState", () => {
+    mocks.projectData = { workspace_id: "ws-abc" };
+    mocks.llmModels = { systemModels: [], byokProviders: [] };
+
+    render(
+      <AiAssistantPanel
+        projectId="proj-1"
+        onClose={mocks.onClose}
+        emptyState={<div>greeting</div>}
+      />,
+    );
+
+    expect(screen.getByText("No LLM models available")).not.toBeNull();
+    expect(screen.queryByText("greeting")).toBeNull();
   });
 });

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi, afterEach } from "vitest";
-import { render, cleanup, screen } from "@testing-library/react";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   projectData: undefined as { workspace_id: string } | undefined,
@@ -76,5 +76,15 @@ describe("AiAssistantPanel", () => {
 
     const link = screen.getByRole("link", { name: /Workspace Settings.*Model Providers/i });
     expect(link.getAttribute("href")).toBe("/workspaces/ws-abc/settings/model-providers");
+  });
+
+  it("renders the Close button in the default rail variant", () => {
+    const { container } = render(<AiAssistantPanel projectId="proj-1" onClose={mocks.onClose} />);
+
+    // The Close button is the only header control rendering an X icon.
+    const closeButton = container.querySelector("svg.lucide-x")?.closest("button");
+    expect(closeButton).not.toBeNull();
+    fireEvent.click(closeButton!);
+    expect(mocks.onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
@@ -20,6 +20,14 @@ interface AiAssistantPanelProps {
    * project-wide right rail used in AppLayout.
    */
   compact?: boolean;
+  /**
+   * Placement variant. `rail` (default) is the side-panel chrome used by the
+   * right rail and the viewer panels: left border, Close button. `page` is the
+   * full-page Home placement: a centered max-width column with no Close button
+   * (the page owns the panel; there is nothing to close). Everything else —
+   * header controls, model gate, messages, input — is identical.
+   */
+  variant?: "rail" | "page";
 }
 
 /**
@@ -32,7 +40,16 @@ interface AiAssistantPanelProps {
  * provider above survives all of these mount/unmount cycles, so chat history
  * and stream state persist across host transitions (#784 decoupling).
  */
-export function AiAssistantPanel({ projectId, onClose, compact = false }: AiAssistantPanelProps) {
+export function AiAssistantPanel({
+  projectId,
+  onClose,
+  compact = false,
+  variant = "rail",
+}: AiAssistantPanelProps) {
+  const rootCls =
+    variant === "page"
+      ? "mx-auto flex h-full w-full max-w-[900px] flex-col bg-background"
+      : "flex h-full flex-col border-l border-border bg-background";
   const headerCls = compact
     ? "flex h-10 items-center gap-1 border-b bg-muted/30 px-3"
     : "flex h-14 items-center gap-1 border-b px-3";
@@ -91,7 +108,7 @@ export function AiAssistantPanel({ projectId, onClose, compact = false }: AiAssi
   };
 
   return (
-    <div className="flex h-full flex-col border-l border-border bg-background">
+    <div className={rootCls}>
       {/* Header */}
       <div className={headerCls}>
         <Button
@@ -131,9 +148,11 @@ export function AiAssistantPanel({ projectId, onClose, compact = false }: AiAssi
           </PopoverContent>
         </Popover>
         <div className="flex-1" />
-        <Button variant="ghost" size="icon" className={btnCls} onClick={handleCloseClick}>
-          <X className={iconCls} />
-        </Button>
+        {variant === "rail" && (
+          <Button variant="ghost" size="icon" className={btnCls} onClick={handleCloseClick}>
+            <X className={iconCls} />
+          </Button>
+        )}
       </div>
 
       {/* Unsupported model warning */}

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { X, Plus, History, Square, AlertTriangle } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
@@ -23,11 +24,21 @@ interface AiAssistantPanelProps {
   /**
    * Placement variant. `rail` (default) is the side-panel chrome used by the
    * right rail and the viewer panels: left border, Close button. `page` is the
-   * full-page Home placement: a centered max-width column with no Close button
-   * (the page owns the panel; there is nothing to close). Everything else —
-   * header controls, model gate, messages, input — is identical.
+   * full-page Home placement: full-width header with the content below it
+   * centered in a max-width column, and no Close button (the page owns the
+   * panel; there is nothing to close). Everything else — header controls,
+   * model gate, messages, input — is identical.
    */
   variant?: "rail" | "page";
+  /**
+   * Optional content rendered vertically centered in the message region while
+   * the conversation is empty, models are available, and no send is in flight
+   * (once streaming starts the message list takes over so its waiting UI
+   * shows). The host page owns the content; the panel owns the placement, so
+   * the greeting sits between the header and the input instead of above the
+   * whole panel.
+   */
+  emptyState?: ReactNode;
 }
 
 /**
@@ -45,14 +56,24 @@ export function AiAssistantPanel({
   onClose,
   compact = false,
   variant = "rail",
+  emptyState,
 }: AiAssistantPanelProps) {
+  // In page placement the root spans the full page so the header's bottom
+  // border runs edge to edge like every other section header; only the
+  // content below it (messages, empty state, input) is centered in the
+  // max-width column.
   const rootCls =
     variant === "page"
-      ? "mx-auto flex h-full w-full max-w-[900px] flex-col bg-background"
+      ? "flex h-full w-full flex-col bg-background"
       : "flex h-full flex-col border-l border-border bg-background";
+  // The page header is a slim toolbar, the same height as a sidebar nav row
+  // (py-2 + 13px text = 36px), since the page already has the app header
+  // above it; the rail keeps its taller chrome.
   const headerCls = compact
     ? "flex h-10 items-center gap-1 border-b bg-muted/30 px-3"
-    : "flex h-14 items-center gap-1 border-b px-3";
+    : variant === "page"
+      ? "flex h-9 items-center gap-1 border-b px-3"
+      : "flex h-14 items-center gap-1 border-b px-3";
   const btnCls = compact ? "h-7 w-7 shrink-0 p-0" : "h-8 w-8 shrink-0";
   const iconCls = compact ? "h-3.5 w-3.5" : "h-4 w-4";
   const { data: project } = useQuery({
@@ -155,71 +176,88 @@ export function AiAssistantPanel({
         )}
       </div>
 
-      {/* Unsupported model warning */}
-      {unsupportedModels.length > 0 && (
-        <div className="mx-3 mt-2 flex items-start gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-[12px] dark:border-yellow-900 dark:bg-yellow-950">
-          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-600" />
-          <div>
-            <p className="font-medium text-yellow-800 dark:text-yellow-200">
-              Unsupported model{unsupportedModels.length > 1 ? "s" : ""} detected
-            </p>
-            <p className="mt-0.5 text-yellow-700 dark:text-yellow-300">
-              {unsupportedModels.map((m) => m.id).join(", ")}{" "}
-              {unsupportedModels.length > 1 ? "are" : "is"} no longer in the supported model list.
-              Update in{" "}
-              <a
-                href={`/workspaces/${workspaceId}/settings/model-providers`}
-                className="font-medium underline"
-              >
-                Settings &rarr; Model Providers
-              </a>
-              .
-            </p>
-          </div>
-        </div>
-      )}
-
-      {/* Messages */}
-      {!hasModels ? (
-        <div className="flex flex-1 items-center justify-center px-6">
-          <div className="flex max-w-[280px] flex-col items-center gap-3 text-center">
-            <AlertTriangle className="h-8 w-8 text-yellow-500" />
-            <p className="text-[13px] font-medium">No LLM models available</p>
-            <p className="text-[12px] text-muted-foreground">
-              To use the AI assistant, configure a system API key (e.g. Anthropic, OpenAI) in your
-              environment, or add a BYOK provider in{" "}
-              <a
-                href={`/workspaces/${workspaceId}/settings/model-providers`}
-                className="font-medium underline"
-              >
-                Workspace Settings &rarr; Model Providers
-              </a>
-              .
-            </p>
-          </div>
-        </div>
-      ) : (
-        <MessageList messages={messages} sessionStreaming={isStreaming} />
-      )}
-
-      {/* Input */}
-      <MessageInput
-        onSend={handleSend}
-        disabled={!projectId || !hasModels}
-        workspaceId={workspaceId}
-        actions={
-          isStreaming && (
-            <button
-              onClick={handleAbort}
-              className="flex items-center gap-1 rounded px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"
-              title="Stop generation"
-            >
-              <Square className="h-3 w-3 fill-current" />
-              Stop
-            </button>
-          )
+      {/* Everything below the header centers in the page column; in rail
+          placement the wrapper spans the panel, so layout is unchanged. */}
+      <div
+        className={
+          variant === "page"
+            ? "mx-auto flex min-h-0 w-full max-w-[900px] flex-1 flex-col"
+            : "flex min-h-0 flex-1 flex-col"
         }
-      />
+      >
+        {/* Unsupported model warning */}
+        {unsupportedModels.length > 0 && (
+          <div className="mx-3 mt-2 flex items-start gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-[12px] dark:border-yellow-900 dark:bg-yellow-950">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-600" />
+            <div>
+              <p className="font-medium text-yellow-800 dark:text-yellow-200">
+                Unsupported model{unsupportedModels.length > 1 ? "s" : ""} detected
+              </p>
+              <p className="mt-0.5 text-yellow-700 dark:text-yellow-300">
+                {unsupportedModels.map((m) => m.id).join(", ")}{" "}
+                {unsupportedModels.length > 1 ? "are" : "is"} no longer in the supported model list.
+                Update in{" "}
+                <a
+                  href={`/workspaces/${workspaceId}/settings/model-providers`}
+                  className="font-medium underline"
+                >
+                  Settings &rarr; Model Providers
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Messages */}
+        {!hasModels ? (
+          <div className="flex flex-1 items-center justify-center px-6">
+            <div className="flex max-w-[280px] flex-col items-center gap-3 text-center">
+              <AlertTriangle className="h-8 w-8 text-yellow-500" />
+              <p className="text-[13px] font-medium">No LLM models available</p>
+              <p className="text-[12px] text-muted-foreground">
+                To use the AI assistant, configure a system API key (e.g. Anthropic, OpenAI) in your
+                environment, or add a BYOK provider in{" "}
+                <a
+                  href={`/workspaces/${workspaceId}/settings/model-providers`}
+                  className="font-medium underline"
+                >
+                  Workspace Settings &rarr; Model Providers
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        ) : messages.length === 0 && emptyState && !isStreaming ? (
+          // m-auto (not items/justify-center) so that when the region is
+          // shorter than the content, the top stays reachable by scrolling
+          // instead of clipping outside the scroll container.
+          <div className="flex flex-1 overflow-y-auto px-6">
+            <div className="m-auto py-6">{emptyState}</div>
+          </div>
+        ) : (
+          <MessageList messages={messages} sessionStreaming={isStreaming} />
+        )}
+
+        {/* Input */}
+        <MessageInput
+          onSend={handleSend}
+          disabled={!projectId || !hasModels}
+          workspaceId={workspaceId}
+          actions={
+            isStreaming && (
+              <button
+                onClick={handleAbort}
+                className="flex items-center gap-1 rounded px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"
+                title="Stop generation"
+              >
+                <Square className="h-3 w-3 fill-current" />
+                Stop
+              </button>
+            )
+          }
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Promotes the AI assistant to a first-class **Home** section at `/projects/{id}/home` — the existing panel rendered as a centered full-page column, first sidebar entry above Tracing. Chat behavior and styling are byte-identical to the current panel; only placement changes.

## What

- **Panel `variant` prop** — `AiAssistantPanel` gains `variant?: "rail" | "page"` (default `rail`; the three existing mounts are untouched and keep the original chrome verbatim). Page mode hides only the Close button and centers the column at the width the message list already adapts to.
- **The page** — claims the AI slot (`registerAiHost` with cleanup) so the right rail can never double-render; breadcrumb; renders the panel full-page over the app-wide chat context, so a conversation started here survives navigation.
- **Sidebar** — `Home` as the first project-scoped entry, above Tracing, exact sibling styling.
- **Empty state** — greeting + three starter prompts sending through the existing send path; chips stay disabled until the workspace model list settles (never a phantom fallback model), and are suppressed during a session handoff.
- **Context defaults** — stale trace context cleared on mount as defense-in-depth (the layout's navigation reset is the primary mechanism, documented as such).
- jsdom tests throughout (page variant, slot lifecycle, sidebar ordering/active state, chip send path, context cases); full ui suite green.

## Notes for review

- Starter chips resolve the auto-pick default model (the input selector's live state is private to `MessageInput` by design); documented at the call site.
- A follow-up research note on agent-surface modularity (per-surface prompts/toolsets, session tagging) accompanies this work: conclusion — nothing to build now; at first real divergence, stamp a `surface` tag in session metadata at creation; nothing in this PR would need rework.

Closes #1733

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the assistant to a project-scoped Home at `/projects/{id}/home`, rendering `AiAssistantPanel` as a centered full-page column with an in-panel greeting and starter prompts. Previously the assistant lived only in the right rail; the new `page` variant hides Close, uses a slim full-width header, and centers content while rail behavior stays unchanged.

- `AiAssistantPanel`: adds `variant?: "rail" | "page"` (default `rail`) and `emptyState?: ReactNode`; existing callers need no changes.
- Home page: claims the assistant slot via `registerAiHost()` with cleanup on unmount; shows the project breadcrumb; uses shared chat context; clears stale `aiContext` on mount unless `aiInitialSessionId` is set.
- Greeting and prompts: greeting renders inside the panel, vertically centered in the empty message region; suppressed during a session handoff and once messages exist. Starter prompts resolve the default model from loaded workspace models (`flattenAvailableModels` → `pickDefaultModel`), stay disabled until models load, and send with model id/provider/source/adapter.
- No-models gate: the "No LLM models available" message wins over `emptyState`.
- Sidebar: adds Home above Tracing with a `House` icon; `bg-muted` marks the active link; tooltip shows when collapsed.
- Layout: page centers the content in a max-width 900px column; header is slim; message list, input, and toolbar controls are otherwise unchanged.

<sup>Written for commit 8c9f4cf8b36af6c6c47f89bb28222c362d5a7e4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

