### PR TITLE
fix(ui): restore the persisted date range after retention resolves

### DIFF
--- a/frontend/ui/src/lib/hooks/use-retention.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-retention.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PlanType } from "@traceroot/core";
+import { useRetention } from "./use-retention";
+
+const state = vi.hoisted(() => ({
+  project: { data: undefined as { workspace_id?: string } | undefined, isPending: true },
+  workspace: { data: undefined as { billingPlan?: string } | undefined, isPending: true },
+}));
+
+vi.mock("@/features/projects/hooks", () => ({
+  useProject: () => state.project,
+}));
+vi.mock("@/features/workspaces/hooks", () => ({
+  useWorkspace: () => state.workspace,
+}));
+
+beforeEach(() => {
+  state.project = { data: undefined, isPending: true };
+  state.workspace = { data: undefined, isPending: true };
+});
+
+describe("useRetention", () => {
+  it("reports retention as unknown while the project lookup is in flight", () => {
+    const { result } = renderHook(() => useRetention("p1"));
+
+    expect(result.current.retentionDays).toBeUndefined();
+  });
+
+  it("reports retention as unknown while the workspace lookup is in flight", () => {
+    state.project = { data: { workspace_id: "w1" }, isPending: false };
+
+    const { result } = renderHook(() => useRetention("p1"));
+
+    expect(result.current.retentionDays).toBeUndefined();
+  });
+
+  it("reports the plan's window once the workspace resolves", () => {
+    state.project = { data: { workspace_id: "w1" }, isPending: false };
+    state.workspace = { data: { billingPlan: PlanType.PRO }, isPending: false };
+
+    const { result } = renderHook(() => useRetention("p1"));
+
+    expect(result.current.retentionDays).toBe(90);
+  });
+
+  it("fails closed for an unrecognized plan string", () => {
+    state.project = { data: { workspace_id: "w1" }, isPending: false };
+    state.workspace = { data: { billingPlan: "constructor" }, isPending: false };
+
+    const { result } = renderHook(() => useRetention("p1"));
+
+    expect(result.current.retentionDays).toBe(15);
+  });
+
+  it("fails closed when the project has no workspace", () => {
+    state.project = { data: {}, isPending: false };
+
+    const { result } = renderHook(() => useRetention("p1"));
+
+    expect(result.current.retentionDays).toBe(15);
+  });
+
+  it("fails closed when the workspace lookup errors out", () => {
+    state.project = { data: { workspace_id: "w1" }, isPending: false };
+    state.workspace = { data: undefined, isPending: false };
+
+    const { result } = renderHook(() => useRetention("p1"));
+
+    expect(result.current.retentionDays).toBe(15);
+  });
+});

