### PR TITLE
fix(integrations): distinguish instrumentation from BYOK model providers

### DIFF
--- a/docs/ai-agent/byok.mdx
+++ b/docs/ai-agent/byok.mdx
@@ -16,7 +16,9 @@ See [Supported Models](/integrations/internal-models) for a description of each 
 
 ## Supported Providers
 
-OpenAI, Anthropic, Azure OpenAI, Google (Gemini), Amazon Bedrock, xAI, DeepSeek, OpenRouter, Kimi, GLM.
+[OpenAI](/integrations/openai), [Anthropic](/integrations/anthropic), [Azure OpenAI](/integrations/azure), [Google (Gemini)](/integrations/gemini), [Amazon Bedrock](/integrations/amazon-bedrock), [xAI](/integrations/xai), [DeepSeek](/integrations/deepseek), [OpenRouter](/integrations/openrouter), [Kimi](/integrations/moonshot), [GLM](/integrations/zai).
+
+This is a separate feature from [tracing your own calls to these providers](/integrations/overview) — a provider being BYOK-supported here doesn't imply it's on that list, and vice versa (for example, Mistral is traceable but not BYOK-supported).
 
 ## Setup
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -173,11 +173,17 @@
           {
             "group": "Model Providers",
             "pages": [
+              "integrations/amazon-bedrock",
               "integrations/anthropic",
+              "integrations/azure",
+              "integrations/deepseek",
               "integrations/gemini",
               "integrations/mistral",
+              "integrations/moonshot",
               "integrations/openai",
-              "integrations/openrouter"
+              "integrations/openrouter",
+              "integrations/xai",
+              "integrations/zai"
             ]
           },
           {

--- a/docs/integrations/amazon-bedrock.mdx
+++ b/docs/integrations/amazon-bedrock.mdx
@@ -1,0 +1,26 @@
+---
+title: AWS Bedrock
+description: Configure AWS Bedrock as a BYOK model provider
+---
+
+AWS Bedrock is supported as a bring-your-own-key (BYOK) model provider — configure it in **Workspace Settings → Model Providers** using your AWS credentials (access key, secret key, and region).
+
+<Note>
+  Bedrock is accessed through the AWS SDK (`boto3` / `@aws-sdk/client-bedrock-runtime`) rather
+  than the OpenAI-compatible pattern used by the other model providers on this page, so its
+  auto-instrumentation setup is different from a simple `base_url` override. This page
+  intentionally does not show a specific `traceroot.initialize(integrations=[...])` snippet —
+  check the [Python SDK](/tracing/python-sdk) or [TypeScript SDK](/tracing/typescript-sdk) docs,
+  or the SDK's own changelog, for the current Bedrock instrumentation entry point before wiring
+  this up.
+</Note>
+
+## BYOK Setup
+
+1. Go to **Workspace Settings → Model Providers**.
+2. Select **AWS Bedrock** and enter your AWS access key, secret key, and region.
+3. Once configured, Bedrock becomes available as a model source for TraceRoot's AI features (trace analysis, root cause analysis, and automated fix PR generation).
+
+## Tracing Your Own Bedrock Calls
+
+If you want TraceRoot to trace calls your own application makes to Bedrock (separate from the BYOK configuration above), consult the SDK documentation directly for the current instrumentation approach — the auto-instrumentation code path for the AWS SDK is not yet documented on this page.

--- a/docs/integrations/azure.mdx
+++ b/docs/integrations/azure.mdx
@@ -1,0 +1,108 @@
+---
+title: Azure OpenAI
+description: Trace Azure OpenAI calls through the OpenAI-compatible SDK
+---
+
+Azure OpenAI is accessed through the same `openai` SDK as OpenAI itself, via the dedicated `AzureOpenAI` client. TraceRoot captures these calls through the existing OpenAI instrumentation — no new Azure-specific instrumentor or enum is required.
+
+## Setup
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    from openai import AzureOpenAI
+    import traceroot
+    from traceroot import Integration
+
+    traceroot.initialize(integrations=[Integration.OPENAI])
+
+    client = AzureOpenAI(
+        api_key=os.environ["AZURE_OPENAI_API_KEY"],
+        azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+        api_version="2024-10-21",
+    )
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import { AzureOpenAI } from 'openai';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { openAI: AzureOpenAI },
+    });
+
+    const client = new AzureOpenAI({
+      apiKey: process.env.AZURE_OPENAI_API_KEY,
+      endpoint: process.env.AZURE_OPENAI_ENDPOINT,
+      apiVersion: '2024-10-21',
+    });
+    ```
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    from openai import AzureOpenAI
+
+    client = AzureOpenAI(
+        api_key=os.environ["AZURE_OPENAI_API_KEY"],
+        azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+        api_version="2024-10-21",
+    )
+
+    # This Azure OpenAI call is traced by TraceRoot's OpenAI integration
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",  # Your Azure deployment name
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ],
+    )
+
+    print(response.choices[0].message.content)
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import { AzureOpenAI } from 'openai';
+
+    const client = new AzureOpenAI({
+      apiKey: process.env.AZURE_OPENAI_API_KEY,
+      endpoint: process.env.AZURE_OPENAI_ENDPOINT,
+      apiVersion: '2024-10-21',
+    });
+
+    // This Azure OpenAI call is traced by TraceRoot's OpenAI integration
+    const response = await client.chat.completions.create({
+      model: 'gpt-4o-mini', // Your Azure deployment name
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'What is the capital of France?' },
+      ],
+    });
+
+    console.log(response.choices[0].message.content);
+    ```
+
+  </Tab>
+</Tabs>
+
+## What Gets Captured
+
+| Attribute  | Description                                                                       |
+| ---------- | ---------------------------------------------------------------------------------- |
+| Model      | Your Azure deployment name                                                        |
+| Messages   | Input messages array                                                              |
+| Response   | Completion content                                                                |
+| Tool calls | Function/tool call inputs and outputs when using the OpenAI SDK tool-calling API   |
+| Tokens     | Prompt, completion, and total tokens when returned by the provider                |
+| Latency    | Request duration                                                                  |

