### PR TITLE
feat(clickhouse): add a queryable metadata_map column

### DIFF
--- a/backend/db/clickhouse/migrations/009_add_metadata_map.sql
+++ b/backend/db/clickhouse/migrations/009_add_metadata_map.sql
@@ -26,12 +26,29 @@
 -- and rewritten on every merge, on the largest table we have. The price paid for leaving it
 -- out is that a span-scope metadata predicate cannot use spans_no_io_by_start_time and drops
 -- to the base table; metadata_map is the only column that scan reads which the projection
--- lacks. The follow-up, if that fallback hurts, is shaped like 008: DROP + ADD the projection
--- with metadata_map in the column list and out of its ORDER BY.
+-- lacks. That fallback loses more than the projection: base spans is ORDER BY (project_id,
+-- trace_id, span_start_time, span_id), with time third, behind a near-unique trace_id, so
+-- primary-index time pruning is effectively nil and only the monthly partition prunes. The
+-- projection's (project_id, span_start_time, trace_id, span_id) is what gives every other
+-- span filter its time pruning, so a metadata predicate reads the whole partition rather
+-- than the time window inside it. The follow-up, if that fallback hurts, is shaped like 008:
+-- DROP + ADD the projection with metadata_map in the column list and out of its ORDER BY.
 
 -- The rule the expression below implements, in the order it is applied:
 --   1. Missing, empty, non-JSON, or non-object metadata yields an empty map --
---      JSONExtractKeysAndValuesRaw returns an empty array for all four.
+--      JSONExtractKeysAndValuesRaw returns an empty array for all four. So does a VALID
+--      JSON object holding a number ClickHouse cannot represent: a single value outside
+--      Int64/UInt64 range, or one that overflows Float64, empties the WHOLE document rather
+--      than that one key, and nesting it inside an object or an array does not spare the
+--      rest. The boundary is exact -- 18446744073709551615 parses, 18446744073709551616
+--      does not, nor do -9223372036854775809 or 1e309, while 1.5e308 is fine. A nanosecond
+--      epoch, a Snowflake id, or a large account number sent as an unquoted JSON number all
+--      land there. Because the column is MATERIALIZED, that empty map is computed at insert
+--      and baked into the part, and 010's MATERIALIZE COLUMN cannot repair it, since the
+--      expression itself is what returns []. The row's `metadata` blob still renders
+--      normally, so such a trace looks healthy while answering every metadata filter as
+--      though it carried no metadata: silent, per row, and permanent. A documented and
+--      accepted limitation -- nothing guards against it today.
 --   2. Keys prefixed `traceroot.` are dropped: the namespace is ours, not the user's. Span
 --      routing attributes and SDK identity land in the blob at ingest and sit on nearly
 --      every span, so left in they outrank every real user key in the frequency-ordered
@@ -83,9 +100,9 @@ ALTER TABLE traces
 
 -- No skip index on metadata_map -- DEFERRED pending measurement, not ruled out. A bloom
 -- filter over mapKeys(metadata_map) is the obvious fit, and the predicate FORM is already
