### PR TITLE
feat(filters): lower keyed metadata predicates at trace or span scope

### DIFF
--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -146,6 +146,12 @@ async def get_filter_fields(
                 "integer": c.is_integer,
             }
             for c in filter_columns.FILTER_COLUMNS
+            # Temporary: a keyed field needs a key control the filter builder does not
+            # have yet. Advertising it now would let a deployed builder render it as a
+            # plain text field and emit a keyless predicate, which the translator rejects
+            # with a 422 — and a 422 on the filter parameter sinks the whole trace list.
+            # Removed by feat/metadata-filter-ui, which ships the key control.
+            if not c.requires_key
         ]
     }
 

--- a/backend/rest/services/filters/columns.py
+++ b/backend/rest/services/filters/columns.py
@@ -21,6 +21,7 @@ class FilterLevel(StrEnum):
     TRACE = "TRACE"  # inline predicate on the traces row (t.*)
     SPAN_MEMBERSHIP = "SPAN_MEMBERSHIP"  # trace_id IN (SELECT … FROM spans WHERE …)
     SPAN_AGGREGATE = "SPAN_AGGREGATE"  # trace_id IN (SELECT … GROUP BY trace_id HAVING …)
+    KEYED_MAP = "KEYED_MAP"  # inline traces-row Map match OR the span semi-join, by key
 
 
 class FilterType(StrEnum):
@@ -63,13 +64,30 @@ class FilterColumn:
     """A single filterable column.
 
     Attributes:
-        name (str): The ClickHouse column name, also the predicate ``field`` key.
+        name (str): The predicate ``field`` key — what a filter names, and what
+            ``get_column`` resolves. For every level except ``KEYED_MAP`` it is also the
+            ClickHouse column read. A ``KEYED_MAP`` field is queried through the Map
+            column DERIVED from it rather than the column of this name: ``metadata`` is
+            filtered as ``metadata_map[key]``, the materialized one-level map of the
+            ``metadata`` JSON blob (migration 009). The translator owns that derivation,
+            so the physical column for a keyed-map field is not declared here.
         label (str): Human-readable label for the filter pill.
         ch_type (str): ClickHouse type, used to bind query parameters.
         level (str): One of ``FilterLevel`` — how the predicate lowers to SQL.
         type (str): One of ``FilterType`` — the UI input kind.
         operators (tuple[str, ...]): Allowed ``FilterOperator`` values (whitelist).
         value_source (str): One of ``ValueSource`` — where options come from.
+        requires_key (bool): Whether a predicate on the field carries a ``key`` slot in
+            addition to op/value (``{field, key, op, value}``) — e.g. which metadata key
+            the value is compared against. Declared per field rather than derived from
+            the level, because keyed-ness and lowering scope are independent axes: a key
+            slot says the predicate names a map entry, the level says which relation the
+            predicate lowers against, and a future keyed field could sit at any level.
+            This is also what ``/filter-fields`` serializes — the UI needs one boolean
+            ("render an extra key control"), and typing the level string on the client
+            would push a backend enum into UI branching. Nothing enforces agreement
+            between this and ``level`` by construction; a registry parity test pins which
+            fields declare it.
         enum_values (tuple[str, ...]): Static options for ``STATIC_ENUM`` fields.
         aggregate_expr (str | None): For ``SPAN_AGGREGATE`` fields, the per-trace
             aggregate the HAVING clause filters on (e.g. ``sum(cost)``). ``None`` for
@@ -87,6 +105,7 @@ class FilterColumn:
     type: str
     operators: tuple[str, ...]
     value_source: str
+    requires_key: bool = False
     enum_values: tuple[str, ...] = ()
     aggregate_expr: str | None = None
     source_columns: tuple[str, ...] = ()
@@ -192,6 +211,30 @@ FILTER_COLUMNS: tuple[FilterColumn, ...] = (
         value_source=ValueSource.RANGE,
         aggregate_expr="countIf(status = 'ERROR')",
         source_columns=("status",),
+    ),
+    # Keyed-map tier — "the trace carries <key> <op> <value>, at either scope".
+    # ONE parameterized field with a key slot, never one row per key: metadata keys are the
+    # user's own data, discovered per window at runtime, while this tuple is a fixed contract.
+    # That works because the key reaches SQL as a bound parameter rather than an identifier,
+    # so any key the user types is safe to query — an unsuggested key simply matches nothing.
+    # The SDK may attach metadata at trace scope (traces.metadata_map, surfaced in the list
+    # as the single default-off Metadata blob cell) or at span scope (spans.metadata_map), and
+    # the two key spaces are disjoint, so the level lowers to an inline traces-row match OR the
+    # span semi-join.
+    # A user filtering by a tag they can see therefore need not know which scope set it;
+    # matching only spans would have dropped every trace-level key. The trace-row arm rides
+    # the scan the list already does, so only the span arm costs a scan. Last in the tuple
+    # because this is also the field dropdown's render order, and metadata is the one field
+    # that renders an extra control.
+    FilterColumn(
+        name="metadata",
+        label="Metadata",
+        ch_type="String",
+        level=FilterLevel.KEYED_MAP,
+        type=FilterType.TEXT,
+        operators=(FilterOperator.EQ, FilterOperator.CONTAINS),
+        value_source=ValueSource.FREE_TEXT,
+        requires_key=True,
     ),
 )
 

--- a/backend/rest/services/filters/translate.py
+++ b/backend/rest/services/filters/translate.py
@@ -6,15 +6,20 @@ BOTH the page CTE and the separate count query. Every condition is keyed on
 ``t.trace_id`` and bound through query parameters (never string-interpolated), so a
 filter narrows the page and the total identically and safely.
 
-Structured as a per-field lowering plus a small assembler that groups predicates by
-registry level. Each membership predicate becomes its own span semi-join (independent
-existence); the safety boundary is the per-field operator whitelist validated against the
-registry here, not downstream.
+Structured as a per-field lowering, dispatched by the predicate's registry level, plus a
+small assembler; aggregate predicates are the one level that merges rather than lowering
+one at a time. Each membership predicate becomes its own span semi-join (independent
+existence) — a keyed one ORs an inline traces-row arm onto that semi-join, because the same
+map key may have been attached at either scope. Every span-level lowering goes through the
+one ``_span_semijoin`` builder, so the scan's safety properties are asserted in one place.
+The safety boundary is the per-field operator whitelist validated against the registry here,
+not downstream.
 """
 
 import json
 import math
-from typing import Any
+from collections.abc import Callable, Sequence
+from typing import Any, NoReturn
 
 from pydantic import BaseModel, ValidationError
 
@@ -37,11 +42,24 @@ class Predicate(BaseModel):
         value (Any): The operand, shaped by the field's type — a list of strings for
             ``in``, a single number for a numeric comparison (``eq``/``gt``/``gte``/
             ``lt``/``lte``), or a string for a text match (``eq``/``contains``).
+        key (str | None): The map key for a keyed field (``requires_key``), e.g. which
+            metadata key the value is compared against. ``None`` for every other field,
+            which is the vast majority — only a keyed field may carry one.
     """
 
     field: str
     op: str
     value: Any
+    key: str | None = None
+
+
+# Inclusive cap on how many predicates one request may carry. Each span-level predicate
+# lowers to its own base-table scan emitted into BOTH the page query and the count query, so
+# the request's scan count grows at twice the array length — the one input on this endpoint
+# whose cost is unbounded by ``limit`` (itself capped at 200 in the router). The builder UI
+# adds one row at a time against a registry of a handful of fields, so a request past this
+# is not something the product can produce.
+MAX_FILTERS = 20
 
 
 def parse_filters_param(raw: str | None) -> list[Predicate]:
@@ -55,8 +73,9 @@ def parse_filters_param(raw: str | None) -> list[Predicate]:
         list[Predicate]: The parsed, registry-validated predicates.
 
     Raises:
-        ValueError: If the value is not a JSON array of valid predicate objects, or
-            names an unknown field or a non-whitelisted operator.
+        ValueError: If the value is not a JSON array of valid predicate objects, carries
+            more than ``MAX_FILTERS`` of them, or names an unknown field or a
+            non-whitelisted operator.
     """
     if not raw:
         return []
@@ -66,6 +85,10 @@ def parse_filters_param(raw: str | None) -> list[Predicate]:
         raise ValueError(f"filters is not valid JSON: {e}") from e
     if not isinstance(data, list):
         raise ValueError("filters must be a JSON array of predicate objects")
+    # Bound the array before validating a single item, so an oversized one costs one
+    # length check rather than a parse per element.
+    if len(data) > MAX_FILTERS:
+        raise ValueError(f"filters carries more than the maximum of {MAX_FILTERS} predicates")
     predicates: list[Predicate] = []
     for item in data:
         if not isinstance(item, dict):
@@ -89,14 +112,15 @@ def validate_predicate(pred: Predicate) -> FilterColumn:
         FilterColumn: The matching registry entry.
 
     Raises:
