### PR TITLE
feat(ui): a column registry for the trace list

### DIFF
--- a/frontend/ui/src/features/traces/column-storage.ts
+++ b/frontend/ui/src/features/traces/column-storage.ts
@@ -1,0 +1,49 @@
+import { isFixedColumnId, type FixedColumnId } from "@/features/traces/columns";
+
+/**
+ * Per-project, per-browser persistence for the trace list's column selection.
+ * The entry holds the ids whose visibility is FLIPPED from the registry default rather than
+ * the ids that are shown, so a column added to the registry later reaches existing users
+ * without a migration.
+ *
+ * The same entry is live in every tab on the project and can be hand-edited, so a read is
+ * never trusted: `normalizeColumns` is the one gate, and anything it cannot recognise reads
+ * as "no deviation from the defaults" instead of reaching the table. Unrecognised properties
+ * on an otherwise valid entry are ignored, so an entry written by an older build keeps the
+ * field choices it holds.
+ */
+
+const STORAGE_VERSION = 1;
+
+/** The stored shape. `fields` is unvalidated on the way in — see the header. */
+export interface StoredColumns {
+  version: number;
+  /** Ids whose visibility is FLIPPED from the registry default, not the ids that are shown. */
+  fields: string[];
+}
+
+/** The entry a project starts from, and what a reset writes back. */
+export const NO_COLUMNS: StoredColumns = { version: STORAGE_VERSION, fields: [] };
+
+const NO_FIELDS: FixedColumnId[] = [];
+
+export function columnsStorageKey(projectId: string): string {
+  return `traceroot:traces:columns:v${STORAGE_VERSION}:${projectId}`;
+}
+
+function asStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+// The one gate every read and mutator passes through. Deduping belongs here, not at the
+// writes: a duplicate can arrive from another tab or a hand-edited entry, bypassing mutators.
+export function normalizeColumns(stored: unknown): FixedColumnId[] {
+  if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return NO_FIELDS;
+  const { fields } = stored as Partial<StoredColumns>;
+  return Array.from(new Set(asStringList(fields).filter(isFixedColumnId)));
+}
+
+export function toStoredColumns(fields: readonly FixedColumnId[]): StoredColumns {
+  return { version: STORAGE_VERSION, fields: [...fields] };
+}

--- a/frontend/ui/src/features/traces/columns.ts
+++ b/frontend/ui/src/features/traces/columns.ts
@@ -1,0 +1,65 @@
+// `user_id` and `session_id` must keep these spellings; earlier releases persisted them.
+export type FixedColumnId =
+  | "timestamp"
+  | "name"
+  | "trace_id"
+  | "errors"
+  | "spans"
+  | "input"
+  | "output"
+  | "user_id"
+  | "session_id"
+  | "input_usage"
+  | "output_usage"
+  | "total_usage"
+  | "tokens"
+  | "cost"
+  | "latency";
+
+export interface FixedColumn {
+  id: FixedColumnId;
+  label: string;
+  isDefaultOn: boolean;
+}
+
+export const FIXED_COLUMNS: readonly FixedColumn[] = [
+  { id: "timestamp", label: "Timestamp", isDefaultOn: true },
+  { id: "name", label: "Name", isDefaultOn: true },
+  { id: "trace_id", label: "Trace ID", isDefaultOn: true },
+  { id: "errors", label: "Errors", isDefaultOn: true },
+  { id: "spans", label: "Spans", isDefaultOn: true },
+  { id: "input", label: "Input", isDefaultOn: true },
+  { id: "output", label: "Output", isDefaultOn: true },
+  { id: "user_id", label: "User ID", isDefaultOn: false },
+  { id: "session_id", label: "Session ID", isDefaultOn: false },
+  { id: "input_usage", label: "Input usage", isDefaultOn: false },
+  { id: "output_usage", label: "Output usage", isDefaultOn: false },
+  { id: "total_usage", label: "Total usage", isDefaultOn: false },
+  { id: "tokens", label: "Tokens", isDefaultOn: true },
+  { id: "cost", label: "Cost", isDefaultOn: true },
+  { id: "latency", label: "Latency", isDefaultOn: true },
+];
+
+const FIXED_COLUMN_IDS: readonly string[] = FIXED_COLUMNS.map((column) => column.id);
+
+/**
+ * The columns to render, in registry order, for a stored set of visibility FLIPS — deviations
+ * from the defaults, not a set of shown ids, so a column added later needs no migration.
+ */
+export function visibleFixedColumns(flipped: readonly FixedColumnId[]): FixedColumnId[] {
+  return FIXED_COLUMNS.filter((column) => column.isDefaultOn !== flipped.includes(column.id)).map(
+    (column) => column.id,
+  );
+}
+
+export function isFixedColumnId(value: unknown): value is FixedColumnId {
+  return typeof value === "string" && FIXED_COLUMN_IDS.includes(value);
+}
+
+export function fixedColumnLabel(id: FixedColumnId): string {
+  return FIXED_COLUMNS.find((column) => column.id === id)?.label ?? id;
+}
+
+export function isDefaultOnColumn(id: FixedColumnId): boolean {
+  return FIXED_COLUMNS.find((column) => column.id === id)?.isDefaultOn ?? false;
+}

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -14,6 +14,9 @@ import { canonicalizeFilters } from "@/features/filters/predicate";
 // Composed state hooks
 export { useTraceListState } from "./use-trace-list-state";
 