--- right for one: `_keyed_map_match` emits `mapContains(metadata_map, key) AND
--- metadata_map[key] OP value`, and that explicit key-membership conjunct is exactly what
--- makes such an index actionable.
+-- right for one: `_keyed_map_match` (arriving with PR #1833) emits
+-- `mapContains(metadata_map, key) AND metadata_map[key] OP value`, and that explicit
+-- key-membership conjunct is exactly what makes such an index actionable.
 --
 -- What blocks it is POSITION, not form. The conjunct sits in the OUTER WHERE, above the
 -- `LIMIT 1 BY project_id, trace_id, span_id` that dedups the ReplacingMergeTree. That order

--- a/backend/db/clickhouse/migrations/009_add_metadata_map.sql
+++ b/backend/db/clickhouse/migrations/009_add_metadata_map.sql
@@ -13,11 +13,13 @@
 -- `SELECT *` is unchanged, since materialized columns are excluded from it.
 --
 -- This file only ADDs the columns, which is metadata-only and rewrites no part. Making
--- EXISTING history answer metadata questions is the heavier step in 010, which is REQUIRED,
--- not an optimization: through the read shape we ship, a pre-ALTER part returns an EMPTY map
--- rather than a computed one, silently. Applying 009 alone is still a complete, safe deploy
--- -- ingestion is unchanged and everything answers correctly for data ingested from here on.
--- Only history stays blank until 010 runs.
+-- EXISTING history STORE the map is the heavier step in 010. On the ClickHouse we pin (25.2)
+-- the read shapes we ship still answer correctly on pre-ALTER parts, computing the map per
+-- read; 010 is what makes those answers survive a server upgrade -- 26.x rewrites the shipped
+-- inline filter into subcolumn reads that return an EMPTY map on unmaterialized parts,
+-- silently -- and what spares old parts a per-row JSON parse. The full account is in 010.
+-- Applying 009 alone is still a complete, safe deploy -- ingestion is unchanged and
+-- everything answers correctly for data ingested from here on.
 --
 -- The no-I/O projection is deliberately untouched, and the tempting justification for that
 -- is wrong: including metadata_map would NOT put user metadata on the unfiltered list

--- a/backend/db/clickhouse/migrations/009_add_metadata_map.sql
+++ b/backend/db/clickhouse/migrations/009_add_metadata_map.sql
@@ -1,0 +1,117 @@
+-- +goose Up
+-- Make user metadata queryable without giving up the raw blob.
+--
+-- `metadata` is an opaque Nullable(String) JSON document on both tables: nothing can filter
+-- it without a full scan and a per-row JSON parse. `metadata_map` is the queryable
+-- projection of that same document -- one level deep, values stringified -- so a metadata
+-- predicate becomes `metadata_map[key] = value` over a small Map column instead of a JSON
+-- parse over a ZSTD blob.
+--
+-- MATERIALIZED, not DEFAULT, gives one implementation: an INSERT may not name a materialized
+-- column, so ingestion cannot write a value of its own, and no insert column list can name
+-- the column and fail all ingestion when the worker ships ahead of this migration.
+-- `SELECT *` is unchanged, since materialized columns are excluded from it.
+--
+-- This file only ADDs the columns, which is metadata-only and rewrites no part. Making
+-- EXISTING history answer metadata questions is the heavier step in 010, which is REQUIRED,
+-- not an optimization: through the read shape we ship, a pre-ALTER part returns an EMPTY map
+-- rather than a computed one, silently. Applying 009 alone is still a complete, safe deploy
+-- -- ingestion is unchanged and everything answers correctly for data ingested from here on.
+-- Only history stays blank until 010 runs.
+--
+-- The no-I/O projection is deliberately untouched, and the tempting justification for that
+-- is wrong: including metadata_map would NOT put user metadata on the unfiltered list
+-- query's path, because a query reads only the columns it references. The real cost is
+-- storage and write amplification -- one more column materialised into every projection part
+-- and rewritten on every merge, on the largest table we have. The price paid for leaving it
+-- out is that a span-scope metadata predicate cannot use spans_no_io_by_start_time and drops
+-- to the base table; metadata_map is the only column that scan reads which the projection
+-- lacks. The follow-up, if that fallback hurts, is shaped like 008: DROP + ADD the projection
+-- with metadata_map in the column list and out of its ORDER BY.
+
+-- The rule the expression below implements, in the order it is applied:
+--   1. Missing, empty, non-JSON, or non-object metadata yields an empty map --
+--      JSONExtractKeysAndValuesRaw returns an empty array for all four.
+--   2. Keys prefixed `traceroot.` are dropped: the namespace is ours, not the user's. Span
+--      routing attributes and SDK identity land in the blob at ingest and sit on nearly
+--      every span, so left in they outrank every real user key in the frequency-ordered
+--      key list.
+--   3. A JSON string value is stored unquoted and unescaped; every other value (number,
+--      bool, null, nested object, array) is stored as its raw JSON text. Keys are one level
+--      deep, so a nested object is a single opaque string value.
+ALTER TABLE spans
+    ADD COLUMN IF NOT EXISTS metadata_map Map(LowCardinality(String), String)
+    MATERIALIZED CAST(
+        arrayMap(
+            kv -> (
+                tupleElement(kv, 1),
+                if(
+                    startsWith(tupleElement(kv, 2), '"'),
+                    JSONExtractString(tupleElement(kv, 2)),
+                    tupleElement(kv, 2)
+                )
+            ),
+            arrayFilter(
+                kv -> NOT startsWith(tupleElement(kv, 1), 'traceroot.'),
+                JSONExtractKeysAndValuesRaw(ifNull(metadata, ''))
+            )
+        ),
+        'Map(LowCardinality(String), String)'
+    );
+
+-- Same column, same expression, on traces. One expression for both tables is what lets a
+-- column and a filter agree on what a key is called and what its value looks like.
+ALTER TABLE traces
+    ADD COLUMN IF NOT EXISTS metadata_map Map(LowCardinality(String), String)
+    MATERIALIZED CAST(
+        arrayMap(
+            kv -> (
+                tupleElement(kv, 1),
+                if(
+                    startsWith(tupleElement(kv, 2), '"'),
+                    JSONExtractString(tupleElement(kv, 2)),
+                    tupleElement(kv, 2)
+                )
+            ),
+            arrayFilter(
+                kv -> NOT startsWith(tupleElement(kv, 1), 'traceroot.'),
+                JSONExtractKeysAndValuesRaw(ifNull(metadata, ''))
+            )
+        ),
+        'Map(LowCardinality(String), String)'
+    );
+
+-- No skip index on metadata_map -- DEFERRED pending measurement, not ruled out. A bloom
+-- filter over mapKeys(metadata_map) is the obvious fit, and the predicate FORM is already
+-- right for one: `_keyed_map_match` emits `mapContains(metadata_map, key) AND
+-- metadata_map[key] OP value`, and that explicit key-membership conjunct is exactly what
+-- makes such an index actionable.
+--
+-- What blocks it is POSITION, not form. The conjunct sits in the OUTER WHERE, above the
+-- `LIMIT 1 BY project_id, trace_id, span_id` that dedups the ReplacingMergeTree. That order
+-- is required for correctness -- predicate first would match a superseded map -- and
+-- ClickHouse does not push a predicate through LIMIT BY, so granule selection happens before
+-- the predicate exists and the index would be maintained on write, never consulted. Key
+-- discovery has no key predicate at all: it arrayJoins mapKeys over the window, so nothing
+-- can prune it.
+--
+-- The restructure that WOULD make an index live, so the next person need not rediscover it:
+-- prefilter candidate spans with a plain index-eligible scan on the base table (project_id,
+-- the same time bound, and the same two map conjuncts, with no LIMIT BY above it), then run
+-- the existing deduped scan restricted to the resulting (project_id, trace_id, span_id)
+-- triples and re-apply the predicate. Correctness holds because the candidate set is a
+-- superset of the true matches, and because restricting by whole triples cannot change which
+-- row wins within a group -- the triple IS the LIMIT BY key. The re-check discards
+-- candidates whose only match lives on a superseded version. What is unmeasured is whether
+-- the prefilter is selective enough to earn a second scan; on a high-frequency key it plainly
+-- would not be.
+--
+-- The trace-level half needs none of that -- an inline predicate with no LIMIT BY between it
+-- and the granules -- but gets no index either, because traces is the small table, already
+-- pruned by the monthly partition and the sort key. Next step for whoever picks this up:
+-- benchmark the restructured span query at realistic key cardinality FIRST, and add the index
+-- only if the prefilter pays.
+
+-- +goose Down
+ALTER TABLE spans  DROP COLUMN IF EXISTS metadata_map;
+ALTER TABLE traces DROP COLUMN IF EXISTS metadata_map;

--- a/backend/db/clickhouse/migrations/010_materialize_metadata_map.sql
+++ b/backend/db/clickhouse/migrations/010_materialize_metadata_map.sql
@@ -10,34 +10,41 @@
 -- automatically and unattended wherever 009 runs. There is no low-traffic window to choose
 -- and no supported way to hold it back.
 --
--- Why it is required, and how that differs from 008's deliberate refusal to materialize:
--- there, a part missing the rebuilt projection is still READ correctly (the query falls back
--- to the base table, same rows, only slower) and parts pick it up as they merge, so skipping
--- costs only time. Here, skipping is a wrong ANSWER and nothing arrives on its own. A part
--- written before 009's ALTER does not store the column, and what decides whether ClickHouse
--- computes it on read is not whether the query also reads `metadata` -- it is whether the
--- read is a WHOLE-column read or a subcolumn one. Several of our reads DO take the blob --
--- trace detail, the per-span and bulk I/O fetches, and `SELECT *` in the internal router --
--- and that is not what settles the answer either way. `SELECT metadata_map` on a pre-ALTER
--- part returns the correctly computed map with no `metadata` in the query at all. But
--- length(metadata_map), metadata_map[key], mapContains() and mapKeys() all read back EMPTY:
--- optimize_functions_to_subcolumns rewrites them into subcolumn reads, and a subcolumn read
--- never evaluates the default expression. Naming `metadata` in the same SELECT list does
--- restore correct values for those expressions -- but it does not rescue the read shape we
--- actually ship. `mapContains(metadata_map, key) AND metadata_map[key] = value` in a WHERE
--- matches ZERO rows even when the query also selects `metadata`, because the filter stage
--- reads the subcolumns before the blob column enters the block. That predicate is exactly
--- what #1833 ships, so a pre-009 part answers a metadata filter with no error and no rows:
--- a trace that behaves as though it carried no metadata. Reproduced on ClickHouse 26.3.3
--- against a pre-ALTER row; optimize_functions_to_subcolumns has defaulted on since 24.8, so
--- the 25.2 server we pin behaves the same way.
+-- Why it ships, and how that differs from 008's deliberate refusal to materialize: there, a
+-- part missing the rebuilt projection is still READ correctly (the query falls back to the
+-- base table, same rows, only slower) and parts pick it up as they merge, so skipping costs
+-- only time. Here the risk is a wrong ANSWER, and whether it bites depends on the SERVER
+-- VERSION, not the query text. A part written before 009's ALTER does not store the column;
+-- what decides whether ClickHouse computes it on read is whether the optimizer leaves the
+-- read as a WHOLE-column read (which evaluates the MATERIALIZED expression -- `SELECT
+-- metadata_map` on a pre-ALTER part returns the correctly computed map with no `metadata`
+-- in the query at all) or rewrites it into a SUBCOLUMN read, which never evaluates the
+-- default and returns the type default instead: length() 0, mapKeys() []. That rewrite is
+-- optimize_functions_to_subcolumns (default on since 24.8), and its REACH grows by release.
+-- On 25.2, the version we pin, it covers select-list length/mapKeys/mapContains -- shapes
+-- we do not ship -- while WHERE-context mapContains and metadata_map[key] stay ordinary
+-- functions, so every read #1833 ships answers correctly on pre-ALTER parts (verified on
+-- 25.2.2.39 against this file's expression, Wide and Compact parts, native and HTTP for the
+-- filter shape). On 26.3 the rewrite also reaches metadata_map[key] and the WHERE context,
+-- and there the shipped trace-half predicate `mapContains(metadata_map, key) AND
+-- metadata_map[key] = value` matches ZERO rows on a pre-ALTER part, even when the query
+-- also selects `metadata` (verified on 26.3.17.110); the span semi-join and key discovery
+-- still answer correctly on both versions, because their subqueries project the whole
+-- column. Merges do bake the stored column into parts they rewrite, but settled partitions
+-- may never merge again, so history does not converge on its own. So 010 is not fixing a
+-- wrong answer the pinned server gives today. It is what makes old history's answers
+-- survive a ClickHouse upgrade (>= 26.x silently flips inline filters on unmaterialized
+-- parts from correct to empty), keeps ad-hoc and future subcolumn-shaped reads honest, and
+-- spares every old-part read a per-row JSON parse of the blob.
 --
 -- The deploy-time hazard: the mutation is asynchronous (mutations_sync=0 by default), so the
 -- statements return as soon as it is QUEUED. History becomes filterable gradually in the
 -- background, unthrottled, competing with live ingestion -- and goose records the version as