-        ValueError: If the field is not filterable or the operator is not whitelisted
-            for that field.
+        ValueError: If the field is not filterable, the operator is not whitelisted for
+            that field, or the key/value doesn't match the field's shape.
     """
     col = get_column(pred.field)
     if col is None:
         raise ValueError(f"unknown filter field: {pred.field!r}")
     if pred.op not in col.operators:
         raise ValueError(f"operator {pred.op!r} not allowed for field {pred.field!r}")
+    _validate_key(pred, col)
     _validate_value(pred, col)
     return col
 
@@ -114,6 +138,58 @@ def _is_number(x: object) -> bool:
 _NUMERIC_TYPE_MAX = {"Int64": 2**63 - 1, "UInt64": 2**64 - 1, "Decimal64(9)": 10**9 - 1}
 
 
+# Inclusive cap on a keyed field's key length. The key is free text the user may type
+# rather than something the registry vouches for, and it binds as a parameter on both the
+# page and the count query, so bound it at the edge instead of shipping an arbitrarily large
+# one to ClickHouse. Real attribute names ("session_id", "tenant_id") are an order of
+# magnitude shorter, so this only rejects input no ingestion path could have produced.
+MAX_KEY_LENGTH = 256
+
+
+# Inclusive cap on a text value's length, and on each element of a categorical ``in`` list —
+# both are free text the caller types, and both bind as parameters on the page query and the
+# count query alike. Larger than the key cap on purpose: a value is compared rather than
+# looked up, so a legitimate one can be a whole prompt fragment or a URL, where a key is an
+# attribute name. It is still bounded, because a ``contains`` value becomes an ILIKE pattern
+# matched against every row the span scan surfaces, which makes an outsized pattern the more
+# expensive of the two inputs. A kilobyte is orders of magnitude past anything a filter box
+# produces, so this only rejects input no legitimate path could have sent.
+MAX_VALUE_LENGTH = 1024
+
+
+def _reject_long_value(pred: Predicate) -> NoReturn:
+    """Raise the over-length value error, worded once for both value shapes."""
+    raise ValueError(
+        f"value on {pred.field!r} exceeds the maximum length of {MAX_VALUE_LENGTH} characters"
+    )
+
+
+def _validate_key(pred: Predicate, col: FilterColumn) -> None:
+    """Check the predicate's key slot against whether the field's level takes a key.
+
+    A keyed field cannot be lowered without a key — there is no default map key to fall
+    back on — and a key on an unkeyed field means the caller has the field's shape wrong,
+    so reject it rather than silently drop it and answer a different question than asked.
+    The key is only ever a bound parameter, so length is the only bound worth enforcing:
+    an unrecognized key is a legitimate query that matches nothing, never an error.
+
+    Raises:
+        ValueError: If a keyed field's key is missing, not a string, empty, or longer than
+            ``MAX_KEY_LENGTH``; or if a key is supplied for a field that takes none.
+    """
+    if not col.requires_key:
+        if pred.key is not None:
+            raise ValueError(f"field {pred.field!r} does not take a key")
+        return
+    # Catches missing (None) and non-string alike — a JSON number or object is not a key.
+    if not isinstance(pred.key, str) or pred.key == "":
+        raise ValueError(f"filter on {pred.field!r} requires a non-empty string key")
+    if len(pred.key) > MAX_KEY_LENGTH:
+        raise ValueError(
+            f"key on {pred.field!r} exceeds the maximum length of {MAX_KEY_LENGTH} characters"
+        )
+
+
 def _validate_value(pred: Predicate, col: FilterColumn) -> None:
     """Check the value matches the field's type, so a malformed (but typed) filter is a
     422 at the edge rather than a 500 from deep in query building. The value's shape is
@@ -122,7 +198,8 @@ def _validate_value(pred: Predicate, col: FilterColumn) -> None:
 
     Raises:
         ValueError: If a categorical ``in`` isn't a non-empty list of strings; if a text
-            value isn't a non-empty string; or if a numeric value can't bind to the
+            value isn't a non-empty string; if a text value or a categorical list element is
+            longer than ``MAX_VALUE_LENGTH``; or if a numeric value can't bind to the
             column's ClickHouse type (see ``_validate_numeric``).
     """
     if col.type == FilterType.CATEGORICAL:
@@ -132,10 +209,15 @@ def _validate_value(pred: Predicate, col: FilterColumn) -> None:
             or not all(isinstance(v, str) for v in pred.value)
         ):
             raise ValueError(f"'in' filter on {pred.field!r} requires a non-empty list of strings")
+        # Each element binds into the same Array parameter, so cap them like a text value.
+        if any(len(v) > MAX_VALUE_LENGTH for v in pred.value):
+            _reject_long_value(pred)
     elif col.type == FilterType.TEXT:
         # bool is not a str, so a JSON boolean is correctly rejected here.
         if not isinstance(pred.value, str) or pred.value == "":
             raise ValueError(f"{pred.op!r} filter on {pred.field!r} requires a non-empty string")
+        if len(pred.value) > MAX_VALUE_LENGTH:
+            _reject_long_value(pred)
     elif col.type == FilterType.NUMERIC:
         _validate_numeric(pred.value, pred, col)
 
@@ -193,8 +275,44 @@ def _span_time_bound(params: dict) -> str:
     return ""
 
 
+def _span_semijoin(value_columns: Sequence[str], tail: str, params: dict) -> str:
+    """The one deduped span scan every span-level predicate filters through.
+
+    Written once so the safety properties are a single-site question. The inner relation
+    dedups ReplacingMergeTree spans to the latest ``ch_update_time`` version per span BEFORE
+    ``tail`` applies (like the aggregate/distinct paths), so a stale row can't match a value
+    the latest version no longer has; it is scoped to the same ``project_id`` as the outer
+    query (tenant isolation); and it carries ``_span_time_bound``'s lower bound with
+    deliberately NO upper bound (see that helper). The result keys on ``t.trace_id``, so it
+    filters the page query and the count query alike.
+
+    Args:
+        value_columns (Sequence[str]): The spans columns ``tail`` reads, projected alongside
+            the structural dedup keys. Order within the projection is not meaningful —
+            ``tail`` names columns, never positions — and duplicates are dropped.
+        tail (str): What the outer SELECT does with the deduped rows: a ``WHERE <predicate>``
+            for an existence check, or a ``GROUP BY ... HAVING ...`` for the aggregate path.
+        params (dict): The query parameter map, read (not bound here) to decide whether the
+            active window contributes a lower bound. Callers bind whatever ``tail`` references.
+
+    Returns:
+        str: A ``t.trace_id IN (...)`` condition for the shared conditions list.
+    """
+    # dict.fromkeys dedups with stable order: a caller's value column may repeat the
+    # structural keys or another predicate's column.
+    projection = dict.fromkeys(("project_id", "trace_id", "span_id", *value_columns))
+    inner = (
+        f"SELECT {', '.join(projection)} "
+        "FROM spans "
+        "WHERE project_id = {project_id:String}" + _span_time_bound(params) + " "
+        "ORDER BY ch_update_time DESC "
+        "LIMIT 1 BY project_id, trace_id, span_id"
+    )
+    return f"t.trace_id IN (SELECT trace_id FROM ({inner}) {tail})"
+
+
 def _membership_semijoin(idx: int, col: FilterColumn, pred: Predicate, params: dict) -> str:
-    """One project-scoped span semi-join for a single membership predicate.
+    """One span semi-join for a single membership predicate.
 
     Independent-existence semantics: each membership predicate becomes its OWN semi-join,
     AND-combined by the caller, so a trace matches if it has >=1 span for EACH predicate
@@ -202,24 +320,89 @@ def _membership_semijoin(idx: int, col: FilterColumn, pred: Predicate, params: d
     "has an X span AND has an error span", not "has one span that is both". A multi-value
     predicate on a single field stays one ``IN (...)`` (OR within the field).
 
-    Dedups ReplacingMergeTree spans to the latest ``ch_update_time`` version per span
-    BEFORE applying the categorical predicate (like the aggregate/distinct paths), so a
-    stale row can't match a value the latest version no longer has. Scoped to the same
-    ``project_id`` as the outer query (tenant isolation) and keyed on ``t.trace_id`` so it
-    filters the page and the count alike. The param name carries the predicate's index so
-    two predicates on the same field don't collide.
+    The param name carries the predicate's index so two predicates on the same field don't
+    collide. Scan safety (dedup before predicate, project scoping, time bound) is
+    ``_span_semijoin``'s.
     """
     pname = f"f_{col.name}_{idx}"
     params[pname] = pred.value