+// Column visibility for the trace list
+export { useTraceColumns } from "./use-trace-columns";
+
 // Live trace streaming
 export { useTraceStream } from "./use-trace-stream";
 

--- a/frontend/ui/src/features/traces/hooks/use-trace-columns.test.tsx
+++ b/frontend/ui/src/features/traces/hooks/use-trace-columns.test.tsx
@@ -1,0 +1,277 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { FixedColumnId } from "@/features/traces/columns";
+import { useTraceColumns } from "./use-trace-columns";
+
+/** The per-project entry the design names, spelled out rather than imported from the module
+ * under test: a key the hook renames is a key every open tab loses, so it is pinned here. */
+const columnsKey = (projectId: string) => `traceroot:traces:columns:v1:${projectId}`;
+
+// Spelled out rather than derived from the registry, so that a change to the registry fails
+// here and gets looked at instead of being quietly absorbed by the expectation.
+const COLUMNS_BEFORE_OPT_INS: FixedColumnId[] = [
+  "timestamp",
+  "name",
+  "trace_id",
+  "errors",
+  "spans",
+  "input",
+  "output",
+];
+const COLUMNS_AFTER_OPT_INS: FixedColumnId[] = ["tokens", "cost", "latency"];
+/** The ten shown by default, in registry order. The rest of the registry is opt-in. */
+const DEFAULT_VISIBLE_COLUMNS: FixedColumnId[] = [
+  ...COLUMNS_BEFORE_OPT_INS,
+  ...COLUMNS_AFTER_OPT_INS,
+];
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(cleanup);
+
+/** Render the hook the way the traces page wires it: a project id and nothing else. The stored
+ * entry is the hook's only input, so every test sets up through storage or the hook's mutators. */
+function renderColumns(projectId = "p-1") {
+  return renderHook(() => useTraceColumns(projectId));
+}
+
+describe("useTraceColumns", () => {
+  it("starts with the ten default columns", () => {
+    const { result } = renderColumns();
+    expect(result.current.visibleColumns).toEqual(DEFAULT_VISIBLE_COLUMNS);
+  });
+
+  describe("toggling a column", () => {
+    it("shows an opt-in column at its registry position and hides it again", () => {
+      const { result } = renderColumns();
+
+      act(() => result.current.toggleField("user_id"));
+      expect(result.current.visibleColumns).toEqual([
+        ...COLUMNS_BEFORE_OPT_INS,
+        "user_id",
+        ...COLUMNS_AFTER_OPT_INS,
+      ]);
+
+      act(() => result.current.toggleField("user_id"));
+      expect(result.current.visibleColumns).toEqual(DEFAULT_VISIBLE_COLUMNS);
+    });
+
+    it("hides a column that is on by default and shows it again", () => {
+      // The half of the picker that is new: the ten that used to be permanent are toggles
+      // like any other, so the same call has to work in the hiding direction too.
+      const { result } = renderColumns();
+
+      act(() => result.current.toggleField("input"));
+      expect(result.current.visibleColumns).toEqual(
+        DEFAULT_VISIBLE_COLUMNS.filter((id) => id !== "input"),
+      );
+
+      act(() => result.current.toggleField("input"));
+      expect(result.current.visibleColumns).toEqual(DEFAULT_VISIBLE_COLUMNS);
+    });
+
+    it("resolves the visible columns in registry order however they were toggled", () => {
+      const { result } = renderColumns();
+
+      act(() => result.current.toggleField("session_id"));
+      act(() => result.current.toggleField("user_id"));
+
+      expect(result.current.visibleColumns).toEqual([
+        ...COLUMNS_BEFORE_OPT_INS,
+        "user_id",
+        "session_id",
+        ...COLUMNS_AFTER_OPT_INS,
+      ]);
+    });
+  });
+
+  describe("reset to default", () => {
+    it("restores the ten defaults, bringing hidden columns back and dropping added ones", () => {
+      const { result } = renderColumns();
+      act(() => result.current.toggleField("user_id"));
+      act(() => result.current.toggleField("input"));
+
+      act(() => result.current.reset());
+
+      expect(result.current.visibleColumns).toEqual(DEFAULT_VISIBLE_COLUMNS);
+    });
+  });
+
+  describe("persistence", () => {
+    it("restores an added column for the same project on the next load", () => {
+      const first = renderColumns();
+      act(() => first.result.current.toggleField("session_id"));
+      cleanup();
+
+      const { result } = renderColumns();
+      expect(result.current.visibleColumns).toEqual([
+        ...COLUMNS_BEFORE_OPT_INS,
+        "session_id",
+        ...COLUMNS_AFTER_OPT_INS,
+      ]);
+    });
+
+    it("restores a hidden default column as hidden on the next load", () => {
+      const first = renderColumns();
+      act(() => first.result.current.toggleField("cost"));
+      cleanup();
+
+      const { result } = renderColumns();
+      expect(result.current.visibleColumns).toEqual(
+        DEFAULT_VISIBLE_COLUMNS.filter((id) => id !== "cost"),
+      );
+    });
+
+    it("keeps each project's column set to itself", () => {
+      const first = renderColumns();
+      act(() => first.result.current.toggleField("cost"));
+      cleanup();
+
+      const { result } = renderColumns("p-2");
+      expect(result.current.visibleColumns).toEqual(DEFAULT_VISIBLE_COLUMNS);
+    });
+
+    it("writes deviations from the default, not the visible set, to the stored entry", () => {
+      // Storing flips rather than the visible set is why a column added to the registry later
+      // shows up for existing users without a migration: `input` is here for being hidden.
+      const { result } = renderColumns();
+      act(() => result.current.toggleField("user_id"));
+      act(() => result.current.toggleField("input"));
+
+      const raw = window.localStorage.getItem(columnsKey("p-1"));
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw as string)).toMatchObject({ fields: ["user_id", "input"] });
+    });
+  });
+
+  describe("a stored entry", () => {
+    // `fields` holds the ids FLIPPED from the registry default, not the ids shown: a shown-set
+    // reading would leave a user with the columns their entry names and none of the defaults.
+    function writeEntry(fields: string[]) {
+      window.localStorage.setItem(columnsKey("p-1"), JSON.stringify({ version: 1, fields }));
+    }
+
+    it("shows both default-off columns an entry names, at their registry positions", () => {
+      writeEntry(["session_id", "user_id"]);
+
+      const { result } = renderColumns();
+
+      expect(result.current.visibleColumns).toEqual([
+        ...COLUMNS_BEFORE_OPT_INS,
+        "user_id",
+        "session_id",
+        ...COLUMNS_AFTER_OPT_INS,
+      ]);
+    });
+
+    it("hides a default-on column its entry names, and keeps the rest of the defaults", () => {
+      // The direction that tells a flip list from a shown list: `input` is on by default, so
+      // naming it means hidden, where a shown-set reading would leave it and `user_id` alone.
+      writeEntry(["input", "user_id"]);
+
+      const { result } = renderColumns();
+
+      expect(result.current.visibleColumns).toEqual([
+        ...COLUMNS_BEFORE_OPT_INS.filter((id) => id !== "input"),
+        "user_id",
+        ...COLUMNS_AFTER_OPT_INS,
+      ]);
+    });
+
+    it("keeps the fields of an entry that still carries a retired metadata list", () => {
+      // Forward compatibility: entries carrying the retired per-key `metadata` list are still
+      // on disk, and voiding them would reset the field choices of everyone who has one.
+      window.localStorage.setItem(
+        columnsKey("p-1"),
+        JSON.stringify({ version: 1, fields: ["user_id"], metadata: ["tenant"] }),
+      );
+
+      const { result } = renderColumns();
+
+      expect(result.current.visibleColumns).toEqual([
+        ...COLUMNS_BEFORE_OPT_INS,
+        "user_id",
+        ...COLUMNS_AFTER_OPT_INS,
+      ]);
+    });
+  });
+
+  describe("hand-edited or stale storage", () => {
+    it.each([
+      ["an entry that is not an object", '"user_id"'],
+      ["a bare array", JSON.stringify(["user_id"])],
+      ["unparseable JSON", "{not json"],
+      ["an entry whose list is not an array", JSON.stringify({ version: 1, fields: "user_id" })],
+    ])("reads %s as no deviations from the defaults", (_case, raw) => {
+      window.localStorage.setItem(columnsKey("p-1"), raw);
+
+      const { result } = renderColumns();
+
+      expect(result.current.visibleColumns).toEqual(DEFAULT_VISIBLE_COLUMNS);
+    });
+
+    it("reads a repeated id as one column", () => {
+      // The table renders one column per entry, so a repeat becomes two identical headers
+      // over two identical cells. First occurrence wins, leaving the user's order untouched.
+      window.localStorage.setItem(
+        columnsKey("p-1"),
+        JSON.stringify({ version: 1, fields: ["user_id", "session_id", "user_id"] }),
+      );
+
+      const { result } = renderColumns();
+
+      expect(result.current.visibleColumns).toEqual([
+        ...COLUMNS_BEFORE_OPT_INS,
+        "user_id",
+        "session_id",
+        ...COLUMNS_AFTER_OPT_INS,
+      ]);
+    });
+
+    it("ignores a stored id that is not a column, and honours the ones that are", () => {
+      // An id dropped from the registry, or a hand-edited entry, must read as "not a
+      // column" rather than reaching the table as an empty header.
+      window.localStorage.setItem(
+        columnsKey("p-1"),
+        JSON.stringify({ version: 1, fields: ["user_id", "not_a_column"] }),
+      );
+
+      const { result } = renderColumns();
+
+      expect(result.current.visibleColumns).toEqual([
+        ...COLUMNS_BEFORE_OPT_INS,
+        "user_id",
+        ...COLUMNS_AFTER_OPT_INS,
+      ]);
+    });
+
+    it("cleans up an entry another tab writes while this list is open", () => {
+      // The hook is not the only writer — the key is live in every tab on the project — so the
+      // read is the gate, and the duplicate and the number are gone before the table sees them.
+      const { result } = renderColumns();
+      expect(result.current.visibleColumns).toEqual(DEFAULT_VISIBLE_COLUMNS);
+
+      act(() => {
+        window.localStorage.setItem(
+          columnsKey("p-1"),
+          JSON.stringify({ version: 1, fields: ["user_id", "user_id", 7] }),
+        );
+        window.dispatchEvent(
+          new StorageEvent("storage", {
+            key: columnsKey("p-1"),
+            storageArea: window.localStorage,
+          }),
+        );
+      });
+
+      expect(result.current.visibleColumns).toEqual([
+        ...COLUMNS_BEFORE_OPT_INS,
+        "user_id",
+        ...COLUMNS_AFTER_OPT_INS,
+      ]);
+    });
+  });
+});