--- applied at the moment of queueing, not completion. A mutation that never finishes, killed
--- by a restart, disk pressure, or a deliberate KILL MUTATION, leaves history permanently
--- unbackfilled, with nothing signalling it and no goose re-run, since the version counts as
+-- applied at the moment of queueing, not completion. The mutation itself is durable table
+-- metadata: a restart RESUMES it (verified -- a queued MATERIALIZE COLUMN survived a server
+-- restart and completed unprompted), and a failing one retries forever with the error in
+-- system.mutations.latest_fail_reason. What abandons it permanently is KILL MUTATION -- and
+-- nothing signals that afterwards or re-runs goose, since the version already counts as
 -- applied.
 --
 -- So verify rather than assume, on the first deploy that applies this file:

--- a/backend/db/clickhouse/migrations/010_materialize_metadata_map.sql
+++ b/backend/db/clickhouse/migrations/010_materialize_metadata_map.sql
@@ -14,12 +14,23 @@
 -- there, a part missing the rebuilt projection is still READ correctly (the query falls back
 -- to the base table, same rows, only slower) and parts pick it up as they merge, so skipping
 -- costs only time. Here, skipping is a wrong ANSWER and nothing arrives on its own. A part
--- written before 009's ALTER does not store the column, and ClickHouse computes it on read
--- ONLY when the query also reads `metadata` -- which ours never do, since reading the blob is
--- the cost this column exists to avoid. So the map reads back EMPTY rather than computed: no
--- error, just a trace that answers every metadata filter as though it carried no metadata.
--- Verified on ClickHouse 25.2 against a pre-ALTER row, where selecting the map alone returns
--- length 0 and selecting it alongside `metadata` returns length 1.
+-- written before 009's ALTER does not store the column, and what decides whether ClickHouse
+-- computes it on read is not whether the query also reads `metadata` -- it is whether the
+-- read is a WHOLE-column read or a subcolumn one. Several of our reads DO take the blob --
+-- trace detail, the per-span and bulk I/O fetches, and `SELECT *` in the internal router --
+-- and that is not what settles the answer either way. `SELECT metadata_map` on a pre-ALTER
+-- part returns the correctly computed map with no `metadata` in the query at all. But
+-- length(metadata_map), metadata_map[key], mapContains() and mapKeys() all read back EMPTY:
+-- optimize_functions_to_subcolumns rewrites them into subcolumn reads, and a subcolumn read
+-- never evaluates the default expression. Naming `metadata` in the same SELECT list does
+-- restore correct values for those expressions -- but it does not rescue the read shape we
+-- actually ship. `mapContains(metadata_map, key) AND metadata_map[key] = value` in a WHERE
+-- matches ZERO rows even when the query also selects `metadata`, because the filter stage
+-- reads the subcolumns before the blob column enters the block. That predicate is exactly
+-- what #1833 ships, so a pre-009 part answers a metadata filter with no error and no rows:
+-- a trace that behaves as though it carried no metadata. Reproduced on ClickHouse 26.3.3
+-- against a pre-ALTER row; optimize_functions_to_subcolumns has defaulted on since 24.8, so
+-- the 25.2 server we pin behaves the same way.
 --
 -- The deploy-time hazard: the mutation is asynchronous (mutations_sync=0 by default), so the
 -- statements return as soon as it is QUEUED. History becomes filterable gradually in the

