### PR TITLE
refactor(rest): split trace discovery out of the trace reader

### DIFF
--- a/backend/db/clickhouse/query_settings.py
+++ b/backend/db/clickhouse/query_settings.py
@@ -1,0 +1,53 @@
+"""Per-query execution bounds shared by every ClickHouse read path.
+
+One definition of "how a read may execute", so no read surface can end up less
+bounded than its siblings. These are the ``settings`` channel documented on
+``ClickHouseClient.query`` — server-side execution policy for a single query,
+never data — and they are deliberately separate from the SQL each caller
+compiles.
+
+Every read behind an interactive surface is the same shape: a project-scoped,
+time-windowed scan or GROUP BY answering a UI control or list. There is no
+reason for two of them to expire or spill at different points, so they share
+one mapping rather than each carrying its own copy.
+"""
+
+from types import MappingProxyType
+from typing import Any
+
+# A read that is slow is already useless to the surface waiting on it, so cap
+# the scan rather than hold a worker on it. The server aborts at ~this many
+# seconds (checked at data-processing checkpoints, not a hard wall-clock kill)
+# with TIMEOUT_EXCEEDED, which surfaces to the caller as a raised exception.
+# Short-lived caches in front of these reads do not protect the FIRST caller,
+# which is the one this bounds.
+QUERY_TIMEOUT_S = 10
+
+# Aggregation memory ceiling before the GROUP BY spills to disk: past this the
+# server writes intermediate state out instead of ballooning its own memory.
+# Slower beats OOM. It matters most where one source row fans out before the
+# aggregation sees it — metadata key discovery arrayJoins over mapKeys, and the
+# trace list's keyed-metadata predicate reads the base table because
+# metadata_map is deliberately absent from the spans no-I/O projection.
+GROUP_BY_SPILL_BYTES = 1 * 1024**3
+
+# Read-only mapping so a caller cannot mutate the shared bounds for every other
+# read path by editing what it was handed. clickhouse-connect only iterates and
+# copies ``settings``, so it consumes a MappingProxyType exactly as it does a
+# dict.
+#
+#   readonly: a read only ever reads; saying so removes the whole class of
+#     write/DDL statements from what these code paths could express.
+#   max_execution_time / max_bytes_before_external_group_by: see the constants
+#     above.
+#
+# use_query_condition_cache would additionally help the repeated same-window
+# scans these surfaces issue, but it needs ClickHouse >= 25.4 — the current
+# server rejects it as an unknown setting, so it is not in the mapping yet.
+READ_QUERY_SETTINGS: MappingProxyType[str, Any] = MappingProxyType(
+    {
+        "readonly": 1,
+        "max_execution_time": QUERY_TIMEOUT_S,
+        "max_bytes_before_external_group_by": GROUP_BY_SPILL_BYTES,
+    }
+)

--- a/backend/rest/routers/dashboards.py
+++ b/backend/rest/routers/dashboards.py
@@ -21,7 +21,7 @@ from rest.retention import clamp_retention_window
 from rest.routers.deps import RateLimitedProjectAccess
 from rest.schemas.dashboards import WidgetQueryRequest, WidgetQueryResponse
 from rest.schemas.traces import FilterValuesResponse
-from rest.services.trace_reader import get_trace_reader_service
+from rest.services.trace_discovery import get_trace_discovery_service
 from rest.services.widget_query import WidgetSpecError, run_widget_query
 from rest.services.widget_registry import REGISTRY, registry_schema
 