-    inner = (
-        f"SELECT project_id, trace_id, span_id, {col.name} "
-        "FROM spans "
-        "WHERE project_id = {project_id:String}" + _span_time_bound(params) + " "
-        "ORDER BY ch_update_time DESC "
-        "LIMIT 1 BY project_id, trace_id, span_id"
-    )
-    where = f"{col.name} IN {{{pname}:Array({col.ch_type})}}"
-    return f"t.trace_id IN (SELECT trace_id FROM ({inner}) WHERE {where})"
+    where = f"WHERE {col.name} IN {{{pname}:Array({col.ch_type})}}"
+    return _span_semijoin((col.name,), where, params)
+
+
+# The Map column a keyed predicate reads. Both `traces` and `spans` carry a column of this
+# name, which is what lets one predicate ask the same question of either row. Named separately
+# from the registry field ("metadata"), which still refers to the original JSON blob column the
+# map is derived from — the blob is what the detail panel renders, the map is what is filterable.
+_METADATA_MAP_COLUMN = "metadata_map"
+
+
+def _keyed_map_match(map_ref: str, key_ref: str, value_ref: str, op: str) -> str:
+    """The key/value comparison against one ``metadata_map`` column.
+
+    Written once and applied to both the traces row and the spans row so the two halves of a
+    metadata predicate cannot drift apart in operator handling.
+
+    ``mapContains`` is not redundant with the comparison: ClickHouse's map subscript returns
+    the value type's default for an absent key, so without the guard a predicate looking for
+    the empty string would match every row that lacks the key entirely.
+
+    Args:
+        map_ref (str): The map column to read, qualified if the query needs it (``t.<col>``).
+        key_ref (str): The bound-parameter reference holding the map key.
+        value_ref (str): The bound-parameter reference holding the compared value. For
+            ``contains`` it is already wrapped in ``%`` wildcards by the caller.
+        op (str): The predicate's ``FilterOperator`` — ``contains`` lowers to ``ILIKE``,
+            anything else (only ``eq`` is whitelisted for this field) to ``=``.
+
+    Returns:
+        str: The guarded comparison, for use as a WHERE fragment.
+    """
+    comparison = "ILIKE" if op == FilterOperator.CONTAINS else "="
+    return f"mapContains({map_ref}, {key_ref}) AND {map_ref}[{key_ref}] {comparison} {value_ref}"
+
+
+def _keyed_metadata_condition(idx: int, col: FilterColumn, pred: Predicate, params: dict) -> str:
+    """One condition matching a keyed metadata pair at EITHER trace or span scope.
+
+    The SDK may attach a tag at either scope and the two key spaces are disjoint, so a trace
+    matches when the pair is on its ``traces`` row OR on at least one of its spans. The trace
+    half is inline on the already-scanned ``t`` row; only the span half is a semi-join. Both
+    the key and the value bind as parameters, which is what makes an arbitrary user-typed key
+    safe without registry membership.
+
+    Args:
+        idx (int): The predicate's position in the request's filter array, used to keep this
+            predicate's parameter names distinct from another predicate's on the same field.
+        col (FilterColumn): The registry entry for the keyed field.
+        pred (Predicate): The predicate being lowered (its ``key`` is already validated
+            non-empty by ``validate_predicate``).
+        params (dict): The query parameter map, mutated in place with the bound key and value.
+
+    Returns:
+        str: A single parenthesised condition for the shared conditions list.
+    """
+    kname = f"f_{col.name}_{idx}_key"
+    vname = f"f_{col.name}_{idx}"
+    params[kname] = pred.key
+    key_ref = f"{{{kname}:String}}"
+    value_ref = f"{{{vname}:{col.ch_type}}}"
+    if pred.op == FilterOperator.CONTAINS:
+        # Case-insensitive substring with the search value's wildcards escaped, so a literal
+        # `%`/`_` in the value matches literally — the same treatment trace_id's contains gets.
+        params[vname] = f"%{escape_ilike(pred.value)}%"
+    else:
+        params[vname] = pred.value  # EQ — exact match
+    trace_half = _keyed_map_match(f"t.{_METADATA_MAP_COLUMN}", key_ref, value_ref, pred.op)
+    span_where = f"WHERE {_keyed_map_match(_METADATA_MAP_COLUMN, key_ref, value_ref, pred.op)}"
+    span_half = _span_semijoin((_METADATA_MAP_COLUMN,), span_where, params)
+    # Parenthesise the OR as one unit before it joins the shared conditions list. That list is
+    # AND-joined, and OR binds looser than AND: unparenthesised, this predicate's span half
+    # would absorb every condition to its left into the left arm of the OR and every condition
+    # to its right into the right arm, so any row matching the span half alone would satisfy the
+    # whole WHERE clause — silently widening the date range and every other active filter. The
+    # inner parentheses around the trace half are for the reader; AND already binds tighter.
+    return f"(({trace_half}) OR {span_half})"
 
 
 # Numeric comparison operators -> their literal SQL. The operand always binds as a param.
@@ -267,37 +450,46 @@ def _having_clause(idx: int, col: FilterColumn, pred: Predicate, params: dict) -
 
 
 def _aggregate_semijoin(frags: list[tuple[int, FilterColumn, Predicate]], params: dict) -> str:
-    """Merge aggregate predicates into one time-bounded GROUP BY ... HAVING semi-join.
+    """Merge aggregate predicates into ONE GROUP BY ... HAVING semi-join.
 
-    Dedups ReplacingMergeTree spans (latest ``ch_update_time`` per span) within the
-    active window, rolls them up per trace, and keeps traces whose aggregates satisfy
-    all HAVING comparisons. Keyed on ``t.trace_id`` so it filters page and count alike.
+    Rolls the deduped spans up per trace and keeps traces whose aggregates satisfy all
+    HAVING comparisons at once. The value columns are the ``source_columns`` of the active
+    predicates, so a new aggregate field is one registry entry with no change here.
     """
     having = [_having_clause(i, col, pred, params) for i, col, pred in frags]
-    # Project the dedup/group keys, UNIONED with the source_columns of the active aggregate
-    # predicates. Registry-driven, so a new aggregate field is one registry entry (its
-    # source_columns) with no change here. dict.fromkeys dedups with stable order.
-    # (span_start_time is filtered in the inner WHERE by _span_time_bound but needn't be
-    # projected; duration_ms's source_columns add it when that field is active.)
-    structural = ("trace_id", "span_id", "project_id")
-    select_cols = list(structural)
-    for _, col, _pred in frags:
-        select_cols.extend(col.source_columns)
-    inner = (
-        f"SELECT {', '.join(dict.fromkeys(select_cols))} "
-        "FROM spans "
-        "WHERE project_id = {project_id:String}" + _span_time_bound(params) + " "
-        "ORDER BY ch_update_time DESC "
-        "LIMIT 1 BY project_id, trace_id, span_id"
-    )
-    return (
-        f"t.trace_id IN (SELECT trace_id FROM ({inner}) "
-        f"GROUP BY trace_id HAVING {' AND '.join(having)})"
-    )
+    value_columns = [c for _, col, _pred in frags for c in col.source_columns]
+    tail = f"GROUP BY trace_id HAVING {' AND '.join(having)}"
+    return _span_semijoin(value_columns, tail, params)
+
+
+# How each filter level lowers: one predicate in, one condition out. SPAN_AGGREGATE is
+# deliberately absent — it is the only level whose predicates do NOT lower independently,
+# since they all merge into a single GROUP BY ... HAVING semi-join, so ``build_conditions``
+# collects those and calls ``_aggregate_semijoin`` once. A level missing from this table is
+# a level with no lowering at all, which is the NotImplementedError case.
+_LEVEL_LOWERING: dict[FilterLevel, Callable[[int, FilterColumn, Predicate, dict], str]] = {
+    # Inline trace-row predicates (t.*), keyed on the outer query so they land in both the
+    # page and count queries.
+    FilterLevel.TRACE: _trace_condition,
+    # One semi-join per membership predicate (independent existence), each AND-combined via
+    # the shared conditions list so every one lands in both the page and count queries.
+    FilterLevel.SPAN_MEMBERSHIP: _membership_semijoin,
+    # The same independent existence, widened by an inline trace-row arm because a keyed
+    # predicate's key may have been attached at either scope.
+    FilterLevel.KEYED_MAP: _keyed_metadata_condition,
+    # SPAN_AGGREGATE is deliberately absent: its predicates merge into ONE semi-join rather
+    # than lowering one at a time, so build_conditions handles it separately.
+}
 
 
 def build_conditions(filters: list[Predicate], params: dict) -> list[str]:
     """Lower filter predicates to parameterized WHERE conditions.
+
+    Each predicate is validated against the registry and then lowered by its level's entry
+    in ``_LEVEL_LOWERING``, in the order the caller sent them. Aggregate predicates are the
+    one exception: they are collected and merged into a single semi-join appended last.
+    Position in the returned list carries no meaning — the caller AND-joins the whole list
+    into one WHERE clause.
 
     Args:
         filters (list[Predicate]): The predicates to apply (AND-combined).
@@ -309,31 +501,21 @@ def build_conditions(filters: list[Predicate], params: dict) -> list[str]:
         (and thus AND-ed into both the page query and the count query).
 
     Raises:
-        ValueError: On an unknown field or a non-whitelisted operator.
+        ValueError: On an unknown field, a non-whitelisted operator, or a key/value that
+            doesn't match the field's shape.
+        NotImplementedError: If a registry column's level has no lowering yet.
     """
-    membership: list[tuple[int, FilterColumn, Predicate]] = []
+    conditions: list[str] = []
     aggregate: list[tuple[int, FilterColumn, Predicate]] = []
-    trace: list[tuple[int, FilterColumn, Predicate]] = []
     for i, pred in enumerate(filters):
         col = validate_predicate(pred)
-        if col.level == FilterLevel.SPAN_MEMBERSHIP:
-            membership.append((i, col, pred))
-        elif col.level == FilterLevel.SPAN_AGGREGATE:
+        if col.level == FilterLevel.SPAN_AGGREGATE:
             aggregate.append((i, col, pred))
-        elif col.level == FilterLevel.TRACE:
-            trace.append((i, col, pred))
-        else:
+            continue
+        lower = _LEVEL_LOWERING.get(col.level)
+        if lower is None:
             raise NotImplementedError(f"level {col.level} not yet lowered: {col.name}")
-
-    conditions: list[str] = []
-    # Inline trace-row predicates (t.*), keyed on the outer query so they land in both the
-    # page and count queries.
-    for i, col, pred in trace:
-        conditions.append(_trace_condition(i, col, pred, params))
-    # One semi-join per membership predicate (independent existence), each AND-combined via
-    # the shared conditions list so every one lands in both the page and count queries.
-    for i, col, pred in membership:
-        conditions.append(_membership_semijoin(i, col, pred, params))
+        conditions.append(lower(i, col, pred, params))
     if aggregate:
         conditions.append(_aggregate_semijoin(aggregate, params))
     return conditions

--- a/tests/rest/test_filter_columns_parity.py
+++ b/tests/rest/test_filter_columns_parity.py
@@ -6,6 +6,7 @@ registry can't silently drift. The ``skipif`` cross-check against the SQL Gatewa
 snapshot stays in sync with the curated-column contract it mirrors.
 """
 
+import dataclasses
 from dataclasses import FrozenInstanceError
 
 import pytest
@@ -13,6 +14,10 @@ import pytest
 from rest.services.filters import columns as reg
 
 MEMBERSHIP_FIELDS = {"model_name", "environment"}
+# Keyed map: its own tier, because the predicate carries a map key as well as a value and
+# lowers to a shape no membership field lowers to. One parameterized field over a Map
+# column, never one registry row per key.
+KEYED_MAP_FIELDS = {"metadata"}
 AGGREGATE_FIELDS = {"cost", "total_tokens", "duration_ms", "errors"}
 TRACE_FIELDS = {"trace_id"}
 
@@ -20,7 +25,7 @@ TRACE_FIELDS = {"trace_id"}
 def test_registry_column_set_is_exactly_the_declared_tiers():
     """The registry holds precisely the membership + aggregate + trace fields."""
     assert {c.name for c in reg.FILTER_COLUMNS} == (
-        MEMBERSHIP_FIELDS | AGGREGATE_FIELDS | TRACE_FIELDS
+        MEMBERSHIP_FIELDS | KEYED_MAP_FIELDS | AGGREGATE_FIELDS | TRACE_FIELDS
     )
 
 