--- a/backend/db/clickhouse/migrations/010_materialize_metadata_map.sql
+++ b/backend/db/clickhouse/migrations/010_materialize_metadata_map.sql
@@ -1,0 +1,52 @@
+-- +goose Up
+
+-- Rewrite pre-009 parts so they STORE metadata_map, making existing history answer metadata
+-- filters, render the metadata column, and contribute discovered keys.
+--
+-- Split from 009 because the two halves have different costs and failure modes, NOT because
+-- this half is optional. Both deploy paths run goose over the whole migrations directory --
+-- docker-compose's `migrate-clickhouse` service, which every app service gates on with
+-- `service_completed_successfully`, and the helm post-install/pre-upgrade Job -- so this runs
+-- automatically and unattended wherever 009 runs. There is no low-traffic window to choose
+-- and no supported way to hold it back.
+--
+-- Why it is required, and how that differs from 008's deliberate refusal to materialize:
+-- there, a part missing the rebuilt projection is still READ correctly (the query falls back
+-- to the base table, same rows, only slower) and parts pick it up as they merge, so skipping
+-- costs only time. Here, skipping is a wrong ANSWER and nothing arrives on its own. A part
+-- written before 009's ALTER does not store the column, and ClickHouse computes it on read
+-- ONLY when the query also reads `metadata` -- which ours never do, since reading the blob is
+-- the cost this column exists to avoid. So the map reads back EMPTY rather than computed: no
+-- error, just a trace that answers every metadata filter as though it carried no metadata.
+-- Verified on ClickHouse 25.2 against a pre-ALTER row, where selecting the map alone returns
+-- length 0 and selecting it alongside `metadata` returns length 1.
+--
+-- The deploy-time hazard: the mutation is asynchronous (mutations_sync=0 by default), so the
+-- statements return as soon as it is QUEUED. History becomes filterable gradually in the
+-- background, unthrottled, competing with live ingestion -- and goose records the version as
+-- applied at the moment of queueing, not completion. A mutation that never finishes, killed
+-- by a restart, disk pressure, or a deliberate KILL MUTATION, leaves history permanently
+-- unbackfilled, with nothing signalling it and no goose re-run, since the version counts as
+-- applied.
+--
+-- So verify rather than assume, on the first deploy that applies this file:
+--   SELECT * FROM system.mutations WHERE table IN ('spans','traces') AND NOT is_done;
+-- Empty means the rewrite finished. A lingering row is in progress; a non-empty
+-- latest_fail_reason is the case above. Recovery is to re-issue the statement by hand --
+-- MATERIALIZE COLUMN is idempotent -- so the lack of a goose re-run path costs nothing but
+-- the noticing. An install large enough that the one-shot rewrite is itself the problem can
+-- re-drive it per partition, newest first, accepting that older partitions answer empty until
+-- their turn:
+--   ALTER TABLE spans MATERIALIZE COLUMN metadata_map IN PARTITION '202607';
+
+ALTER TABLE spans  MATERIALIZE COLUMN metadata_map;
+ALTER TABLE traces MATERIALIZE COLUMN metadata_map;
+
+-- +goose Down
+
+-- Deliberately a no-op. There is no inverse that un-stores a value the expression already
+-- defines, and un-storing it would change no answer, since a stored map and a computed map
+-- are the same map. The reversible half of this feature is 009's DROP COLUMN, so rolling back
+-- means rolling back past 009. The statement below exists only to give goose something to
+-- execute.
+SELECT 1;