--- a/frontend/ui/src/features/traces/hooks/use-trace-columns.test.tsx
+++ b/frontend/ui/src/features/traces/hooks/use-trace-columns.test.tsx
@@ -273,5 +273,25 @@ describe("useTraceColumns", () => {
         ...COLUMNS_AFTER_OPT_INS,
       ]);
     });
+
+    it("keeps a column another tab added when the storage event has not arrived yet", () => {
+      // A tab writes localStorage synchronously and its `storage` event reaches the other tabs
+      // afterwards, so there is a window where this tab's state is a version behind the entry.
+      // Toggling in that window has to flip what is on disk: flipping the stale state instead
+      // would write back a selection with the other tab's column silently dropped.
+      const { result } = renderColumns();
+
+      window.localStorage.setItem(
+        columnsKey("p-1"),
+        JSON.stringify({ version: 1, fields: ["user_id"] }),
+      );
+
+      act(() => result.current.toggleField("session_id"));
+
+      expect(JSON.parse(window.localStorage.getItem(columnsKey("p-1")) ?? "null")).toEqual({
+        version: 1,
+        fields: ["user_id", "session_id"],
+      });
+    });
   });
 });

--- a/frontend/ui/src/features/traces/hooks/use-trace-columns.ts
+++ b/frontend/ui/src/features/traces/hooks/use-trace-columns.ts
@@ -1,0 +1,51 @@
+"use client";
+
+/**
+ * Column visibility for the trace list, persisted per project. The list shows fixed registry
+ * columns only: which ones is entirely the user's choice in the column picker, and nothing
+ * else — a filter included — puts a column on screen.
+ */
+import { useCallback, useMemo } from "react";
+import { useLocalStorage } from "@/lib/hooks/use-local-storage";
+import { visibleFixedColumns, type FixedColumnId } from "@/features/traces/columns";
+import {
+  columnsStorageKey,
+  normalizeColumns,
+  toStoredColumns,
+  NO_COLUMNS,
+  type StoredColumns,
+} from "@/features/traces/column-storage";
+
+export interface UseTraceColumnsReturn {
+  /** Fixed columns to render, already resolved against the defaults, in registry order. */
+  visibleColumns: FixedColumnId[];
+  toggleField: (id: FixedColumnId) => void;
+  reset: () => void;
+}
+
+export function useTraceColumns(projectId: string): UseTraceColumnsReturn {
+  const [stored, setStored] = useLocalStorage<StoredColumns>(
+    columnsStorageKey(projectId),
+    NO_COLUMNS,
+  );
+
+  const visibleColumns = useMemo(() => visibleFixedColumns(normalizeColumns(stored)), [stored]);
+
+  const toggleField = useCallback(
+    (id: FixedColumnId) => {
+      // Normalizes the previous entry rather than the rendered selection: the entry is live in
+      // every tab on the project, so the value being flipped has to be the one on disk now.
+      setStored((previous) => {
+        const flipped = normalizeColumns(previous);
+        return toStoredColumns(
+          flipped.includes(id) ? flipped.filter((existing) => existing !== id) : [...flipped, id],
+        );
+      });
+    },
+    [setStored],
+  );
+
+  const reset = useCallback(() => setStored(NO_COLUMNS), [setStored]);
+
+  return { visibleColumns, toggleField, reset };
+}