@@ -61,6 +66,54 @@ def test_trace_id_is_a_text_trace_level_field():
     assert col.source_columns == ()
 
 
+def test_metadata_is_a_keyed_map_text_field_on_its_own_level():
+    """Metadata declares the keyed-map level rather than borrowing the membership one:
+    it lowers to an inline traces-row map match ORed onto a span semi-join, which no
+    membership field lowers to. It takes a key alongside its value and matches text with
+    the string operators only."""
+    col = reg.get_column("metadata")
+    assert col.level is reg.FilterLevel.KEYED_MAP
+    assert col.level is not reg.FilterLevel.SPAN_MEMBERSHIP
+    assert col.type is reg.FilterType.TEXT
+    assert col.operators == (reg.FilterOperator.EQ, reg.FilterOperator.CONTAINS)
+    assert col.requires_key is True
+    assert col.ch_type == "String"
+    assert col.aggregate_expr is None
+    assert col.source_columns == ()
+
+
+def test_requires_key_is_declared_per_field_and_agrees_with_the_level():
+    """``requires_key`` is a declared field, not a property derived from ``level``, because
+    keyed-ness and lowering scope are independent axes: a key slot says the predicate names
+    a map entry, the level says which relation the predicate lowers against, and a keyed
+    field could sit at any level. Deriving one from the other collapses the two into a
+    flattened matrix the moment a second keyed field appears at a different scope, while
+    the wire contract was already two-axis.
+
+    Their agreement therefore used to hold by construction and is now a checked invariant,
+    which is what this test is: a registry entry could otherwise claim a key the
+    translator's lowering never reads (or the reverse) and the two would disagree silently.
+    Adding a keyed field at a new scope fails here, which is the signal to keep the two
+    axes in step deliberately rather than by accident."""
+    declared = {f.name: f for f in dataclasses.fields(reg.FilterColumn)}
+    assert "requires_key" in declared
+    # Unkeyed is the default, so every entry but the keyed one omits the kwarg entirely.
+    assert declared["requires_key"].default is False
+    for col in reg.FILTER_COLUMNS:
+        assert col.requires_key is (col.level is reg.FilterLevel.KEYED_MAP)
+    # Every other field's predicate is {field, op, value}, so the UI renders the extra key
+    # control for exactly one field.
+    assert {c.name for c in reg.FILTER_COLUMNS if c.requires_key} == KEYED_MAP_FIELDS
+
+
+def test_metadata_options_are_suggestions_not_an_enumerated_value_set():
+    """The value is free text — a metadata value is never enumerated into a dropdown, so
+    an unsuggested value stays typable. (Key discovery has its own endpoint.)"""
+    col = reg.get_column("metadata")
+    assert col.value_source is reg.ValueSource.FREE_TEXT
+    assert col.enum_values == ()
+
+
 def test_errors_is_a_numeric_count_of_error_spans():
     """`errors` is a derived per-trace count, filtered like the other numeric aggregates."""
     col = reg.get_column("errors")
@@ -93,7 +146,7 @@ def test_aggregate_source_columns_name_the_referenced_spans_columns():
     assert reg.get_column("total_tokens").source_columns == ("total_tokens",)
     assert reg.get_column("duration_ms").source_columns == ("span_start_time", "span_end_time")
     assert reg.get_column("errors").source_columns == ("status",)
-    for name in MEMBERSHIP_FIELDS | TRACE_FIELDS:
+    for name in MEMBERSHIP_FIELDS | KEYED_MAP_FIELDS | TRACE_FIELDS:
         assert reg.get_column(name).source_columns == ()
 
 

--- a/tests/rest/test_filter_translate.py
+++ b/tests/rest/test_filter_translate.py
@@ -1,17 +1,32 @@
 """Translator unit tests: predicates -> parameterized WHERE conditions.
 
-The translator's contract is the load-bearing correctness piece: every condition it
-returns is appended to the shared ``conditions`` list in ``list_traces`` (the one that
-feeds BOTH the page CTE and the separate count query), so a membership / aggregate /
-trace-level filter keyed on ``t.trace_id`` filters the page and the total identically.
+Every condition the translator returns is appended to the shared ``conditions`` list in
+``list_traces``, which feeds BOTH the page CTE and the separate count query, so a condition
+keyed on ``t.trace_id`` filters the page and the total identically.
 
-Operators are explicit and scalar: categorical ``in`` (array),
-numeric ``eq/gt/gte/lt/lte`` (a single number), and text ``eq/contains`` (a string).
+Operators are explicit and scalar: categorical ``in`` (array), numeric ``eq/gt/gte/lt/lte``
+(one number), text ``eq/contains`` (a string). A keyed field (``metadata``) adds a ``key``
+slot bound as a parameter rather than resolved as an identifier, and matches the pair at
+either scope — the traces row or any of the trace's spans — so its two halves are asserted
+separately throughout, its span half through the one shared span-scan builder.
 """
+
+import json
 
 import pytest
 