--- a/tests/db/test_client.py
+++ b/tests/db/test_client.py
@@ -1,12 +1,41 @@
 """Unit tests for ClickHouseClient row-building logic.
 
 Tests row construction without a real ClickHouse connection.
+
+Values are read out of a row BY COLUMN NAME rather than by a hardcoded index. The insert
+is positional: clickhouse-connect zips the row tuple against ``column_names``, so a value
+inserted at the wrong offset is written into a neighbouring column of the same type with
+no error anywhere. Looking each value up through the column list is what turns that
+silent corruption into a failing assertion.
 """
 
 from datetime import datetime
+from typing import Any
 from unittest.mock import MagicMock
 
 from db.clickhouse.client import ClickHouseClient
+
+
+def _insert_call(mock_internal: MagicMock) -> tuple[str, list[Any], list[str]]:
+    """Unpack the single recorded insert into (table, row, column_names).
+
+    Also asserts the row is exactly as wide as the column list, since a width mismatch
+    is what shifts every subsequent value into the wrong column.
+    """
+    mock_internal.insert.assert_called_once()
+    call_args = mock_internal.insert.call_args
+    table = call_args[0][0]
+    rows = call_args[0][1]
+    columns = call_args[1]["column_names"]
+    assert len(rows) == 1
+    assert len(rows[0]) == len(columns), "row is not as wide as column_names"
+    return table, rows[0], columns
+
+
+def _value(row: list[Any], columns: list[str], name: str) -> Any:
+    """The row value written into the named column."""
+    assert name in columns, f"{name} is not an insert column"
+    return row[columns.index(name)]
 
 
 class TestInsertTracesBatch:
@@ -32,32 +61,61 @@ class TestInsertTracesBatch:
         ]
         client.insert_traces_batch(traces)
 
-        mock_internal.insert.assert_called_once()
-        call_args = mock_internal.insert.call_args
-        table = call_args[0][0]
-        rows = call_args[0][1]
-        columns = call_args[1]["column_names"]
+        table, row, columns = _insert_call(mock_internal)
 
         assert table == "traces"
-        assert len(rows) == 1
-        row = rows[0]
-        assert row[0] == "trace-1"  # trace_id
-        assert row[1] == "proj-1"  # project_id
-        assert row[3] == "test-trace"  # name
-        assert row[4] == "user"  # source (default)
-        assert row[5] == "user-1"  # user_id
-        assert row[6] == "sess-1"  # session_id
-        assert row[7] == "abc123"  # git_ref
-        assert row[8] == "owner/repo"  # git_repo
-        assert row[9] == "hello"  # input
-        assert row[10] == "world"  # output
-        assert row[11] is None  # metadata
+        assert _value(row, columns, "trace_id") == "trace-1"
+        assert _value(row, columns, "project_id") == "proj-1"
+        assert _value(row, columns, "name") == "test-trace"
+        assert _value(row, columns, "source") == "user"
+        assert _value(row, columns, "environment") == "production"
+        assert _value(row, columns, "user_id") == "user-1"
+        assert _value(row, columns, "session_id") == "sess-1"
+        assert _value(row, columns, "git_ref") == "abc123"
+        assert _value(row, columns, "git_repo") == "owner/repo"
+        assert _value(row, columns, "input") == "hello"
+        assert _value(row, columns, "output") == "world"
+        assert _value(row, columns, "metadata") is None
         # ch_create_time and ch_update_time are auto-set
-        assert isinstance(row[12], datetime)
-        assert isinstance(row[13], datetime)
-        assert len(columns) == 15
-        assert "environment" in columns
-        assert row[columns.index("environment")] == "production"
+        assert isinstance(_value(row, columns, "ch_create_time"), datetime)
+        assert isinstance(_value(row, columns, "ch_update_time"), datetime)
+
+    def test_column_names_are_the_traces_schema_in_order(self):
+        """Pin the written column list. The insert is positional, so the order here is
+        half of the contract with the row builder; a column added to one side only would
+        otherwise shift every value after it into its neighbour."""
+        mock_internal = MagicMock()
+        client = ClickHouseClient(mock_internal)
+
+        client.insert_traces_batch(
+            [
+                {
+                    "trace_id": "trace-1",
+                    "project_id": "proj-1",
+                    "trace_start_time": datetime(2024, 1, 15, 12, 0, 0),
+                    "name": "test-trace",
+                }
+            ]
+        )
+
+        _table, _row, columns = _insert_call(mock_internal)
+        assert columns == [
+            "trace_id",
+            "project_id",
+            "trace_start_time",
+            "name",
+            "source",
+            "user_id",
+            "session_id",
+            "git_ref",
+            "git_repo",
+            "input",
+            "output",
+            "metadata",
+            "ch_create_time",
+            "ch_update_time",
+            "environment",
+        ]
 
     def test_empty_batch_no_insert(self):
         """Empty list -> no _client.insert() call."""