--- a/docs/integrations/deepseek.mdx
+++ b/docs/integrations/deepseek.mdx
@@ -1,0 +1,104 @@
+---
+title: DeepSeek
+description: Trace DeepSeek calls through the OpenAI-compatible SDK
+---
+
+DeepSeek is OpenAI-compatible: use the standard `openai` SDK with the DeepSeek base URL (`https://api.deepseek.com`). TraceRoot captures these calls through the existing OpenAI instrumentation — no new DeepSeek-specific instrumentor or enum is required.
+
+## Setup
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+    import traceroot
+    from traceroot import Integration
+
+    traceroot.initialize(integrations=[Integration.OPENAI])
+
+    client = openai.OpenAI(
+        api_key=os.environ["DEEPSEEK_API_KEY"],
+        base_url="https://api.deepseek.com",
+    )
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { openAI: OpenAI },
+    });
+
+    const openai = new OpenAI({
+      apiKey: process.env.DEEPSEEK_API_KEY,
+      baseURL: 'https://api.deepseek.com',
+    });
+    ```
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+
+    client = openai.OpenAI(
+        api_key=os.environ["DEEPSEEK_API_KEY"],
+        base_url="https://api.deepseek.com",
+    )
+
+    # This DeepSeek call is traced by TraceRoot's OpenAI integration
+    response = client.chat.completions.create(
+        model="deepseek-chat",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ],
+    )
+
+    print(response.choices[0].message.content)
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+
+    const openai = new OpenAI({
+      apiKey: process.env.DEEPSEEK_API_KEY,
+      baseURL: 'https://api.deepseek.com',
+    });
+
+    // This DeepSeek call is traced by TraceRoot's OpenAI integration
+    const response = await openai.chat.completions.create({
+      model: 'deepseek-chat',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'What is the capital of France?' },
+      ],
+    });
+
+    console.log(response.choices[0].message.content);
+    ```
+
+  </Tab>
+</Tabs>
+
+## What Gets Captured
+
+| Attribute  | Description                                                                       |
+| ---------- | ---------------------------------------------------------------------------------- |
+| Model      | Any DeepSeek model string, such as `deepseek-chat` or `deepseek-reasoner`          |
+| Messages   | Input messages array                                                              |
+| Response   | Completion content                                                                |
+| Tool calls | Function/tool call inputs and outputs when using the OpenAI SDK tool-calling API   |
+| Tokens     | Prompt, completion, and total tokens when returned by the provider                |
+| Latency    | Request duration                                                                  |

--- a/docs/integrations/moonshot.mdx
+++ b/docs/integrations/moonshot.mdx
@@ -1,0 +1,104 @@
+---
+title: Moonshot (Kimi)
+description: Trace Moonshot AI (Kimi) calls through the OpenAI-compatible SDK
+---
+
+Moonshot AI (Kimi) is OpenAI-compatible: use the standard `openai` SDK with the Moonshot base URL (`https://api.moonshot.ai/v1`). TraceRoot captures these calls through the existing OpenAI instrumentation — no new Moonshot-specific instrumentor or enum is required.
+
+## Setup
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+    import traceroot
+    from traceroot import Integration
+
+    traceroot.initialize(integrations=[Integration.OPENAI])
+
+    client = openai.OpenAI(
+        api_key=os.environ["MOONSHOT_API_KEY"],
+        base_url="https://api.moonshot.ai/v1",
+    )
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { openAI: OpenAI },
+    });
+
+    const openai = new OpenAI({
+      apiKey: process.env.MOONSHOT_API_KEY,
+      baseURL: 'https://api.moonshot.ai/v1',
+    });
+    ```
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+
+    client = openai.OpenAI(
+        api_key=os.environ["MOONSHOT_API_KEY"],
+        base_url="https://api.moonshot.ai/v1",
+    )
+
+    # This Moonshot call is traced by TraceRoot's OpenAI integration
+    response = client.chat.completions.create(
+        model="kimi-k2-0905-preview",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ],
+    )
+
+    print(response.choices[0].message.content)
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+
+    const openai = new OpenAI({
+      apiKey: process.env.MOONSHOT_API_KEY,
+      baseURL: 'https://api.moonshot.ai/v1',
+    });
+
+    // This Moonshot call is traced by TraceRoot's OpenAI integration
+    const response = await openai.chat.completions.create({
+      model: 'kimi-k2-0905-preview',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'What is the capital of France?' },
+      ],
+    });
+
+    console.log(response.choices[0].message.content);
+    ```
+
+  </Tab>
+</Tabs>
+
+## What Gets Captured
+
+| Attribute  | Description                                                                       |
+| ---------- | ---------------------------------------------------------------------------------- |
+| Model      | Any Moonshot model string, such as `kimi-k2-0905-preview`                          |
+| Messages   | Input messages array                                                              |
+| Response   | Completion content                                                                |
+| Tool calls | Function/tool call inputs and outputs when using the OpenAI SDK tool-calling API   |
+| Tokens     | Prompt, completion, and total tokens when returned by the provider                |
+| Latency    | Request duration                                                                  |

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -155,10 +155,25 @@ Trace direct calls to LLM providers.
 
 <IntegrationGrid cols={3}>
   <IntegrationCard