+from rest.services.filters import translate
+from rest.services.filters.columns import (
+    FILTER_COLUMNS,
+    FilterColumn,
+    FilterOperator,
+    FilterType,
+    ValueSource,
+)
 from rest.services.filters.translate import (
+    MAX_FILTERS,
+    MAX_KEY_LENGTH,
+    MAX_VALUE_LENGTH,
     SPAN_TIME_BOUND_LOOKBACK_HOURS,
     Predicate,
     build_conditions,
@@ -62,6 +77,30 @@ def test_parse_rejects_bad_operator_for_field():
         parse_filters_param('[{"field":"cost","op":"in","value":[1]}]')
 
 
+def _filters_json(count: int, field: str = "model_name") -> str:
+    """A filters param carrying ``count`` well-formed predicates on one field."""
+    return json.dumps([{"field": field, "op": "in", "value": ["gpt-4"]} for _ in range(count)])
+
+
+def test_parse_accepts_the_maximum_number_of_predicates_and_rejects_one_more():
+    # Every span-level predicate lowers to its own scan in BOTH the page and the count
+    # query, so the array length is the one input whose cost `limit` doesn't bound.
+    assert len(parse_filters_param(_filters_json(MAX_FILTERS))) == MAX_FILTERS
+    with pytest.raises(ValueError):
+        parse_filters_param(_filters_json(MAX_FILTERS + 1))
+
+
+def test_parse_rejects_an_oversized_array_without_validating_its_items():
+    """The bound sits before the per-item loop, so an oversized array costs one length
+    check rather than a parse and a registry lookup per element. Asserted through the
+    error it raises rather than by reaching into the parser: every item here would also
+    fail validation (unknown field, no op, no value), so the length message can only be
+    the one raised if the check ran first."""
+    raw = json.dumps([{"field": "nope"} for _ in range(MAX_FILTERS + 1)])
+    with pytest.raises(ValueError, match="more than the maximum"):
+        parse_filters_param(raw)
+
+
 # --- categorical `in` validation -------------------------------------------
 
 
@@ -75,6 +114,19 @@ def test_validation_rejects_malformed_in_value():
 def test_validation_rejects_empty_in_list():
     with pytest.raises(ValueError):
         build_conditions([Predicate(field="model_name", op="in", value=[])], {})
+
+
+def test_in_list_element_at_the_length_cap_is_accepted_and_beyond_it_is_rejected():
+    """The cap is per element, not on the list: each one binds into the same Array
+    parameter on both the page and the count query. The list is deliberately short in both
+    cases, so neither outcome can come from a bound on how many values an `in` may carry."""
+
+    def one_long_element(length: int) -> Predicate:
+        return Predicate(field="model_name", op="in", value=["gpt-4", "m" * length])
+
+    assert build_conditions([one_long_element(MAX_VALUE_LENGTH)], {"project_id": "p1"})
+    with pytest.raises(ValueError):
+        build_conditions([one_long_element(MAX_VALUE_LENGTH + 1)], {"project_id": "p1"})
 
 
 # --- numeric comparison validation -----------------------------------------
@@ -141,6 +193,92 @@ def test_text_op_requires_a_non_empty_string():
             build_conditions([Predicate(field="trace_id", op="contains", value=bad)], {})
 
 
+def test_text_value_at_the_length_cap_is_accepted_and_beyond_it_is_rejected():
+    """A value is free text the caller types and binds on the page and the count query
+    alike, so it is bounded at the edge like the key. It gets more room than a key —
+    a value is compared, not looked up — and a `contains` one becomes an ILIKE pattern
+    matched against every row the scan surfaces, which is why it is bounded at all."""
+    for op in ("eq", "contains"):
+        at_cap = Predicate(field="trace_id", op=op, value="x" * MAX_VALUE_LENGTH)
+        assert build_conditions([at_cap], {"project_id": "p1"})
+        over_cap = Predicate(field="trace_id", op=op, value="x" * (MAX_VALUE_LENGTH + 1))
+        with pytest.raises(ValueError):
+            build_conditions([over_cap], {"project_id": "p1"})
+
+
+# --- keyed field (metadata) key validation ---------------------------------
+
+
+def _metadata(op="eq", value="acme-corp", key="tenant_id") -> Predicate:
+    """A well-formed metadata predicate; per-test overrides isolate one bad slot."""
+    return Predicate(field="metadata", op=op, value=value, key=key)
+
+
+@pytest.mark.parametrize(
+    "key_json", ["", ',"key":""', ',"key":5', ',"key":{"a":1}', ',"key":["tenant_id"]']
+)
+def test_a_metadata_predicate_needs_a_non_empty_string_key(key_json):
+    # There is no default map key to fall back on, and a JSON number/object/array is not a
+    # key: reject at the edge (422) rather than answer a different question than the one asked.
+    with pytest.raises(ValueError):
+        parse_filters_param(f'[{{"field":"metadata","op":"eq","value":"acme-corp"{key_json}}}]')
+
+
+def test_metadata_key_at_the_length_cap_is_accepted_and_beyond_it_is_rejected():
+    # The key is free text the registry never vouches for and it binds on both the page
+    # and the count query, so it is bounded at the edge instead of shipped to ClickHouse.
+    at_cap = "k" * MAX_KEY_LENGTH
+    assert build_conditions([_metadata(key=at_cap)], {"project_id": "p1"})
+    with pytest.raises(ValueError):
+        build_conditions([_metadata(key="k" * (MAX_KEY_LENGTH + 1))], {"project_id": "p1"})
+
+
+def test_key_on_a_field_that_takes_none_is_rejected():
+    # A key on an unkeyed field means the caller has the field's shape wrong; silently
+    # dropping it would answer a different question than the one asked.
+    for pred in (
+        Predicate(field="model_name", op="in", value=["gpt-4"], key="tenant_id"),
+        Predicate(field="trace_id", op="eq", value="abc", key="tenant_id"),
+        Predicate(field="cost", op="gt", value=1, key="tenant_id"),
+    ):
+        with pytest.raises(ValueError):
+            build_conditions([pred], {"project_id": "p1"})
+
+
+def test_metadata_operator_whitelist_is_eq_and_contains_only():
+    # No per-key type inference in v1 — no numeric comparisons, no categorical `in`.
+    for op in ("in", "gt", "gte", "lt", "lte"):
+        with pytest.raises(ValueError):
+            build_conditions([_metadata(op=op, value="acme-corp")], {"project_id": "p1"})
+
+
+def test_metadata_value_must_be_a_non_empty_string():
+    # An empty value is rejected at the edge for both operators: with ClickHouse's map
+    # subscript defaulting, a bare `= ''` would otherwise be a match-everything filter.
+    for bad in ("", 5, None, ["acme-corp"], True):
+        for op in ("eq", "contains"):
+            with pytest.raises(ValueError):
+                build_conditions([_metadata(op=op, value=bad)], {"project_id": "p1"})
+
+
+def test_metadata_value_is_bounded_like_any_other_text_value():
+    # The keyed field bounds its key and its value independently: a key at its own cap
+    # alongside a value one character past the value cap is still rejected.
+    assert build_conditions([_metadata(value="v" * MAX_VALUE_LENGTH)], {"project_id": "p1"})
+    with pytest.raises(ValueError):
+        build_conditions(
+            [_metadata(key="k" * MAX_KEY_LENGTH, value="v" * (MAX_VALUE_LENGTH + 1))],
+            {"project_id": "p1"},
+        )
+
+
+def test_parse_round_trips_a_metadata_key_from_the_filters_param():
+    preds = parse_filters_param(
+        '[{"field":"metadata","op":"eq","value":"acme-corp","key":"tenant_id"}]'
+    )
+    assert preds == [Predicate(field="metadata", op="eq", value="acme-corp", key="tenant_id")]
+
+
 # --- whitelist boundary ----------------------------------------------------
 
 
@@ -197,6 +335,191 @@ def test_membership_predicates_on_different_fields_emit_independent_semijoins():
     assert "model_name IN" not in env_cond
     assert params["f_model_name_0"] == ["gpt-4"]
     assert params["f_environment_1"] == ["prod"]
+
+
+# --- keyed map (metadata) lowering -----------------------------------------
+# Trace-scope and span-scope keys are disjoint, so one keyed predicate matches at EITHER
+# scope. Both halves are asserted separately, because a half that quietly stops matching is
+# invisible in a test that only looks at the whole condition.
+
+
+def _or_parts_at_top_level(expr: str) -> list[str]:
+    """Split a SQL expression on ``OR`` at parenthesis depth zero.
+
+    Conditions are AND-joined and OR binds looser than AND, so an OR surviving at depth zero
+    is one that pulls the surrounding filters into its arms. One part means the OR is safely
+    enclosed, more than one means it is not.
+    """
+    parts: list[str] = []
+    depth = 0
+    start = 0
+    for i, ch in enumerate(expr):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif depth == 0 and expr.startswith(" OR ", i):
+            parts.append(expr[start:i])
+            start = i + len(" OR ")
+    parts.append(expr[start:])
+    return parts
+
+
+def _metadata_halves(cond: str) -> tuple[str, str]:
+    """Return a keyed metadata condition's ``(trace_half, span_half)``.
+
+    Asserts on the way through that the condition is a single parenthesised group whose OR
+    is inside it, which is the property that keeps the condition from widening its
+    neighbours once the caller ANDs it into the shared WHERE clause.
+    """
+    assert cond.startswith("(") and cond.endswith(")")
+    assert len(_or_parts_at_top_level(cond)) == 1
+    parts = _or_parts_at_top_level(cond[1:-1])
+    assert len(parts) == 2, f"expected one trace half and one span half, got: {parts}"
+    return parts[0], parts[1]
+
+
+def test_metadata_predicate_matches_the_trace_row_or_any_of_its_spans():
+    """A tag the user can see must be filterable wherever the SDK attached it. The trace
+    half reads the already-scanned ``t`` row inline; the span half is the semi-join."""
+    params = {"project_id": "p1", "start_after": "2026-06-01 00:00:00"}
+    conditions = build_conditions([_metadata()], params)
+
+    assert len(conditions) == 1
+    trace_half, span_half = _metadata_halves(conditions[0])
+    # Trace half: no extra scan, just the row the list already reads — and no time bound of
+    # its own, because the outer window has already restricted that row.
+    assert "t.metadata_map" in trace_half
+    assert "FROM spans" not in trace_half
+    assert "span_start_time" not in trace_half
+    # Span half: the existing membership semi-join, unchanged.
+    assert span_half.startswith("t.trace_id IN (")
+    assert "FROM spans" in span_half
+    assert "project_id = {project_id:String}" in span_half
+
+
+def test_a_metadata_predicate_still_constrains_the_filters_beside_it():
+    """The consequence of the parenthesisation, stated as behaviour: with a metadata
+    predicate in the list, the assembled WHERE clause is still a conjunction, so the
+    model_name filter beside it can never be satisfied merely by the metadata match."""
+    params = {"project_id": "p1", "start_after": "2026-06-01 00:00:00"}
+    conditions = build_conditions(
+        [
+            Predicate(field="model_name", op="in", value=["gpt-4"]),
+            _metadata(key="tenant_id", value="acme-corp"),
+        ],
+        params,
+    )
+    where = " AND ".join(conditions)
+
+    assert len(_or_parts_at_top_level(where)) == 1
+    # The model_name semi-join is still its own top-level conjunct rather than an OR arm.
+    model_cond = next(c for c in conditions if "model_name IN" in c)
+    assert len(_or_parts_at_top_level(model_cond)) == 1
+
+
+def test_metadata_predicate_binds_the_key_and_the_value_as_parameters_in_both_halves():
+    """The key is DATA, not an identifier — that is what makes an arbitrary user-typed
+    key safe to query without registry membership. Neither slot is interpolated on either
+    side, and both halves reference the SAME bound names, so the two can never end up
+    comparing different values."""
+    params = {"project_id": "p1"}
+    cond = build_conditions([_metadata(key="tenant_id", value="acme-corp")], params)[0]
+    trace_half, span_half = _metadata_halves(cond)
+
+    assert params["f_metadata_0_key"] == "tenant_id"
+    assert params["f_metadata_0"] == "acme-corp"
+    assert "tenant_id" not in cond
+    assert "acme-corp" not in cond
+    assert "t.metadata_map[{f_metadata_0_key:String}] = {f_metadata_0:String}" in trace_half
+    assert "metadata_map[{f_metadata_0_key:String}] = {f_metadata_0:String}" in span_half
+    # Bound once each, not once per half.
+    assert [k for k in params if k.startswith("f_metadata_")] == [
+        "f_metadata_0_key",
+        "f_metadata_0",
+    ]
+
+
+def test_metadata_predicate_omits_the_span_bound_when_the_list_has_no_start():
+    """No window bound to inherit means no span bound emitted — identical to the
+    categorical path. (``list_traces`` defaults one whenever filters are present.)"""
+    params = {"project_id": "p1"}
+    cond = build_conditions([_metadata()], params)[0]
+
+    assert "span_start_time" not in cond
+
+
+def test_metadata_predicate_guards_an_absent_key_in_both_halves():
+    """ClickHouse's map subscript returns the value type's default for an absent key, so
+    without ``mapContains`` a filter for the empty string would match every row that never
+    carried the key at all. Each half needs its own guard — one guarded half and one
+    unguarded half is still a predicate that matches rows it should not."""
+    for op in ("eq", "contains"):
+        params = {"project_id": "p1"}
+        trace_half, span_half = _metadata_halves(build_conditions([_metadata(op=op)], params)[0])
+
+        trace_guard = "mapContains(t.metadata_map, {f_metadata_0_key:String})"
+        assert f"{trace_guard} AND " in trace_half
+        assert trace_half.index(trace_guard) < trace_half.index(
+            "t.metadata_map[{f_metadata_0_key:String}]"
+        )
+
+        span_guard = "mapContains(metadata_map, {f_metadata_0_key:String})"
+        assert f"{span_guard} AND " in span_half
+        assert span_half.index(span_guard) < span_half.index(
+            "metadata_map[{f_metadata_0_key:String}]"
+        )
+
+
+def test_metadata_contains_lowers_to_a_parameterized_ilike_in_both_halves():
+    params = {"project_id": "p1"}
+    trace_half, span_half = _metadata_halves(
+        build_conditions([_metadata(op="contains", value="acme")], params)[0]
+    )
+
+    assert "t.metadata_map[{f_metadata_0_key:String}] ILIKE {f_metadata_0:String}" in trace_half
+    assert "metadata_map[{f_metadata_0_key:String}] ILIKE {f_metadata_0:String}" in span_half
+    assert params["f_metadata_0"] == "%acme%"  # case-insensitive substring
+
+
+def test_metadata_contains_escapes_ilike_wildcards_for_both_halves():
+    # A literal % or _ in the search must match literally, the same treatment trace_id's
+    # contains gets — otherwise "100%" would match every value containing "100". One bound
+    # value serves both halves, so the escaping cannot apply to only one of them.
+    params = {"project_id": "p1"}
+    trace_half, span_half = _metadata_halves(
+        build_conditions([_metadata(op="contains", value="a%b_c")], params)[0]
+    )
+
+    assert params["f_metadata_0"] == "%a\\%b\\_c%"
+    assert "{f_metadata_0:String}" in trace_half
+    assert "{f_metadata_0:String}" in span_half
+
+
+def test_two_metadata_predicates_on_different_keys_do_not_collide():
+    """Independent existence, one condition each, and param names indexed by predicate
+    position so the second key/value pair cannot overwrite the first."""
+    params = {"project_id": "p1"}
+    conditions = build_conditions(
+        [
+            _metadata(key="tenant_id", value="acme-corp"),
+            _metadata(key="release", value="v2026.06"),
+        ],
+        params,
+    )
+
+    assert len(conditions) == 2
+    for cond in conditions:
+        trace_half, span_half = _metadata_halves(cond)  # both halves survive duplication
+        assert "t.metadata_map" in trace_half
+        assert span_half.startswith("t.trace_id IN (")
+    assert params["f_metadata_0_key"] == "tenant_id"
+    assert params["f_metadata_0"] == "acme-corp"
+    assert params["f_metadata_1_key"] == "release"
+    assert params["f_metadata_1"] == "v2026.06"
+    # Each condition references only its own bound pair.
+    assert "f_metadata_1" not in conditions[0]
+    assert "f_metadata_0" not in conditions[1]
 
 
 # --- numeric aggregate lowering (explicit operators) -----------------------
@@ -360,3 +683,272 @@ def test_trace_id_condition_has_no_span_time_bound():
     params = {"project_id": "p1", "start_after": "2026-06-01 00:00:00"}
     cond = build_conditions([Predicate(field="trace_id", op="contains", value="x")], params)[0]
     assert "span_start_time" not in cond
+
+
+# --- the one span-scan builder ---------------------------------------------
+# Keyed, membership and aggregate lowerings all filter through a single deduped scan, so its
+# safety properties are asked of all three paths at once rather than once per path.
+
+_SPAN_SCAN_PATHS = {
+    "keyed": Predicate(field="metadata", op="eq", value="acme-corp", key="tenant_id"),
+    "membership": Predicate(field="model_name", op="in", value=["gpt-4"]),
+    "aggregate": Predicate(field="cost", op="gt", value=0.5),
+}
+_DEDUP = "LIMIT 1 BY project_id, trace_id, span_id"
+
+
+def _span_scan(pred: Predicate, params: dict) -> str:
+    """The span-scan condition one predicate lowers to, keyed condition unwrapped.
+
+    The keyed lowering wraps its scan in an OR with an inline traces-row arm; the other two
+    are the bare scan. Unwrapping is what lets one assertion body speak for all three paths.
+    """
+    cond = build_conditions([pred], params)[0]
+    return _metadata_halves(cond)[1] if pred.field == "metadata" else cond
+
+
+@pytest.mark.parametrize("path", sorted(_SPAN_SCAN_PATHS))
+def test_every_span_scan_is_project_scoped(path):
+    """Tenant isolation: an unscoped inner relation would let a trace id from another
+    project into the semi-join and past the outer query's own project predicate."""
+    scan = _span_scan(_SPAN_SCAN_PATHS[path], {"project_id": "p1"})
+
+    assert "FROM spans" in scan
+    assert "project_id = {project_id:String}" in scan
+    assert scan.startswith("t.trace_id IN (")  # keyed on the outer query, page and count
+
+
+@pytest.mark.parametrize("path", sorted(_SPAN_SCAN_PATHS))
+def test_every_span_scan_is_lower_bounded_with_the_backoff_and_never_upper_bounded(path):
+    """The user's date range is the outer bound. Each scan inherits its LOWER bound backed
+    off for clock skew, and deliberately takes no upper bound: an in-window trace may have
+    matching spans starting after the window's end, and the outer trace-level window
+    re-filters the ids anyway, so an upper bound here could only false-negative."""
+    params = {
+        "project_id": "p1",
+        "start_after": "2026-06-01 00:00:00",
+        "end_before": "2026-06-02 00:00:00",
+    }
+
+    scan = _span_scan(_SPAN_SCAN_PATHS[path], params)
+
+    assert (
+        f"span_start_time >= {{start_after:DateTime64(3)}} - INTERVAL "
+        f"{SPAN_TIME_BOUND_LOOKBACK_HOURS} HOUR" in scan
+    )
+    assert "span_start_time <" not in scan
+    assert "end_before" not in scan
+
+
+@pytest.mark.parametrize("path", sorted(_SPAN_SCAN_PATHS))
+def test_every_span_scan_dedups_before_its_predicate_runs(path):
+    """ReplacingMergeTree keeps superseded span versions until a merge, so a scan that
+    filters before deduping can match a value the latest version no longer carries. The
+    dedup therefore sits in the inner relation and the tail — a WHERE for the existence
+    paths, a GROUP BY ... HAVING for the aggregate — runs above it."""
+    scan = _span_scan(_SPAN_SCAN_PATHS[path], {"project_id": "p1"})
+
+    assert "ORDER BY ch_update_time DESC" in scan
+    assert _DEDUP in scan
+    tail_start = min(
+        i for i in (scan.find("WHERE ", scan.index(_DEDUP)), scan.find("GROUP BY ")) if i != -1
+    )
+    assert scan.index(_DEDUP) < tail_start
+
+
+def test_the_three_span_scans_share_one_inner_relation():
+    """One builder, so the properties above are a single-site question: the keyed,
+    membership and aggregate scans differ only in the projected value columns and the
+    tail, and are otherwise character-identical."""
+    scans = {
+        path: _span_scan(pred, {"project_id": "p1", "start_after": "2026-06-01 00:00:00"})
+        for path, pred in _SPAN_SCAN_PATHS.items()
+    }
+    # Everything from the source table to the end of the dedup is the shared relation.
+    skeletons = {
+        scan[scan.index("FROM spans") : scan.index(_DEDUP) + len(_DEDUP)] for scan in scans.values()
+    }
+    assert len(skeletons) == 1
+
+
+# --- a whole filter list at once -------------------------------------------
+# A real request spans several tiers and the translator walks it in one pass, so the list as
+# a whole is the unit worth asserting on: how many conditions come out of how many
+# predicates, that bound parameters follow the predicate rather than the condition's
+# position, and that a bad predicate anywhere still stops the whole thing.
+
+_HAVING = "GROUP BY trace_id HAVING"
+
+
+def test_the_merged_aggregate_condition_is_emitted_after_the_per_predicate_ones():
+    """Aggregate predicates are the one tier that cannot lower where it stands — they all
+    fold into a single GROUP BY ... HAVING scan, which can only be built once the whole
+    list has been walked. So an aggregate predicate sent FIRST still yields its condition
+    last, and its bound parameter keeps the index of its position in the REQUEST, not the
+    index of the condition it ended up in — the two are deliberately decoupled."""
+    params = {"project_id": "p1"}
+    conditions = build_conditions(
+        [
+            Predicate(field="cost", op="gt", value=1),
+            Predicate(field="model_name", op="in", value=["gpt-4"]),
+            Predicate(field="trace_id", op="eq", value="abc123"),
+        ],
+        params,
+    )
+
+    assert len(conditions) == 3
+    assert _HAVING in conditions[-1]
+    assert [c for c in conditions if _HAVING in c] == [conditions[-1]]
+    # The cost predicate sat at request position 0 even though its condition is last.
+    assert params["f_cost_0"] == 1
+    assert "{f_cost_0:Decimal64(9)}" in conditions[-1]
+
+
+def test_a_filter_list_spanning_every_tier_merges_only_its_aggregates():
+    """Five predicates across all four registry levels lower to four conditions: one each
+    for the trace-row, membership and keyed-map predicates, and ONE for both aggregates
+    together. Merging matters beyond condition count — two aggregate predicates lowered
+    separately would be two independent span roll-ups, so "cost > 1 AND errors >= 2" would
+    match a trace satisfying each in isolation instead of both at once."""
+    params = {"project_id": "p1"}
+    conditions = build_conditions(
+        [
+            Predicate(field="trace_id", op="eq", value="abc123"),
+            Predicate(field="cost", op="gt", value=1),
+            Predicate(field="model_name", op="in", value=["gpt-4"]),
+            _metadata(key="tenant_id", value="acme-corp"),
+            Predicate(field="errors", op="gte", value=2),
+        ],
+        params,
+    )
+
+    assert len(conditions) == 4
+    aggregates = [c for c in conditions if _HAVING in c]
+    assert len(aggregates) == 1
+    # Both comparisons in the one HAVING, so a trace must satisfy them simultaneously.
+    assert "sum(cost) > {f_cost_1:Decimal64(9)}" in aggregates[0]
+    assert "countIf(status = 'ERROR') >= {f_errors_4:UInt64}" in aggregates[0]
+    # The merged scan projects both fields' source_columns, still registry-driven.
+    scan = aggregates[0]
+    inner = scan[scan.index("SELECT", scan.index("SELECT") + 1) : scan.index("FROM spans")]
+    assert "cost" in inner and "status" in inner
+    # The other three lowered independently, one per predicate.
+    others = [c for c in conditions if _HAVING not in c]
+    assert "t.trace_id = {f_trace_id_0:String}" in others
+    assert len([c for c in others if "model_name IN" in c]) == 1
+    assert len([c for c in others if "t.metadata_map" in c]) == 1
+
+
+_VALID_PREFIX = (
+    Predicate(field="trace_id", op="eq", value="abc123"),
+    Predicate(field="model_name", op="in", value=["gpt-4"]),
+    Predicate(field="cost", op="gt", value=1),
+    Predicate(field="metadata", op="eq", value="acme-corp", key="tenant_id"),
+)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        pytest.param(Predicate(field="not_a_field", op="eq", value="x"), id="unknown-field"),
+        pytest.param(Predicate(field="cost", op="in", value=["1"]), id="operator-off-whitelist"),
+        pytest.param(Predicate(field="model_name", op="in", value=[]), id="empty-in-list"),
+        pytest.param(Predicate(field="metadata", op="eq", value="x"), id="keyed-field-no-key"),
+        pytest.param(
+            Predicate(field="trace_id", op="eq", value="x", key="tenant_id"),
+            id="key-on-unkeyed-field",
+        ),
+    ],
+)
+def test_a_bad_predicate_is_rejected_however_many_valid_ones_precede_it(bad):
+    """Validation is the registry safety boundary, and it has to hold for every predicate
+    in the list, not just the first. The prefix here covers all four tiers — including the
+    aggregate one, whose predicates take a different route through the translator — so a
+    bad predicate can't slip past by sitting behind them and no partial condition list is
+    returned in its place."""
+    assert len(build_conditions(list(_VALID_PREFIX), {"project_id": "p1"})) == 4
+
+    with pytest.raises(ValueError):
+        build_conditions([*_VALID_PREFIX, bad], {"project_id": "p1"})
+
+
+def test_no_two_predicates_in_a_list_bind_the_same_parameter_name():
+    """Every value reaches ClickHouse as a bound parameter in a single flat map shared by
+    the page and the count query, so two predicates binding one name is not a SQL error —
+    it is the second value silently answering for the first. Names carry the predicate's
+    request position, which stays unique across repeats of a field and across tiers even
+    though the conditions are now emitted interleaved."""
+    params = {"project_id": "p1"}
+    conditions = build_conditions(
+        [
+            Predicate(field="trace_id", op="eq", value="abc123"),
+            Predicate(field="cost", op="gt", value=1),
+            Predicate(field="model_name", op="in", value=["gpt-4"]),
+            Predicate(field="cost", op="lt", value=9),
+            _metadata(key="tenant_id", value="acme-corp"),
+        ],
+        params,
+    )
+
+    bound = {k: v for k, v in params.items() if k.startswith("f_")}
+    assert bound == {
+        "f_trace_id_0": "abc123",
+        "f_cost_1": 1,
+        "f_model_name_2": ["gpt-4"],
+        "f_cost_3": 9,
+        "f_metadata_4_key": "tenant_id",
+        "f_metadata_4": "acme-corp",
+    }
+    # Both cost bounds survive into the one HAVING rather than one overwriting the other.
+    aggregate = next(c for c in conditions if _HAVING in c)
+    assert "{f_cost_1:Decimal64(9)}" in aggregate and "{f_cost_3:Decimal64(9)}" in aggregate
+
+
+# --- every registry level has a lowering -----------------------------------
+
+
+def _valid_predicate_for(col: FilterColumn) -> Predicate:
+    """A minimally valid predicate for any registry column, derived from what the column
+    declares, so a newly registered field is exercised without editing this test."""
+    value = {FilterType.CATEGORICAL: ["x"], FilterType.NUMERIC: 1, FilterType.TEXT: "x"}[col.type]
+    return Predicate(
+        field=col.name,
+        op=col.operators[0],
+        value=value,
+        key="some_key" if col.requires_key else None,
+    )
+
+
+def test_every_registered_field_lowers_rather_than_raising_not_implemented():
+    """The registry is what ``/filter-fields`` offers the UI, so a field whose level the
+    translator has no lowering for is a filter the user can build and a 500 when they
+    apply it. Walking the real registry makes that a test failure the moment a field is
+    added on a level nobody wired up, instead of a runtime error in production."""
+    for col in FILTER_COLUMNS:
+        conditions = build_conditions([_valid_predicate_for(col)], {"project_id": "p1"})
+        assert len(conditions) == 1, f"{col.name} ({col.level}) produced {conditions}"
+
+
+def test_a_level_with_no_lowering_raises_not_implemented_naming_the_level_and_field(monkeypatch):
+    """The lowering table is a dict lookup, so an unhandled level must not surface as a
+    bare KeyError or, worse, a skipped predicate — a dropped condition would widen the
+    result set silently. The error has to name both the level and the field, since that is
+    all a responder gets to identify which registry entry is unwired."""
+    unlowered = FilterColumn(
+        name="future_field",
+        label="Future",
+        ch_type="String",
+        level="SPAN_WINDOW",  # a level no lowering handles
+        type=FilterType.TEXT,
+        operators=(FilterOperator.EQ,),
+        value_source=ValueSource.FREE_TEXT,
+    )
+    monkeypatch.setattr(translate, "get_column", lambda name: unlowered)
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        build_conditions(
+            [Predicate(field="future_field", op="eq", value="x")], {"project_id": "p1"}
+        )
+
+    assert "SPAN_WINDOW" in str(excinfo.value)
+    assert "future_field" in str(excinfo.value)