@@ -147,32 +205,73 @@ class TestInsertSpansBatch:
         ]
         client.insert_spans_batch(spans)
 
-        mock_internal.insert.assert_called_once()
-        call_args = mock_internal.insert.call_args
-        table = call_args[0][0]
-        rows = call_args[0][1]
-        columns = call_args[1]["column_names"]
+        table, row, columns = _insert_call(mock_internal)
 
         assert table == "spans"
-        assert len(rows) == 1
-        row = rows[0]
-        assert row[0] == "span-1"  # span_id
-        assert row[1] == "trace-1"  # trace_id
-        assert row[2] is None  # parent_span_id
-        assert row[3] == "proj-1"  # project_id
-        assert row[7] == "LLM"  # span_kind
-        assert row[8] == "user"  # source (default)
-        assert row[11] == "gpt-4o"  # model_name
-        assert row[12] == 0.005  # cost
-        assert row[13] == 100  # input_tokens
-        assert row[14] == 50  # output_tokens
-        assert row[15] == 150  # total_tokens
-        # 3 fixed breakdown columns collapsed into one usage_details map (net -2),
-        # then source and environment added.
-        assert len(columns) == 26
+        assert _value(row, columns, "span_id") == "span-1"
+        assert _value(row, columns, "trace_id") == "trace-1"
+        assert _value(row, columns, "parent_span_id") is None
+        assert _value(row, columns, "project_id") == "proj-1"
+        assert _value(row, columns, "span_kind") == "LLM"
+        assert _value(row, columns, "source") == "user"
+        assert _value(row, columns, "model_name") == "gpt-4o"
+        assert _value(row, columns, "cost") == 0.005
+        assert _value(row, columns, "input_tokens") == 100
+        assert _value(row, columns, "output_tokens") == 50
+        assert _value(row, columns, "total_tokens") == 150
         assert "usage_details" in columns
         assert "environment" in columns
         assert row[columns.index("environment")] == "production"
+
+    def test_column_names_are_the_spans_schema_in_order(self):
+        """Pin the written column list, for the same positional reason as the traces
+        insert. (The three fixed token-breakdown columns are collapsed into the single
+        usage_details map.)"""
+        mock_internal = MagicMock()
+        client = ClickHouseClient(mock_internal)
+
+        client.insert_spans_batch(
+            [
+                {
+                    "span_id": "span-1",
+                    "trace_id": "trace-1",
+                    "project_id": "proj-1",
+                    "span_start_time": datetime(2024, 1, 15, 12, 0, 0),
+                    "name": "test-span",
+                    "span_kind": "LLM",
+                }
+            ]
+        )
+
+        _table, _row, columns = _insert_call(mock_internal)
+        assert columns == [
+            "span_id",
+            "trace_id",
+            "parent_span_id",
+            "project_id",
+            "span_start_time",
+            "span_end_time",
+            "name",
+            "span_kind",
+            "source",
+            "status",
+            "status_message",
+            "model_name",
+            "cost",
+            "input_tokens",
+            "output_tokens",
+            "total_tokens",
+            "usage_details",
+            "input",
+            "output",
+            "metadata",
+            "git_source_file",
+            "git_source_line",
+            "git_source_function",
+            "ch_create_time",
+            "ch_update_time",
+            "environment",
+        ]
 
     def test_optional_fields_none(self):
         """None values for optional fields (cost, tokens)."""
@@ -191,17 +290,16 @@ class TestInsertSpansBatch:
         ]
         client.insert_spans_batch(spans)
 
-        row = mock_internal.insert.call_args[0][1][0]
-        assert row[2] is None  # parent_span_id
-        assert row[5] is None  # span_end_time
-        assert row[10] is None  # status_message
-        assert row[11] is None  # model_name
-        assert row[12] is None  # cost
-        assert row[13] is None  # input_tokens
-        assert row[14] is None  # output_tokens
-        assert row[15] is None  # total_tokens
-        columns = mock_internal.insert.call_args[1]["column_names"]
-        assert row[columns.index("environment")] is None
+        _table, row, columns = _insert_call(mock_internal)
+        assert _value(row, columns, "parent_span_id") is None
+        assert _value(row, columns, "span_end_time") is None
+        assert _value(row, columns, "status_message") is None
+        assert _value(row, columns, "model_name") is None
+        assert _value(row, columns, "cost") is None
+        assert _value(row, columns, "input_tokens") is None
+        assert _value(row, columns, "output_tokens") is None
+        assert _value(row, columns, "total_tokens") is None
+        assert _value(row, columns, "environment") is None
 
     def test_source_passthrough_and_default(self):
         """Spans carry their source through; spans without one write 'user'."""
@@ -235,3 +333,57 @@ class TestInsertSpansBatch:
         assert rows[0][source_idx] == "detector"
         assert rows[1][source_idx] == "user"
         assert all(len(row) == len(columns) for row in rows)