+    logo="../logo/integrations/amazon-bedrock.svg"
+    title="AWS Bedrock"
+    href="/integrations/amazon-bedrock"
+  />
+  <IntegrationCard
     logo="../logo/integrations/anthropic.svg"
     logoDark="../logo/integrations/anthropic-dark.svg"
     title="Anthropic"
     href="/integrations/anthropic"
+  />
+  <IntegrationCard
+    logo="../logo/integrations/azure.svg"
+    title="Azure OpenAI"
+    href="/integrations/azure"
+  />
+  <IntegrationCard
+    logo="../logo/integrations/deepseek.svg"
+    title="DeepSeek"
+    href="/integrations/deepseek"
   />
   <IntegrationCard
     logo="../logo/integrations/gemini.svg"
@@ -171,6 +186,11 @@ Trace direct calls to LLM providers.
     href="/integrations/mistral"
   />
   <IntegrationCard
+    logo="../logo/integrations/moonshot.svg"
+    title="Moonshot (Kimi)"
+    href="/integrations/moonshot"
+  />
+  <IntegrationCard
     logo="../logo/integrations/openai.svg"
     logoDark="../logo/integrations/openai-dark.svg"
     title="OpenAI"
@@ -181,6 +201,16 @@ Trace direct calls to LLM providers.
     logoDark="../logo/integrations/openrouter-dark.svg"
     title="OpenRouter"
     href="/integrations/openrouter"
+  />
+  <IntegrationCard
+    logo="../logo/integrations/xai.svg"
+    title="xAI"
+    href="/integrations/xai"
+  />
+  <IntegrationCard
+    logo="../logo/integrations/zai.svg"
+    title="Z.AI (GLM)"
+    href="/integrations/zai"
   />
 </IntegrationGrid>
 

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -149,9 +149,12 @@ Trace popular agent frameworks and orchestration libraries.
   />
 </IntegrationGrid>
 
-## Model Providers
+## Model Providers (Traced Automatically)
 
-Trace direct calls to LLM providers.
+Trace direct calls to LLM providers made from your own application code. This is
+a different feature from [BYOK model providers](/ai-agent/byok), which power
+TraceRoot's own AI agent — a provider can support one, both, or neither, so
+appearing here doesn't imply BYOK support (see the BYOK page for that list).
 
 <IntegrationGrid cols={3}>
   <IntegrationCard

--- a/docs/integrations/xai.mdx
+++ b/docs/integrations/xai.mdx
@@ -1,0 +1,104 @@
+---
+title: xAI
+description: Trace xAI (Grok) calls through the OpenAI-compatible SDK
+---
+
+xAI is OpenAI-compatible: use the standard `openai` SDK with the xAI base URL (`https://api.x.ai/v1`). TraceRoot captures these calls through the existing OpenAI instrumentation — no new xAI-specific instrumentor or enum is required.
+
+## Setup
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+    import traceroot
+    from traceroot import Integration
+
+    traceroot.initialize(integrations=[Integration.OPENAI])
+
+    client = openai.OpenAI(
+        api_key=os.environ["XAI_API_KEY"],
+        base_url="https://api.x.ai/v1",
+    )
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { openAI: OpenAI },
+    });
+
+    const openai = new OpenAI({
+      apiKey: process.env.XAI_API_KEY,
+      baseURL: 'https://api.x.ai/v1',
+    });
+    ```
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+
+    client = openai.OpenAI(
+        api_key=os.environ["XAI_API_KEY"],
+        base_url="https://api.x.ai/v1",
+    )
+
+    # This xAI call is traced by TraceRoot's OpenAI integration
+    response = client.chat.completions.create(
+        model="grok-4",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ],
+    )
+
+    print(response.choices[0].message.content)
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+
+    const openai = new OpenAI({
+      apiKey: process.env.XAI_API_KEY,
+      baseURL: 'https://api.x.ai/v1',
+    });
+
+    // This xAI call is traced by TraceRoot's OpenAI integration
+    const response = await openai.chat.completions.create({
+      model: 'grok-4',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'What is the capital of France?' },
+      ],
+    });
+
+    console.log(response.choices[0].message.content);
+    ```
+
+  </Tab>
+</Tabs>
+
+## What Gets Captured
+
+| Attribute  | Description                                                                       |
+| ---------- | ---------------------------------------------------------------------------------- |
+| Model      | Any xAI model string, such as `grok-4` or `grok-4-fast`                           |
+| Messages   | Input messages array                                                              |
+| Response   | Completion content                                                                |
+| Tool calls | Function/tool call inputs and outputs when using the OpenAI SDK tool-calling API   |
+| Tokens     | Prompt, completion, and total tokens when returned by the provider                |
+| Latency    | Request duration                                                                  |