--- a/tests/rest/test_trace_filter_meta.py
+++ b/tests/rest/test_trace_filter_meta.py
@@ -57,7 +57,11 @@ class TestFilterFields:
         resp = client.get("/api/v1/projects/p1/traces/filter-fields")
         assert resp.status_code == 200
         fields = resp.json()["fields"]
-        assert {f["field"] for f in fields} == {c.name for c in reg.FILTER_COLUMNS}
+        # ... except the ones held back by the temporary keyed-field gate in
+        # get_filter_fields, which feat/metadata-filter-ui removes along with this clause.
+        assert {f["field"] for f in fields} == {
+            c.name for c in reg.FILTER_COLUMNS if not c.requires_key
+        }
 
     def test_serializes_field_shape_from_registry(self, client):
         fields = {

--- a/tests/rest/test_trace_list_filters.py
+++ b/tests/rest/test_trace_list_filters.py
@@ -60,6 +60,28 @@ def test_no_filters_param_threads_an_empty_list(client, mock_trace_reader):
     assert mock_trace_reader.list_traces.call_args.kwargs["filters"] == []
 
 
+def test_metadata_predicate_carries_its_key_through_to_the_service(client, mock_trace_reader):
+    raw = json.dumps([{"field": "metadata", "op": "eq", "value": "acme-corp", "key": "tenant_id"}])
+    resp = client.get("/api/v1/projects/p1/traces", params={"filters": raw})
+    assert resp.status_code == 200
+    threaded = mock_trace_reader.list_traces.call_args.kwargs["filters"]
+    assert threaded == [Predicate(field="metadata", op="eq", value="acme-corp", key="tenant_id")]
+
+
+def test_metadata_predicate_without_a_key_returns_422(client, mock_trace_reader):
+    raw = json.dumps([{"field": "metadata", "op": "eq", "value": "acme-corp"}])
+    resp = client.get("/api/v1/projects/p1/traces", params={"filters": raw})
+    assert resp.status_code == 422
+    mock_trace_reader.list_traces.assert_not_called()
+
+
+def test_key_on_a_field_that_takes_none_returns_422(client, mock_trace_reader):
+    raw = json.dumps([{"field": "model_name", "op": "in", "value": ["gpt-4"], "key": "x"}])
+    resp = client.get("/api/v1/projects/p1/traces", params={"filters": raw})
+    assert resp.status_code == 422
+    mock_trace_reader.list_traces.assert_not_called()
+
+
 def test_unknown_field_returns_422(client, mock_trace_reader):
     raw = json.dumps([{"field": "nope", "op": "in", "value": ["x"]}])
     resp = client.get("/api/v1/projects/p1/traces", params={"filters": raw})

--- a/tests/rest/test_trace_reader_filters.py
+++ b/tests/rest/test_trace_reader_filters.py
@@ -14,6 +14,7 @@ from rest.services.filters.translate import Predicate
 from rest.services.trace_reader import DEFAULT_SPAN_SCAN_LOOKBACK_HOURS, TraceReaderService
 
 _MODEL_FILTER = [Predicate(field="model_name", op="in", value=["gpt-4"])]
+_METADATA_FILTER = [Predicate(field="metadata", op="eq", value="acme-corp", key="tenant_id")]
 
 
 def _service_with_mock_client():
@@ -73,6 +74,129 @@ def test_independent_membership_predicates_emit_two_semijoins_in_both_queries():
     params = svc._client.query.call_args_list[0].kwargs["parameters"]
     assert params["f_model_name_0"] == ["gpt-4"]
     assert params["f_environment_1"] == ["prod"]
+
+
+def test_metadata_filter_lands_in_both_page_and_count_queries():
+    """A keyed predicate joins the SAME shared condition list as every other filter, so
+    the metadata-filtered page and its total can never disagree."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1", filters=_METADATA_FILTER)
+
+    assert svc._client.query.call_count == 2
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    count_sql = svc._client.query.call_args_list[1].args[0]
+    for sql in (page_sql, count_sql):
+        assert "mapContains(metadata_map, {f_metadata_0_key:String})" in sql
+        assert "metadata_map[{f_metadata_0_key:String}] = {f_metadata_0:String}" in sql
+    # One parameter map feeds both queries, so the bound key/value are shared too.
+    params = svc._client.query.call_args_list[0].kwargs["parameters"]
+    assert params["f_metadata_0_key"] == "tenant_id"
+    assert params["f_metadata_0"] == "acme-corp"
+    assert svc._client.query.call_args_list[1].kwargs["parameters"] is params
+
+
+def _outer_where_clause(sql: str) -> str:
+    """The trace-level WHERE clause of an assembled list query.
+
+    The one line where every condition the translator produced is AND-joined together —
+    the place where a loosely-bound operator in one condition would reach the others.
+    """
+    return next(line.strip() for line in sql.splitlines() if line.strip().startswith("WHERE t."))
+
+
+def _or_operators_outside_parentheses(clause: str) -> int:
+    """Count ``OR`` operators in ``clause`` that sit outside every parenthesis group.
+
+    The conditions are AND-joined and OR binds looser than AND, so an OR left outside the
+    parentheses is an OR that takes the conditions beside it as its arms.
+    """
+    count = 0
+    depth = 0
+    for i, ch in enumerate(clause):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif depth == 0 and clause.startswith(" OR ", i):
+            count += 1
+    return count
+
+
+def test_metadata_filter_matches_either_scope_in_both_queries():
+    """Both halves of the predicate reach the page and the count. A trace-level tag can
+    never appear on a span, so a span-only match would drop exactly the traces whose cell
+    the user clicked."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1", filters=_METADATA_FILTER)
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    count_sql = svc._client.query.call_args_list[1].args[0]
+    for sql in (page_sql, count_sql):
+        assert "mapContains(t.metadata_map, {f_metadata_0_key:String})" in sql  # trace row
+        assert "mapContains(metadata_map, {f_metadata_0_key:String})" in sql  # its spans
+
+
+def test_a_metadata_filter_does_not_widen_the_filters_beside_it():
+    """The assembled WHERE clause stays a conjunction: the window and the model_name
+    filter still constrain the result even though the metadata condition contains an OR.
+    Left unparenthesised, a row matching only the metadata span half would satisfy the
+    whole clause and the date range would stop applying."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(
+        project_id="p1",
+        start_after=datetime(2026, 6, 1),
+        end_before=datetime(2026, 6, 2),
+        filters=_MODEL_FILTER + _METADATA_FILTER,
+    )
+
+    for call in svc._client.query.call_args_list:
+        clause = _outer_where_clause(call.args[0])
+        assert " OR " in clause  # the metadata predicate is present
+        assert _or_operators_outside_parentheses(clause) == 0
+        # ... and the conditions it sits beside are still conjuncts.
+        assert "t.trace_start_time >= {start_after:DateTime64(3)} AND" in clause
+        assert "t.trace_start_time < {end_before:DateTime64(3)} AND" in clause
+        assert "model_name IN {f_model_name_0:Array(String)}" in clause
+
+
+def test_metadata_filter_inherits_the_list_window_in_both_queries():
+    """The picked date range is the outer bound: the trace query is bounded at both ends
+    and the metadata span scan inherits the same lower bound (backed off for drift)."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+    start, end = datetime(2026, 6, 1), datetime(2026, 6, 2)
+
+    svc.list_traces(project_id="p1", start_after=start, end_before=end, filters=_METADATA_FILTER)
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    count_sql = svc._client.query.call_args_list[1].args[0]
+    for sql in (page_sql, count_sql):
+        assert "t.trace_start_time >= {start_after:DateTime64(3)}" in sql
+        assert "t.trace_start_time < {end_before:DateTime64(3)}" in sql
+        assert "span_start_time >= {start_after:DateTime64(3)} - INTERVAL" in sql
+    params = svc._client.query.call_args_list[0].kwargs["parameters"]
+    assert params["start_after"] == start
+    assert params["end_before"] == end
+
+
+def test_metadata_filter_without_a_window_gets_the_default_lookback():
+    """A metadata-filtered list with no lower bound must not emit an all-time span scan;
+    it is defaulted exactly like the categorical membership path."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1", filters=_METADATA_FILTER)
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    assert "t.trace_start_time >= {start_after:DateTime64(3)}" in page_sql
+    assert "span_start_time >= {start_after:DateTime64(3)} - INTERVAL" in page_sql
+    assert "start_after" in svc._client.query.call_args_list[0].kwargs["parameters"]
 
 
 def test_aggregate_filter_lands_in_both_page_and_count_queries():

--- a/tests/rest/test_widget_filter_registry_parity.py
+++ b/tests/rest/test_widget_filter_registry_parity.py
@@ -60,3 +60,18 @@ def test_membership_filter_fields_are_widget_span_dimensions():
         # Same physical column: the widget expr is the bare column name the filter
         # semi-join scans, so both read identical stored values.
         assert widget_field.expr == col.name
+
+
+def test_keyed_fields_are_a_separate_level_so_they_never_enter_the_dimension_check():
+    """A keyed field has no single physical column to be a dimension over: its values
+    live behind a user-supplied key inside a Map, so the widget equivalent would be one
+    dimension per key — the same reason the filter registry holds one parameterized
+    entry rather than a row per key. It carries its own level rather than an exemption
+    inside the membership contract above, so a future unkeyed membership field is still
+    caught by that contract without anyone remembering to narrow a guard."""
+    keyed = [c for c in filter_reg.FILTER_COLUMNS if c.requires_key]
+    assert keyed, "no keyed field left to distinguish from the membership tier"
+    for col in keyed:
+        assert col.level is filter_reg.FilterLevel.KEYED_MAP
+        assert col.level is not filter_reg.FilterLevel.SPAN_MEMBERSHIP
+        assert col.name not in WIDGET_SPANS_FIELDS


### PR DESCRIPTION
Part of #1824

> [!NOTE]
> Stacked on #1832 (`refactor/trace-discovery-split`).

## Summary

The predicate half of the metadata filter: one parameterized field, validated at the edge,
lowered to SQL that matches a key set at either scope.

- **Registry**: a new `KEYED_MAP` level and one `metadata` entry with `requires_key=True`,
  text-typed, `eq` and `contains` only (values are stored stringified, so there is no
  per-key type to infer). One parameterized field carries every key — keys are the user's
  own data, discovered per window, while the registry is a fixed contract.
- **`requires_key` is declared per field, not derived from the level.** Keyed-ness and
  lowering scope are independent axes: a key slot says the predicate names a map entry, the
  level says which relation it lowers against. A parity test pins that the two agree, so a
  future keyed field at a different scope fails loudly instead of silently.
- **Predicate IR** gains an optional `key`. `_validate_key` requires a non-empty string key
  on a keyed field and rejects a key supplied for a field that takes none — a stray key
  means the caller has the shape wrong, and dropping it silently would answer a different
  question than the one asked.
- **Bounds**: `MAX_KEY_LENGTH` 256, `MAX_VALUE_LENGTH` 1024 applied to text
  values and to each element of a categorical `in` list, and `MAX_FILTERS` 20 checked
  before a single item is validated. Each span-level predicate emits its own base-table
  scan into both the page query and the count query, so the filter array is the one input
  on this endpoint whose cost is not bounded by `limit`.
- **Lowering**: `(t.metadata_map[key] OP value) OR <span semi-join on spans.metadata_map>`.
  The SDK may attach metadata at trace scope or span scope and the two key spaces are
  disjoint, so a user filtering on a tag they can see does not have to know which scope set
  it. The trace arm rides the scan the list already does; only the span arm costs a scan.
- `mapContains` guards the subscript — ClickHouse returns the value type's default for an
  absent key, so without it a predicate looking for the empty string would match every row
  that lacks the key entirely.
- **The OR is parenthesised as one unit** before it joins the AND-joined condition list.
  Unparenthesised, `OR` binding looser than `AND` would let this predicate absorb every
  condition beside it, silently widening the date range and every other active filter.
- Key and value each bind **once**, as parameters, with both arms referencing the same
  names — so an arbitrary user-typed key is safe to query without registry membership, an
  unrecognized key is an empty result rather than an error, and the two arms can never
  compare different values.
- **`build_conditions` now dispatches through a level → lowering table**, and every
  span-level lowering goes through one `_span_semijoin` builder, so the scan's safety
  properties (dedup to the latest version before the predicate applies, project scoping,
  the lower time bound) are asserted in one place instead of three. Aggregate predicates
  stay the one level that merges rather than lowering one at a time.
- `contains` lowers to `ILIKE` with the search value's wildcards escaped, the same
  treatment `trace_id`'s `contains` gets.

## Type of Change

- [x] feat - A new feature

## Details

**Temporary gate — please read, it is new code, not from the feature branch.**
`get_filter_fields` in this PR skips registry columns with `requires_key=True`, so
`/filter-fields` does not advertise `metadata` yet. Without the gate, the moment this merges
a deployed frontend that knows nothing about the key slot would render metadata as a plain
text field like `trace_id`, emit a keyless predicate, and get a 422 from `_validate_key` —
and a 422 on `?filters=` sinks the entire trace list, not just the one filter. The
validation and the lowering both land in full here; nothing can *send* the predicate yet.
**The gate is removed in #1835** (`feat/metadata-filter-ui`), the same PR that ships the
key control, and the code comment names it. It is about three lines plus one test.

**Size.** Roughly 70% of this diff is tests — `tests/rest/test_filter_translate.py` alone is
606 lines, plus the registry parity tests, the list-endpoint tests, and the reader
integration tests. It is cut whole on purpose: the only clean split (validation in one PR,
lowering in the next) leaves a mid-state where `parse_filters_param` accepts a metadata
predicate that `build_conditions` cannot lower, which is an accept-then-500 window on the
raw API. Happy to split it if you would rather review it in two halves.

Tests cover: key required / key rejected / over-long key and value / over-long `in` element
/ over-count filter array; both arms present in the page query and the count query; the OR
parenthesised so a metadata filter does not widen the filters beside it; the predicate
inheriting the list's window, and getting the default lookback when the request carries
none; and the registry parity checks described above.

## Notes

- `MAX_KEY_LENGTH` gets mirrored on the client in #1835, because an over-long key
  admitted into state would persist to the URL and then 422 every list request until the
  user found it by hand. `MAX_VALUE_LENGTH` and `MAX_FILTERS` are enforced server-side only
  for now — the builder adds one row at a time and cannot produce either, so a client mirror
  buys nothing today. Say the word if you want them mirrored anyway.
- No migration here; the `metadata_map` column this reads lands in #1830.

## Screenshots / Recordings (if applicable)

Not applicable — backend only, and the field is gated out of `/filter-fields` in this PR.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