+
+
+class TestDerivedColumnsAreNotInserted:
+    """The queryable metadata map is derived in ClickHouse, so the writer never sends it.
+
+    Naming a materialized column in an explicit INSERT column list is rejected outright,
+    which would fail EVERY insert in the batch — including the deploy window where a
+    writer that names the column ships ahead of the migration that adds it. Deriving the
+    map in one place also removes the second spelling of it that a Python twin would keep
+    in step only by convention.
+    """
+
+    def test_traces_insert_does_not_name_the_derived_map(self):
+        mock_internal = MagicMock()
+        client = ClickHouseClient(mock_internal)
+
+        client.insert_traces_batch(
+            [
+                {
+                    "trace_id": "trace-1",
+                    "project_id": "proj-1",
+                    "trace_start_time": datetime(2024, 1, 15, 12, 0, 0),
+                    "name": "test-trace",
+                    "metadata": '{"experiment": "v2"}',
+                }
+            ]
+        )
+
+        _table, row, columns = _insert_call(mock_internal)
+        assert "metadata_map" not in columns
+        # The blob the map is derived from is still written.
+        assert _value(row, columns, "metadata") == '{"experiment": "v2"}'
+
+    def test_spans_insert_does_not_name_the_derived_map(self):
+        mock_internal = MagicMock()
+        client = ClickHouseClient(mock_internal)
+
+        client.insert_spans_batch(
+            [
+                {
+                    "span_id": "span-1",
+                    "trace_id": "trace-1",
+                    "project_id": "proj-1",
+                    "span_start_time": datetime(2024, 1, 15, 12, 0, 0),
+                    "name": "test-span",
+                    "span_kind": "LLM",
+                    "metadata": '{"session_id": "s-1"}',
+                }
+            ]
+        )
+
+        _table, row, columns = _insert_call(mock_internal)
+        assert "metadata_map" not in columns
+        assert _value(row, columns, "metadata") == '{"session_id": "s-1"}'

--- a/tests/db/test_migration_versions_are_unique.py
+++ b/tests/db/test_migration_versions_are_unique.py
@@ -1,0 +1,134 @@
+"""Guards that no two ClickHouse migrations claim the same goose version.
+
+goose identifies a migration by the numeric prefix of its filename, so two
+files sharing a prefix are a fatal collision: `goose: duplicate version 9
+detected` is raised inside `Migrations.Less` while migrations are collected
+off disk, before the database is ever dialed. Every migration then fails,
+not just the colliding pair, and anything gated on the migrate container
+(`service_completed_successfully`, the helm pre-upgrade hook) stalls with it.
+
+Git will not catch this: two branches adding `009_a.sql` and `009_b.sql`
+merge cleanly because the filenames differ. Versions are parsed here the way
+goose parses them rather than listed literally, so a migration added later is
+covered without touching this file.
+"""
+
+import re
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+
+MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[2] / "backend" / "db" / "clickhouse" / "migrations"
+)
+
+VERSION_PREFIX = re.compile(r"^(\d+)_")
+
+
+def _goose_version(filename: str) -> int | None:
+    """Parse the goose version out of a migration filename.
+
+    Mirrors goose's own rule: the digits before the first underscore, read
+    as an integer that must be greater than zero. Reading it as an integer
+    (not as text) is what makes `009_x.sql` and `9_y.sql` the same version,
+    exactly as goose sees them.
+
+    Args:
+        filename (str): Bare migration filename, e.g. `009_add_metadata_map.sql`.
+
+    Returns:
+        int | None: The version, or None if goose could not parse one.
+    """
+    match = VERSION_PREFIX.match(filename)
+    if match is None:
+        return None
+    version = int(match.group(1))
+    return version if version > 0 else None
+
+
+def _duplicate_versions(filenames: Iterable[str]) -> dict[int, list[str]]:
+    """Find versions claimed by more than one migration filename.
+
+    Args:
+        filenames (Iterable[str]): Bare migration filenames.
+
+    Returns:
+        dict[int, list[str]]: Colliding version to the filenames claiming it,
+            both ordered so the failure message is stable.
+    """
+    by_version: dict[int, list[str]] = defaultdict(list)
+    for name in filenames:
+        version = _goose_version(name)
+        if version is not None:
+            by_version[version].append(name)
+    return {
+        version: sorted(names) for version, names in sorted(by_version.items()) if len(names) > 1
+    }
+
+
+def test_goose_version_reads_the_numeric_prefix():
+    """Zero padding is insignificant and an unparseable name yields no version."""
+    assert _goose_version("009_add_metadata_map.sql") == 9
+    assert _goose_version("9_add_metadata_map.sql") == 9
+    assert _goose_version("010_materialize_metadata_map.sql") == 10
+    assert _goose_version("add_metadata_map.sql") is None
+    assert _goose_version("000_zeroth.sql") is None
+
+
+def test_duplicate_versions_reports_every_colliding_filename():
+    """Distinct filenames sharing one version are grouped under that version."""
+    duplicates = _duplicate_versions(
+        [
+            "008_add_source_to_spans_projection.sql",
+            "009_add_metadata_map.sql",
+            "009_partition_detector_tables_by_month.sql",
+            "9_partition_detector_tables_by_month.sql",
+            "010_materialize_metadata_map.sql",
+        ]
+    )
+    assert duplicates == {
+        9: [
+            "009_add_metadata_map.sql",
+            "009_partition_detector_tables_by_month.sql",
+            "9_partition_detector_tables_by_month.sql",
+        ]
+    }
+
+
+def test_duplicate_versions_accepts_gaps_and_unordered_input():
+    """Gaps and out-of-order files are legitimate; only collisions are reported."""
+    assert _duplicate_versions(["005_e.sql", "001_a.sql", "042_f.sql"]) == {}
+
+
+def test_every_migration_filename_carries_a_goose_version():
+    """No migration escapes the uniqueness check by being unparseable.
+
+    goose refuses to collect a file it cannot version, so a misnamed
+    migration is broken on its own account, and it would also slip past
+    the duplicate check below unnoticed.
+    """
+    migration_files = sorted(MIGRATIONS_DIR.glob("*.sql"))
+    assert migration_files, f"no migrations found in {MIGRATIONS_DIR}"
+
+    unversioned = [path.name for path in migration_files if _goose_version(path.name) is None]
+    assert not unversioned, (
+        "every migration filename must start with a positive version number followed by "
+        f"'_', as goose parses it; these do not: {unversioned}"
+    )
+
+
+def test_migration_versions_are_unique():
+    """Every migration on disk claims a version no other migration claims."""
+    migration_files = sorted(MIGRATIONS_DIR.glob("*.sql"))
+    assert migration_files, f"no migrations found in {MIGRATIONS_DIR}"
+
+    duplicates = _duplicate_versions(path.name for path in migration_files)
+    collisions = "; ".join(
+        f"version {version} is claimed by {' and '.join(names)}"
+        for version, names in duplicates.items()
+    )
+    assert not duplicates, (
+        f"duplicate migration versions in {MIGRATIONS_DIR}: {collisions}. "
+        "goose panics with 'duplicate version N detected' and every migration fails, "
+        "not just these. Renumber the newer file to the next unused version."
+    )


