### PR TITLE
feat(tools): registry package generated from the public OpenAPI schema

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Build @traceroot/agent
         run: cd frontend/packages/agent && pnpm build
 
+      - name: Build tools package
+        run: cd frontend/packages/tools && pnpm build
+
       - name: Build traceroot-worker (billing)
         run: cd frontend/worker && pnpm build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
           cd frontend
 
           FAIL=0
-          for pkg in ui worker packages/core packages/agent packages/slack packages/github; do
+          for pkg in ui worker packages/core packages/agent packages/slack packages/github packages/tools; do
             echo "::group::test:coverage — $pkg"
             cd "$pkg"
             pnpm test:coverage || FAIL=1
@@ -135,6 +135,7 @@ jobs:
             "frontend/packages/agent"
             "frontend/packages/slack"
             "frontend/packages/github"
+            "frontend/packages/tools"
           )
 
           > coverage-frontend.lcov  # truncate / create

--- a/frontend/packages/tools/package.json
+++ b/frontend/packages/tools/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@traceroot-ai/tools",
+  "version": "0.1.0",
+  "description": "TraceRoot tool registry: generated from the public OpenAPI schema; one definition per tool, dispatched generically by the CLI, MCP, and agent surfaces.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20.3"
+  },
+  "scripts": {
+    "build": "tsc",
+    "generate": "tsx scripts/generate-registry.ts && pnpm exec prettier --write src/registry.generated.ts",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@vitest/coverage-v8": "^3.2.6",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/frontend/packages/tools/scripts/generate-registry.ts
+++ b/frontend/packages/tools/scripts/generate-registry.ts
@@ -1,0 +1,27 @@
+/**
+ * Regenerate src/registry.generated.ts from the committed public OpenAPI
+ * schema. Run with: pnpm --filter @traceroot-ai/tools generate
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateRegistry, type OpenApiDocument } from "../src/generate.js";
+
+const packageDir = fileURLToPath(new URL("..", import.meta.url));
+const schemaPath = join(packageDir, "../../../backend/rest/openapi/public.json");
+const outputPath = join(packageDir, "src/registry.generated.ts");
+
+const doc = JSON.parse(readFileSync(schemaPath, "utf8")) as OpenApiDocument;
+const registry = generateRegistry(doc);
+
+const banner = `// Generated from backend/rest/openapi/public.json — do not edit.
+// Regenerate with: pnpm --filter @traceroot-ai/tools generate
+`;
+
+const contents = `${banner}import type { RegistryEntry } from "./types.js";
+
+export const REGISTRY: readonly RegistryEntry[] = ${JSON.stringify(registry, null, 2)};
+`;
+
+writeFileSync(outputPath, contents);
+console.log(`Wrote ${registry.length} registry entries to ${outputPath}`);

--- a/frontend/packages/tools/src/__tests__/dispatch.test.ts
+++ b/frontend/packages/tools/src/__tests__/dispatch.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import { ApiClient, ApiError, bearerAuth, internalAuth } from "../client.js";
+import { dispatch, fillPath } from "../dispatch.js";
+import type { RegistryEntry } from "../types.js";
+
+function fakeFetch(status: number, body: unknown) {
+  return vi.fn(
+    async () =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+}
+
+function makeEntry(overrides: Partial<RegistryEntry> = {}): RegistryEntry {
+  return {
+    name: "get_trace",
+    description: "Fetch one trace.",
+    method: "get",
+    path: "/api/v1/public/traces/{trace_id}",
+    inputSchema: {
+      type: "object",
+      properties: {
+        trace_id: { type: "string" },
+        fields: { type: "string" },
+      },
+      required: ["trace_id"],
+      additionalProperties: false,
+    },
+    ...overrides,
+  };
+}
+
+describe("fillPath", () => {
+  it("substitutes and URI-encodes path params", () => {
+    expect(fillPath("/api/v1/public/traces/{trace_id}", { trace_id: "a/b c" })).toBe(
+      "/api/v1/public/traces/a%2Fb%20c",
+    );
+  });
+
+  it("throws when a path param is missing", () => {
+    expect(() => fillPath("/api/v1/public/traces/{trace_id}", {})).toThrow(
+      /path parameter "trace_id"/,
+    );
+  });
+
+  it("throws when a path param is an empty string", () => {
+    // `/traces/` would slash-redirect to the list route and return the wrong
+    // resource, so an empty segment must fail loudly instead.
+    expect(() => fillPath("/api/v1/public/traces/{trace_id}", { trace_id: "" })).toThrow(
+      /path parameter "trace_id"/,
+    );
+  });
+});
+
+describe("dispatch", () => {
+  it("routes schema params to the query string and ignores unknown args", async () => {
+    const fetchImpl = fakeFetch(200, { data: {} });
+    const client = new ApiClient({ baseUrl: "http://x", headers: {}, fetchImpl });
+    await dispatch(makeEntry(), { trace_id: "t1", fields: "full", bogus: "nope" }, client);
+    const [url] = fetchImpl.mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect(parsed.pathname).toBe("/api/v1/public/traces/t1");
+    expect(parsed.searchParams.get("fields")).toBe("full");
+    expect(parsed.searchParams.has("bogus")).toBe(false);
+    expect(parsed.searchParams.has("trace_id")).toBe(false);
+  });
+
+  it("honors pathOverride with extra path params supplied as args", async () => {
+    const fetchImpl = fakeFetch(200, { data: {} });
+    const client = new ApiClient({ baseUrl: "http://x", headers: {}, fetchImpl });
+    await dispatch(makeEntry(), { trace_id: "t1", project_id: "p9", fields: "core" }, client, {
+      pathOverride: "/api/v1/projects/{project_id}/traces/{trace_id}",
+    });
+    const [url] = fetchImpl.mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect(parsed.pathname).toBe("/api/v1/projects/p9/traces/t1");
+    expect(parsed.searchParams.get("fields")).toBe("core");
+    expect(parsed.searchParams.has("project_id")).toBe(false);
+  });
+
+  it("JSON-serializes non-scalar args into the query string", async () => {
+    const fetchImpl = fakeFetch(200, { data: [] });
+    const client = new ApiClient({ baseUrl: "http://x", headers: {}, fetchImpl });
+    const listEntry: RegistryEntry = {
+      name: "list_traces",
+      description: "List traces.",
+      method: "get",
+      path: "/api/v1/public/traces",
+      inputSchema: {
+        type: "object",
+        properties: { filters: { type: "array" }, limit: { type: "integer" } },
+        required: [],
+        additionalProperties: false,
+      },
+    };
+    const filters = [{ field: "model_name", op: "in", value: ["gpt-4o"] }];
+    await dispatch(listEntry, { filters, limit: 5 }, client);
+    const [url] = fetchImpl.mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect(JSON.parse(parsed.searchParams.get("filters")!)).toEqual(filters);
+    expect(parsed.searchParams.get("limit")).toBe("5");
+  });
+
+  it("forwards the caller's abort signal to fetch", async () => {
+    const fetchImpl = fakeFetch(200, { data: {} });
+    const client = new ApiClient({ baseUrl: "http://x", headers: {}, fetchImpl });
+    const controller = new AbortController();
+    await dispatch(makeEntry(), { trace_id: "t1" }, client, { signal: controller.signal });
+    const [, init] = fetchImpl.mock.calls[0]! as unknown as [string, RequestInit];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("returns the parsed response body", async () => {
+    const fetchImpl = fakeFetch(200, { data: { trace_id: "t1" } });
+    const client = new ApiClient({ baseUrl: "http://x", headers: {}, fetchImpl });
+    const result = await dispatch(makeEntry(), { trace_id: "t1" }, client);
+    expect(result).toEqual({ data: { trace_id: "t1" } });
+  });
+
+  it("throws ApiError carrying the backend detail on non-2xx responses", async () => {
+    const fetchImpl = fakeFetch(404, { detail: "Trace not found" });
+    const client = new ApiClient({ baseUrl: "http://x", headers: {}, fetchImpl });
+    const promise = dispatch(makeEntry(), { trace_id: "t1" }, client);
+    await expect(promise).rejects.toThrow(ApiError);
+    await expect(dispatch(makeEntry(), { trace_id: "t1" }, client)).rejects.toMatchObject({
+      status: 404,
+      detail: "Trace not found",
+    });
+  });
+});
+
+describe("ApiClient", () => {
+  it("sends the configured headers", async () => {
+    const fetchImpl = fakeFetch(200, {});
+    const client = new ApiClient({
+      baseUrl: "http://x",
+      headers: bearerAuth("sk-test"),
+      fetchImpl,
+      timeoutMs: 5_000,
+    });
+    await client.request("get", "/api/v1/public/whoami", {});
+    const [, init] = fetchImpl.mock.calls[0]! as unknown as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer sk-test");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("falls back to the raw body when the error payload is not JSON detail", async () => {
+    const fetchImpl = vi.fn(async () => new Response("gateway timeout", { status: 504 }));
+    const client = new ApiClient({ baseUrl: "http://x", headers: {}, fetchImpl });
+    await expect(client.request("get", "/whoami", {})).rejects.toMatchObject({
+      status: 504,
+      detail: "gateway timeout",
+    });
+  });
+});
+
+describe("auth header helpers", () => {
+  it("builds bearer and internal auth headers", () => {
+    expect(bearerAuth("sk-1")).toEqual({ Authorization: "Bearer sk-1" });
+    expect(internalAuth("secret", "u1")).toEqual({
+      "X-Internal-Secret": "secret",
+      "x-user-id": "u1",
+    });
+  });
+});

--- a/frontend/packages/tools/src/__tests__/generate.test.ts
+++ b/frontend/packages/tools/src/__tests__/generate.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import { generateRegistry, type OpenApiDocument } from "../generate.js";
+
+/** Minimal fake of the public OpenAPI document, in the shapes FastAPI emits. */
+function fakeDoc(): OpenApiDocument {
+  return {
+    paths: {
+      "/api/v1/public/traces": {
+        get: {
+          "x-tool": {
+            enabled: true,
+            name: "list_traces",
+            description: "List traces.",
+          },
+          parameters: [
+            {
+              name: "limit",
+              in: "query",
+              required: false,
+              description: "Items per page",
+              schema: {
+                type: "integer",
+                title: "Limit",
+                default: 50,
+                minimum: 1,
+                maximum: 200,
+                description: "Items per page",
+              },
+            },
+            {
+              name: "start_after",
+              in: "query",
+              required: false,
+              description: "Only traces after this time",
+              schema: {
+                anyOf: [{ type: "string", format: "date-time" }, { type: "null" }],
+                title: "Start After",
+                description: "Only traces after this time",
+              },
+            },
+            {
+              name: "filters",
+              in: "query",
+              required: false,
+              description: "JSON array of typed filter predicates",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "array",
+                    items: {
+                      anyOf: [
+                        {
+                          type: "object",
+                          properties: {
+                            field: { const: "model_name" },
+                            op: { enum: ["eq", "in"] },
+                            value: {},
+                          },
+                          required: ["field", "op", "value"],
+                          additionalProperties: false,
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+        post: {
+          "x-tool": { enabled: false },
+        },
+      },
+      "/api/v1/public/traces/{trace_id}": {
+        get: {
+          "x-tool": {
+            enabled: true,
+            name: "get_trace",
+            description: "Fetch one trace.",
+          },
+          parameters: [
+            {
+              name: "trace_id",
+              in: "path",
+              required: true,
+              schema: { type: "string", title: "Trace Id" },
+            },
+            {
+              name: "ignored_header",
+              in: "header",
+              required: false,
+              schema: { type: "string" },
+            },
+          ],
+        },
+      },
+      "/api/v1/public/whoami": {
+        get: {
+          "x-tool": {
+            enabled: true,
+            name: "whoami",
+            description: "Identify the project.",
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("generateRegistry", () => {
+  it("emits one entry per enabled operation, sorted by name, skipping disabled ops", () => {
+    const registry = generateRegistry(fakeDoc());
+    expect(registry.map((entry) => entry.name)).toEqual(["get_trace", "list_traces", "whoami"]);
+    expect(registry.map((entry) => entry.method)).toEqual(["get", "get", "get"]);
+    const whoami = registry.find((entry) => entry.name === "whoami")!;
+    expect(whoami.path).toBe("/api/v1/public/whoami");
+    expect(whoami.inputSchema).toEqual({
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    });
+  });
+
+  it("flattens anyOf [T, null] plain params and strips titles", () => {
+    const registry = generateRegistry(fakeDoc());
+    const listTraces = registry.find((entry) => entry.name === "list_traces")!;
+    expect(listTraces.inputSchema.properties.start_after).toEqual({
+      type: "string",
+      format: "date-time",
+      description: "Only traces after this time",
+    });
+    expect(listTraces.inputSchema.properties.limit).toEqual({
+      type: "integer",
+      default: 50,
+      minimum: 1,
+      maximum: 200,
+      description: "Items per page",
+    });
+  });
+
+  it("marks path params required and skips non-query/path params", () => {
+    const registry = generateRegistry(fakeDoc());
+    const getTrace = registry.find((entry) => entry.name === "get_trace")!;
+    expect(getTrace.inputSchema.required).toEqual(["trace_id"]);
+    expect(getTrace.inputSchema.properties.trace_id).toEqual({ type: "string" });
+    expect(getTrace.inputSchema.properties).not.toHaveProperty("ignored_header");
+  });
+
+  it("carries JSON-content params verbatim, merging the param description", () => {
+    const registry = generateRegistry(fakeDoc());
+    const listTraces = registry.find((entry) => entry.name === "list_traces")!;
+    expect(listTraces.inputSchema.properties.filters).toEqual({
+      type: "array",
+      items: {
+        anyOf: [
+          {
+            type: "object",
+            properties: {
+              field: { const: "model_name" },
+              op: { enum: ["eq", "in"] },
+              value: {},
+            },
+            required: ["field", "op", "value"],
+            additionalProperties: false,
+          },
+        ],
+      },
+      description: "JSON array of typed filter predicates",
+    });
+    expect(listTraces.inputSchema.required).toEqual([]);
+  });
+
+  it("normalizes multi-variant anyOf params (null variant and titles dropped) and tolerates schema-less params", () => {
+    const doc = fakeDoc();
+    doc.paths["/api/v1/public/whoami"].get.parameters = [
+      {
+        name: "cursor",
+        in: "query",
+        required: false,
+        schema: {
+          anyOf: [{ type: "string", title: "Cursor Token" }, { type: "integer" }, { type: "null" }],
+          title: "Cursor",
+        },
+      },
+      { name: "bare", in: "query", required: false },
+    ];
+    const registry = generateRegistry(doc);
+    const whoami = registry.find((entry) => entry.name === "whoami")!;
+    // Same treatment as single-variant unions: optionality lives in `required`,
+    // so the null variant is dropped, and titles are stripped at every level.
+    expect(whoami.inputSchema.properties.cursor).toEqual({
+      anyOf: [{ type: "string" }, { type: "integer" }],
+    });
+    expect(whoami.inputSchema.properties.bare).toEqual({});
+  });
+
+  it("throws on an enabled operation missing its x-tool name or description", () => {
+    const doc = fakeDoc();
+    doc.paths["/api/v1/public/whoami"].get["x-tool"] = { enabled: true };
+    expect(() => generateRegistry(doc)).toThrow(/missing an x-tool name or description/);
+  });
+
+  it("throws on an enabled non-GET operation", () => {
+    const doc = fakeDoc();
+    doc.paths["/api/v1/public/traces"].post = {
+      "x-tool": { enabled: true, name: "ingest_traces", description: "Ingest." },
+    };
+    expect(() => generateRegistry(doc)).toThrow(/GET/);
+  });
+});

--- a/frontend/packages/tools/src/__tests__/pi.test.ts
+++ b/frontend/packages/tools/src/__tests__/pi.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import { ApiClient } from "../client.js";
+import { INTERNAL_BINDINGS } from "../internal.js";
+import { toPiAgentTool } from "../pi.js";
+import type { RegistryEntry } from "../types.js";
+
+function fakeFetch(status: number, body: unknown) {
+  return vi.fn(
+    async () =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+}
+
+const listTracesEntry: RegistryEntry = {
+  name: "list_traces",
+  description: "List traces.",
+  method: "get",
+  path: "/api/v1/public/traces",
+  inputSchema: {
+    type: "object",
+    properties: {
+      limit: { type: "integer", description: "Items per page" },
+      filters: {
+        type: "array",
+        items: { anyOf: [{ type: "object" }] },
+        description: "Typed filter predicates",
+      },
+    },
+    required: [],
+    additionalProperties: false,
+  },
+};
+
+describe("toPiAgentTool", () => {
+  it("injects a required label param and strips it before dispatch", async () => {
+    const fetchImpl = fakeFetch(200, { data: [] });
+    const client = new ApiClient({ baseUrl: "http://x", headers: {}, fetchImpl });
+    const tool = toPiAgentTool(listTracesEntry, { client });
+
+    expect(tool.name).toBe("list_traces");
+    expect(tool.description).toBe("List traces.");
+    expect(tool.parameters.properties).toHaveProperty("label");
+    expect(tool.parameters.required).toContain("label");
+
+    await tool.execute("call-1", { label: "Searching traces", limit: 3 });
+    const [url] = fetchImpl.mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect(parsed.searchParams.get("limit")).toBe("3");
+    expect(parsed.searchParams.has("label")).toBe(false);
+  });
+
+  it("passes structured param schemas through unchanged for the model", () => {
+    const client = new ApiClient({
+      baseUrl: "http://x",
+      headers: {},
+      fetchImpl: fakeFetch(200, {}),
+    });
+    const tool = toPiAgentTool(listTracesEntry, { client });
+    expect(tool.parameters.properties.filters).toEqual(
+      listTracesEntry.inputSchema.properties.filters,
+    );
+  });
+
+  it("hides fixedArgs from the model schema but sends them, honoring pathOverride", async () => {
+    const fetchImpl = fakeFetch(200, { data: [] });
+    const client = new ApiClient({ baseUrl: "http://x", headers: {}, fetchImpl });
+    const tool = toPiAgentTool(listTracesEntry, {
+      client,
+      pathOverride: "/api/v1/projects/{project_id}/traces",
+      fixedArgs: { project_id: "p9", limit: 10 },
+    });
+
+    expect(tool.parameters.properties).not.toHaveProperty("project_id");
+    expect(tool.parameters.properties).not.toHaveProperty("limit");
+
+    await tool.execute("call-1", { label: "Searching" });
+    const [url] = fetchImpl.mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect(parsed.pathname).toBe("/api/v1/projects/p9/traces");
+    expect(parsed.searchParams.get("limit")).toBe("10");
+  });
+
+  it("formats results with formatResult, defaulting to pretty JSON", async () => {
+    const client = new ApiClient({
+      baseUrl: "http://x",
+      headers: {},
+      fetchImpl: fakeFetch(200, { data: [{ trace_id: "t1" }] }),
+    });
+    const formatted = toPiAgentTool(listTracesEntry, {
+      client,
+      formatResult: (result) => `rows: ${(result as { data: unknown[] }).data.length}`,
+    });
+    const formattedResult = await formatted.execute("call-1", { label: "x" });
+    expect(formattedResult).toEqual({
+      content: [{ type: "text", text: "rows: 1" }],
+      details: undefined,
+    });
+
+    const plain = toPiAgentTool(listTracesEntry, {
+      client: new ApiClient({
+        baseUrl: "http://x",
+        headers: {},
+        fetchImpl: fakeFetch(200, { data: [] }),
+      }),
+    });
+    const plainResult = await plain.execute("call-1", { label: "x" });
+    expect(plainResult.content[0]!.text).toBe(JSON.stringify({ data: [] }, null, 2));
+  });
+
+  it("renders errors as text instead of throwing", async () => {
+    const client = new ApiClient({
+      baseUrl: "http://x",
+      headers: {},
+      fetchImpl: fakeFetch(403, { detail: "Forbidden" }),
+    });
+    const tool = toPiAgentTool(listTracesEntry, { client });
+    const result = await tool.execute("call-1", { label: "x" });
+    expect(result.details).toBeUndefined();
+    expect(result.content[0]!.text).toContain("list_traces");
+    expect(result.content[0]!.text).toContain("Forbidden");
+  });
+});
+
+describe("INTERNAL_BINDINGS", () => {
+  it("covers exactly the agent's current read set with project-scoped templates", () => {
+    expect(INTERNAL_BINDINGS).toEqual({
+      list_traces: "/api/v1/projects/{project_id}/traces",
+      list_sessions: "/api/v1/projects/{project_id}/sessions",
+      get_session: "/api/v1/projects/{project_id}/sessions/{session_id}",
+    });
+  });
+});

--- a/frontend/packages/tools/src/__tests__/registry-drift.test.ts
+++ b/frontend/packages/tools/src/__tests__/registry-drift.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+// Imported through the package entry point so the public surface is exercised.
+import { generateRegistry, REGISTRY, type OpenApiDocument } from "../index.js";
+
+const schemaPath = fileURLToPath(
+  new URL("../../../../../backend/rest/openapi/public.json", import.meta.url),
+);
+
+describe("committed registry", () => {
+  it("matches a fresh generation from the committed public schema (no drift)", () => {
+    const doc = JSON.parse(readFileSync(schemaPath, "utf8")) as OpenApiDocument;
+    expect(REGISTRY).toEqual(generateRegistry(doc));
+  });
+
+  it("pins the curated 11-tool surface", () => {
+    expect(REGISTRY.map((entry) => entry.name)).toEqual([
+      "export_trace",
+      "get_finding",
+      "get_finding_by_trace",
+      "get_session",
+      "get_trace",
+      "list_detectors",
+      "list_findings",
+      "list_sessions",
+      "list_trace_filter_values",
+      "list_traces",
+      "whoami",
+    ]);
+  });
+});

--- a/frontend/packages/tools/src/client.ts
+++ b/frontend/packages/tools/src/client.ts
@@ -1,0 +1,85 @@
+/** Error raised for non-2xx API responses, carrying the backend's detail message. */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly detail: string;
+
+  constructor(status: number, detail: string) {
+    super(`API error ${status}: ${detail}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+/** Headers for public-API access with a TraceRoot API key. */
+export function bearerAuth(apiKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${apiKey}` };
+}
+
+/** Headers for internal-API access on behalf of a user (service-to-service). */
+export function internalAuth(secret: string, userId: string): Record<string, string> {
+  return { "X-Internal-Secret": secret, "x-user-id": userId };
+}
+
+export interface ApiClientOptions {
+  /** Origin (plus optional prefix) the paths are resolved against, e.g. "https://api.example.com". */
+  baseUrl: string;
+  /** Headers sent with every request (auth, content negotiation). */
+  headers: Record<string, string>;
+  /** Fetch implementation override, for tests. Defaults to the global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Per-request timeout; no timeout when omitted. */
+  timeoutMs?: number;
+}
+
+/** Minimal HTTP client the dispatcher calls registry entries through. */
+export class ApiClient {
+  private readonly options: ApiClientOptions;
+
+  constructor(options: ApiClientOptions) {
+    this.options = options;
+  }
+
+  async request(
+    method: "get",
+    path: string,
+    query: Record<string, string>,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    const url = new URL(this.options.baseUrl.replace(/\/$/, "") + path);
+    for (const [name, value] of Object.entries(query)) {
+      url.searchParams.set(name, value);
+    }
+
+    const signals: AbortSignal[] = [];
+    if (signal !== undefined) {
+      signals.push(signal);
+    }
+    if (this.options.timeoutMs !== undefined) {
+      signals.push(AbortSignal.timeout(this.options.timeoutMs));
+    }
+
+    const fetchImpl = this.options.fetchImpl ?? fetch;
+    const response = await fetchImpl(url.toString(), {
+      method: method.toUpperCase(),
+      headers: this.options.headers,
+      signal: signals.length > 0 ? AbortSignal.any(signals) : undefined,
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      let detail = body;
+      try {
+        const parsed = JSON.parse(body) as { detail?: unknown };
+        if (typeof parsed.detail === "string") {
+          detail = parsed.detail;
+        }
+      } catch {
+        // non-JSON error body: keep the raw text as the detail
+      }
+      throw new ApiError(response.status, detail);
+    }
+
+    return response.json();
+  }
+}

--- a/frontend/packages/tools/src/dispatch.ts
+++ b/frontend/packages/tools/src/dispatch.ts
@@ -1,0 +1,55 @@
+import type { ApiClient } from "./client.js";
+import type { RegistryEntry } from "./types.js";
+
+/** Substitute `{param}` placeholders in a path template with URI-encoded arg values. */
+export function fillPath(template: string, args: Record<string, unknown>): string {
+  return template.replace(/\{([^{}]+)\}/g, (_match, name: string) => {
+    const value = args[name];
+    // An empty string is as missing as null for a URL segment: it would
+    // produce a path like `/traces/`, which redirects to the list route and
+    // silently returns the wrong resource.
+    if (value === undefined || value === null || value === "") {
+      throw new Error(`Missing or empty path parameter "${name}" for path template "${template}"`);
+    }
+    return encodeURIComponent(String(value));
+  });
+}
+
+export interface DispatchOptions {
+  /**
+   * Alternative path template (e.g. an internal project-scoped route). Extra
+   * path params beyond the entry's schema are taken from args.
+   */
+  pathOverride?: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Call a registry entry through the given client: fill the path template from
+ * args, route the entry's remaining schema params to the query string (scalars
+ * stringified, objects and arrays JSON-serialized), ignore unknown args.
+ */
+export async function dispatch(
+  entry: RegistryEntry,
+  args: Record<string, unknown>,
+  client: ApiClient,
+  options: DispatchOptions = {},
+): Promise<unknown> {
+  const template = options.pathOverride ?? entry.path;
+  const path = fillPath(template, args);
+  const pathParams = new Set([...template.matchAll(/\{([^{}]+)\}/g)].map((match) => match[1]));
+
+  const query: Record<string, string> = {};
+  for (const name of Object.keys(entry.inputSchema.properties)) {
+    if (pathParams.has(name)) {
+      continue;
+    }
+    const value = args[name];
+    if (value === undefined || value === null) {
+      continue;
+    }
+    query[name] = typeof value === "object" ? JSON.stringify(value) : String(value);
+  }
+
+  return client.request(entry.method, path, query, options.signal);
+}

--- a/frontend/packages/tools/src/generate.ts
+++ b/frontend/packages/tools/src/generate.ts
@@ -1,0 +1,115 @@
+import type { InputSchema, ParamSchema, RegistryEntry } from "./types.js";
+
+interface OpenApiParameter {
+  name: string;
+  in: string;
+  required?: boolean;
+  description?: string;
+  schema?: Record<string, unknown>;
+  content?: Record<string, { schema?: Record<string, unknown> }>;
+}
+
+interface ToolCuration {
+  enabled?: boolean;
+  name?: string;
+  description?: string;
+}
+
+interface OpenApiOperation {
+  parameters?: OpenApiParameter[];
+  "x-tool"?: ToolCuration;
+}
+
+export interface OpenApiDocument {
+  paths: Record<string, Record<string, OpenApiOperation>>;
+}
+
+/**
+ * Flatten one plain (non-JSON-content) parameter schema: collapse FastAPI's
+ * `anyOf [T, null]` wrapper for optional params into T and drop the generated
+ * `title`, keeping every other constraint (format, bounds, default, ...).
+ */
+function flattenParamSchema(schema: Record<string, unknown> | undefined): ParamSchema {
+  if (schema === undefined) {
+    return {};
+  }
+  const {
+    anyOf,
+    title: _title,
+    ...rest
+  } = schema as {
+    anyOf?: Record<string, unknown>[];
+    title?: unknown;
+  } & Record<string, unknown>;
+  if (Array.isArray(anyOf)) {
+    const variants = anyOf.filter((variant) => variant.type !== "null");
+    if (variants.length === 1) {
+      const { title: _variantTitle, ...variant } = variants[0]!;
+      return { ...variant, ...rest };
+    }
+    // Multi-variant unions get the same treatment as single ones: drop the
+    // null variant (optionality lives in `required`) and the noise titles.
+    return {
+      anyOf: variants.map(({ title: _variantTitle, ...variant }) => variant),
+      ...rest,
+    };
+  }
+  return rest;
+}
+
+/** Build the flat input schema for one operation's path + query parameters. */
+function buildInputSchema(op: OpenApiOperation): InputSchema {
+  const properties: Record<string, ParamSchema> = {};
+  const required: string[] = [];
+  for (const param of op.parameters ?? []) {
+    if (param.in !== "query" && param.in !== "path") {
+      continue;
+    }
+    const contentSchema = param.content?.["application/json"]?.schema;
+    const flattened: ParamSchema =
+      contentSchema !== undefined
+        ? { ...contentSchema } // structured param: carry the schema verbatim
+        : flattenParamSchema(param.schema); // plain param: flatten anyOf-null, strip title
+    if (param.description !== undefined) {
+      flattened.description = param.description;
+    }
+    properties[param.name] = flattened;
+    if (param.required === true || param.in === "path") {
+      required.push(param.name);
+    }
+  }
+  return { type: "object", properties, required, additionalProperties: false };
+}
+
+/**
+ * Generate the tool registry from the public OpenAPI document: one entry per
+ * operation whose x-tool curation is enabled, sorted by tool name. Only GET
+ * operations are supported — write support must be a deliberate extension.
+ */
+export function generateRegistry(doc: OpenApiDocument): RegistryEntry[] {
+  const entries: RegistryEntry[] = [];
+  for (const [path, operations] of Object.entries(doc.paths)) {
+    for (const [method, op] of Object.entries(operations)) {
+      const tool = op["x-tool"];
+      if (tool?.enabled !== true) {
+        continue;
+      }
+      if (method !== "get") {
+        throw new Error(
+          `Enabled tool on ${method.toUpperCase()} ${path}: only GET operations are supported`,
+        );
+      }
+      if (tool.name === undefined || tool.description === undefined) {
+        throw new Error(`Enabled tool on GET ${path} is missing an x-tool name or description`);
+      }
+      entries.push({
+        name: tool.name,
+        description: tool.description,
+        method: "get",
+        path,
+        inputSchema: buildInputSchema(op),
+      });
+    }
+  }
+  return entries.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/frontend/packages/tools/src/index.ts
+++ b/frontend/packages/tools/src/index.ts
@@ -1,5 +1,17 @@
+// The package's entire public surface: `exports` maps only this entry point,
+// so consumers get exactly these names. REGISTRY is the generated tool data,
+// dispatch/client the engine, pi/internal the per-surface adapters —
+// everything not re-exported here is private implementation detail.
 export type { InputSchema, ParamSchema, RegistryEntry } from "./types.js";
 export { generateRegistry, type OpenApiDocument } from "./generate.js";
 export { REGISTRY } from "./registry.generated.js";
 export { ApiClient, ApiError, bearerAuth, internalAuth, type ApiClientOptions } from "./client.js";
 export { dispatch, fillPath, type DispatchOptions } from "./dispatch.js";
+export {
+  toPiAgentTool,
+  type PiAgentTool,
+  type PiToolResult,
+  type PiToolResultContent,
+  type ToPiAgentToolOptions,
+} from "./pi.js";
+export { INTERNAL_BINDINGS } from "./internal.js";

--- a/frontend/packages/tools/src/index.ts
+++ b/frontend/packages/tools/src/index.ts
@@ -1,3 +1,5 @@
 export type { InputSchema, ParamSchema, RegistryEntry } from "./types.js";
 export { generateRegistry, type OpenApiDocument } from "./generate.js";
 export { REGISTRY } from "./registry.generated.js";
+export { ApiClient, ApiError, bearerAuth, internalAuth, type ApiClientOptions } from "./client.js";
+export { dispatch, fillPath, type DispatchOptions } from "./dispatch.js";

--- a/frontend/packages/tools/src/index.ts
+++ b/frontend/packages/tools/src/index.ts
@@ -1,0 +1,3 @@
+export type { InputSchema, ParamSchema, RegistryEntry } from "./types.js";
+export { generateRegistry, type OpenApiDocument } from "./generate.js";
+export { REGISTRY } from "./registry.generated.js";

--- a/frontend/packages/tools/src/internal.ts
+++ b/frontend/packages/tools/src/internal.ts
@@ -1,0 +1,12 @@
+/**
+ * Internal project-scoped route templates, keyed by tool name, for surfaces
+ * that call the internal API instead of the public one (via dispatch's
+ * pathOverride). The extra `project_id` path param is supplied through
+ * fixedArgs. Only the agent's current read set is bound; widening this map is
+ * a deliberate per-tool decision.
+ */
+export const INTERNAL_BINDINGS: Readonly<Record<string, string>> = {
+  list_traces: "/api/v1/projects/{project_id}/traces",
+  list_sessions: "/api/v1/projects/{project_id}/sessions",
+  get_session: "/api/v1/projects/{project_id}/sessions/{session_id}",
+};

--- a/frontend/packages/tools/src/pi.ts
+++ b/frontend/packages/tools/src/pi.ts
@@ -1,0 +1,100 @@
+import type { ApiClient } from "./client.js";
+import { dispatch } from "./dispatch.js";
+import type { ParamSchema, RegistryEntry } from "./types.js";
+
+/** One text block of a pi tool result. */
+export interface PiToolResultContent {
+  type: "text";
+  text: string;
+}
+
+export interface PiToolResult {
+  content: PiToolResultContent[];
+  details: undefined;
+}
+
+/**
+ * The agent runtime's tool shape, matched structurally so this package needs
+ * no dependency on it.
+ */
+export interface PiAgentTool {
+  name: string;
+  label: string;
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Record<string, ParamSchema>;
+    required: string[];
+    additionalProperties: false;
+  };
+  execute: (toolCallId: string, rawParams: unknown, signal?: AbortSignal) => Promise<PiToolResult>;
+}
+
+export interface ToPiAgentToolOptions {
+  client: ApiClient;
+  /** Alternative path template (e.g. an internal project-scoped route). */
+  pathOverride?: string;
+  /**
+   * Args injected on every call and hidden from the model's schema
+   * (e.g. the project id an internal route template needs).
+   */
+  fixedArgs?: Record<string, unknown>;
+  /** Renders the API result for the model; defaults to pretty-printed JSON. */
+  formatResult?: (result: unknown) => string;
+}
+
+/** "list_traces" -> "List traces" for the tool's human-readable label. */
+function humanizeName(name: string): string {
+  const words = name.replace(/_/g, " ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * Adapt a registry entry to the pi agent tool shape: inject the required
+ * model-supplied `label` param, hide fixedArgs from the model, and render
+ * results and errors as text content.
+ */
+export function toPiAgentTool(entry: RegistryEntry, options: ToPiAgentToolOptions): PiAgentTool {
+  const { client, pathOverride, fixedArgs = {}, formatResult } = options;
+
+  const properties: Record<string, ParamSchema> = {
+    label: {
+      type: "string",
+      description: "Brief description of what this call is doing (shown to the user)",
+    },
+  };
+  for (const [name, schema] of Object.entries(entry.inputSchema.properties)) {
+    if (name in fixedArgs) {
+      continue;
+    }
+    properties[name] = schema;
+  }
+  const required = ["label", ...entry.inputSchema.required.filter((name) => !(name in fixedArgs))];
+
+  return {
+    name: entry.name,
+    label: humanizeName(entry.name),
+    description: entry.description,
+    parameters: { type: "object", properties, required, additionalProperties: false },
+    execute: async (_toolCallId, rawParams, signal): Promise<PiToolResult> => {
+      const { label: _label, ...params } = (rawParams ?? {}) as Record<string, unknown>;
+      const args = { ...params, ...fixedArgs };
+      try {
+        const result = await dispatch(entry, args, client, { pathOverride, signal });
+        const text = formatResult ? formatResult(result) : JSON.stringify(result, null, 2);
+        return { content: [{ type: "text", text }], details: undefined };
+      } catch (error) {
+        // Deliberate divergence from the runtime's throw-on-failure contract:
+        // errors are returned as tool-result text so the model can read the
+        // failure (status, detail) and adapt — matching how the in-app agent's
+        // existing query tools behave. Revisit if runtime error accounting
+        // (isError marking) becomes load-bearing.
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text", text: `Error calling ${entry.name}: ${message}` }],
+          details: undefined,
+        };
+      }
+    },
+  };
+}

--- a/frontend/packages/tools/src/registry.generated.ts
+++ b/frontend/packages/tools/src/registry.generated.ts
@@ -1,0 +1,468 @@
+// Generated from backend/rest/openapi/public.json — do not edit.
+// Regenerate with: pnpm --filter @traceroot-ai/tools generate
+import type { RegistryEntry } from "./types.js";
+
+export const REGISTRY: readonly RegistryEntry[] = [
+  {
+    name: "export_trace",
+    description: "Export the complete bundle (trace, spans, git context, manifest) for one trace.",
+    method: "get",
+    path: "/api/v1/public/traces/{trace_id}/export",
+    inputSchema: {
+      type: "object",
+      properties: {
+        trace_id: {
+          type: "string",
+        },
+        fields: {
+          type: "string",
+          description:
+            "Comma-separated field groups to include: 'core' (tree/timing/status, always included), 'usage' (tokens/cost), 'io' (per-span input/output), 'metadata' (per-span metadata). Aliases: 'skeleton' (core,usage), 'full' (everything). Unknown groups return 400.",
+        },
+      },
+      required: ["trace_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_finding",
+    description: "Fetch one detector finding by id, with its full analysis detail.",
+    method: "get",
+    path: "/api/v1/public/detectors/findings/{finding_id}",
+    inputSchema: {
+      type: "object",
+      properties: {
+        finding_id: {
+          type: "string",
+        },
+      },
+      required: ["finding_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_finding_by_trace",
+    description: "Fetch the detector finding attached to a specific trace, if any.",
+    method: "get",
+    path: "/api/v1/public/detectors/traces/{trace_id}/finding",
+    inputSchema: {
+      type: "object",
+      properties: {
+        trace_id: {
+          type: "string",
+        },
+      },
+      required: ["trace_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_session",
+    description:
+      "Fetch one session with all its traces (ids, names, status, I/O summaries). Use before deep-diving individual traces of a conversation.",
+    method: "get",
+    path: "/api/v1/public/sessions/{session_id}",
+    inputSchema: {
+      type: "object",
+      properties: {
+        session_id: {
+          type: "string",
+        },
+        start_after: {
+          format: "date-time",
+          type: "string",
+          description: "Only traces at or after this time (inclusive, ISO 8601)",
+        },
+        end_before: {
+          format: "date-time",
+          type: "string",
+          description: "Only traces before this time (exclusive, ISO 8601)",
+        },
+      },
+      required: ["session_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_trace",
+    description:
+      "Fetch one trace with its span tree. Defaults to the lightweight skeleton projection; pass fields=full for per-span input/output/metadata.",
+    method: "get",
+    path: "/api/v1/public/traces/{trace_id}",
+    inputSchema: {
+      type: "object",
+      properties: {
+        trace_id: {
+          type: "string",
+        },
+        fields: {
+          type: "string",
+          description:
+            "Comma-separated field groups to include: 'core' (tree/timing/status, always included), 'usage' (tokens/cost), 'io' (per-span input/output), 'metadata' (per-span metadata). Aliases: 'skeleton' (core,usage), 'full' (everything). Unknown groups return 400.",
+        },
+      },
+      required: ["trace_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_detectors",
+    description: "List the project's detectors (id, name, template, enabled flag, creation time).",
+    method: "get",
+    path: "/api/v1/public/detectors",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          default: 50,
+          description: "Items per page",
+          maximum: 200,
+          minimum: 1,
+          type: "integer",
+        },
+        start_after: {
+          format: "date-time",
+          type: "string",
+          description: "Only detectors created at or after this time (inclusive, ISO 8601)",
+        },
+        end_before: {
+          format: "date-time",
+          type: "string",
+          description: "Only detectors created before this time (exclusive, ISO 8601)",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_findings",
+    description:
+      "List detector findings for the project, optionally filtered by detector (id, name, or template), trace id, or time range.",
+    method: "get",
+    path: "/api/v1/public/detectors/findings",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          default: 50,
+          description: "Items per page",
+          maximum: 200,
+          minimum: 1,
+          type: "integer",
+        },
+        start_after: {
+          format: "date-time",
+          type: "string",
+          description: "Only findings at or after this time (inclusive, ISO 8601)",
+        },
+        end_before: {
+          format: "date-time",
+          type: "string",
+          description: "Only findings before this time (exclusive, ISO 8601)",
+        },
+        detector: {
+          type: "string",
+          description: "Filter by detector id, name, or template",
+        },
+        trace_id: {
+          type: "string",
+          description: "Filter to a single trace",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_sessions",
+    description:
+      "List recent sessions (groups of traces sharing a session id) for the project, with trace counts and durations. Search by session id substring.",
+    method: "get",
+    path: "/api/v1/public/sessions",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          default: 50,
+          description: "Items per page",
+          maximum: 200,
+          minimum: 1,
+          type: "integer",
+        },
+        search_query: {
+          type: "string",
+          description: "Search by session_id",
+        },
+        start_after: {
+          format: "date-time",
+          type: "string",
+          description: "Only sessions with traces at or after this time (inclusive, ISO 8601)",
+        },
+        end_before: {
+          format: "date-time",
+          type: "string",
+          description: "Only sessions with traces before this time (exclusive, ISO 8601)",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_trace_filter_values",
+    description:
+      "Discover the current values of a categorical trace filter field (e.g. model_name, environment) for the project — use before filtering the trace list by that field.",
+    method: "get",
+    path: "/api/v1/public/traces/filter-values/{field}",
+    inputSchema: {
+      type: "object",
+      properties: {
+        field: {
+          type: "string",
+        },
+        start_after: {
+          format: "date-time",
+          type: "string",
+          description: "Only consider spans starting at or after this timestamp",
+        },
+        end_before: {
+          format: "date-time",
+          type: "string",
+          description: "Only consider spans starting before this timestamp",
+        },
+      },
+      required: ["field"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_traces",
+    description:
+      "List recent traces for the project (newest first). Filter by time range, trace name, user id, or a free-text search across trace/session/user ids and names. Use this for discovery before fetching a specific trace. Structured filters (model, environment, cost, tokens, latency, error count, keyed metadata) are available via the typed filters parameter.",
+    method: "get",
+    path: "/api/v1/public/traces",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          default: 50,
+          description: "Items per page",
+          maximum: 200,
+          minimum: 1,
+          type: "integer",
+        },
+        start_after: {
+          format: "date-time",
+          type: "string",
+          description: "Only traces that started at or after this time (inclusive, ISO 8601)",
+        },
+        end_before: {
+          format: "date-time",
+          type: "string",
+          description: "Only traces that started before this time (exclusive, ISO 8601)",
+        },
+        name: {
+          type: "string",
+          description: "Filter by trace name (substring match)",
+        },
+        user_id: {
+          type: "string",
+          description: "Filter by the user id recorded on the trace",
+        },
+        search_query: {
+          type: "string",
+          description: "Search across trace_id, name, session_id, user_id",
+        },
+        filters: {
+          items: {
+            anyOf: [
+              {
+                additionalProperties: false,
+                properties: {
+                  field: {
+                    const: "trace_id",
+                    title: "Trace ID",
+                  },
+                  op: {
+                    enum: ["eq", "contains"],
+                  },
+                  value: {
+                    maxLength: 1024,
+                    minLength: 1,
+                    type: "string",
+                  },
+                },
+                required: ["field", "op", "value"],
+                type: "object",
+              },
+              {
+                additionalProperties: false,
+                properties: {
+                  field: {
+                    const: "model_name",
+                    title: "Model",
+                  },
+                  op: {
+                    enum: ["in"],
+                  },
+                  value: {
+                    items: {
+                      maxLength: 1024,
+                      type: "string",
+                    },
+                    minItems: 1,
+                    type: "array",
+                  },
+                },
+                required: ["field", "op", "value"],
+                type: "object",
+              },
+              {
+                additionalProperties: false,
+                properties: {
+                  field: {
+                    const: "environment",
+                    title: "Environment",
+                  },
+                  op: {
+                    enum: ["in"],
+                  },
+                  value: {
+                    items: {
+                      maxLength: 1024,
+                      type: "string",
+                    },
+                    minItems: 1,
+                    type: "array",
+                  },
+                },
+                required: ["field", "op", "value"],
+                type: "object",
+              },
+              {
+                additionalProperties: false,
+                properties: {
+                  field: {
+                    const: "cost",
+                    title: "Cost",
+                  },
+                  op: {
+                    enum: ["eq", "gt", "gte", "lt", "lte"],
+                  },
+                  value: {
+                    maximum: 999999999,
+                    minimum: 0,
+                    type: "number",
+                  },
+                },
+                required: ["field", "op", "value"],
+                type: "object",
+              },
+              {
+                additionalProperties: false,
+                properties: {
+                  field: {
+                    const: "total_tokens",
+                    title: "Tokens",
+                  },
+                  op: {
+                    enum: ["eq", "gt", "gte", "lt", "lte"],
+                  },
+                  value: {
+                    maximum: 9223372036854776000,
+                    minimum: 0,
+                    type: "integer",
+                  },
+                },
+                required: ["field", "op", "value"],
+                type: "object",
+              },
+              {
+                additionalProperties: false,
+                properties: {
+                  field: {
+                    const: "duration_ms",
+                    title: "Latency",
+                  },
+                  op: {
+                    enum: ["eq", "gt", "gte", "lt", "lte"],
+                  },
+                  value: {
+                    maximum: 9223372036854776000,
+                    minimum: 0,
+                    type: "integer",
+                  },
+                },
+                required: ["field", "op", "value"],
+                type: "object",
+              },
+              {
+                additionalProperties: false,
+                properties: {
+                  field: {
+                    const: "errors",
+                    title: "Errors",
+                  },
+                  op: {
+                    enum: ["eq", "gt", "gte", "lt", "lte"],
+                  },
+                  value: {
+                    maximum: 18446744073709552000,
+                    minimum: 0,
+                    type: "integer",
+                  },
+                },
+                required: ["field", "op", "value"],
+                type: "object",
+              },
+              {
+                additionalProperties: false,
+                properties: {
+                  field: {
+                    const: "metadata",
+                    title: "Metadata",
+                  },
+                  key: {
+                    description: "Which metadata key the value is compared against",
+                    maxLength: 256,
+                    minLength: 1,
+                    type: "string",
+                  },
+                  op: {
+                    enum: ["eq", "contains"],
+                  },
+                  value: {
+                    maxLength: 1024,
+                    minLength: 1,
+                    type: "string",
+                  },
+                },
+                required: ["field", "key", "op", "value"],
+                type: "object",
+              },
+            ],
+          },
+          maxItems: 20,
+          type: "array",
+          description:
+            "JSON array of typed filter predicates ({field, op, value}); the field catalog and per-field operators are defined in the schema",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "whoami",
+    description: "Identify the project and workspace the current credential belongs to.",
+    method: "get",
+    path: "/api/v1/public/whoami",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    },
+  },
+];

--- a/frontend/packages/tools/src/types.ts
+++ b/frontend/packages/tools/src/types.ts
@@ -1,0 +1,31 @@
+/** JSON-schema fragment for one tool parameter. Plain params arrive flattened
+ * (no anyOf-null); structured params (e.g. typed filter arrays) are carried
+ * verbatim from the public schema. */
+export interface ParamSchema {
+  type?: string;
+  description?: string;
+  format?: string;
+  [key: string]: unknown;
+}
+
+/** Flat JSON-schema object covering an operation's path + query parameters. */
+export interface InputSchema {
+  type: "object";
+  properties: Record<string, ParamSchema>;
+  required: string[];
+  additionalProperties: false;
+}
+
+/**
+ * One tool in the shared registry. Inert data — where and how to call the API —
+ * generated from the public OpenAPI schema's x-tool curation. Logic lives in
+ * the backend service layer; surfaces adapt (client, shape) but never reimplement.
+ */
+export interface RegistryEntry {
+  name: string;
+  description: string;
+  method: "get";
+  /** Public path template, e.g. "/api/v1/public/traces/{trace_id}". */
+  path: string;
+  inputSchema: InputSchema;
+}

--- a/frontend/packages/tools/tsconfig.json
+++ b/frontend/packages/tools/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rewriteRelativeImportExtensions": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/__tests__/**", "scripts"]
+}

--- a/frontend/packages/tools/vitest.config.ts
+++ b/frontend/packages/tools/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      reporter: ["lcov"],
+      reportsDirectory: "./coverage",
+      reportOnFailure: true,
+      exclude: ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts", "**/types.ts", "scripts/**"],
+    },
+  },
+});

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -171,6 +171,24 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/tools:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: ^3.2.6
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+
   ui:
     dependencies:
       '@hookform/resolvers':


### PR DESCRIPTION
The single source of truth for the tool surface: `@traceroot-ai/tools`, a publishable zero-runtime-dependency workspace package containing the registry generated from the public OpenAPI schema, a generic dispatcher + API client, and per-surface adapters.

**Stacked PR** — layer 5 of the stack; base is `feat/public-trace-filters`.

## What

- **Generator + committed registry** — `generateRegistry(public.json)` emits one inert entry per enabled `x-tool` operation (`{name, description, method, path, inputSchema}`); handles plain params (FastAPI's `anyOf [T, null]` flattened, titles stripped — uniformly for multi-variant unions too) and JSON-content params carried verbatim (the typed `filters` schema reaches every surface unmangled). Loud-fail on enabled non-GET ops and malformed curation. `registry.generated.ts` is committed (11 entries), prettier-normalized by the generate script (regeneration on a clean tree is a zero-diff no-op), and drift-tested against the schema; a names test pins the exact tool surface.
- **Dispatcher + client** — `dispatch(entry, args, client)` is the one place surfaces call the backend from: path templates filled with URI-encoding, schema-declared args to the query string (objects/arrays JSON-serialized), unknown args ignored, `pathOverride` for per-surface route bindings. `ApiClient` with injectable fetch/timeout, `ApiError(status, detail)`, `bearerAuth`/`internalAuth` helpers.
- **Adapters** — `toPiAgentTool` (structural agent-tool shape, no runtime dependency: injects the required `label` param, hides harness-supplied `fixedArgs` from the model schema while still sending them, formatter hook, errors returned as tool-result text so the model can read and adapt — deliberate, documented divergence from throw-on-failure); `INTERNAL_BINDINGS` (the project-scoped internal route templates for in-product surfaces).
- **CI** — the package is wired into the frontend test/coverage matrix and the build workflow, so the drift test runs on every PR.

27 tests, 100% line coverage on `src`, build with declarations, zero runtime deps. Publishing to npm is a separate follow-up step.

Closes #1734

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@traceroot-ai/tools`, a generated registry of public OpenAPI `x-tool` GET operations with a generic dispatcher, minimal HTTP client, and a pi agent adapter. This centralizes tool definitions, keeps them schema‑synced via drift tests, and enables internal project‑scoped bindings for in‑app use.

- Generator + committed registry: emits one entry per enabled `x-tool` GET; flattens plain params (`anyOf [T, null]`), carries JSON-content params verbatim; commits `registry.generated.ts`; drift test pins 11 tools including `list_trace_filter_values`.
- Dispatcher + client: fills and URI‑encodes path params (missing/empty throws); maps schema params to query (JSON for objects/arrays); ignores unknown args; supports `pathOverride`; forwards abort and optional timeout; `ApiError` carries backend detail; `bearerAuth` and `internalAuth` helpers.
- Pi agent adapter: `toPiAgentTool` injects required `label`, hides `fixedArgs` from the model while sending them, supports `formatResult`, and returns errors as result text; `INTERNAL_BINDINGS` provide project‑scoped internal routes for `list_traces`, `list_sessions`, and `get_session`.
- CI: builds `frontend/packages/tools`, includes it in test/coverage, and runs the registry drift check on every PR.

<sup>Written for commit c4b2f1ae4009fec7d8b795d311f712e4d5b17db2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