--- a/frontend/ui/src/features/traces/hooks/use-trace-columns.ts
+++ b/frontend/ui/src/features/traces/hooks/use-trace-columns.ts
@@ -6,7 +6,7 @@
  * else — a filter included — puts a column on screen.
  */
 import { useCallback, useMemo } from "react";
-import { useLocalStorage } from "@/lib/hooks/use-local-storage";
+import { readStored, useLocalStorage } from "@/lib/hooks/use-local-storage";
 import { visibleFixedColumns, type FixedColumnId } from "@/features/traces/columns";
 import {
   columnsStorageKey,
@@ -33,16 +33,26 @@ export function useTraceColumns(projectId: string): UseTraceColumnsReturn {
 
   const toggleField = useCallback(
     (id: FixedColumnId) => {
-      // Normalizes the previous entry rather than the rendered selection: the entry is live in
-      // every tab on the project, so the value being flipped has to be the one on disk now.
-      setStored((previous) => {
-        const flipped = normalizeColumns(previous);
-        return toStoredColumns(
-          flipped.includes(id) ? flipped.filter((existing) => existing !== id) : [...flipped, id],
-        );
-      });
+      // Flips the entry on disk rather than the rendered selection. The entry is live in every
+      // tab on the project, and `useLocalStorage` only catches up on a `storage` event, which
+      // the writing tab queues rather than delivering with the write — so between another tab's
+      // toggle and that event this tab's state is a version behind, and flipping it would write
+      // back a selection missing that tab's column.
+      //
+      // Read here rather than inside the setter's updater: StrictMode invokes an updater twice
+      // and the setter persists on every call, so a read inside it would see its own first write
+      // and flip the value straight back. `stored` is the fallback so that a browser where
+      // storage is unavailable keeps toggling against the in-session value.
+      const current = normalizeColumns(
+        readStored<StoredColumns>(columnsStorageKey(projectId), stored),
+      );
+      setStored(
+        toStoredColumns(
+          current.includes(id) ? current.filter((existing) => existing !== id) : [...current, id],
+        ),
+      );
     },
-    [setStored],
+    [projectId, setStored, stored],
   );
 
   const reset = useCallback(() => setStored(NO_COLUMNS), [setStored]);


### PR DESCRIPTION
Closes #1825 

## Summary

The trace list's column set expressed as data, so that adding a column later is a registry
entry rather than a change to the table's markup. No UI in this PR.

- `features/traces/columns.ts` — 15 fixed columns, each an id, a label, and `isDefaultOn`.
  The ten the list renders today are default-on; five (User ID, Session ID, Input usage,
  Output usage, Total usage) are default-off and, as of this PR, have no way to be turned
  on.
- `visibleFixedColumns` resolves a stored selection into the columns to render, in registry
  order.
- `column-storage.ts` persists, per project and per browser, the ids whose visibility is
  **flipped from the registry default** — not the set that is shown. That is the deliberate
  choice #1825 asks for: a column added to the registry later reaches existing users at its
  intended default with no migration of anyone's stored preference.
- `normalizeColumns` is the single gate every read and every mutator passes through. The
  entry is live in every tab on the project and can be hand-edited, so a read is never
  trusted: anything unrecognisable reads as "no deviation from the defaults" rather than
  reaching the table, unknown ids are dropped, and duplicates are deduped there rather than
  at the writes.
- `useTraceColumns(projectId)` exposes `visibleColumns`, `toggleField`, and `reset`. The
  toggle normalizes the **entry on disk**, not the rendered selection, so a change made in
  another tab is not clobbered by a stale render.

## Type of Change

- [x] feat - A new feature

## Details

Unrecognised properties on an otherwise valid entry are ignored, so an entry written by an
older build keeps the field choices it holds.

The `FixedColumnId` union is the registry's own ids, so a table renderer keyed on it becomes
a compile error the moment an id is added or renamed — that is what the extraction PR
depends on.

Tests: the storage normalizer (non-object, array, missing `fields`, non-string entries,
unknown ids, duplicates), `visibleFixedColumns` against defaults and flips, and the hook's
toggle/reset behavior including the read-then-flip path.

## Notes

- First of four PRs for #1825. Nothing imports the hook yet; the table extraction is
  #1838, the picker #1839, and the Metadata column #1840.
- Storage is per project and per browser (local storage), not synced server-side. #1825 asks
  for per-project, which this satisfies; a synced preference would be a different feature.

## Screenshots / Recordings (if applicable)

Not applicable — no rendered change in this PR.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