@@ -92,7 +92,7 @@ async def get_widget_field_values(
     # (mirrors the list endpoints; unlimited plans pass through unchanged).
     start_time, end_time = clamp_retention_window(_access.billing_plan, start_time, end_time)
 
-    service = get_trace_reader_service()
+    service = get_trace_discovery_service()
     # String dims declare their expr as the bare physical column name on the
     # view's source table, so it feeds the distinct scan directly.
     if view == "spans":

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -31,6 +31,7 @@ from rest.schemas.traces import (
 )
 from rest.services.filters import columns as filter_columns
 from rest.services.filters.translate import parse_filters_param
+from rest.services.trace_discovery import get_trace_discovery_service
 from rest.services.trace_reader import get_trace_reader_service
 
 logger = logging.getLogger(__name__)
@@ -201,7 +202,7 @@ async def get_filter_values(
             detail=f"Field '{field}' does not support distinct-value listing",
         )
 
-    service = get_trace_reader_service()
+    service = get_trace_discovery_service()
     values = service.get_distinct_span_values(
         project_id=project_id, column=column.name, start_after=start_after, end_before=end_before
     )

--- a/backend/rest/services/trace_discovery.py
+++ b/backend/rest/services/trace_discovery.py
@@ -1,0 +1,323 @@
+"""Option discovery for the filter UI: the distinct values a column takes.
+
+Every read here answers "what could the user pick?", never "what matches?". Suggestion is
+not permission — a value that falls outside an answer here stays filterable.
+"""
+
+import time
+from datetime import datetime
+
+from db.clickhouse import get_clickhouse_client
+from db.clickhouse.query_settings import READ_QUERY_SETTINGS
+from rest.services.trace_reader import customer_traffic_only, default_lookback_start
+from rest.sql_utils import to_utc_naive
+
+# Every discovery answer: cap the option list and cache briefly. A picker only needs the
+# frequent entries, and the GROUP BY over spans is the heavy part. The cap bounds each
+# option list; the cache bounds all of them together, since they share one dict keyed by
+# namespace.
+DISCOVERY_LIMIT = 100
+DISCOVERY_CACHE_TTL_SECONDS = 30
+DISCOVERY_CACHE_MAX = 256
+
+# Execution bounds come from db.clickhouse.query_settings (READ_QUERY_SETTINGS), shared
+# with the trace list and the widget queries: the same ClickHouse, the same kind of
+# interactive, time-windowed GROUP BY behind a UI control, so there is no reason for them
+# to expire or spill at different points. The rationale for each setting lives in that
+# module. Note for this module in particular: the 30s discovery cache does not protect the
+# FIRST caller, which is the one max_execution_time bounds.
+
+
+def _floor_minute(dt: datetime | None) -> datetime | None:
+    """Truncate a datetime to the whole minute (for the discovery cache key)."""
+    return dt.replace(second=0, microsecond=0) if dt is not None else None
+
+
+def _discovery_cache_key(
+    namespace: str,
+    project_id: str,
+    subject: str,
+    normalized_start: datetime,
+    normalized_end: datetime | None,
+) -> tuple:
+    """Cache key for one discovery answer.
+
+    Quantized to whole minutes so per-render jitter in the window bounds (the UI
+    recomputes "now - duration" every render) can't bypass the cache and force a fresh
+    full-project GROUP BY on every open.
+
+    Args:
+        namespace (str): Which discovery answer space the key belongs to — the scanned
+            table for a column enumeration. Two answers can only collide if they share
+            this.
+        project_id (str): Project the answer is scoped to.
+        subject (str): What was enumerated within the namespace — a registry-resolved
+            column name.
+        normalized_start (datetime): Naive-UTC lower window bound.
+        normalized_end (datetime | None): Naive-UTC upper window bound, or ``None``.
+
+    Returns:
+        tuple: The cache key.
+    """
+    return (
+        namespace,
+        project_id,
+        subject,
+        _floor_minute(normalized_start),
+        _floor_minute(normalized_end),
+    )
+
+
+def _resolve_scan_window(
+    start_after: datetime | None,
+    end_before: datetime | None,
+) -> tuple[datetime, datetime | None]:
+    """Normalize a discovery window to the bounds the scan will really use.
+
+    Every discovery query resolves its window through here, so none of them can drift into
+    a different default or a different notion of "open-ended".
+
+    Args:
+        start_after (datetime | None): Requested lower bound on the scanned table's time
+            column, or ``None`` for an open-ended window.
+        end_before (datetime | None): Requested upper bound (exclusive), or ``None``.
+
+    Returns:
+        tuple[datetime, datetime | None]: Naive-UTC ``(lower, upper)`` bounds. The lower
+        bound is never ``None``; the upper bound stays ``None`` when open-ended.
+    """
+    normalized_start = to_utc_naive(start_after) if start_after is not None else None
+    normalized_end = to_utc_naive(end_before) if end_before is not None else None
+    # Never scan spans unbounded (the OOM class the filtered list guards against): the UI
+    # always sends a window, this bounds a direct API caller that omits one.
+    if normalized_start is None:
+        normalized_start = default_lookback_start(normalized_end)
+    return normalized_start, normalized_end
+
+
+def _window_scan(
+    time_column: str,
+    project_id: str,
+    normalized_start: datetime,
+    normalized_end: datetime | None,
+) -> tuple[str, dict]:
+    """WHERE clause + bound parameters for a self-contained, project-scoped discovery scan.
+
+    The window is applied at BOTH ends here: a discovery scan stands alone, with no
+    trace-level semi-join above it to re-filter what it admits, so it must not offer options
+    from outside the active window. Shared by every discovery query so no surface can
+    quietly widen its own window or drop the customer-traffic restriction.
+
+    Args:
+        time_column (str): The scanned table's time column to bound (``span_start_time`` or
+            ``trace_start_time``). A literal chosen by the caller, never user input — it is
+            interpolated because column names cannot be bound as query parameters.
+        project_id (str): Project that scopes the scan (tenant isolation).
+        normalized_start (datetime): Naive-UTC lower bound on ``time_column``.
+        normalized_end (datetime | None): Naive-UTC exclusive upper bound, or ``None``.
+
+    Returns:
+        tuple[str, dict]: The AND-joined WHERE clause and the parameters it binds.
+    """
+    params: dict = {"project_id": project_id, "start_after": normalized_start}
+    # Exact bound, no lookback back-off: with no trace-level semi-join above it, the
+    # boundary-drift reasoning behind SPAN_TIME_BOUND_LOOKBACK_HOURS doesn't apply here.
+    # Detector self-traces are excluded because a suggestion list is customer-facing.
+    conditions = [
+        "project_id = {project_id:String}",
+        customer_traffic_only(),
+        f"{time_column} >= {{start_after:DateTime64(3)}}",
+    ]
+    if normalized_end is not None:
+        conditions.append(f"{time_column} < {{end_before:DateTime64(3)}}")
+        params["end_before"] = normalized_end
+    return " AND ".join(conditions), params
+
+
+class TraceDiscoveryService:
+    """Enumerate the filter UI's options from ClickHouse, behind a short-lived cache."""
+
+    def __init__(self):
+        self._client = get_clickhouse_client()
+        # Per-(namespace, project, subject, window) cache of discovery answers:
+        # key -> (expiry, rows).
+        self._discovery_cache: dict[tuple, tuple[float, list[dict]]] = {}
+
+    def _cache_get(self, cache_key: tuple) -> list[dict] | None:
+        """Return the unexpired cached rows for a discovery key, or ``None``.
+
+        Args:
+            cache_key (tuple): Key from ``_discovery_cache_key``.
+
+        Returns:
+            list[dict] | None: The cached rows, or ``None`` on a miss or an expired entry.
+        """
+        cached = self._discovery_cache.get(cache_key)
+        # Monotonic, like the other in-process TTL caches (trace_reader): a wall-clock step
+        # (NTP, DST-free but still steppable) must not expire or extend an entry.
+        if cached is not None and cached[0] > time.monotonic():
+            return cached[1]
+        return None
+
+    def _cache_put(self, cache_key: tuple, rows: list[dict]) -> None:
+        """Cache one discovery answer, keeping the cache size bounded.
+
+        Args:
+            cache_key (tuple): Key from ``_discovery_cache_key``.
+            rows (list[dict]): The rows to serve for the TTL.
+        """
+        now = time.monotonic()
+        self._discovery_cache = {k: v for k, v in self._discovery_cache.items() if v[0] > now}
+        if len(self._discovery_cache) >= DISCOVERY_CACHE_MAX:
+            self._discovery_cache.pop(next(iter(self._discovery_cache)))
+        self._discovery_cache[cache_key] = (now + DISCOVERY_CACHE_TTL_SECONDS, rows)
+
+    def get_distinct_span_values(
+        self,
+        project_id: str,
+        column: str,
+        start_after: datetime | None = None,
+        end_before: datetime | None = None,
+    ) -> list[dict]:
+        """Distinct values of a span column within the active window, by frequency.
+
+        Powers the filter dropdown's categorical options (model, environment) and
+        the widget builder's spans-view value dropdowns. Time-bounded and briefly
+        cached so repeatedly opening the same filter does not re-scan spans.
+
+        Args:
+            project_id (str): Project that scopes the span scan (tenant isolation).
+            column (str): A spans column name. MUST be a registry-resolved identifier,
+                never raw user input — it is interpolated into the SQL because column
+                names cannot be bound as query parameters.
+            start_after (datetime | None): Lower bound on ``span_start_time``; prunes
+                monthly partitions. ``None`` defaults to a fixed lookback rather than
+                scanning all time.
+            end_before (datetime | None): Upper bound on ``span_start_time`` (exclusive),
+                symmetric with the trace list's window so the dropdown never offers
+                values from traces newer than the active window's end.
+
+        Returns:
+            list[dict]: ``[{"value": str, "count": int}]`` ordered by descending
+            frequency, capped at ``DISCOVERY_LIMIT``.
+        """
+        return self._distinct_values(
+            table="spans",
+            time_column="span_start_time",
+            dedup_keys="project_id, trace_id, span_id",
+            project_id=project_id,
+            column=column,
+            start_after=start_after,
+            end_before=end_before,
+        )
+
+    def get_distinct_trace_values(
+        self,
+        project_id: str,
+        column: str,
+        start_after: datetime | None = None,
+        end_before: datetime | None = None,
+    ) -> list[dict]:
+        """Distinct values of a traces column within the active window, by frequency.
+
+        The traces-table sibling of ``get_distinct_span_values`` — powers the widget
+        builder's traces-view value dropdowns (trace name, user, session, environment).
+
+        Args:
+            project_id (str): Project that scopes the trace scan (tenant isolation).
+            column (str): A traces column name. MUST be a registry-resolved identifier,
+                never raw user input — it is interpolated into the SQL because column
+                names cannot be bound as query parameters.
+            start_after (datetime | None): Lower bound on ``trace_start_time``; prunes
+                monthly partitions. ``None`` defaults a lookback (never all-time).
+            end_before (datetime | None): Upper bound on ``trace_start_time``
+                (exclusive), symmetric with the widget query window.
+
+        Returns:
+            list[dict]: ``[{"value": str, "count": int}]`` ordered by descending
+            frequency, capped at ``DISCOVERY_LIMIT``.
+        """
+        return self._distinct_values(
+            table="traces",
+            time_column="trace_start_time",
+            dedup_keys="project_id, trace_id",
+            project_id=project_id,
+            column=column,
+            start_after=start_after,
+            end_before=end_before,
+        )
+
+    def _distinct_values(
+        self,
+        table: str,
+        time_column: str,
+        dedup_keys: str,
+        project_id: str,
+        column: str,
+        start_after: datetime | None,
+        end_before: datetime | None,
+    ) -> list[dict]:
+        """Shared distinct-values scan: dedup, group, count, cache.
+
+        Window resolution and the scan's WHERE clause come from ``_resolve_scan_window``
+        and ``_window_scan``, shared by every discovery query.
+
+        Args:
+            table (str): Source table (``spans`` or ``traces``) — a literal chosen by
+                the public wrappers, never user input.
+            time_column (str): The table's partition/time column the window bounds.
+            dedup_keys (str): ``LIMIT 1 BY`` key list that identifies one logical row
+                in the table's ReplacingMergeTree.
+            project_id (str): Project that scopes the scan (tenant isolation).
+            column (str): Registry-resolved column to enumerate (interpolated; column
+                names cannot be bound as query parameters).
+            start_after (datetime | None): Lower window bound on ``time_column``.
+            end_before (datetime | None): Upper window bound on ``time_column``.
+
+        Returns:
+            list[dict]: ``[{"value": str, "count": int}]`` by descending frequency.
+        """
+        normalized_start, normalized_end = _resolve_scan_window(start_after, end_before)
+        cache_key = _discovery_cache_key(
+            table, project_id, column, normalized_start, normalized_end
+        )
+        cached = self._cache_get(cache_key)
+        if cached is not None:
+            return cached
+
+        inner_where, params = _window_scan(
+            time_column, project_id, normalized_start, normalized_end
+        )
+
+        # Dedup ReplacingMergeTree rows to the latest version per logical row BEFORE
+        # counting, so a since-updated row can't inflate a value's count or surface a stale
+        # value.
+        query = f"""
+            SELECT value, count() AS n
+            FROM (
+                SELECT {column} AS value
+                FROM {table}
+                WHERE {inner_where}
+                ORDER BY ch_update_time DESC
+                LIMIT 1 BY {dedup_keys}
+            )
+            WHERE value IS NOT NULL AND value != ''
+            GROUP BY value
+            ORDER BY n DESC
+            LIMIT {DISCOVERY_LIMIT}
+        """
+        result = self._client.query(query, parameters=params, settings=READ_QUERY_SETTINGS)
+        rows = [{"value": str(row[0]), "count": int(row[1])} for row in result.result_rows]
+        self._cache_put(cache_key, rows)
+        return rows
+
+
+_service: TraceDiscoveryService | None = None
+
+
+def get_trace_discovery_service() -> TraceDiscoveryService:
+    """Get or create the singleton TraceDiscoveryService."""
+    global _service
+    if _service is None:
+        _service = TraceDiscoveryService()
+    return _service

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -23,14 +23,6 @@ from worker.tokens.pricing import cost_breakdown_from_buckets, get_model_price
 # the same old monthly partitions.
 TRACE_SPAN_LOOKBACK_HOURS = 1
 
-# Distinct-values endpoint: cap the option list and cache briefly. The dropdown only
-# needs the frequent values, and the GROUP BY over spans is the heavy part — a short
-# TTL absorbs repeated opens of the same filter without staleness mattering.
-DISTINCT_VALUES_LIMIT = 100
-DISTINCT_VALUES_CACHE_TTL_SECONDS = 30
-# Bound the in-process cache so it can't grow without limit across projects/windows.
-DISTINCT_VALUES_CACHE_MAX = 256
-
 # Default lookback for a span scan that arrives with no lower time bound (the filtered
 # trace list AND the categorical distinct-values dropdown). Those scan spans, so an
 # unbounded window is a full-project span scan — the OOM-prone class. The dashboard
@@ -68,17 +60,13 @@ def customer_traffic_only(alias: str = "") -> str:
     return f"{column} = '{USER_SOURCE}'"
 
 
-def _floor_minute(dt: datetime | None) -> datetime | None:
-    """Truncate a datetime to the whole minute (for the distinct-values cache key)."""
-    return dt.replace(second=0, microsecond=0) if dt is not None else None
-
-
-def _default_lookback_start(normalized_end: datetime | None) -> datetime:
+def default_lookback_start(normalized_end: datetime | None) -> datetime:
     """Default lower bound for an otherwise-unbounded span scan.
 
     A fixed lookback before the window's end (``normalized_end``) — or before now when
-    the window is open-ended — so the filtered list and the distinct-values query share
-    one symmetric default and neither ever scans spans all-time.
+    the window is open-ended — so the filtered list and the discovery scans share one
+    symmetric default and neither ever scans spans all-time. Public for the discovery
+    module, which defaults its own window to the same bound.
 
     Args:
         normalized_end (datetime | None): Naive-UTC upper bound of the active window,
@@ -144,8 +132,6 @@ class TraceReaderService:
 
     def __init__(self):
         self._client = get_clickhouse_client()
-        # Per-(project, column, window) cache of distinct values: key -> (expiry, rows).
-        self._distinct_cache: dict[tuple, tuple[float, list[dict]]] = {}
         # has_traces cache: project_id -> (expiry, result). True results use a
         # long TTL (1 hour); False results expire after 10s so the onboarding
         # poll doesn't scan all partitions every 3s. Bounded to 1024 entries.
@@ -153,172 +139,6 @@ class TraceReaderService:
         # Trace start time cache: "project:trace" -> (expiry, datetime|None).
         # Immutable once written, so 1-hour TTL is safe. Bounded to 1024 entries.
         self._trace_start_cache: dict[str, tuple[float, datetime | None]] = {}
-
-    def get_distinct_span_values(
-        self,
-        project_id: str,
-        column: str,
-        start_after: datetime | None = None,
-        end_before: datetime | None = None,
-    ) -> list[dict]:
-        """Distinct values of a span column within the active window, by frequency.
-
-        Powers the filter dropdown's categorical options (model, environment) and
-        the widget builder's spans-view value dropdowns. Time-bounded and briefly
-        cached so repeatedly opening the same filter does not re-scan spans.
-
-        Args:
-            project_id (str): Project that scopes the span scan (tenant isolation).
-            column (str): A spans column name. MUST be a registry-resolved identifier,
-                never raw user input — it is interpolated into the SQL because column
-                names cannot be bound as query parameters.
-            start_after (datetime | None): Lower bound on ``span_start_time``; prunes
-                monthly partitions. ``None`` scans all time.
-            end_before (datetime | None): Upper bound on ``span_start_time`` (exclusive),
-                symmetric with the trace list's window so the dropdown never offers
-                values from traces newer than the active window's end.
-
-        Returns:
-            list[dict]: ``[{"value": str, "count": int}]`` ordered by descending
-            frequency, capped at ``DISTINCT_VALUES_LIMIT``.
-        """
-        return self._distinct_values(
-            table="spans",
-            time_column="span_start_time",
-            dedup_keys="project_id, trace_id, span_id",
-            project_id=project_id,
-            column=column,
-            start_after=start_after,
-            end_before=end_before,
-        )
-
-    def get_distinct_trace_values(
-        self,
-        project_id: str,
-        column: str,
-        start_after: datetime | None = None,
-        end_before: datetime | None = None,
-    ) -> list[dict]:
-        """Distinct values of a traces column within the active window, by frequency.
-
-        The traces-table sibling of ``get_distinct_span_values`` — powers the widget
-        builder's traces-view value dropdowns (trace name, user, session, environment).
-
-        Args:
-            project_id (str): Project that scopes the trace scan (tenant isolation).
-            column (str): A traces column name. MUST be a registry-resolved identifier,
-                never raw user input — it is interpolated into the SQL because column
-                names cannot be bound as query parameters.
-            start_after (datetime | None): Lower bound on ``trace_start_time``; prunes
-                monthly partitions. ``None`` defaults a lookback (never all-time).
-            end_before (datetime | None): Upper bound on ``trace_start_time``
-                (exclusive), symmetric with the widget query window.
-
-        Returns:
-            list[dict]: ``[{"value": str, "count": int}]`` ordered by descending
-            frequency, capped at ``DISTINCT_VALUES_LIMIT``.
-        """
-        return self._distinct_values(
-            table="traces",
-            time_column="trace_start_time",
-            dedup_keys="project_id, trace_id",
-            project_id=project_id,
-            column=column,
-            start_after=start_after,
-            end_before=end_before,
-        )
-
-    def _distinct_values(
-        self,
-        table: str,
-        time_column: str,
-        dedup_keys: str,
-        project_id: str,
-        column: str,
-        start_after: datetime | None,
-        end_before: datetime | None,
-    ) -> list[dict]:
-        """Shared distinct-values scan: dedup, group, count, cache.
-
-        Args:
-            table (str): Source table (``spans`` or ``traces``) — a literal chosen by
-                the public wrappers, never user input.
-            time_column (str): The table's partition/time column the window bounds.
-            dedup_keys (str): ``LIMIT 1 BY`` key list that identifies one logical row
-                in the table's ReplacingMergeTree.
-            project_id (str): Project that scopes the scan (tenant isolation).
-            column (str): Registry-resolved column to enumerate (interpolated; column
-                names cannot be bound as query parameters).
-            start_after (datetime | None): Lower window bound on ``time_column``.
-            end_before (datetime | None): Upper window bound on ``time_column``.
-
-        Returns:
-            list[dict]: ``[{"value": str, "count": int}]`` by descending frequency.
-        """
-        normalized_start = to_utc_naive(start_after) if start_after is not None else None
-        normalized_end = to_utc_naive(end_before) if end_before is not None else None
-        # Never scan unbounded (the OOM class the filtered list guards against): if no
-        # lower bound was given, default one — symmetric with the filtered trace list. The UI
-        # always sends a window; this bounds a direct API caller that omits one.
-        if normalized_start is None:
-            normalized_start = _default_lookback_start(normalized_end)
-        # Quantize the cache key to whole minutes so per-render jitter in the window
-        # bounds (the UI recomputes "now - duration" every render) can't trivially
-        # bypass the cache and force a fresh full-project GROUP BY on every open. The
-        # 30s TTL already accepts this much staleness in the returned option list.
-        cache_key = (
-            table,
-            project_id,
-            column,
-            _floor_minute(normalized_start),
-            _floor_minute(normalized_end),
-        )
-        now = time.time()
-        cached = self._distinct_cache.get(cache_key)
-        if cached is not None and cached[0] > now:
-            return cached[1]
-
-        params: dict = {"project_id": project_id}
-        # Detector self-traces carry their own model/environment/name values; excluding
-        # them keeps internal telemetry out of the customer's filter dropdown options.
-        inner_conditions = ["project_id = {project_id:String}", customer_traffic_only()]
-        if normalized_start is not None:
-            # Exact bound, no lookback back-off: this is a self-contained window scan with
-            # no trace-level semi-join, so the boundary-drift false-negative reasoning that
-            # SPAN_TIME_BOUND_LOOKBACK_HOURS guards against in the filtered list doesn't apply.
-            inner_conditions.append(f"{time_column} >= {{start_after:DateTime64(3)}}")
-            params["start_after"] = normalized_start
-        if normalized_end is not None:
-            inner_conditions.append(f"{time_column} < {{end_before:DateTime64(3)}}")
-            params["end_before"] = normalized_end
-        inner_where = " AND ".join(inner_conditions)
-
-        # Dedup ReplacingMergeTree rows to the latest version per logical row BEFORE
-        # counting, so a since-updated row can't inflate a value's count or surface a stale
-        # value. The column non-empty filter runs on the deduped (latest) value in the
-        # outer query.
-        query = f"""
-            SELECT value, count() AS n
-            FROM (
-                SELECT {column} AS value
-                FROM {table}
-                WHERE {inner_where}
-                ORDER BY ch_update_time DESC
-                LIMIT 1 BY {dedup_keys}
-            )
-            WHERE value IS NOT NULL AND value != ''
-            GROUP BY value
-            ORDER BY n DESC
-            LIMIT {DISTINCT_VALUES_LIMIT}
-        """
-        result = self._client.query(query, parameters=params)
-        rows = [{"value": str(row[0]), "count": int(row[1])} for row in result.result_rows]
-        # Bound the cache: drop expired entries, then evict oldest if still at capacity.
-        self._distinct_cache = {k: v for k, v in self._distinct_cache.items() if v[0] > now}
-        if len(self._distinct_cache) >= DISTINCT_VALUES_CACHE_MAX:
-            self._distinct_cache.pop(next(iter(self._distinct_cache)))
-        self._distinct_cache[cache_key] = (now + DISTINCT_VALUES_CACHE_TTL_SECONDS, rows)
-        return rows
 
     _HAS_TRACES_CACHE_MAX = 1024
 
@@ -435,7 +255,7 @@ class TraceReaderService:
         # Default a lookback window so those sub-queries prune monthly partitions, and bound
         # the trace query to the same window so the page, count, and span scans stay consistent.
         if filters and start_after is None:
-            params["start_after"] = _default_lookback_start(normalized_end)
+            params["start_after"] = default_lookback_start(normalized_end)
             conditions.append("t.trace_start_time >= {start_after:DateTime64(3)}")
 
         # Registry-driven attribute filters (model/cost/errors/...). Appended to the

--- a/backend/rest/services/widget_query.py
+++ b/backend/rest/services/widget_query.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from db.clickhouse import get_clickhouse_client
+from db.clickhouse.query_settings import READ_QUERY_SETTINGS
 from rest.schemas.dashboards import WidgetSpec
 from rest.services.widget_registry import REGISTRY, FieldDef
 from rest.sql_utils import escape_ilike, to_utc_naive
@@ -17,9 +18,7 @@ from rest.sql_utils import escape_ilike, to_utc_naive
 MAX_GROUPS = 50  # top-N breakdown groups; remainder folds into "other"
 MAX_TABLE_ROWS = 1000
 HISTOGRAM_BINS = 20
-QUERY_TIMEOUT_S = 10
 HOUR_BUCKET_MAX = timedelta(days=2)
-GROUP_BY_SPILL_BYTES = 1 * 1024**3  # aggregation memory ceiling before disk spill
 
 _AGG_SQL = {
     "count": "count({expr})",
@@ -271,20 +270,10 @@ def run_widget_query(
     end_time = to_utc_naive(end_time)
     sql, params = compile_widget_query(spec, project_id, start_time, end_time)
     client = get_clickhouse_client()
-    result = client.query(
-        sql,
-        parameters=params,
-        settings={
-            "readonly": 1,
-            "max_execution_time": QUERY_TIMEOUT_S,
-            # Large breakdown GROUP BYs spill to disk past this threshold
-            # instead of ballooning server memory: slower beats OOM for a
-            # dashboard tile. (use_query_condition_cache would help the
-            # repeated same-window scans too, but it needs ClickHouse >= 25.4
-            # — the current server rejects it as an unknown setting.)
-            "max_bytes_before_external_group_by": GROUP_BY_SPILL_BYTES,
-        },
-    )
+    # Execution bounds (readonly, timeout, GROUP BY spill ceiling) are the shared read
+    # settings: a dashboard tile is the same interactive, time-windowed GROUP BY as the
+    # trace list and the filter-option scans, so it gets the same ceilings.
+    result = client.query(sql, parameters=params, settings=READ_QUERY_SETTINGS)
     meta: dict[str, Any] = {}
     if spec.display.type in ("line", "area"):
         meta["granularity"] = _pick_granularity(start_time, end_time)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,8 +34,12 @@ def _reset_singletons(monkeypatch):
     """
     import db.clickhouse.client as ch_mod
     import rest.services.s3 as s3_mod
+    import rest.services.trace_discovery as td_mod
     import rest.services.trace_reader as tr_mod
 
     monkeypatch.setattr(ch_mod, "_client", None)
     monkeypatch.setattr(s3_mod, "_s3_service", None)
     monkeypatch.setattr(tr_mod, "_service", None)
+    # Discovery holds a client AND a short-lived answer cache, so a leaked instance
+    # can serve one test's rows to the next.
+    monkeypatch.setattr(td_mod, "_service", None)

--- a/tests/db/test_query_settings.py
+++ b/tests/db/test_query_settings.py
@@ -1,0 +1,56 @@
+"""Unit tests for the shared ClickHouse read bounds.
+
+The point of one shared mapping is that every read surface expires and spills at the
+same place. That only holds if a caller cannot edit what it was handed: the mapping is
+passed by reference to clickhouse-connect from several call sites, so a single in-place
+edit anywhere would move the bounds for every other read path in the process, with no
+import and no diff at those sites to show for it.
+"""
+
+import pytest
+
+from db.clickhouse.query_settings import (
+    GROUP_BY_SPILL_BYTES,
+    QUERY_TIMEOUT_S,
+    READ_QUERY_SETTINGS,
+)
+
+
+def test_a_caller_cannot_edit_the_shared_bounds():
+    with pytest.raises(TypeError):
+        READ_QUERY_SETTINGS["max_execution_time"] = 3600
+
+
+def test_a_caller_cannot_add_a_setting_for_everyone_else():
+    with pytest.raises(TypeError):
+        READ_QUERY_SETTINGS["readonly"] = 0
+
+    with pytest.raises(TypeError):
+        READ_QUERY_SETTINGS["max_result_rows"] = 1
+
+    with pytest.raises(TypeError):
+        del READ_QUERY_SETTINGS["readonly"]
+
+    assert READ_QUERY_SETTINGS["readonly"] == 1
+
+
+def test_the_bounds_are_the_three_a_read_needs():
+    """A read is read-only, expires, and spills rather than OOMing.
+
+    Named here so dropping one from the mapping is a failure rather than a quiet
+    loosening of every read surface at once.
+    """
+    assert dict(READ_QUERY_SETTINGS) == {
+        "readonly": 1,
+        "max_execution_time": QUERY_TIMEOUT_S,
+        "max_bytes_before_external_group_by": GROUP_BY_SPILL_BYTES,
+    }
+
+
+def test_copying_the_bounds_yields_a_plain_editable_mapping():
+    """A caller that needs one extra setting derives a copy instead of editing shared
+    state — the supported escape hatch, and proof the proxy is not simply frozen data."""
+    derived = {**READ_QUERY_SETTINGS, "max_result_rows": 10}
+
+    assert derived["max_execution_time"] == QUERY_TIMEOUT_S
+    assert "max_result_rows" not in READ_QUERY_SETTINGS

--- a/tests/rest/test_dashboards_router.py
+++ b/tests/rest/test_dashboards_router.py
@@ -126,15 +126,15 @@ def test_query_endpoint_no_auth_is_not_200():
 
 
 @pytest.fixture()
-def mock_trace_reader():
-    reader = MagicMock()
-    with patch("rest.routers.dashboards.get_trace_reader_service", return_value=reader):
-        yield reader
+def mock_discovery():
+    service = MagicMock()
+    with patch("rest.routers.dashboards.get_trace_discovery_service", return_value=service):
+        yield service
 
 
 class TestWidgetFieldValues:
-    def test_spans_view_uses_the_span_distinct_query(self, client, mock_trace_reader):
-        mock_trace_reader.get_distinct_span_values.return_value = [
+    def test_spans_view_uses_the_span_distinct_query(self, client, mock_discovery):
+        mock_discovery.get_distinct_span_values.return_value = [
             {"value": "gpt-4o", "count": 12},
             {"value": "claude-opus-4-8", "count": 7},
         ]
@@ -143,81 +143,81 @@ class TestWidgetFieldValues:
         body = resp.json()
         assert body["field"] == "model_name"
         assert body["values"][0] == {"value": "gpt-4o", "count": 12}
-        kw = mock_trace_reader.get_distinct_span_values.call_args.kwargs
+        kw = mock_discovery.get_distinct_span_values.call_args.kwargs
         # project scoping comes from the path; the column is registry-resolved
         assert kw["project_id"] == "proj-1"
         assert kw["column"] == "model_name"
-        mock_trace_reader.get_distinct_trace_values.assert_not_called()
+        mock_discovery.get_distinct_trace_values.assert_not_called()
 
-    def test_traces_view_uses_the_trace_distinct_query(self, client, mock_trace_reader):
-        mock_trace_reader.get_distinct_trace_values.return_value = [{"value": "u-1", "count": 3}]
+    def test_traces_view_uses_the_trace_distinct_query(self, client, mock_discovery):
+        mock_discovery.get_distinct_trace_values.return_value = [{"value": "u-1", "count": 3}]
         resp = client.get("/api/v1/projects/proj-1/widgets/field-values/traces/user_id")
         assert resp.status_code == 200
         assert resp.json()["values"] == [{"value": "u-1", "count": 3}]
-        kw = mock_trace_reader.get_distinct_trace_values.call_args.kwargs
+        kw = mock_discovery.get_distinct_trace_values.call_args.kwargs
         assert kw["project_id"] == "proj-1"
         assert kw["column"] == "user_id"
-        mock_trace_reader.get_distinct_span_values.assert_not_called()
+        mock_discovery.get_distinct_span_values.assert_not_called()
 
-    def test_time_window_threads_to_the_service(self, enterprise_client, mock_trace_reader):
+    def test_time_window_threads_to_the_service(self, enterprise_client, mock_discovery):
         # Unlimited retention: the requested window reaches the service verbatim.
-        mock_trace_reader.get_distinct_span_values.return_value = []
+        mock_discovery.get_distinct_span_values.return_value = []
         resp = enterprise_client.get(
             "/api/v1/projects/proj-1/widgets/field-values/spans/environment"
             "?start_time=2026-06-01T00:00:00&end_time=2026-06-02T00:00:00"
         )
         assert resp.status_code == 200
-        kw = mock_trace_reader.get_distinct_span_values.call_args.kwargs
+        kw = mock_discovery.get_distinct_span_values.call_args.kwargs
         assert kw["start_after"] == datetime(2026, 6, 1, 0, 0, 0)
         assert kw["end_before"] == datetime(2026, 6, 2, 0, 0, 0)
 
-    def test_no_window_passes_none_bounds(self, enterprise_client, mock_trace_reader):
+    def test_no_window_passes_none_bounds(self, enterprise_client, mock_discovery):
         """Unlimited retention: the service itself defaults a lookback; the endpoint passes None."""
-        mock_trace_reader.get_distinct_span_values.return_value = []
+        mock_discovery.get_distinct_span_values.return_value = []
         resp = enterprise_client.get("/api/v1/projects/proj-1/widgets/field-values/spans/status")
         assert resp.status_code == 200
-        kw = mock_trace_reader.get_distinct_span_values.call_args.kwargs
+        kw = mock_discovery.get_distinct_span_values.call_args.kwargs
         assert kw["start_after"] is None
         assert kw["end_before"] is None
 
-    def test_out_of_window_start_is_clamped_for_limited_plan(self, client, mock_trace_reader):
+    def test_out_of_window_start_is_clamped_for_limited_plan(self, client, mock_discovery):
         # Free plan (15-day retention): a request reaching past the window is
         # silently pulled forward to the cutoff — the server-side safety net.
-        mock_trace_reader.get_distinct_span_values.return_value = []
+        mock_discovery.get_distinct_span_values.return_value = []
         resp = client.get(
             "/api/v1/projects/proj-1/widgets/field-values/spans/environment"
             "?start_time=2020-01-01T00:00:00"
         )
         assert resp.status_code == 200
-        clamped = mock_trace_reader.get_distinct_span_values.call_args.kwargs["start_after"]
+        clamped = mock_discovery.get_distinct_span_values.call_args.kwargs["start_after"]
         assert clamped > datetime(2020, 1, 2)  # not the ancient input
         assert clamped >= _free_clamp_floor()  # pulled up to ~ now - 15 days
 
-    def test_missing_start_is_clamped_for_limited_plan(self, client, mock_trace_reader):
+    def test_missing_start_is_clamped_for_limited_plan(self, client, mock_discovery):
         # Free plan with no start_time would otherwise scan back to day zero.
-        mock_trace_reader.get_distinct_span_values.return_value = []
+        mock_discovery.get_distinct_span_values.return_value = []
         resp = client.get("/api/v1/projects/proj-1/widgets/field-values/spans/status")
         assert resp.status_code == 200
-        clamped = mock_trace_reader.get_distinct_span_values.call_args.kwargs["start_after"]
+        clamped = mock_discovery.get_distinct_span_values.call_args.kwargs["start_after"]
         assert clamped is not None
         assert clamped >= _free_clamp_floor()
 
-    def test_unknown_view_is_404(self, client, mock_trace_reader):
+    def test_unknown_view_is_404(self, client, mock_discovery):
         resp = client.get("/api/v1/projects/proj-1/widgets/field-values/sessions/name")
         assert resp.status_code == 404
-        mock_trace_reader.get_distinct_span_values.assert_not_called()
+        mock_discovery.get_distinct_span_values.assert_not_called()
 
-    def test_unknown_field_is_404(self, client, mock_trace_reader):
+    def test_unknown_field_is_404(self, client, mock_discovery):
         resp = client.get("/api/v1/projects/proj-1/widgets/field-values/spans/not_a_field")
         assert resp.status_code == 404
-        mock_trace_reader.get_distinct_span_values.assert_not_called()
+        mock_discovery.get_distinct_span_values.assert_not_called()
 
-    def test_numeric_field_is_400(self, client, mock_trace_reader):
+    def test_numeric_field_is_400(self, client, mock_discovery):
         resp = client.get("/api/v1/projects/proj-1/widgets/field-values/spans/cost")
         assert resp.status_code == 400
-        mock_trace_reader.get_distinct_span_values.assert_not_called()
+        mock_discovery.get_distinct_span_values.assert_not_called()
 
-    def test_count_field_is_400(self, client, mock_trace_reader):
+    def test_count_field_is_400(self, client, mock_discovery):
         resp = client.get("/api/v1/projects/proj-1/widgets/field-values/spans/count")
         assert resp.status_code == 400
-        mock_trace_reader.get_distinct_span_values.assert_not_called()
+        mock_discovery.get_distinct_span_values.assert_not_called()

--- a/tests/rest/test_trace_filter_meta.py
+++ b/tests/rest/test_trace_filter_meta.py
@@ -1,9 +1,9 @@
-"""Unit tests for the trace-filter meta endpoints and the distinct-values query.
+"""Unit tests for the trace-filter meta endpoints and the discovery queries.
 
 Covers ``GET /traces/filter-fields`` (registry serialization) and
 ``GET /traces/filter-values/{field}`` (distinct categorical values), plus the
-``TraceReaderService.get_distinct_span_values`` query + cache. Uses TestClient with
-mocked dependencies — no ClickHouse needed.
+``TraceDiscoveryService`` queries + cache behind them. Uses TestClient with mocked
+dependencies — no ClickHouse needed.
 """
 
 from datetime import datetime
@@ -17,30 +17,38 @@ from rest.routers.deps import ProjectAccessInfo, get_project_access
 from rest.services.filters import columns as reg
 
 
-@pytest.fixture()
-def mock_trace_reader():
-    return MagicMock()
+def _client_for_plan(mock_discovery, billing_plan: str) -> TestClient:
+    """TestClient whose project access reports ``billing_plan``, with discovery mocked."""
 
-
-@pytest.fixture()
-def client(mock_trace_reader):
     async def mock_get_access(project_id: str, x_user_id=None):
         return ProjectAccessInfo(
             project_id=project_id,
             user_id="test-user",
             role="ADMIN",
             workspace_id="ws-test",
-            billing_plan="enterprise",
+            billing_plan=billing_plan,
         )
 
     app.dependency_overrides[get_project_access] = mock_get_access
 
     import rest.routers.traces as traces_mod
 
-    original = traces_mod.get_trace_reader_service
-    traces_mod.get_trace_reader_service = lambda: mock_trace_reader
-    yield TestClient(app)
-    traces_mod.get_trace_reader_service = original
+    traces_mod.get_trace_discovery_service = lambda: mock_discovery
+    return TestClient(app)
+
+
+@pytest.fixture()
+def mock_discovery():
+    return MagicMock()
+
+
+@pytest.fixture()
+def client(mock_discovery):
+    import rest.routers.traces as traces_mod
+
+    original = traces_mod.get_trace_discovery_service
+    yield _client_for_plan(mock_discovery, "enterprise")
+    traces_mod.get_trace_discovery_service = original
     app.dependency_overrides.clear()
 
 
@@ -78,8 +86,8 @@ class TestFilterFields:
 
 
 class TestFilterValues:
-    def test_model_name_returns_values_by_frequency(self, client, mock_trace_reader):
-        mock_trace_reader.get_distinct_span_values.return_value = [
+    def test_model_name_returns_values_by_frequency(self, client, mock_discovery):
+        mock_discovery.get_distinct_span_values.return_value = [
             {"value": "gpt-4", "count": 10},
             {"value": "claude-opus-4.8", "count": 4},
         ]
@@ -88,48 +96,48 @@ class TestFilterValues:
         body = resp.json()
         assert body["field"] == "model_name"
         assert body["values"][0] == {"value": "gpt-4", "count": 10}
-        kw = mock_trace_reader.get_distinct_span_values.call_args.kwargs
+        kw = mock_discovery.get_distinct_span_values.call_args.kwargs
         assert kw["project_id"] == "p1"
         assert kw["column"] == "model_name"
 
-    def test_start_after_is_threaded_to_the_service(self, client, mock_trace_reader):
-        mock_trace_reader.get_distinct_span_values.return_value = []
+    def test_start_after_is_threaded_to_the_service(self, client, mock_discovery):
+        mock_discovery.get_distinct_span_values.return_value = []
         resp = client.get(
             "/api/v1/projects/p1/traces/filter-values/environment?start_after=2026-06-01T00:00:00"
         )
         assert resp.status_code == 200
-        assert mock_trace_reader.get_distinct_span_values.call_args.kwargs[
-            "start_after"
-        ] == datetime(2026, 6, 1, 0, 0, 0)
+        assert mock_discovery.get_distinct_span_values.call_args.kwargs["start_after"] == datetime(
+            2026, 6, 1, 0, 0, 0
+        )
 
-    def test_end_before_is_threaded_to_the_service(self, client, mock_trace_reader):
-        mock_trace_reader.get_distinct_span_values.return_value = []
+    def test_end_before_is_threaded_to_the_service(self, client, mock_discovery):
+        mock_discovery.get_distinct_span_values.return_value = []
         resp = client.get(
             "/api/v1/projects/p1/traces/filter-values/environment"
             "?start_after=2026-06-01T00:00:00&end_before=2026-06-02T00:00:00"
         )
         assert resp.status_code == 200
-        kw = mock_trace_reader.get_distinct_span_values.call_args.kwargs
+        kw = mock_discovery.get_distinct_span_values.call_args.kwargs
         assert kw["start_after"] == datetime(2026, 6, 1, 0, 0, 0)
         assert kw["end_before"] == datetime(2026, 6, 2, 0, 0, 0)
 
-    def test_unknown_field_is_404(self, client, mock_trace_reader):
+    def test_unknown_field_is_404(self, client, mock_discovery):
         resp = client.get("/api/v1/projects/p1/traces/filter-values/not_a_field")
         assert resp.status_code == 404
-        mock_trace_reader.get_distinct_span_values.assert_not_called()
+        mock_discovery.get_distinct_span_values.assert_not_called()
 
-    def test_numeric_field_is_rejected(self, client, mock_trace_reader):
+    def test_numeric_field_is_rejected(self, client, mock_discovery):
         resp = client.get("/api/v1/projects/p1/traces/filter-values/cost")
         assert resp.status_code == 400
-        mock_trace_reader.get_distinct_span_values.assert_not_called()
+        mock_discovery.get_distinct_span_values.assert_not_called()
 
 
 class TestGetDistinctSpanValues:
     def _service(self, monkeypatch, mock_client):
-        import rest.services.trace_reader as tr_mod
+        import rest.services.trace_discovery as discovery_mod
 
-        monkeypatch.setattr(tr_mod, "get_clickhouse_client", lambda: mock_client)
-        return tr_mod.TraceReaderService()
+        monkeypatch.setattr(discovery_mod, "get_clickhouse_client", lambda: mock_client)
+        return discovery_mod.TraceDiscoveryService()
 
     def test_builds_grouped_project_scoped_query(self, monkeypatch):
         mock_client = MagicMock()
@@ -270,26 +278,26 @@ class TestGetDistinctSpanValues:
         assert "LIMIT 1 BY project_id, trace_id, span_id" in query_text
 
     def test_cache_is_bounded(self, monkeypatch):
-        from rest.services.trace_reader import DISTINCT_VALUES_CACHE_MAX
+        from rest.services.trace_discovery import DISCOVERY_CACHE_MAX
 
         mock_client = MagicMock()
         mock_client.query.return_value.result_rows = []
         svc = self._service(monkeypatch, mock_client)
 
         # Far more distinct cache keys than the cap; size must stay bounded.
-        for i in range(DISTINCT_VALUES_CACHE_MAX + 50):
+        for i in range(DISCOVERY_CACHE_MAX + 50):
             svc.get_distinct_span_values(project_id=f"p{i}", column="model_name")
-        assert len(svc._distinct_cache) <= DISTINCT_VALUES_CACHE_MAX
+        assert len(svc._discovery_cache) <= DISCOVERY_CACHE_MAX
 
 
 class TestGetDistinctTraceValues:
     """The traces-table variant that powers the widget builder's traces-view dropdowns."""
 
     def _service(self, monkeypatch, mock_client):
-        import rest.services.trace_reader as tr_mod
+        import rest.services.trace_discovery as discovery_mod
 
-        monkeypatch.setattr(tr_mod, "get_clickhouse_client", lambda: mock_client)
-        return tr_mod.TraceReaderService()
+        monkeypatch.setattr(discovery_mod, "get_clickhouse_client", lambda: mock_client)
+        return discovery_mod.TraceDiscoveryService()
 
     def test_builds_grouped_project_scoped_traces_query(self, monkeypatch):
         mock_client = MagicMock()
@@ -382,3 +390,17 @@ class TestGetDistinctTraceValues:
         second = svc.get_distinct_trace_values(project_id="p1", column="environment")
         assert first == second
         mock_client.query.assert_called_once()
+
+
+class TestGetTraceDiscoveryService:
+    """The accessor hands out one service, so the answer cache it holds is shared."""
+
+    def test_repeated_calls_return_the_same_instance(self, monkeypatch):
+        import rest.services.trace_discovery as discovery_mod
+
+        monkeypatch.setattr(discovery_mod, "get_clickhouse_client", lambda: MagicMock())
+        monkeypatch.setattr(discovery_mod, "_service", None)
+
+        assert discovery_mod.get_trace_discovery_service() is (
+            discovery_mod.get_trace_discovery_service()
+        )

--- a/tests/rest/test_trace_reader_source.py
+++ b/tests/rest/test_trace_reader_source.py
@@ -97,8 +97,21 @@ class TestCustomerTrafficOnlyHelper:
 
 
 class TestDistinctSpanValuesExcludesDetector:
+    """Discovery lives in its own service now, but it reuses this module's shared
+    predicate, so the exclusion is asserted here alongside every other customer-facing
+    read rather than only where discovery's own tests live."""
+
+    def _discovery_with_mock_client(self):
+        with patch("rest.services.trace_discovery.get_clickhouse_client") as get_client:
+            client = MagicMock()
+            get_client.return_value = client
+            from rest.services.trace_discovery import TraceDiscoveryService
+
+            service = TraceDiscoveryService()
+        return service, client
+
     def test_dropdown_options_skip_detector_spans(self):
-        service, client = _service_with_mock_client()
+        service, client = self._discovery_with_mock_client()
         result = MagicMock()
         result.result_rows = []
         client.query.return_value = result

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -78,8 +78,19 @@ def mock_trace_reader():
 
 
 @pytest.fixture()
-def client(mock_trace_reader):
-    """TestClient with mocked auth and trace reader."""
+def mock_trace_discovery():
+    """Mock TraceDiscoveryService.
+
+    Distinct-value and metadata-key routes read from discovery, not the reader. Left
+    unpatched they build a real service and open a real ClickHouse connection, so these
+    tests pass or fail on whether a container happens to be listening.
+    """
+    return MagicMock()
+
+
+@pytest.fixture()
+def client(mock_trace_reader, mock_trace_discovery):
+    """TestClient with mocked auth and trace services."""
 
     async def mock_get_access(project_id: str, x_user_id=None):
         # Mirror the validate-project-access contract (workspaceId + billingPlan)
@@ -98,11 +109,14 @@ def client(mock_trace_reader):
     import rest.routers.traces as traces_mod
 
     original = traces_mod.get_trace_reader_service
+    original_discovery = traces_mod.get_trace_discovery_service
     traces_mod.get_trace_reader_service = lambda: mock_trace_reader
+    traces_mod.get_trace_discovery_service = lambda: mock_trace_discovery
 
     yield TestClient(app)
 
     traces_mod.get_trace_reader_service = original
+    traces_mod.get_trace_discovery_service = original_discovery
 
 
 class TestTracesExist:
@@ -459,7 +473,7 @@ class TestDashboardKeepsSpanTreeMetadata:
 
 
 @pytest.fixture()
-def free_plan_client(mock_trace_reader):
+def free_plan_client(mock_trace_reader, mock_trace_discovery):
     """TestClient with free-plan billing for retention gate tests."""
 
     async def mock_get_access(project_id: str, x_user_id=None):
@@ -476,11 +490,14 @@ def free_plan_client(mock_trace_reader):
     import rest.routers.traces as traces_mod
 
     original = traces_mod.get_trace_reader_service
+    original_discovery = traces_mod.get_trace_discovery_service
     traces_mod.get_trace_reader_service = lambda: mock_trace_reader
+    traces_mod.get_trace_discovery_service = lambda: mock_trace_discovery
 
     yield TestClient(app)
 
     traces_mod.get_trace_reader_service = original
+    traces_mod.get_trace_discovery_service = original_discovery
 
 
 def _now_naive():
@@ -517,14 +534,17 @@ class TestRetentionGate:
         assert abs((kw["start_after"] - expected).total_seconds()) < 2
 
     def test_get_filter_values_clamps_when_outside_window(
-        self, free_plan_client, mock_trace_reader
+        self, free_plan_client, mock_trace_discovery
     ):
-        mock_trace_reader.get_distinct_span_values.return_value = []
+        mock_trace_discovery.get_distinct_span_values.return_value = []
         old = (_now_naive() - timedelta(days=30)).isoformat()
         response = free_plan_client.get(
             f"/api/v1/projects/test-project/traces/filter-values/model_name?start_after={old}"
         )
         assert response.status_code == 200
+        kw = mock_trace_discovery.get_distinct_span_values.call_args.kwargs
+        expected = _now_naive() - timedelta(days=15, hours=1)
+        assert abs((kw["start_after"] - expected).total_seconds()) < 2
 
     def test_get_trace_403_when_trace_outside_window(self, free_plan_client, mock_trace_reader):
         old_trace = {**TRACE_DETAIL, "trace_start_time": datetime(2020, 1, 1)}

--- a/tests/rest/test_widget_query.py
+++ b/tests/rest/test_widget_query.py
@@ -8,6 +8,11 @@ import pytest
 from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
 
+from db.clickhouse.query_settings import (
+    GROUP_BY_SPILL_BYTES,
+    QUERY_TIMEOUT_S,
+    READ_QUERY_SETTINGS,
+)
 from rest.schemas.dashboards import (
     AggName,
     WidgetFilter,
@@ -466,8 +471,14 @@ def test_compile_cache_tokens_traces():
 
 
 def test_run_widget_query_sets_execution_guards(monkeypatch):
-    """Every widget query runs read-only, time-capped, and with a GROUP BY
-    memory ceiling that spills to disk instead of OOMing the server."""
+    """Every widget query runs under the SHARED read bounds, not a private copy.
+
+    What matters is that this read is bound to the same mapping as every other read
+    surface — read-only, time-capped, and with a GROUP BY memory ceiling that spills to
+    disk instead of OOMing the server. Asserting the mapping the call received is the
+    shared one, rather than re-deriving its three fields here, is what makes a future
+    edit to the shared bounds carry to this query instead of silently drifting from it.
+    """
     fake_result = MagicMock(column_names=["value"], result_rows=[(1,)])
     fake_client = MagicMock()
     fake_client.query.return_value = fake_result
@@ -481,6 +492,8 @@ def test_run_widget_query_sets_execution_guards(monkeypatch):
     )
 
     settings = fake_client.query.call_args.kwargs["settings"]
+    assert settings is READ_QUERY_SETTINGS
+    # Spelled out once so the shared mapping cannot be emptied without a failure here.
     assert settings["readonly"] == 1
-    assert settings["max_execution_time"] == wq.QUERY_TIMEOUT_S
-    assert settings["max_bytes_before_external_group_by"] == wq.GROUP_BY_SPILL_BYTES
+    assert settings["max_execution_time"] == QUERY_TIMEOUT_S
+    assert settings["max_bytes_before_external_group_by"] == GROUP_BY_SPILL_BYTES


### PR DESCRIPTION
Part of #1824

> [!NOTE]
> Stacked on #1830 (`feat/metadata-map-column`).

## Summary

Two homes, one for each kind of read the trace surfaces do.

- New `rest/services/trace_discovery.py` takes the option-list reads out of
  `TraceReaderService`: `get_distinct_span_values`, `get_distinct_trace_values`, the shared
  dedup/group/count scan, and the short-lived answer cache. The reader answers "what
  matches"; discovery answers "what could the user pick".
- Window handling becomes two helpers (`_resolve_scan_window`, `_window_scan`) that every
  discovery query goes through, so no surface can widen its own window, lose the exclusive
  upper bound, or drop the customer-traffic restriction on its own.
- Cache keys lead with a namespace (the scanned table for a column enumeration), so two
  answer spaces can only collide if they share it.
- `_default_lookback_start` becomes public `default_lookback_start`: discovery defaults its
  window to the same bound the filtered list defaults to, from one definition.
- Callers switched to the discovery service: `GET /traces/filter-values/{field}` and the
  dashboard widget builder's field-values endpoint.
- New `db/clickhouse/query_settings.py` holding `READ_QUERY_SETTINGS` — `readonly`,
  `max_execution_time`, and the GROUP BY spill ceiling — replacing the settings dict spelled
  inline in `widget_query`. Every read behind an interactive surface is the same shape, so
  there is no reason for two of them to expire or spill at different points.
- `tests/conftest.py` resets the discovery singleton between tests: it holds a client **and**
  a short-lived answer cache, so a leaked instance can serve one test's rows to the next.

## Type of Change

- [x] refactor - A code change that neither fixes a bug nor adds a feature

## Details

No API surface changes: same routes, same response shapes, same SQL for the distinct-value
scans (dedup before counting, project scoping, detector self-traces excluded, defaulted
lookback rather than an all-time scan).

The widget query's execution settings are the same three values it already sent, moved
rather than changed — `readonly: 1`, a 10s `max_execution_time`, and a 1 GiB
`max_bytes_before_external_group_by`.

**Two deliberate behavior changes, so this is not a pure move:**

1. The distinct-value scans now run under those shared settings, which they previously ran
   without. Same query and same rows; they now abort at the shared execution ceiling and
   spill to disk rather than balloon server memory. That is the point of giving the settings
   one home — the moved reads were the ones that were less bounded than their siblings.
2. The discovery cache's clock moves from `time.time()` to `time.monotonic()`
   (`trace_discovery.py:158`, `:169`). Wall-clock time can jump; the cache only ever asks how
   long since an entry was written, so a monotonic source is the correct one, and it matches
   the sibling caches it was split away from. Read and write use the same clock, so no entry
   is evaluated against a different one than it was stamped with.

Tests move with the code: the dashboards-router suite follows the caller switch, the
filter-meta fixtures rename from `mock_trace_reader` to `mock_discovery`, and there are new
suites for `query_settings` and for the widget query reading them.

## Notes

- `trace_discovery.py` imports `READ_QUERY_SETTINGS` directly, so the settings module has to
  exist no later than this PR — that is why the two land together rather than as separate
  PRs.
- The trace list's own queries are not touched here; they get the same bounds in #1834,
  where the reason they need them arrives with the keyed filter.

## Screenshots / Recordings (if applicable)

Not applicable — backend only, no user-visible change.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