--- a/frontend/ui/src/lib/hooks/use-retention.ts
+++ b/frontend/ui/src/lib/hooks/use-retention.ts
@@ -6,12 +6,20 @@ import { useProject } from "@/features/projects/hooks";
 import { useWorkspace } from "@/features/workspaces/hooks";
 
 export function useRetention(projectId: string) {
-  const { data: project } = useProject(projectId);
+  const { data: project, isPending: projectPending } = useProject(projectId);
   const workspaceId = project?.workspace_id ?? "";
-  const { data: workspace } = useWorkspace(workspaceId, !!workspaceId);
+  const { data: workspace, isPending: workspacePending } = useWorkspace(workspaceId, !!workspaceId);
 
+  // While either lookup is in flight the plan is unknown: report undefined so
+  // consumers don't clamp or lock selections against the free plan's window
+  // during the gap (a hard reload would briefly narrow every stored range).
+  // Once the lookups settle, anything unresolved — a missing workspace, an
+  // errored query, an unrecognized plan string — still fails closed to the
+  // most restrictive window. (A disabled query reports pending forever, so
+  // each pending flag only counts while its query is actually enabled.)
+  const resolving = (!!projectId && projectPending) || (!!workspaceId && workspacePending);
   const billingPlan = (workspace?.billingPlan as string) || PlanType.FREE;
-  const retentionDays = getRetentionDays(billingPlan);
+  const retentionDays = resolving ? undefined : getRetentionDays(billingPlan);
 
   const [showPricing, setShowPricing] = useState(false);
   const onUpgradeClick = useCallback(() => setShowPricing(true), []);

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.test.tsx
@@ -35,6 +35,22 @@ describe("useUrlDateFilter persistence", () => {
     await waitFor(() => expect(result.current.dateFilter.id).toBe("7d"));
   });
 
+  it("re-evaluates a restored preset when retention becomes available", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "30d" }));
+    let retentionDays = 15;
+
+    const { result, rerender } = renderHook(() =>
+      useUrlDateFilter(undefined, undefined, retentionDays),
+    );
+
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("14d"));
+
+    retentionDays = 90;
+    rerender();
+
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("30d"));
+  });
+
   it("lets an explicit URL filter win over the stored preference", async () => {
     localStorage.setItem(KEY, JSON.stringify({ id: "7d" }));
     search = "date_filter=30m";

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.test.tsx
@@ -35,22 +35,6 @@ describe("useUrlDateFilter persistence", () => {
     await waitFor(() => expect(result.current.dateFilter.id).toBe("7d"));
   });
 
-  it("re-evaluates a restored preset when retention becomes available", async () => {
-    localStorage.setItem(KEY, JSON.stringify({ id: "30d" }));
-    let retentionDays = 15;
-
-    const { result, rerender } = renderHook(() =>
-      useUrlDateFilter(undefined, undefined, retentionDays),
-    );
-
-    await waitFor(() => expect(result.current.dateFilter.id).toBe("14d"));
-
-    retentionDays = 90;
-    rerender();
-
-    await waitFor(() => expect(result.current.dateFilter.id).toBe("30d"));
-  });
-
   it("lets an explicit URL filter win over the stored preference", async () => {
     localStorage.setItem(KEY, JSON.stringify({ id: "7d" }));
     search = "date_filter=30m";
@@ -149,6 +133,90 @@ describe("useUrlDateFilter persistence", () => {
       expect(result.current.dateFilter.id).toBe(DATE_FILTER_OPTIONS.find((o) => o.id === "1d")!.id),
     );
     expect(result.current.customStartDate).toBeNull();
+  });
+
+  it("adopts the stored selection once the real retention replaces the transient fallback", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "30d" }));
+
+    // Mirror a hard reload: retention reads as the free plan's 15 days while
+    // the workspace lookup is in flight, then resolves to the real plan.
+    const { result, rerender } = renderHook(
+      ({ retention }: { retention: number | null | undefined }) =>
+        useUrlDateFilter(undefined, undefined, retention),
+      { initialProps: { retention: 15 as number | null | undefined } },
+    );
+
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("14d"));
+
+    rerender({ retention: 90 });
+    expect(result.current.dateFilter.id).toBe("30d");
+  });
+
+  it("shows the stored selection unclamped while retention is still unknown", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "30d" }));
+
+    const { result, rerender } = renderHook(
+      ({ retention }: { retention: number | null | undefined }) =>
+        useUrlDateFilter(undefined, undefined, retention),
+      { initialProps: { retention: undefined as number | null | undefined } },
+    );
+
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("30d"));
+
+    rerender({ retention: 90 });
+    expect(result.current.dateFilter.id).toBe("30d");
+  });
+
+  it("re-clamps display and timestamps when retention narrows below the selection", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "30d" }));
+
+    const { result, rerender } = renderHook(
+      ({ retention }: { retention: number | null | undefined }) =>
+        useUrlDateFilter(undefined, undefined, retention),
+      { initialProps: { retention: undefined as number | null | undefined } },
+    );
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("30d"));
+
+    rerender({ retention: 15 });
+    expect(result.current.dateFilter.id).toBe("14d");
+    const windowMs = Date.now() - new Date(result.current.timestamps.startAfter!).getTime();
+    expect(Math.round(windowMs / 86_400_000)).toBe(14);
+    // The raw preference survives the clamp — only the effective value narrows.
+    expect(readStoredDateFilter("p1")?.id).toBe("30d");
+  });
+
+  it("resets pagination when a retention clamp narrows the window after mount", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "30d" }));
+    const onFilterChange = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ retention }: { retention: number | null | undefined }) =>
+        useUrlDateFilter(onFilterChange, undefined, retention),
+      { initialProps: { retention: undefined as number | null | undefined } },
+    );
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("30d"));
+    expect(onFilterChange).toHaveBeenCalledTimes(1); // restore adopted 30d
+
+    rerender({ retention: 15 });
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("14d"));
+    expect(onFilterChange).toHaveBeenCalledTimes(2); // clamp narrowed the window
+  });
+
+  it("does not double-fire the change callback on an explicit pick", () => {
+    const onFilterChange = vi.fn();
+
+    const { result } = renderHook(() => useUrlDateFilter(onFilterChange, undefined, 90));
+
+    act(() => result.current.setDateFilter(findDateFilterOption("7d")));
+    expect(onFilterChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("clamps an explicit URL filter against the resolved retention", () => {
+    search = "date_filter=90d";
+
+    const { result } = renderHook(() => useUrlDateFilter(undefined, undefined, 30));
+
+    expect(result.current.dateFilter.id).toBe("30d");
   });
 
   it("settles data queries on the restored window, not the default", async () => {

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.ts
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.ts
@@ -48,7 +48,10 @@ export function useUrlDateFilter(
   const urlStartDate = searchParams.get("start");
   const urlEndDate = searchParams.get("end");
 
-  // Parse URL values into state
+  // Parse URL values into state. State holds the selection as picked (URL,
+  // default, restore, or user action); clamping to the retention window is a
+  // derived read below, so it re-evaluates when retention resolves instead of
+  // being baked in here while it's still unknown.
   const initialDateFilter = urlDateFilterId
     ? findDateFilterOption(urlDateFilterId)
     : defaultId
@@ -57,14 +60,10 @@ export function useUrlDateFilter(
   const initialCustomStart = urlStartDate ? new Date(urlStartDate) : null;
   const initialCustomEnd = urlEndDate ? new Date(urlEndDate) : null;
 
-  const [dateFilter, setDateFilterState] = useState<DateFilterOption>(initialDateFilter);
+  const [rawDateFilter, setRawDateFilter] = useState<DateFilterOption>(initialDateFilter);
   const [customStartDate, setCustomStartDateState] = useState<Date | null>(initialCustomStart);
   const [customEndDate, setCustomEndDateState] = useState<Date | null>(initialCustomEnd);
   const [filterVersion, setFilterVersion] = useState(0);
-  const effectiveDateFilter = useMemo(
-    () => clampDateFilter(dateFilter, retentionDays),
-    [dateFilter, retentionDays],
-  );
 
   // Use ref for callback to avoid dependency issues
   const onFilterChangeRef = useRef(onFilterChange);
@@ -95,16 +94,16 @@ export function useUrlDateFilter(
       if (!start || !end || isNaN(start.getTime()) || isNaN(end.getTime()) || end < start) return;
       setCustomStartDateState(start);
       setCustomEndDateState(end);
-    } else if (option.id === dateFilter.id) {
+    } else if (option.id === rawDateFilter.id) {
       // Stored matches what's already showing — nothing to adopt.
       return;
     }
-    setDateFilterState(option);
+    setRawDateFilter(option);
     setFilterVersion((v) => v + 1);
     // The effective window changed under the page: consumers that paginate
     // must reset (a stale ?page_index can point past the restored window).
     onFilterChangeRef.current?.();
-    // dateFilter.id is deliberately not a dependency: it's read only on the
+    // rawDateFilter.id is deliberately not a dependency: it's read only on the
     // once-guarded first run, and restoredRef prevents any re-run. (The lint
     // rule doesn't check custom-named hooks, so this documents what it can't.)
   }, [projectId, searchParams]);
@@ -132,8 +131,8 @@ export function useUrlDateFilter(
 
     if (newDateFilterId) {
       const newFilter = findDateFilterOption(newDateFilterId);
-      if (newFilter.id !== dateFilter.id) {
-        setDateFilterState(newFilter);
+      if (newFilter.id !== rawDateFilter.id) {
+        setRawDateFilter(newFilter);
         setFilterVersion((v) => v + 1);
       }
     }
@@ -151,7 +150,7 @@ export function useUrlDateFilter(
         setCustomEndDateState(parsed);
       }
     }
-  }, [searchParams, dateFilter, customStartDate, customEndDate, retentionDays]);
+  }, [searchParams, rawDateFilter, customStartDate, customEndDate]);
 
   // Update URL when state changes
   const updateUrl = useCallback(
@@ -178,7 +177,7 @@ export function useUrlDateFilter(
 
   const setDateFilter = useCallback(
     (option: DateFilterOption) => {
-      setDateFilterState(option);
+      setRawDateFilter(option);
       setFilterVersion((v) => v + 1);
 
       if (!option.isCustom) {
@@ -197,7 +196,7 @@ export function useUrlDateFilter(
       setCustomEndDateState(end);
 
       const customOption = DATE_FILTER_OPTIONS.find((o) => o.isCustom)!;
-      setDateFilterState(customOption);
+      setRawDateFilter(customOption);
       updateUrl("custom", start, end);
       persistSelection("custom", start, end);
 
@@ -206,17 +205,41 @@ export function useUrlDateFilter(
     [updateUrl, persistSelection],
   );
 
+  // Clamp to the retention window at read time. Retention is unknown while
+  // the workspace lookup is in flight (a hard reload), so clamping when state
+  // is written would bake the fail-closed fallback into the restored
+  // selection; deriving keeps the raw pick and re-clamps once retention
+  // resolves.
+  const dateFilter = useMemo(
+    () => clampDateFilter(rawDateFilter, retentionDays),
+    [rawDateFilter, retentionDays],
+  );
+
+  // Retention resolving after mount can change the effective window with no
+  // user action, and consumers that paginate must reset like on any other
+  // window change (a stale ?page_index can point past the clamped window).
+  // Explicit picks and the restore path fire the callback themselves, so only
+  // a clamp-driven change — same raw selection, different effective filter —
+  // fires here.
+  const prevFilterIdsRef = useRef({ rawId: rawDateFilter.id, effectiveId: dateFilter.id });
+  useEffect(() => {
+    const prev = prevFilterIdsRef.current;
+    const clampChanged = prev.effectiveId !== dateFilter.id && prev.rawId === rawDateFilter.id;
+    prevFilterIdsRef.current = { rawId: rawDateFilter.id, effectiveId: dateFilter.id };
+    if (clampChanged) onFilterChangeRef.current?.();
+  }, [rawDateFilter.id, dateFilter.id]);
+
   // Calculate timestamps
   const timestamps = useMemo(() => {
     return toTimestampBounds(
-      effectiveDateFilter.id,
+      dateFilter.id,
       customStartDate ?? undefined,
       customEndDate ?? undefined,
     );
-  }, [effectiveDateFilter.id, customStartDate, customEndDate, filterVersion]);
+  }, [dateFilter.id, customStartDate, customEndDate, filterVersion]);
 
   return {
-    dateFilter: effectiveDateFilter,
+    dateFilter,
     customStartDate,
     customEndDate,
     setDateFilter,

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.ts
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.ts
@@ -49,14 +49,11 @@ export function useUrlDateFilter(
   const urlEndDate = searchParams.get("end");
 
   // Parse URL values into state
-  const initialDateFilter = clampDateFilter(
-    urlDateFilterId
-      ? findDateFilterOption(urlDateFilterId)
-      : defaultId
-        ? findDateFilterOption(defaultId)
-        : DEFAULT_DATE_FILTER,
-    retentionDays,
-  );
+  const initialDateFilter = urlDateFilterId
+    ? findDateFilterOption(urlDateFilterId)
+    : defaultId
+      ? findDateFilterOption(defaultId)
+      : DEFAULT_DATE_FILTER;
   const initialCustomStart = urlStartDate ? new Date(urlStartDate) : null;
   const initialCustomEnd = urlEndDate ? new Date(urlEndDate) : null;
 
@@ -64,6 +61,10 @@ export function useUrlDateFilter(
   const [customStartDate, setCustomStartDateState] = useState<Date | null>(initialCustomStart);
   const [customEndDate, setCustomEndDateState] = useState<Date | null>(initialCustomEnd);
   const [filterVersion, setFilterVersion] = useState(0);
+  const effectiveDateFilter = useMemo(
+    () => clampDateFilter(dateFilter, retentionDays),
+    [dateFilter, retentionDays],
+  );
 
   // Use ref for callback to avoid dependency issues
   const onFilterChangeRef = useRef(onFilterChange);
@@ -85,7 +86,7 @@ export function useUrlDateFilter(
     if (!projectId || searchParams.get("date_filter")) return;
     const stored = readStoredDateFilter(projectId);
     if (!stored) return;
-    const option = clampDateFilter(findDateFilterOption(stored.id), retentionDays);
+    const option = findDateFilterOption(stored.id);
     if (option.isCustom) {
       const start = stored.start ? new Date(stored.start) : null;
       const end = stored.end ? new Date(stored.end) : null;
@@ -130,7 +131,7 @@ export function useUrlDateFilter(
     const newEndDate = searchParams.get("end");
 
     if (newDateFilterId) {
-      const newFilter = clampDateFilter(findDateFilterOption(newDateFilterId), retentionDays);
+      const newFilter = findDateFilterOption(newDateFilterId);
       if (newFilter.id !== dateFilter.id) {
         setDateFilterState(newFilter);
         setFilterVersion((v) => v + 1);
@@ -208,14 +209,14 @@ export function useUrlDateFilter(
   // Calculate timestamps
   const timestamps = useMemo(() => {
     return toTimestampBounds(
-      dateFilter.id,
+      effectiveDateFilter.id,
       customStartDate ?? undefined,
       customEndDate ?? undefined,
     );
-  }, [dateFilter.id, customStartDate, customEndDate, filterVersion]);
+  }, [effectiveDateFilter.id, customStartDate, customEndDate, filterVersion]);
 
   return {
-    dateFilter,
+    dateFilter: effectiveDateFilter,
     customStartDate,
     customEndDate,
     setDateFilter,


### PR DESCRIPTION
## Summary

Fixes #1822.

The hook now keeps the raw per-project date-filter selection in state and derives the retention-clamped option for display and timestamps. When workspace retention changes from the loading fallback to the actual plan, a stored `30d` selection is re-evaluated instead of remaining stuck at `14d`.

## Verification

- `pnpm exec vitest run src/lib/hooks/use-url-date-filter.test.tsx` (11 passed)
- `pnpm exec eslint src/lib/hooks/use-url-date-filter.ts src/lib/hooks/use-url-date-filter.test.tsx` (0 errors)
- `pnpm exec prettier --check src/lib/hooks/use-url-date-filter.ts src/lib/hooks/use-url-date-filter.test.tsx`
- `git diff --check`

The repository-wide TypeScript check and production build are currently blocked by the checkout's missing Prisma generated client; the changed files pass their focused checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the user's saved date range after retention resolves and prevents a brief clamp to the free plan on reload. The hooks keep the raw pick and derive the clamped window for display and timestamps.

- **Bug Fixes**
  - Report retention as undefined while project/workspace lookups are pending, so restored ranges don’t clamp in the interim.
  - Re-clamp on resolution and fire the change callback when the effective window narrows to reset pagination.
  - Clamp explicit URL selections against the resolved retention and extend tests for pending state, re-clamp timestamps, raw preference persistence, and clamp-driven resets.

<sup>Written for commit e736dc79a2ba1107e11d031d14d87128dc92df13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