### PR DESCRIPTION
Closes #1824 

## Summary

Makes user metadata filterable by deriving a Map column from the JSON already stored,
rather than by changing what ingestion writes.

- **009** adds `metadata_map Map(LowCardinality(String), String)` `MATERIALIZED` on both
  `spans` and `traces`, computed from the existing `metadata` blob: one level deep, keys in
  the `traceroot.` namespace dropped, a JSON string value stored unquoted and every other
  value stored as its raw JSON text. One expression on both tables, so a column and a
  filter agree on what a key is called and what its value looks like.
- **`MATERIALIZED`, not `DEFAULT`**: an INSERT may not name a materialized column, so
  ingestion cannot write a value of its own and a second implementation is unrepresentable.
  It also removes a deploy-ordering trap — there is no insert column list that could name
  the column and fail all ingestion when the worker ships ahead of the migration.
  `SELECT *` is unchanged, since materialized columns are excluded from it.
- **Nothing about the write path or either SDK changes.** History becomes filterable once
  backfilled.
- **010** runs `MATERIALIZE COLUMN` on both tables. This is required, not an optimization:
  a part written before 009 computes the map only when the query also reads `metadata`, and
  none of our read paths do — reading the blob is the cost this column exists to avoid — so
  an unmaterialized part reads back an **empty** map with no error.
- The spans no-I/O projection is deliberately left alone. Including the column would not
  put user metadata on the unfiltered list query's path (a query reads only the columns it
  names); the real cost is storage and write amplification on the largest table. The price
  is that a span-scope metadata predicate cannot use that projection and falls back to the
  base table — written down in 009, with the shape of the follow-up if it ever measures
  badly.
- `tests/db/test_client.py` now reads inserted rows **by column name** and pins the written
  column list. The insert is positional — a value at the wrong offset is written into a
  neighbouring column of the same type with no error anywhere — and the column list is
  exactly what the `MATERIALIZED` choice depends on staying free of `metadata_map`.

## Type of Change

- [x] feat - A new feature

## Details

Both migration files are on the migration path and run unattended on every deploy
(`migrate-clickhouse` in compose, the helm migration Job), so there is no low-traffic
window to pick and no supported way to hold 010 back. Applying 009 alone is still a
complete, safe deploy: ingestion is unchanged and every metadata surface answers correctly
for data ingested from that point; only history stays blank.

010's mutation is asynchronous, so the statements return as soon as the rewrite is
**queued** and goose records the version as applied at that moment. On the first deploy
that applies it, verify rather than assume:

```sql
SELECT * FROM system.mutations WHERE table IN ('spans','traces') AND NOT is_done;
```

Empty means the rewrite finished. A lingering row with a non-empty `latest_fail_reason` is
the case where history stays permanently blank with nothing signalling it — recovery is
re-issuing the statement by hand, which is safe because `MATERIALIZE COLUMN` is idempotent.
A large install can re-drive it per partition, newest first.

Rollback: 009's Down drops both columns. 010's Down is a deliberate no-op — there is no
inverse that un-stores a value the expression already defines, so rolling this back means
rolling back past 009.

No skip index on either table. Deferred, not ruled out: the predicate form we emit is the
one a `mapKeys` bloom filter could act on, but its position (above the `LIMIT 1 BY` that
dedups spans) means it would be maintained on write and never consulted. The restructure
that would make one live is written into 009 so the next person does not rediscover it.

Nothing reads the column yet — surfacing it on the list item is #1840.

## Notes

- Diff coverage: this PR is SQL plus tests, so it ships no coverage-measurable production
  lines.
- First PR of the stack for #1824. The keyed filter that consumes the column comes in
  #1833; stack 2's Metadata column PR (#1840) also waits on this one.

## Screenshots / Recordings (if applicable)

Not applicable — schema and tests only.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
