### PR TITLE
fix(rest): bound the trace list queries and keep them off the event loop

### DIFF
--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -1,5 +1,6 @@
 """Trace query endpoints (user-authenticated, not public API)."""
 
+import asyncio
 import logging
 from datetime import datetime
 from typing import Literal
@@ -90,7 +91,13 @@ async def list_traces(
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e)) from e
     try:
         service = get_trace_reader_service()
-        result = service.list_traces(
+        # Off the event loop: clickhouse-connect is synchronous, and this is the widest
+        # scan the dashboard issues (a filtered list runs a page query and a count query
+        # back to back, both capped at the shared execution timeout). Awaiting it inline
+        # would stall every other request in the process — the REST service runs a single
+        # uvicorn worker, single replica, so there is no second process to absorb it.
+        result = await asyncio.to_thread(
+            service.list_traces,
             project_id=project_id,
             page=page,
             limit=limit,

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -4,6 +4,7 @@ import time
 from datetime import UTC, datetime, timedelta
 
 from db.clickhouse import get_clickhouse_client
+from db.clickhouse.query_settings import READ_QUERY_SETTINGS
 from rest.services.filters.translate import Predicate, build_conditions
 from rest.sql_utils import escape_ilike, to_utc_naive
 from shared.span_attributes import (
@@ -332,7 +333,14 @@ class TraceReaderService:
             ORDER BY p.trace_start_time DESC
         """
 
-        result = self._client.query(query, parameters=params)
+        # Bounded by the shared read settings, page and count alike. Most span-level
+        # filters project cleanly through the spans no-I/O projection, but a keyed
+        # metadata predicate cannot: metadata_map is deliberately absent from that
+        # projection (see migrations/009_add_metadata_map.sql), so the predicate falls
+        # back to the base table, whose ordering prunes by time only weakly — and it runs
+        # twice per request, here and in the count below. A scan that wide must hit an
+        # execution cap rather than run until the client gives up.
+        result = self._client.query(query, parameters=params, settings=READ_QUERY_SETTINGS)
         rows = result.result_rows
 
         # Get total count (count(DISTINCT) dedupes ReplacingMergeTree rows; no FINAL)
@@ -341,7 +349,9 @@ class TraceReaderService:
             FROM traces AS t
             WHERE {where_clause}
         """
-        count_result = self._client.query(count_query, parameters=params)
+        count_result = self._client.query(
+            count_query, parameters=params, settings=READ_QUERY_SETTINGS
+        )
         total = count_result.result_rows[0][0] if count_result.result_rows else 0
 
         # Convert rows to dicts

--- a/tests/rest/test_trace_reader_filters.py
+++ b/tests/rest/test_trace_reader_filters.py
@@ -5,11 +5,16 @@ physically separate queries — the paginated page and the ``count(DISTINCT ...)
 — off one shared ``where_clause``. If a filter reached only the page, ``meta.total``
 would exceed the visible rows. These tests assert the filter condition is interpolated
 into both, using a mocked ClickHouse client (no live DB), mirroring the repo's pattern.
+
+The same page/count split is why the execution bounds are asserted here too: settings
+are per-query, so bounding the page leaves the count free to run until the client gives
+up.
 """
 
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
+from db.clickhouse.query_settings import QUERY_TIMEOUT_S, READ_QUERY_SETTINGS
 from rest.services.filters.translate import Predicate
 from rest.services.trace_reader import DEFAULT_SPAN_SCAN_LOOKBACK_HOURS, TraceReaderService
 
@@ -292,3 +297,53 @@ def test_unfiltered_list_without_window_stays_unbounded():
     params = svc._client.query.call_args_list[0].kwargs["parameters"]
     assert "start_after" not in params
     assert "t.trace_start_time >=" not in page_sql
+
+
+# ── Execution bounds: both queries, not just the page ────────────────────────────
+#
+# Same shape as the filter-wiring invariant above and the same failure mode: the count
+# query is physically separate from the page query, so a bound applied to one is not
+# applied to the other. The count is the easier of the two to forget precisely because
+# nothing in the response reveals it ran — and it scans the same filtered predicate.
+
+
+def test_page_query_runs_under_the_shared_read_bounds():
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1")
+
+    page_settings = svc._client.query.call_args_list[0].kwargs.get("settings")
+    assert page_settings is READ_QUERY_SETTINGS
+
+
+def test_count_query_runs_under_the_shared_read_bounds():
+    """The count is a second unbounded scan if it is left out — it re-evaluates the same
+    ``where_clause`` the page did, keyed-metadata semi-joins and all."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1")
+
+    assert svc._client.query.call_count == 2
+    count_settings = svc._client.query.call_args_list[1].kwargs.get("settings")
+    assert count_settings is READ_QUERY_SETTINGS
+
+
+def test_both_queries_carry_an_execution_ceiling_and_the_readonly_flag():
+    """The properties the bounds exist for, asserted on what the queries actually got.
+
+    Identity with the shared mapping is the primary guard (above); this pins the two
+    properties that make it a bound at all, so emptying or renaming a field in the shared
+    module fails here rather than silently unbinding the widest scan the dashboard runs.
+    A filtered list is used because that is the path that reaches the base table.
+    """
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1", filters=_METADATA_FILTER)
+
+    for call in svc._client.query.call_args_list:
+        settings = call.kwargs["settings"]
+        assert settings["max_execution_time"] == QUERY_TIMEOUT_S
+        assert settings["readonly"] == 1

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -3,6 +3,7 @@
 Uses FastAPI TestClient with mocked dependencies — no ClickHouse needed.
 """
 
+import asyncio
 import copy
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
@@ -606,3 +607,81 @@ class TestRetentionGateEnterprise:
         mock_trace_reader.get_trace.return_value = old_trace
         response = client.get("/api/v1/projects/test-project/traces/old")
         assert response.status_code == 200
+
+
+class TestBlockingReadsRunOffTheEventLoop:
+    """The synchronous ClickHouse reads must be handed to a worker thread.
+
+    Nothing observable changes when this regresses. The endpoint returns the same body
+    with the same status; the only difference is that the whole process's event loop is
+    parked for the duration of the query, so every other in-flight request stalls behind
+    it (one uvicorn worker, one replica — there is no second process to absorb it). That
+    makes it exactly the kind of change a later refactor drops without noticing.
+
+    What IS observable is where the blocking call runs. Work handed to
+    ``asyncio.to_thread`` executes on a worker thread, which has no running event loop,
+    while a call awaited inline executes on the loop thread itself — so asking for the
+    running loop from inside the mocked service call distinguishes the two directly.
+    """
+
+    @staticmethod
+    def _loop_visible_to(recorder: list[bool], result):
+        """Service stub recording whether it ran somewhere an event loop was running."""
+
+        def _call(*_args, **_kwargs):
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                recorder.append(False)
+            else:
+                recorder.append(True)
+            return result
+
+        return _call
+
+    def test_the_sentinel_would_catch_a_call_left_on_the_loop(self):
+        """Guard on the guard: the two tests below only mean something if this stub
+        reports True when it really does run on the event loop."""
+        ran_on_loop: list[bool] = []
+        stub = self._loop_visible_to(ran_on_loop, None)
+
+        async def call_inline():
+            stub()
+
+        asyncio.run(call_inline())
+
+        assert ran_on_loop == [True]
+
+    def test_list_traces_reads_off_the_loop(self, client, mock_trace_reader):
+        ran_on_loop: list[bool] = []
+        mock_trace_reader.list_traces.side_effect = self._loop_visible_to(
+            ran_on_loop,
+            {"data": [], "meta": {"page": 0, "limit": 50, "total": 0}},
+        )
+
+        response = client.get("/api/v1/projects/test-project/traces")
+
+        assert response.status_code == 200
+        assert ran_on_loop == [False]
+
+    def test_a_read_that_raises_in_the_worker_thread_still_maps_to_500(
+        self, client, mock_trace_reader
+    ):
+        """The thread hop must not swallow or reshape the failure: the exception has to
+        propagate back out of the await and into the handler's own except block."""
+        mock_trace_reader.list_traces.side_effect = Exception("ClickHouse down")
+
+        response = client.get("/api/v1/projects/test-project/traces")
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Failed to list traces"
+
+    def test_a_bad_predicate_is_rejected_before_any_thread_is_taken(
+        self, client, mock_trace_reader
+    ):
+        """Filter parsing stays in front of the hop, so a malformed predicate is a 422
+        and never costs a worker thread or a query."""
+        response = client.get("/api/v1/projects/test-project/traces?filters=not-json")
+
+        assert response.status_code == 422
+        mock_trace_reader.list_traces.assert_not_called()


### PR DESCRIPTION
Part of #1824

> [!NOTE]
> Stacked on #1833 (`feat/keyed-metadata-lowering`).

## Summary

- Both trace list queries — the page query and the count query — now run with the shared
  `READ_QUERY_SETTINGS`: `readonly`, a 10s execution ceiling, and the GROUP BY spill
  threshold.
- `list_traces` moves off the event loop via `asyncio.to_thread`.

**Why this is the PR that forces it.** The keyed metadata predicate is the first span-level
filter that cannot use the spans no-I/O projection: `metadata_map` is deliberately absent
from it, and a projection only serves a query whose referenced columns it all carries. So
the predicate drops to the base table, whose sort key prunes by time only weakly, and it
runs **twice per request** — once in the page query and once in the count. A scan that wide
has to hit an execution cap rather than run until the client gives up.

The event-loop half is the same fact from the other side: `clickhouse-connect` is
synchronous, the REST service runs a single uvicorn worker on a single replica, so awaiting
the widest scan the dashboard issues inline stalls every other request in the process. There
is no second process to absorb it.

## Type of Change

- [x] fix - A bug fix
- [x] perf - A code change that improves performance

## Details

About two dozen production lines. Tests carried with them:

- The page query and the count query each assert they run under the shared settings, and
  that both carry an execution ceiling and the `readonly` flag.
- An off-loop suite with a sentinel that fails if the read is left on the loop, plus a test
  proving the sentinel would actually catch that (a guard that cannot fail is not a guard).
- An exception raised inside the worker thread still maps to a 500.
- A malformed predicate is rejected before any thread is taken.

No API change; no response shape change.

## Notes

- Nothing here is specific to metadata — both list queries get the bounds, including the
  unfiltered path. The keyed predicate is what made the ceiling load-bearing rather than
  precautionary.
- The settings module itself lands in #1832 with the discovery split.

## Screenshots / Recordings (if applicable)

Not applicable — backend only.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the trace list page and count queries with shared read settings (10s timeout, readonly) and moved blocking ClickHouse reads off the event loop via `asyncio.to_thread`. No API or response shape changes.

- **Bug Fixes**
  - Applied `READ_QUERY_SETTINGS` to both queries (`max_execution_time=10s`, `readonly=1`).
  - Called `service.list_traces` via `asyncio.to_thread` to keep `clickhouse-connect` off the event loop and avoid stalls on a single `uvicorn` worker.
  - Tests: assert settings on page/count; verify off-loop execution with a loop sentinel; 500 on internal errors; 422 for malformed filters.

<sup>Written for commit 63ea7e8377476bed4f862804bc9ede256a6c891d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

