### PR TITLE
feat(backend): add ingestion log timings

### DIFF
--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -15,6 +15,7 @@ import gzip
 import logging
 import uuid
 from datetime import UTC, datetime
+from time import perf_counter
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request, Response, status
@@ -98,6 +99,8 @@ async def ingest_traces(
     Body:
         OTLP trace data in protobuf format
     """
+    ingest_started_at = perf_counter()
+
     # Check if ingestion is blocked (free plan limit exceeded)
     # This flag is updated hourly by the billing worker
     # Skip enforcement when billing is disabled (e.g. self-hosted)
@@ -167,11 +170,16 @@ async def ingest_traces(
     )
 
     # 5. Upload JSON to S3
+    storage_started_at = perf_counter()
     try:
         s3_service = get_s3_service()
         s3_service.ensure_bucket_exists()
         s3_service.upload_json(s3_key, trace_data)
-        logger.info(f"Stored OTEL JSON to {s3_key} for project {project_id}")
+        logger.info(
+            f"Stored OTEL JSON to {s3_key} for project {project_id} "
+            f"(payload_bytes={len(body)}, "
+            f"storage_duration_ms={(perf_counter() - storage_started_at) * 1000:.2f})"
+        )
     except Exception as e:
         logger.error(f"Failed to upload OTEL JSON to S3: {e}")
         raise HTTPException(
@@ -180,9 +188,14 @@ async def ingest_traces(
         ) from e
 
     # 6. Enqueue Celery task for async processing (S3 reference only, not full payload)
+    enqueue_started_at = perf_counter()
     try:
         process_s3_traces.delay(s3_key=s3_key, project_id=project_id)
-        logger.info(f"Enqueued Celery task for {s3_key}")
+        logger.info(
+            f"Enqueued Celery task for {s3_key} "
+            f"(enqueue_duration_ms={(perf_counter() - enqueue_started_at) * 1000:.2f}, "
+            f"total_duration_ms={(perf_counter() - ingest_started_at) * 1000:.2f})"
+        )
     except Exception as e:
         # Log but don't fail the request - S3 has the data, can retry later
         logger.error(f"Failed to enqueue Celery task for {s3_key}: {e}")

--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -7,6 +7,7 @@ import json
 import logging
 from collections import defaultdict
 from datetime import datetime
+from time import perf_counter
 
 from worker.celery_app import app
 
@@ -93,7 +94,11 @@ def process_s3_traces(self, s3_key: str, project_id: str) -> dict:
     from rest.services.s3 import get_s3_service
     from worker.otel_transform import transform_otel_to_clickhouse
 
-    logger.info(f"Processing S3 traces: {s3_key} for project {project_id}")
+    task_started_at = perf_counter()
+    logger.info(
+        f"Processing S3 traces: {s3_key} for project {project_id} "
+        f"(retry_count={self.request.retries})"
+    )
 
     try:
         # 1. Download from S3
@@ -141,12 +146,20 @@ def process_s3_traces(self, s3_key: str, project_id: str) -> dict:
                     ]
 
                 if traces:
+                    insert_started_at = perf_counter()
                     ch_client.insert_traces_batch(traces)
-                    logger.info(f"Inserted {len(traces)} traces into ClickHouse")
+                    logger.info(
+                        f"Inserted {len(traces)} traces into ClickHouse "
+                        f"(duration_ms={(perf_counter() - insert_started_at) * 1000:.2f})"
+                    )
 
             if spans:
+                insert_started_at = perf_counter()
                 ch_client.insert_spans_batch(spans)
-                logger.info(f"Inserted {len(spans)} spans into ClickHouse")
+                logger.info(
+                    f"Inserted {len(spans)} spans into ClickHouse "
+                    f"(duration_ms={(perf_counter() - insert_started_at) * 1000:.2f})"
+                )
 
         # Trigger detector runs (fire-and-forget, non-blocking). The batch that
         # carries a trace's root span triggers detection exactly once — a Redis
@@ -174,5 +187,10 @@ def process_s3_traces(self, s3_key: str, project_id: str) -> dict:
         }
 
     except Exception as e:
-        logger.error(f"Failed to process {s3_key}: {e}", exc_info=True)
+        logger.error(
+            f"Failed to process {s3_key}: {e} "
+            f"(retry_count={self.request.retries}, "
+            f"total_duration_ms={(perf_counter() - task_started_at) * 1000:.2f})",
+            exc_info=True,
+        )
         raise  # Re-raise to trigger Celery retry


### PR DESCRIPTION
## Summary

Adds operational timing and retry context to the existing trace ingestion logs without introducing new infrastructure, dependencies, or endpoints.

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies
- [ ] ci - Changes to CI configuration
- [ ] chore - Other changes that don't modify source or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to GitHub configuration
- [ ] other

## Details

Extended the existing backend logs with:

- S3 payload size and storage duration
- Celery enqueue duration
- Total ingestion request duration
- Celery retry count
- ClickHouse trace insertion duration
- ClickHouse span insertion duration
- Failed task duration and retry count

The change is limited to the existing REST ingestion route and Celery ingestion task. It adds no monitoring infrastructure, dependencies, API endpoints, or architectural changes.

Validation performed:

- Ruff formatting check
- Ruff lint check
- Python compilation check
- Git diff/whitespace check

## Screenshots / Recordings (if applicable)

Not applicable; there are no UI changes.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds precise timings and retry context to trace ingestion logs in the REST ingest route and the worker. Improves observability for S3 upload, task enqueueing, ClickHouse inserts, and total durations without adding infra or new deps.

- New Features
  - REST: log S3 `payload_bytes` and `storage_duration_ms`.
  - REST: log `enqueue_duration_ms` and request `total_duration_ms`.
  - Worker: log `retry_count` at start.
  - Worker: log ClickHouse insert `duration_ms` for traces and spans.
  - Worker: on failure, log `retry_count` and task `total_duration_ms`.
  - Scope: limited to existing ingestion route and Celery task; no new endpoints or dependencies.

<sup>Written for commit 288423616ae73fa10cc55b5e751eb53e9df47466. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