--- a/docs/integrations/zai.mdx
+++ b/docs/integrations/zai.mdx
@@ -1,0 +1,104 @@
+---
+title: Z.AI (GLM)
+description: Trace Z.AI (GLM) calls through the OpenAI-compatible SDK
+---
+
+Z.AI (GLM) is OpenAI-compatible: use the standard `openai` SDK with the Z.AI base URL (`https://api.z.ai/api/paas/v4`). TraceRoot captures these calls through the existing OpenAI instrumentation — no new Z.AI-specific instrumentor or enum is required.
+
+## Setup
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+    import traceroot
+    from traceroot import Integration
+
+    traceroot.initialize(integrations=[Integration.OPENAI])
+
+    client = openai.OpenAI(
+        api_key=os.environ["ZAI_API_KEY"],
+        base_url="https://api.z.ai/api/paas/v4",
+    )
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { openAI: OpenAI },
+    });
+
+    const openai = new OpenAI({
+      apiKey: process.env.ZAI_API_KEY,
+      baseURL: 'https://api.z.ai/api/paas/v4',
+    });
+    ```
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import os
+    import openai
+
+    client = openai.OpenAI(
+        api_key=os.environ["ZAI_API_KEY"],
+        base_url="https://api.z.ai/api/paas/v4",
+    )
+
+    # This Z.AI call is traced by TraceRoot's OpenAI integration
+    response = client.chat.completions.create(
+        model="glm-4.6",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ],
+    )
+
+    print(response.choices[0].message.content)
+    ```
+
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+
+    const openai = new OpenAI({
+      apiKey: process.env.ZAI_API_KEY,
+      baseURL: 'https://api.z.ai/api/paas/v4',
+    });
+
+    // This Z.AI call is traced by TraceRoot's OpenAI integration
+    const response = await openai.chat.completions.create({
+      model: 'glm-4.6',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'What is the capital of France?' },
+      ],
+    });
+
+    console.log(response.choices[0].message.content);
+    ```
+
+  </Tab>
+</Tabs>
+
+## What Gets Captured
+
+| Attribute  | Description                                                                       |
+| ---------- | ---------------------------------------------------------------------------------- |
+| Model      | Any Z.AI model string, such as `glm-4.6`                                          |
+| Messages   | Input messages array                                                              |
+| Response   | Completion content                                                                |
+| Tool calls | Function/tool call inputs and outputs when using the OpenAI SDK tool-calling API   |
+| Tokens     | Prompt, completion, and total tokens when returned by the provider                |
+| Latency    | Request duration                                                                  |

--- a/docs/logo/integrations/amazon-bedrock.svg
+++ b/docs/logo/integrations/amazon-bedrock.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>AWS Bedrock</title><circle cx="12" cy="12" r="12" fill="#FF9900"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">AB</text></svg>

--- a/docs/logo/integrations/azure.svg
+++ b/docs/logo/integrations/azure.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Azure OpenAI</title><circle cx="12" cy="12" r="12" fill="#0078D4"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">AZ</text></svg>

--- a/docs/logo/integrations/deepseek.svg
+++ b/docs/logo/integrations/deepseek.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>DeepSeek</title><circle cx="12" cy="12" r="12" fill="#4D6BFE"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">DS</text></svg>

--- a/docs/logo/integrations/moonshot.svg
+++ b/docs/logo/integrations/moonshot.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Moonshot (Kimi)</title><circle cx="12" cy="12" r="12" fill="#7C3AED"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">MS</text></svg>

--- a/docs/logo/integrations/xai.svg
+++ b/docs/logo/integrations/xai.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>xAI</title><circle cx="12" cy="12" r="12" fill="#1A1A1A"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">X</text></svg>

--- a/docs/logo/integrations/zai.svg
+++ b/docs/logo/integrations/zai.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Z.AI (GLM)</title><circle cx="12" cy="12" r="12" fill="#14B8A6"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">Z</text></svg>

--- a/frontend/ui/public/logo/integrations/azure.svg
+++ b/frontend/ui/public/logo/integrations/azure.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Azure OpenAI</title><circle cx="12" cy="12" r="12" fill="#0078D4"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">AZ</text></svg>

--- a/frontend/ui/public/logo/integrations/deepseek.svg
+++ b/frontend/ui/public/logo/integrations/deepseek.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>DeepSeek</title><circle cx="12" cy="12" r="12" fill="#4D6BFE"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">DS</text></svg>

--- a/frontend/ui/public/logo/integrations/moonshot.svg
+++ b/frontend/ui/public/logo/integrations/moonshot.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Moonshot (Kimi)</title><circle cx="12" cy="12" r="12" fill="#7C3AED"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">MS</text></svg>

--- a/frontend/ui/public/logo/integrations/xai.svg
+++ b/frontend/ui/public/logo/integrations/xai.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>xAI</title><circle cx="12" cy="12" r="12" fill="#1A1A1A"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">X</text></svg>

--- a/frontend/ui/public/logo/integrations/zai.svg
+++ b/frontend/ui/public/logo/integrations/zai.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Z.AI (GLM)</title><circle cx="12" cy="12" r="12" fill="#14B8A6"/><text x="12" y="16" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">Z</text></svg>

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.test.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.test.tsx
@@ -31,4 +31,13 @@ describe("ManualTab", () => {
     expect(screen.getByTestId("github-connect")).toBeDefined();
     expect(screen.getByTestId("slack-connect")).toBeDefined();
   });
+
+  // #1796: the bare word "providers" reads as implying BYOK support, which this
+  // list doesn't carry — every provider here is auto-traced instrumentation,
+  // a separate, independent feature from BYOK model providers.
+  it("labels the provider picker group as auto-traced, not implying BYOK support", () => {
+    render(<ManualTab projectId="proj_1" />);
+    expect(screen.getByText("Model providers (traced automatically)")).toBeDefined();
+    expect(screen.queryByText("Model providers", { exact: true })).toBeNull();
+  });
 });

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -9,8 +9,13 @@ import { ExternalIntegrations } from "./ExternalIntegrations";
 import { IntegrationPickerCard } from "./IntegrationPickerCard";
 import { ALL_LANGS, INTEGRATIONS, type IntegrationCategory, type Lang } from "./integrations";
 
+// "Model providers" here means auto-traced direct API calls, not the
+// separate BYOK model providers configured in Workspace Settings — the two
+// are independent lists (a provider can be traceable, BYOK-supported,
+// neither, or both). Spelled out in the label since the bare word
+// "providers" alone reads as implying BYOK support (#1796).
 const INTEGRATION_GROUPS: { category: IntegrationCategory; label: string }[] = [
-  { category: "provider", label: "Model providers" },
+  { category: "provider", label: "Model providers (traced automatically)" },
   { category: "framework", label: "Frameworks" },
 ];
 

--- a/frontend/ui/src/features/traces/components/GettingStarted/integrations-parity.test.ts
+++ b/frontend/ui/src/features/traces/components/GettingStarted/integrations-parity.test.ts
@@ -28,6 +28,7 @@ const PICKER_EXCEPTIONS = new Set(["amazon-bedrock"]);
 const DOCS_ROOT = path.resolve(process.cwd(), "../../docs");
 const INTEGRATIONS_DIR = path.join(DOCS_ROOT, "integrations");
 const OVERVIEW_MDX_PATH = path.join(INTEGRATIONS_DIR, "overview.mdx");
+const BYOK_MDX_PATH = path.join(DOCS_ROOT, "ai-agent", "byok.mdx");
 const DOCS_JSON_PATH = path.join(DOCS_ROOT, "docs.json");
 
 function readText(filePath: string): string {
@@ -113,5 +114,18 @@ describe("Docs stay in 1:1 correspondence: overview.mdx cards, docs.json nav, *.
   it("every docs/integrations/*.mdx file except overview.mdx itself is linked from overview.mdx", () => {
     const expected = mdxFileIds.filter((id) => id !== "overview");
     expect([...overviewLinkedIds].sort()).toEqual([...expected].sort());
+  });
+});
+
+describe("Instrumentation and BYOK model providers are labeled as distinct concepts (#1796)", () => {
+  it("overview.mdx's Model Providers section cross-references the BYOK docs", () => {
+    const overview = readText(OVERVIEW_MDX_PATH);
+    expect(overview).toContain("## Model Providers (Traced Automatically)");
+    expect(overview).toContain("/ai-agent/byok");
+  });
+
+  it("byok.mdx's Supported Providers section cross-references the instrumentation docs", () => {
+    const byok = readText(BYOK_MDX_PATH);
+    expect(byok).toContain("/integrations/overview");
   });
 });

--- a/frontend/ui/src/features/traces/components/GettingStarted/integrations-parity.test.ts
+++ b/frontend/ui/src/features/traces/components/GettingStarted/integrations-parity.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { ADAPTER_CONFIG } from "@traceroot/core";
+import { INTEGRATIONS } from "./integrations";
+
+// This suite is a drift guard for issue #1795: BYOK model providers
+// (ADAPTER_CONFIG, the source of truth) must stay in sync with every
+// display surface that's supposed to list them — the getting-started
+// picker and the docs. It intentionally does NOT cover "instrumentation
+// integrations" (agent frameworks) against the Python/TS SDK enums —
+// those enums live in the traceroot-py / traceroot-ts repos, which are
+// not part of this checkout, so there is no source-of-truth file here
+// to check against.
+
+// ADAPTER_CONFIG keys the same provider `google` where docs/picker call
+// it `gemini`. Every other key matches its docs/picker id verbatim.
+const ADAPTER_ID_TO_DOCS_ID: Record<string, string> = {
+  google: "gemini",
+};
+
+// AWS Bedrock needs boto3-based instrumentation with no verified
+// `Integration` enum member available to this repo (see its docs page) —
+// intentionally left out of the getting-started picker, which cannot
+// render an entry with zero code examples (see ManualTab.tsx's guard).
+const PICKER_EXCEPTIONS = new Set(["amazon-bedrock"]);
+
+const DOCS_ROOT = path.resolve(process.cwd(), "../../docs");
+const INTEGRATIONS_DIR = path.join(DOCS_ROOT, "integrations");
+const OVERVIEW_MDX_PATH = path.join(INTEGRATIONS_DIR, "overview.mdx");
+const DOCS_JSON_PATH = path.join(DOCS_ROOT, "docs.json");
+
+function readText(filePath: string): string {
+  return fs.readFileSync(filePath, "utf-8");
+}
+
+// Recursively collect every `docs.json` "pages" entry, repo-wide — not just
+// under the Integrations tab — so this doesn't silently stop working if the
+// nav gets reorganized.
+function collectDocsJsonPages(node: unknown, out: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (const item of node) collectDocsJsonPages(item, out);
+  } else if (node && typeof node === "object") {
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (key === "pages" && Array.isArray(value)) {
+        for (const page of value) {
+          if (typeof page === "string") out.push(page);
+        }
+      } else {
+        collectDocsJsonPages(value, out);
+      }
+    }
+  }
+  return out;
+}
+
+const byokIds = Object.keys(ADAPTER_CONFIG).map((key) => ADAPTER_ID_TO_DOCS_ID[key] ?? key);
+
+const pickerProviderIds = INTEGRATIONS.filter((i) => i.category === "provider").map((i) => i.id);
+
+const docsJsonPages = collectDocsJsonPages(JSON.parse(readText(DOCS_JSON_PATH)));
+const docsJsonIntegrationIds = docsJsonPages
+  .filter((p) => p.startsWith("integrations/"))
+  .map((p) => p.replace("integrations/", ""));
+
+const mdxFileIds = fs
+  .readdirSync(INTEGRATIONS_DIR)
+  .filter((f) => f.endsWith(".mdx"))
+  .map((f) => f.replace(/\.mdx$/, ""));
+
+const overviewMdx = readText(OVERVIEW_MDX_PATH);
+const overviewLinkedIds = Array.from(overviewMdx.matchAll(/\/integrations\/([a-z0-9-]+)"/g)).map(
+  (m) => m[1],
+);
+
+describe("BYOK model providers stay in sync with the picker and docs (#1795)", () => {
+  it("every ADAPTER_CONFIG provider has a docs.json nav entry", () => {
+    for (const id of byokIds) {
+      expect(docsJsonIntegrationIds, `${id} missing from docs.json nav`).toContain(id);
+    }
+  });
+
+  it("every ADAPTER_CONFIG provider has a docs/integrations/*.mdx page", () => {
+    for (const id of byokIds) {
+      expect(mdxFileIds, `${id} missing a docs/integrations/*.mdx page`).toContain(id);
+    }
+  });
+
+  it("every ADAPTER_CONFIG provider has an overview.mdx card", () => {
+    for (const id of byokIds) {
+      expect(overviewLinkedIds, `${id} missing an overview.mdx card`).toContain(id);
+    }
+  });
+
+  it("every ADAPTER_CONFIG provider (except documented exceptions) has a getting-started picker entry", () => {
+    for (const id of byokIds) {
+      if (PICKER_EXCEPTIONS.has(id)) continue;
+      expect(pickerProviderIds, `${id} missing from the getting-started picker`).toContain(id);
+    }
+  });
+
+  // Not tested in reverse: the picker's "provider" category means
+  // "instrumentable" (you can trace your own calls to it), which is a
+  // legitimately broader set than "BYOK-configurable" — e.g. Mistral is
+  // instrumentable but isn't in ADAPTER_CONFIG, and that's not drift.
+});
+
+describe("Docs stay in 1:1 correspondence: overview.mdx cards, docs.json nav, *.mdx files (#1795)", () => {
+  it("every docs/integrations/*.mdx file has a docs.json nav entry, and vice versa", () => {
+    expect([...mdxFileIds].sort()).toEqual([...docsJsonIntegrationIds].sort());
+  });
+
+  it("every docs/integrations/*.mdx file except overview.mdx itself is linked from overview.mdx", () => {
+    const expected = mdxFileIds.filter((id) => id !== "overview");
+    expect([...overviewLinkedIds].sort()).toEqual([...expected].sort());
+  });
+});

--- a/frontend/ui/src/features/traces/components/GettingStarted/integrations.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/integrations.tsx
@@ -364,6 +364,82 @@ const client = new Anthropic();`,
     },
   },
   {
+    id: "azure",
+    name: "Azure OpenAI",
+    href: "https://traceroot.ai/docs/integrations/azure",
+    category: "provider",
+    logo: "/logo/integrations/azure.svg",
+    languages: {
+      python: {
+        installCommand: "pip install traceroot openai",
+        initSnippet: `import os
+from openai import AzureOpenAI
+import traceroot
+from traceroot import Integration
+
+traceroot.initialize(integrations=[Integration.OPENAI])
+
+client = AzureOpenAI(
+    api_key=os.environ["AZURE_OPENAI_API_KEY"],
+    azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+    api_version="2024-10-21",
+)`,
+      },
+      typescript: {
+        installCommand: "npm install @traceroot-ai/traceroot openai",
+        initSnippet: `import { AzureOpenAI } from "openai";
+import { TraceRoot } from "@traceroot-ai/traceroot";
+
+TraceRoot.initialize({
+  instrumentModules: { openAI: AzureOpenAI },
+});
+
+const client = new AzureOpenAI({
+  apiKey: process.env.AZURE_OPENAI_API_KEY,
+  endpoint: process.env.AZURE_OPENAI_ENDPOINT,
+  apiVersion: "2024-10-21",
+});`,
+      },
+    },
+  },
+  {
+    id: "deepseek",
+    name: "DeepSeek",
+    href: "https://traceroot.ai/docs/integrations/deepseek",
+    category: "provider",
+    logo: "/logo/integrations/deepseek.svg",
+    languages: {
+      python: {
+        installCommand: "pip install traceroot openai",
+        initSnippet: `import os
+import openai
+import traceroot
+from traceroot import Integration
+
+traceroot.initialize(integrations=[Integration.OPENAI])
+
+client = openai.OpenAI(
+    api_key=os.environ["DEEPSEEK_API_KEY"],
+    base_url="https://api.deepseek.com",
+)`,
+      },
+      typescript: {
+        installCommand: "npm install @traceroot-ai/traceroot openai",
+        initSnippet: `import OpenAI from "openai";
+import { TraceRoot } from "@traceroot-ai/traceroot";
+
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+const client = new OpenAI({
+  apiKey: process.env.DEEPSEEK_API_KEY,
+  baseURL: "https://api.deepseek.com",
+});`,
+      },
+    },
+  },
+  {
     id: "gemini",
     name: "Google Gemini",
     href: "https://traceroot.ai/docs/integrations/gemini",
@@ -457,6 +533,117 @@ TraceRoot.initialize({
 const openai = new OpenAI({
   apiKey: process.env.OPENROUTER_API_KEY,
   baseURL: "https://openrouter.ai/api/v1",
+});`,
+      },
+    },
+  },
+  {
+    id: "xai",
+    name: "xAI",
+    href: "https://traceroot.ai/docs/integrations/xai",
+    category: "provider",
+    logo: "/logo/integrations/xai.svg",
+    languages: {
+      python: {
+        installCommand: "pip install traceroot openai",
+        initSnippet: `import os
+import openai
+import traceroot
+from traceroot import Integration
+
+traceroot.initialize(integrations=[Integration.OPENAI])
+
+client = openai.OpenAI(
+    api_key=os.environ["XAI_API_KEY"],
+    base_url="https://api.x.ai/v1",
+)`,
+      },
+      typescript: {
+        installCommand: "npm install @traceroot-ai/traceroot openai",
+        initSnippet: `import OpenAI from "openai";
+import { TraceRoot } from "@traceroot-ai/traceroot";
+
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+const client = new OpenAI({
+  apiKey: process.env.XAI_API_KEY,
+  baseURL: "https://api.x.ai/v1",
+});`,
+      },
+    },
+  },
+  {
+    id: "moonshot",
+    name: "Moonshot (Kimi)",
+    href: "https://traceroot.ai/docs/integrations/moonshot",
+    category: "provider",
+    logo: "/logo/integrations/moonshot.svg",
+    languages: {
+      python: {
+        installCommand: "pip install traceroot openai",
+        initSnippet: `import os
+import openai
+import traceroot
+from traceroot import Integration
+
+traceroot.initialize(integrations=[Integration.OPENAI])
+
+client = openai.OpenAI(
+    api_key=os.environ["MOONSHOT_API_KEY"],
+    base_url="https://api.moonshot.ai/v1",
+)`,
+      },
+      typescript: {
+        installCommand: "npm install @traceroot-ai/traceroot openai",
+        initSnippet: `import OpenAI from "openai";
+import { TraceRoot } from "@traceroot-ai/traceroot";
+
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+const client = new OpenAI({
+  apiKey: process.env.MOONSHOT_API_KEY,
+  baseURL: "https://api.moonshot.ai/v1",
+});`,
+      },
+    },
+  },
+  {
+    id: "zai",
+    name: "Z.AI (GLM)",
+    href: "https://traceroot.ai/docs/integrations/zai",
+    category: "provider",
+    logo: "/logo/integrations/zai.svg",
+    languages: {
+      python: {
+        installCommand: "pip install traceroot openai",
+        initSnippet: `import os
+import openai
+import traceroot
+from traceroot import Integration
+
+traceroot.initialize(integrations=[Integration.OPENAI])
+
+client = openai.OpenAI(
+    api_key=os.environ["ZAI_API_KEY"],
+    base_url="https://api.z.ai/api/paas/v4",
+)`,
+      },
+      typescript: {
+        installCommand: "npm install @traceroot-ai/traceroot openai",
+        initSnippet: `import OpenAI from "openai";
+import { TraceRoot } from "@traceroot-ai/traceroot";
+
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+const client = new OpenAI({
+  apiKey: process.env.ZAI_API_KEY,
+  baseURL: "https://api.z.ai/api/paas/v4",
 });`,
       },
     },


### PR DESCRIPTION
## Summary

Fixes #1815, a sub-issue of the epic (#1796) covering its first acceptance criterion — *"Each surface distinguishes instrumentation integrations from BYOK model providers (labels/sections), instead of one ambiguous 'model providers' list"* — which wasn't covered by any of the three originally-named sub-issues (#1793, #1794, #1795).

The epic conflates two independent concepts under one label:
- **Instrumentation integrations** — "we auto-trace your own calls to this provider."
- **BYOK model providers** — "bring an API key to power the assistant/detectors."

A provider can be one, both, or neither (Mistral is the concrete example the epic calls out: traceable, but not BYOK-supported) — and the bare label "Model Providers" doesn't communicate that anywhere it appears.

## ⚠️ Stacked PR — please read before reviewing

This branch is based on **#1800** (my own PR, not yet merged — the parity-test sub-issue #1795). The diff below includes #1800's changes too, until that one merges. **The actual new work in this PR is a single commit: `ca69a3e2`.** Recommend reviewing #1800 first, or just look at that one commit directly.

There are now three open PRs all touching `integrations.tsx`/`overview.mdx`/`docs.json`: #1799 (xAI/Moonshot/Z.AI), #1813 (Groq/Bedrock/Azure), and my own #1800 (parity test + the same six providers, self-contained per earlier discussion). Whichever merges in what order will need routine conflict resolution — this PR adds to that pile since it touches the same section headings, but the actual diff here is small and additive (labels/cross-references only, no new providers).

## Changes

- **Getting-started picker**: relabeled the group from "Model providers" to "Model providers (traced automatically)".
- **`docs/integrations/overview.mdx`**: renamed the section heading to match, and added a sentence explicitly cross-referencing the separate BYOK docs page.
- **`docs/ai-agent/byok.mdx`**: linked every entry in "Supported Providers" (previously plain, unlinked text) to its actual `/integrations/*` page, and added the reverse cross-reference explaining that BYOK support and instrumentation support are independent, using Mistral as the concrete example.
- **Tests**: added a test locking the new picker label in place (mutation-tested — temporarily reverted the label, confirmed the test fails, restored it), and two tests locking the doc cross-references into the existing `integrations-parity.test.ts` file from #1800.

## Test plan

- [x] New/updated tests: 4 pass (1 in `ManualTab.test.tsx`, 2 in `integrations-parity.test.ts`, matching count)
- [x] Mutation-tested the picker label test — confirmed it actually catches the regression
- [x] `tsc --noEmit` and `eslint` clean on all touched files
- [x] Full frontend suite: 1051/1053 pass (2 pre-existing, unrelated environment flakes — same ones noted on #1800)
- [x] Local diff-cover: 100% on this PR's diff

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the difference between instrumentation integrations and BYOK model providers across the UI and docs, so users know what’s auto-traced vs what powers BYOK. Addresses #1796 and adds parity checks to keep BYOK provider lists in sync with UI/docs.

- **New Features**
  - Getting-started picker: label changed to "Model providers (traced automatically)".
  - Docs: renamed the "Model Providers" section; added cross-links between instrumentation overview and the BYOK page; BYOK provider list now links to each integration page.
  - Added pages, overview cards, and placeholder logos for Azure OpenAI, DeepSeek, xAI, Moonshot (Kimi), and Z.AI; picker now includes these. Added AWS Bedrock docs (docs-only; not in picker, since it uses the AWS SDK instrumentation path).
  - Added parity tests to prevent drift between BYOK providers and their presence in the picker, docs overview, and `docs.json`.

<sup>Written for commit ca69a3e2ebc0ce0b99423a99277339e9fbe4674d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


