### PR TITLE
feat(ui): filter traces by a metadata key

### DIFF
--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -151,14 +151,9 @@ async def get_filter_fields(
                 "value_source": c.value_source,
                 "enum_values": list(c.enum_values),
                 "integer": c.is_integer,
+                "requires_key": c.requires_key,
             }
             for c in filter_columns.FILTER_COLUMNS
-            # Temporary: a keyed field needs a key control the filter builder does not
-            # have yet. Advertising it now would let a deployed builder render it as a
-            # plain text field and emit a keyless predicate, which the translator rejects
-            # with a 422 — and a 422 on the filter parameter sinks the whole trace list.
-            # Removed by feat/metadata-filter-ui, which ships the key control.
-            if not c.requires_key
         ]
     }
 

--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -139,6 +139,10 @@ class FilterField(BaseModel):
     # True for integer-typed numeric fields (tokens/latency/errors), so the UI can
     # restrict their inputs to whole numbers.
     integer: bool = False
+    # True for the one parameterized field (metadata), whose predicate carries a key as
+    # well as an operator and a value. The builder renders a key control only for these,
+    # so the one-row filter shape holds for every other field.
+    requires_key: bool = False
 
 
 class FilterFieldsResponse(BaseModel):

--- a/frontend/ui/src/components/icons/domain-icons.ts
+++ b/frontend/ui/src/components/icons/domain-icons.ts
@@ -2,6 +2,7 @@ import type { LucideIcon } from "lucide-react";
 import {
   ArrowRight,
   Bot,
+  Braces,
   BotMessageSquare,
   Box,
   CircleAlert,
@@ -61,6 +62,8 @@ export const DOMAIN_ICONS = {
   workspace: LayoutGrid,
   detector: Eye,
   environment: Globe,
+  // Free-form key/value data the user attached to a trace, not a traceroot field.
+  metadata: Braces,
   dashboard: LayoutDashboard,
   // Neutral "unknown field" fallback for filter/widget dropdowns. Kept
   // decoupled from `model` even though both currently render as Box — if the

--- a/frontend/ui/src/features/filters/filter-builder.test.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.test.tsx
@@ -50,6 +50,19 @@ const MODEL: FilterFieldDef = {
   enum_values: [],
 };
 
+const METADATA: FilterFieldDef = {
+  field: "metadata",
+  label: "Metadata",
+  type: "text",
+  // Keyed-map tier, matching the backend registry — metadata is the one field whose
+  // predicate carries a key, and SPAN_MEMBERSHIP here contradicted columns.py.
+  level: "KEYED_MAP",
+  operators: ["eq", "contains"],
+  value_source: "free_text",
+  enum_values: [],
+  requires_key: true,
+};
+
 const TRACE_ID: FilterFieldDef = {
   field: "trace_id",
   label: "Trace ID",
@@ -258,6 +271,12 @@ describe("FilterBuilder (Basic row)", () => {
     expect(screen.getByRole("button", { name: "Add filter" })).toHaveProperty("disabled", true);
   });
 
+  it("shows no metadata key control for an unkeyed field", () => {
+    renderBuilder([TRACE_ID]);
+    pickField(/Trace ID/);
+    expect(screen.queryByLabelText("metadata key")).toBeNull();
+  });
+
   it("threads both window bounds into the distinct-values query for a categorical field", () => {
     mockUseFilterValues.mockClear();
     render(
@@ -278,5 +297,102 @@ describe("FilterBuilder (Basic row)", () => {
       "2026-06-02T00:00:00Z",
       true,
     );
+  });
+});
+
+describe("FilterBuilder (Metadata key)", () => {
+  const fillKeyAndValue = (key: string, value: string) => {
+    fireEvent.change(screen.getByLabelText("metadata key"), { target: { value: key } });
+    fireEvent.change(screen.getByLabelText("value"), { target: { value } });
+  };
+
+  it("reveals the key control when Metadata is selected", () => {
+    renderBuilder([METADATA, TRACE_ID]);
+    expect(screen.queryByLabelText("metadata key")).toBeNull();
+    pickField(/Metadata/);
+    expect(screen.getByLabelText("metadata key")).toBeTruthy();
+  });
+
+  it("keeps Add filter disabled until the key is filled", () => {
+    renderBuilder([METADATA]);
+    pickField(/Metadata/);
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "v1" } });
+    expect(screen.getByRole("button", { name: "Add filter" })).toHaveProperty("disabled", true);
+    fireEvent.change(screen.getByLabelText("metadata key"), { target: { value: "k" } });
+    expect(screen.getByRole("button", { name: "Add filter" })).toHaveProperty("disabled", false);
+  });
+
+  it("treats a whitespace-only key as no key at all", () => {
+    renderBuilder([METADATA]);
+    pickField(/Metadata/);
+    fillKeyAndValue("   ", "v1");
+    expect(screen.getByRole("button", { name: "Add filter" })).toHaveProperty("disabled", true);
+  });
+
+  it("trims surrounding whitespace off a typed key", () => {
+    const onSubmit = renderBuilder([METADATA]);
+    pickField(/Metadata/);
+    fillKeyAndValue("  session_id  ", "s-1");
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      field: "metadata",
+      key: "session_id",
+      op: "eq",
+      value: "s-1",
+    });
+  });
+
+  it("offers `=` and `contains` for metadata, and emits `contains` when chosen", () => {
+    const onSubmit = renderBuilder([METADATA]);
+    pickField(/Metadata/);
+    fireEvent.click(screen.getByRole("button", { name: "=" })); // operator dropdown
+    expect(screen.queryByRole("option", { name: "is" })).toBeNull();
+    fireEvent.click(screen.getByRole("option", { name: "contains" }));
+    fillKeyAndValue("session_id", "s-");
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      field: "metadata",
+      key: "session_id",
+      op: "contains",
+      value: "s-",
+    });
+  });
+
+  it("applies the filter when Enter is pressed in the key field", () => {
+    const onSubmit = renderBuilder([METADATA]);
+    pickField(/Metadata/);
+    fillKeyAndValue("session_id", "s-1");
+    fireEvent.keyDown(screen.getByLabelText("metadata key"), { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith({
+      field: "metadata",
+      key: "session_id",
+      op: "eq",
+      value: "s-1",
+    });
+  });
+
+  it("clears the key along with the rest of the row after adding", () => {
+    const onSubmit = renderBuilder([METADATA]);
+    pickField(/Metadata/);
+    fillKeyAndValue("session_id", "s-1");
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    // Field is unset again, so the key control is gone with it rather than retaining a
+    // key that would silently attach to the next filter.
+    expect(screen.getByRole("button", { name: "Field" })).toBeTruthy();
+    expect(screen.queryByLabelText("metadata key")).toBeNull();
+  });
+
+  it("takes a free-text value rather than the distinct-values dropdown", () => {
+    mockUseFilterValues.mockClear();
+    renderBuilder([METADATA]);
+    pickField(/Metadata/);
+    // The value is free text because the field's registry TYPE is text — discovery
+    // answers which KEYS exist, not which values a key takes, so there is no per-key
+    // value list to open.
+    expect(screen.getByLabelText("value").tagName).toBe("INPUT");
+    for (const call of mockUseFilterValues.mock.calls) {
+      expect(call).not.toContain("metadata");
+    }
   });
 });

--- a/frontend/ui/src/features/filters/filter-builder.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import type { Predicate } from "@/types/api";
 import { useFilterValues } from "./hooks";
 import type { FilterFieldDef } from "./registry";
+import { MAX_KEY_LENGTH } from "./predicate";
 import { buildInPredicate, buildNumericPredicate, buildTextPredicate } from "./predicate-ui";
 import {
   Dropdown,
@@ -57,6 +58,11 @@ const REGISTRY_OP_TO_UI: Record<string, UiOp> = {
 const opsFor = (f: FilterFieldDef): UiOp[] =>
   f.operators.map((op) => REGISTRY_OP_TO_UI[op]).filter((o): o is UiOp => o !== undefined);
 
+// Text-valued fields (`trace_id` and metadata) take a typed value rather than a picked
+// one, so the builder emits a string predicate for them. Read off the registry type
+// alone, exactly as the value control dispatches.
+const isTextValued = (f: FilterFieldDef): boolean => f.type === "text";
+
 interface FilterBuilderProps {
   projectId: string;
   fields: FilterFieldDef[];
@@ -75,23 +81,27 @@ export function FilterBuilder({
   const [field, setField] = useState<FilterFieldDef | null>(null);
   const [op, setOp] = useState<UiOp>("is");
   const [value, setValue] = useState("");
+  const [metadataKey, setMetadataKey] = useState("");
 
   const reset = () => {
     setField(null);
     setOp("is");
     setValue("");
+    setMetadataKey("");
   };
   const pickField = (f: FilterFieldDef) => {
     setField(f);
     setOp(opsFor(f)[0]);
     setValue("");
+    setMetadataKey("");
   };
 
   const num = (s: string) => (s.trim() === "" ? null : Number(s));
-  const predicate = (): Predicate | null => {
+  const basePredicate = (): Predicate | null => {
     if (!field) return null;
-    if (field.type === "text") {
-      // trace_id: a `contains` substring or an exact `=` — a string value, not a number.
+    if (isTextValued(field)) {
+      // trace_id / metadata: a `contains` substring or an exact `=` — a string value,
+      // not a number.
       if (value === "") return null;
       return buildTextPredicate(field.field, op === "contains" ? "contains" : "eq", value);
     }
@@ -107,6 +117,18 @@ export function FilterBuilder({
     // No recognized operator (e.g. a field whose registry `operators` map to none) — build
     // nothing rather than silently falling through to a comparison.
     return null;
+  };
+  const predicate = (): Predicate | null => {
+    const base = basePredicate();
+    if (!base || !field) return null;
+    if (!field.requires_key) return base;
+    // Metadata is the one keyed field: its predicate carries a key alongside
+    // field/op/value. The ONLY requirement on the key is that it is non-empty — never
+    // that it was one of the suggestions. A key reaches SQL as a bound parameter rather
+    // than an identifier, so an unsuggested key is safe to query and simply matches
+    // nothing, which is a correct empty result and not a reason to refuse the filter.
+    const trimmed = metadataKey.trim();
+    return trimmed === "" ? null : { ...base, key: trimmed };
   };
   const built = predicate();
   // Immediate apply, then clear the row so another filter can be added without the
@@ -127,6 +149,24 @@ export function FilterBuilder({
           if (f) pickField(f);
         }}
       />
+      {field?.requires_key && (
+        // Typed by hand for now; feat/metadata-key-suggestions replaces this with a
+        // combobox that suggests the keys discovery found. Nothing here restricts the
+        // key to a known one either way — it reaches ClickHouse as a bound parameter.
+        <div className="flex h-7 min-w-0 flex-1 items-center rounded-md border border-input bg-transparent px-2 focus-within:ring-1 focus-within:ring-ring">
+          <input
+            aria-label="metadata key"
+            placeholder="Key"
+            maxLength={MAX_KEY_LENGTH}
+            value={metadataKey}
+            onChange={(e) => setMetadataKey(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submit();
+            }}
+            className="min-w-0 flex-1 bg-transparent text-[13px] outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+      )}
       <Dropdown
         disabled={!field}
         trigger={<span className="whitespace-nowrap">{field ? OP_LABEL[op] : "is"}</span>}

--- a/frontend/ui/src/features/filters/filter-controls.test.tsx
+++ b/frontend/ui/src/features/filters/filter-controls.test.tsx
@@ -9,6 +9,7 @@ import {
   TextField,
   ValueDropdown,
 } from "./filter-controls";
+import { MAX_VALUE_LENGTH } from "./predicate";
 
 afterEach(cleanup);
 
@@ -91,6 +92,13 @@ describe("TextField", () => {
     fireEvent.change(input, { target: { value: "abc" } });
     expect(onChange).toHaveBeenCalledWith("abc");
     fireEvent.keyDown(input, { key: "Enter" });
+  });
+
+  it("clamps typed and pasted text at the backend's value cap", () => {
+    // The affordance rather than the guard: it keeps the common path from ever building a
+    // predicate the list would 422, which isValidPredicate then covers for pasted URLs.
+    render(<TextField ariaLabel="value" placeholder="Enter value" value="" onChange={vi.fn()} />);
+    expect(screen.getByLabelText("value").getAttribute("maxLength")).toBe(String(MAX_VALUE_LENGTH));
   });
 });
 

--- a/frontend/ui/src/features/filters/filter-controls.tsx
+++ b/frontend/ui/src/features/filters/filter-controls.tsx
@@ -24,6 +24,7 @@ export const FIELD_ICONS: Record<string, LucideIcon> = {
   errors: DOMAIN_ICONS.error,
   model_name: DOMAIN_ICONS.model,
   environment: DOMAIN_ICONS.environment,
+  metadata: DOMAIN_ICONS.metadata,
 };
 
 // Text sizing depends on where the filter lives: the trace-list search bar uses

--- a/frontend/ui/src/features/filters/filter-controls.tsx
+++ b/frontend/ui/src/features/filters/filter-controls.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
+import { MAX_VALUE_LENGTH } from "./predicate";
 
 // Icons mirror the trace detail / list UI for consistency; the model and environment
 // fields, which have no trace-detail icon, use a generic one. The dashboard widget
@@ -95,6 +96,10 @@ export function TextField({
       aria-label={ariaLabel}
       placeholder={placeholder}
       value={value}
+      // Clamps a typed or pasted value at the backend's cap, so the common path never builds
+      // a predicate the list would 422. It is the affordance, not the guard: a programmatic
+      // set or a hand-edited `?filters=` bypasses it, which is what isValidPredicate covers.
+      maxLength={MAX_VALUE_LENGTH}
       onChange={(e) => onChange(e.target.value)}
       onKeyDown={(e) => {
         if (e.key === "Enter") onEnter?.();

--- a/frontend/ui/src/features/filters/predicate-ui.test.ts
+++ b/frontend/ui/src/features/filters/predicate-ui.test.ts
@@ -37,6 +37,26 @@ describe("predicateLabel", () => {
     );
   });
 
+  it("names the key of a keyed predicate, since the field alone does not say what was filtered", () => {
+    expect(
+      predicateLabel({ field: "metadata", key: "session_id", op: "eq", value: "s-1" }, "metadata"),
+    ).toBe("metadata.session_id = s-1");
+    expect(
+      predicateLabel(
+        { field: "metadata", key: "tenant", op: "contains", value: "acme" },
+        "metadata",
+      ),
+    ).toBe("metadata.tenant contains acme");
+  });
+
+  it("appends the key itself, so the display name it is given is the bare field name", () => {
+    // The label owns the dotting. A caller that pre-dots the key into the name it passes
+    // gets the key spelled twice, which is what this pins against.
+    expect(
+      predicateLabel({ field: "metadata", key: "session_id", op: "eq", value: "s-1" }, "metadata"),
+    ).not.toContain("session_id.session_id");
+  });
+
   it("uses the supplied display name in place of the raw field key", () => {
     expect(predicateLabel({ field: "duration_ms", op: "gte", value: 5 }, "latency")).toBe(
       "latency ≥ 5",
@@ -70,6 +90,21 @@ describe("predicate builders", () => {
       op: "contains",
       value: "abc",
     });
+  });
+
+  it("buildTextPredicate carries a key for a keyed field", () => {
+    expect(buildTextPredicate("metadata", "eq", "s-1", "session_id")).toEqual({
+      field: "metadata",
+      key: "session_id",
+      op: "eq",
+      value: "s-1",
+    });
+  });
+
+  it("buildTextPredicate omits the key member entirely for an unkeyed field", () => {
+    // A stray key on an unkeyed field fails validation, so it must be absent rather
+    // than present-and-undefined.
+    expect("key" in buildTextPredicate("trace_id", "eq", "abc")).toBe(false);
   });
 });
 
@@ -140,6 +175,18 @@ describe("upsertPredicate", () => {
     expect(upsertPredicate(start, buildTextPredicate("trace_id", "eq", "xyz"))).toEqual([
       buildTextPredicate("trace_id", "eq", "xyz"),
     ]);
+  });
+
+  it("keeps two metadata keys as independent filters rather than replacing one with the other", () => {
+    const session = buildTextPredicate("metadata", "eq", "s-1", "session_id");
+    const tenant = buildTextPredicate("metadata", "eq", "acme", "tenant");
+    expect(upsertPredicate([session], tenant)).toEqual([session, tenant]);
+  });
+
+  it("replaces the existing filter on the SAME metadata key", () => {
+    const first = buildTextPredicate("metadata", "eq", "s-1", "session_id");
+    const second = buildTextPredicate("metadata", "contains", "s-", "session_id");
+    expect(upsertPredicate([first], second)).toEqual([second]);
   });
 
   it("never touches predicates on other fields", () => {

--- a/frontend/ui/src/features/filters/predicate-ui.test.ts
+++ b/frontend/ui/src/features/filters/predicate-ui.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { MAX_FILTERS } from "./predicate";
 import {
   predicateLabel,
   buildInPredicate,
@@ -196,5 +197,41 @@ describe("upsertPredicate", () => {
       gte("cost", 1),
       lte("duration_ms", 10),
     ]);
+  });
+
+  describe("at the filter-count cap", () => {
+    // Distinct predicates: metadata keys are independent filters, so `n` of them are `n` chips.
+    const atCap = Array.from({ length: MAX_FILTERS }, (_, i) =>
+      buildTextPredicate("metadata", "eq", `v${i}`, `key_${i}`),
+    );
+
+    it("refuses a genuinely new predicate that would push the array past the cap", () => {
+      // Admitting it would 422 the list and lose the results for all twenty; dropping it
+      // loses only the one filter the user has not seen results for yet.
+      const newField = buildInPredicate("model_name", ["gpt-4o"]);
+      expect(upsertPredicate(atCap, newField)).toEqual(atCap);
+    });
+
+    it("still applies an upsert that supersedes an existing filter, since the count cannot grow", () => {
+      // Editing the twentieth chip must keep working: replacing one filter with another
+      // leaves the array at the cap rather than past it.
+      const edited = buildTextPredicate("metadata", "contains", "edited", "key_0");
+      const result = upsertPredicate(atCap, edited);
+      expect(result).toHaveLength(MAX_FILTERS);
+      expect(result).toContainEqual(edited);
+      expect(result).not.toContainEqual(atCap[0]);
+    });
+
+    it("still applies an upsert that supersedes a filter one below the cap", () => {
+      const belowCap = atCap.slice(0, MAX_FILTERS - 1);
+      const edited = buildTextPredicate("metadata", "contains", "edited", "key_0");
+      expect(upsertPredicate(belowCap, edited)).toHaveLength(MAX_FILTERS - 1);
+    });
+
+    it("admits a new predicate while the array is still one below the cap", () => {
+      const belowCap = atCap.slice(0, MAX_FILTERS - 1);
+      const newField = buildInPredicate("model_name", ["gpt-4o"]);
+      expect(upsertPredicate(belowCap, newField)).toEqual([...belowCap, newField]);
+    });
   });
 });

--- a/frontend/ui/src/features/filters/predicate-ui.ts
+++ b/frontend/ui/src/features/filters/predicate-ui.ts
@@ -11,10 +11,14 @@ import type { Predicate } from "@/types/api";
  * `in [...]`; numeric `eq/gt/gte/lt/lte` show as `= / > / ≥ / < / ≤`; text `contains`
  * shows as `contains`.
  *
- * `name` is the field's display name (its registry label, lowercased — e.g. `latency`
- * for `duration_ms`); it defaults to the raw field key when a label isn't available.
+ * `displayName` is the field's BARE display name (its registry label, lowercased — e.g.
+ * `latency` for `duration_ms`); it defaults to the raw field key when a label isn't
+ * available. A keyed predicate has its key appended HERE (`metadata.session_id = ...`),
+ * because the field alone does not say what was filtered and two keys can be active at
+ * once — so a caller that pre-dots the key into the name would spell it twice.
  */
-export function predicateLabel(p: Predicate, name: string = p.field): string {
+export function predicateLabel(p: Predicate, displayName: string = p.field): string {
+  const name = p.key === undefined ? displayName : `${displayName}.${p.key}`;
   switch (p.op) {
     case "in":
       return p.value.length === 1
@@ -49,9 +53,18 @@ export function buildNumericPredicate(
   return { field, op, value };
 }
 
-/** Construct a text predicate: exact `eq` or case-insensitive `contains`. */
-export function buildTextPredicate(field: string, op: "eq" | "contains", value: string): Predicate {
-  return { field, op, value };
+/**
+ * Construct a text predicate: exact `eq` or case-insensitive `contains`. `key` is supplied
+ * only for a keyed field (metadata) and is omitted entirely otherwise, since a stray key on
+ * an unkeyed field fails validation.
+ */
+export function buildTextPredicate(
+  field: string,
+  op: "eq" | "contains",
+  value: string,
+  key?: string,
+): Predicate {
+  return key === undefined ? { field, op, value } : { field, key, op, value };
 }
 
 // Which "slot" a predicate occupies on its field, so we know what a new predicate
@@ -81,11 +94,15 @@ function slotOf(p: Predicate): Slot {
  * same field coexist (e.g. `latency > 5` AND `latency ≤ 10`, which the backend
  * AND-combines). A categorical value, an exact `=`, a text match, a same-direction bound,
  * or a contradictory opposite bound replaces the matching predicate rather than stacking.
+ *
+ * Slots belong to a field AND its key, so two metadata keys are two independent filters
+ * (`metadata.session_id = a` AND `metadata.user_id = b`) rather than one replacing the other.
+ * That matches the backend, which lowers each metadata predicate as its own semi-join.
  */
 export function upsertPredicate(filters: Predicate[], next: Predicate): Predicate[] {
   const ns = slotOf(next);
   const keep = (e: Predicate): boolean => {
-    if (e.field !== next.field) return true;
+    if (e.field !== next.field || e.key !== next.key) return true;
     // A categorical value, an exact `=`, or a text match supersedes everything on the field.
     if (ns === "in" || ns === "exact" || ns === "text") return false;
     // A new one-sided bound keeps the opposite existing bound ONLY if the two form a

--- a/frontend/ui/src/features/filters/predicate-ui.ts
+++ b/frontend/ui/src/features/filters/predicate-ui.ts
@@ -4,6 +4,7 @@
  * and unit-tested; kept separate from `predicate.ts` (serialization/canonicalization).
  */
 import type { Predicate } from "@/types/api";
+import { MAX_FILTERS } from "./predicate";
 
 /**
  * Human-readable label for an active-filter chip. Mirrors how the predicate reads and
@@ -113,7 +114,13 @@ export function upsertPredicate(filters: Predicate[], next: Predicate): Predicat
     if (ns === "upper" && es === "lower") return boundsFormRange(e, next);
     return false;
   };
-  return [...filters.filter(keep), next];
+  const kept = filters.filter(keep);
+  // Refuse a chip that would push the array past what the backend accepts. Only an addition
+  // can trip this — an upsert that supersedes an existing chip leaves the count unchanged, and
+  // editing the 20th filter still works. Dropping the new chip loses one filter the user has
+  // not seen results for yet; admitting it would 422 the list and lose all twenty.
+  if (kept.length >= MAX_FILTERS) return filters;
+  return [...kept, next];
 }
 
 // Whether a lower bound (`>`/`≥`) and an upper bound (`<`/`≤`) describe a non-empty range.

--- a/frontend/ui/src/features/filters/predicate.test.ts
+++ b/frontend/ui/src/features/filters/predicate.test.ts
@@ -1,9 +1,117 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import type { Predicate } from "@/types/api";
-import { canonicalizeFilters, serializeFiltersParam, parseFiltersParam } from "./predicate";
+import {
+  canonicalizeFilters,
+  isValidPredicate,
+  serializeFiltersParam,
+  parseFiltersParam,
+  MAX_KEY_LENGTH,
+} from "./predicate";
 
 const modelFilter: Predicate = { field: "model_name", op: "in", value: ["a", "b"] };
 const costFilter: Predicate = { field: "cost", op: "gte", value: 0.5 };
+const metadataFilter: Predicate = {
+  field: "metadata",
+  key: "session_id",
+  op: "eq",
+  value: "abc",
+};
+
+describe("isValidPredicate (keyed fields)", () => {
+  it("accepts a well-formed metadata predicate carrying a key", () => {
+    expect(isValidPredicate(metadataFilter)).toBe(true);
+  });
+
+  it("accepts a metadata `contains` predicate", () => {
+    expect(
+      isValidPredicate({ field: "metadata", key: "user_id", op: "contains", value: "ab" }),
+    ).toBe(true);
+  });
+
+  it("accepts a key that no discovery response ever suggested (suggestion is not permission)", () => {
+    // The key binds as a parameter rather than an identifier, so an unknown key is a
+    // legal filter that simply matches nothing — never a rejection.
+    expect(
+      isValidPredicate({ field: "metadata", key: "never_seen_key", op: "eq", value: "x" }),
+    ).toBe(true);
+  });
+
+  // An empty key would reach the backend as a lookup for the "" key, which is not what any
+  // surface displayed; a missing or non-string one has no key to look up at all.
+  it.each([
+    ["no key", { field: "metadata", op: "eq", value: "abc" }],
+    ["an empty key", { field: "metadata", key: "", op: "eq", value: "abc" }],
+    ["a key that is not a string", { field: "metadata", key: 7, op: "eq", value: "abc" }],
+  ])("rejects a metadata predicate with %s", (_case, predicate) => {
+    expect(isValidPredicate(predicate)).toBe(false);
+  });
+
+  it("rejects a key on a field that takes none", () => {
+    // Ignoring the stray key instead would leave the chip, the URL, and the query the
+    // backend runs describing different filters.
+    expect(
+      isValidPredicate({ field: "model_name", key: "session_id", op: "in", value: ["a"] }),
+    ).toBe(false);
+    expect(isValidPredicate({ field: "cost", key: "session_id", op: "gte", value: 1 })).toBe(false);
+  });
+
+  it("still accepts an unkeyed predicate on an unkeyed field", () => {
+    expect(isValidPredicate(modelFilter)).toBe(true);
+    expect(isValidPredicate(costFilter)).toBe(true);
+  });
+
+  it("rejects a metadata predicate with an empty value", () => {
+    expect(isValidPredicate({ field: "metadata", key: "session_id", op: "eq", value: "" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("MAX_KEY_LENGTH", () => {
+  it("accepts a key of exactly MAX_KEY_LENGTH characters", () => {
+    // The cap is inclusive on both sides of the wire: a key the client admits at the
+    // boundary must not be the one the backend 422s on the very next list request.
+    expect(
+      isValidPredicate({
+        field: "metadata",
+        key: "k".repeat(MAX_KEY_LENGTH),
+        op: "eq",
+        value: "x",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a key one character past MAX_KEY_LENGTH", () => {
+    // Rejected here rather than admitted and rejected later: an over-long key would
+    // persist to the URL and to storage and then 422 every request until removed by hand.
+    expect(
+      isValidPredicate({
+        field: "metadata",
+        key: "k".repeat(MAX_KEY_LENGTH + 1),
+        op: "eq",
+        value: "x",
+      }),
+    ).toBe(false);
+  });
+
+  it("equals the backend cap in translate.py, which TypeScript cannot import from Python", () => {
+    // Two independent declarations tied together by a comment: if they drift, the looser
+    // side admits keys the other rejects and every list request 422s (or vice versa).
+    const translatePath = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../../../../../backend/rest/services/filters/translate.py",
+    );
+    const match = readFileSync(translatePath, "utf8").match(/^MAX_KEY_LENGTH\s*=\s*(\d+)$/m);
+    expect(match, `MAX_KEY_LENGTH is no longer declared in ${translatePath}`).not.toBeNull();
+    expect(
+      Number(match![1]),
+      "the backend key-length cap moved — update MAX_KEY_LENGTH in features/filters/predicate.ts",
+    ).toBe(MAX_KEY_LENGTH);
+  });
+});
 
 describe("canonicalizeFilters", () => {
   it("is independent of predicate order — order-only differences collapse to one key", () => {
@@ -20,6 +128,41 @@ describe("canonicalizeFilters", () => {
 
   it("maps empty and undefined to the same stable key", () => {
     expect(canonicalizeFilters([])).toBe(canonicalizeFilters(undefined));
+  });
+
+  it("produces different keys for two metadata predicates differing only by their key", () => {
+    // Cache-collision regression: `metadata.session_id = x` and `metadata.user_id = x`
+    // select different traces, so one cache entry would serve one filter's rows for the other.
+    const bySession = canonicalizeFilters([
+      { field: "metadata", key: "session_id", op: "eq", value: "x" },
+    ]);
+    const byUser = canonicalizeFilters([
+      { field: "metadata", key: "user_id", op: "eq", value: "x" },
+    ]);
+    expect(bySession).not.toBe(byUser);
+  });
+
+  it("leaves an unkeyed predicate's cache key with no key member at all", () => {
+    // Unkeyed predicates keep the exact shape their cache entries were written under: a
+    // `"key":null` member would orphan every entry a running session had already filled.
+    expect(canonicalizeFilters([costFilter])).toBe(
+      JSON.stringify({ field: "cost", op: "gte", value: 0.5 }),
+    );
+    expect(canonicalizeFilters([costFilter])).not.toContain("key");
+  });
+
+  it("folds two identical metadata predicates to the same key", () => {
+    const a = canonicalizeFilters([metadataFilter]);
+    const b = canonicalizeFilters([
+      { field: "metadata", key: "session_id", op: "eq", value: "abc" },
+    ]);
+    expect(a).toBe(b);
+  });
+
+  it("is independent of order when metadata predicates on two keys are both active", () => {
+    const session: Predicate = { field: "metadata", key: "session_id", op: "eq", value: "a" };
+    const user: Predicate = { field: "metadata", key: "user_id", op: "eq", value: "b" };
+    expect(canonicalizeFilters([session, user])).toBe(canonicalizeFilters([user, session]));
   });
 
   it("folds an `in` value list that differs only in order to one key", () => {
@@ -41,6 +184,24 @@ describe("serializeFiltersParam", () => {
     const raw = serializeFiltersParam([modelFilter, costFilter]);
     expect(raw).not.toBeNull();
     expect(parseFiltersParam(raw)).toEqual([modelFilter, costFilter]);
+  });
+
+  it("round-trips a metadata predicate's key through serialize and parse", () => {
+    const raw = serializeFiltersParam([metadataFilter]);
+    expect(parseFiltersParam(raw)).toEqual([metadataFilter]);
+  });
+
+  it("keeps two metadata keys distinct across a round-trip", () => {
+    const filters: Predicate[] = [
+      { field: "metadata", key: "session_id", op: "eq", value: "a" },
+      { field: "metadata", key: "user_id", op: "contains", value: "b" },
+    ];
+    expect(parseFiltersParam(serializeFiltersParam(filters))).toEqual(filters);
+  });
+
+  it("drops a keyless metadata predicate on the way out", () => {
+    const keyless = { field: "metadata", op: "eq", value: "abc" } as unknown as Predicate;
+    expect(JSON.parse(serializeFiltersParam([modelFilter, keyless])!)).toEqual([modelFilter]);
   });
 
   it("drops invalid predicates on the way out (symmetric with parse)", () => {
@@ -85,6 +246,16 @@ describe("parseFiltersParam", () => {
       { field: "trace_id", op: "contains", value: "abc" },
     ];
     expect(parseFiltersParam(JSON.stringify(preds))).toEqual(preds);
+  });
+
+  it("drops a hand-edited metadata predicate that lost its key", () => {
+    const raw = JSON.stringify([modelFilter, { field: "metadata", op: "eq", value: "abc" }]);
+    expect(parseFiltersParam(raw)).toEqual([modelFilter]);
+  });
+
+  it("keeps a metadata predicate whose key was never suggested", () => {
+    const typed: Predicate = { field: "metadata", key: "typed_by_hand", op: "eq", value: "v" };
+    expect(parseFiltersParam(JSON.stringify([typed]))).toEqual([typed]);
   });
 
   it("drops a numeric predicate with a non-finite value (1e999 -> Infinity)", () => {

--- a/frontend/ui/src/features/filters/predicate.test.ts
+++ b/frontend/ui/src/features/filters/predicate.test.ts
@@ -8,8 +8,24 @@ import {
   isValidPredicate,
   serializeFiltersParam,
   parseFiltersParam,
+  MAX_FILTERS,
   MAX_KEY_LENGTH,
+  MAX_VALUE_LENGTH,
 } from "./predicate";
+
+// The backend's own declarations, read at test time: TypeScript cannot import a Python
+// constant, so the two sides are tied together here instead. If they drift, the looser side
+// admits filters the other rejects and every list request 422s (or vice versa).
+const TRANSLATE_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../../../backend/rest/services/filters/translate.py",
+);
+function backendCap(name: string): number | null {
+  const match = readFileSync(TRANSLATE_PATH, "utf8").match(
+    new RegExp(`^${name}\\s*=\\s*(\\d+)$`, "m"),
+  );
+  return match === null ? null : Number(match[1]);
+}
 
 const modelFilter: Predicate = { field: "model_name", op: "in", value: ["a", "b"] };
 const costFilter: Predicate = { field: "cost", op: "gte", value: 0.5 };
@@ -98,18 +114,149 @@ describe("MAX_KEY_LENGTH", () => {
   });
 
   it("equals the backend cap in translate.py, which TypeScript cannot import from Python", () => {
-    // Two independent declarations tied together by a comment: if they drift, the looser
-    // side admits keys the other rejects and every list request 422s (or vice versa).
-    const translatePath = path.resolve(
-      path.dirname(fileURLToPath(import.meta.url)),
-      "../../../../../backend/rest/services/filters/translate.py",
-    );
-    const match = readFileSync(translatePath, "utf8").match(/^MAX_KEY_LENGTH\s*=\s*(\d+)$/m);
-    expect(match, `MAX_KEY_LENGTH is no longer declared in ${translatePath}`).not.toBeNull();
+    const cap = backendCap("MAX_KEY_LENGTH");
+    expect(cap, `MAX_KEY_LENGTH is no longer declared in ${TRANSLATE_PATH}`).not.toBeNull();
     expect(
-      Number(match![1]),
+      cap,
       "the backend key-length cap moved — update MAX_KEY_LENGTH in features/filters/predicate.ts",
     ).toBe(MAX_KEY_LENGTH);
+  });
+});
+
+describe("MAX_VALUE_LENGTH", () => {
+  const atCap = "x".repeat(MAX_VALUE_LENGTH);
+  const overCap = "x".repeat(MAX_VALUE_LENGTH + 1);
+
+  it("accepts a `contains` value of exactly MAX_VALUE_LENGTH characters", () => {
+    // The cap is inclusive on both sides of the wire: a value the client admits at the
+    // boundary must not be the one the backend 422s on the very next list request.
+    expect(isValidPredicate({ field: "trace_id", op: "contains", value: atCap })).toBe(true);
+  });
+
+  it("rejects a `contains` value one character past MAX_VALUE_LENGTH", () => {
+    // Admitted, it would persist to the `?filters=` URL and 422 every list request on
+    // every page load until the user found and removed the chip by hand.
+    expect(isValidPredicate({ field: "trace_id", op: "contains", value: overCap })).toBe(false);
+  });
+
+  it("accepts a text `eq` value at the cap and rejects one character past it", () => {
+    expect(isValidPredicate({ field: "trace_id", op: "eq", value: atCap })).toBe(true);
+    expect(isValidPredicate({ field: "trace_id", op: "eq", value: overCap })).toBe(false);
+  });
+
+  it("caps each `in` element rather than the list, so several at-cap values are valid", () => {
+    // The backend caps the elements individually, so a list whose total length far exceeds
+    // the cap is legitimate as long as no single value does.
+    expect(isValidPredicate({ field: "model_name", op: "in", value: [atCap, atCap] })).toBe(true);
+  });
+
+  it("rejects an `in` list holding one over-cap element", () => {
+    expect(isValidPredicate({ field: "model_name", op: "in", value: ["a", overCap] })).toBe(false);
+  });
+
+  it("caps the value of a keyed predicate too", () => {
+    expect(isValidPredicate({ field: "metadata", key: "session_id", op: "eq", value: atCap })).toBe(
+      true,
+    );
+    expect(
+      isValidPredicate({ field: "metadata", key: "session_id", op: "eq", value: overCap }),
+    ).toBe(false);
+  });
+
+  it("leaves a numeric `eq` unaffected — the cap measures characters, not magnitude", () => {
+    expect(isValidPredicate({ field: "cost", op: "eq", value: 1e300 })).toBe(true);
+    expect(isValidPredicate({ field: "cost", op: "eq", value: 0 })).toBe(true);
+  });
+
+  it("leaves the numeric comparison operators unaffected", () => {
+    expect(isValidPredicate({ field: "cost", op: "gt", value: 1e300 })).toBe(true);
+    expect(isValidPredicate({ field: "cost", op: "gte", value: 1e300 })).toBe(true);
+    expect(isValidPredicate({ field: "cost", op: "lt", value: 1e300 })).toBe(true);
+    expect(isValidPredicate({ field: "cost", op: "lte", value: 1e300 })).toBe(true);
+  });
+
+  it("is a separate limit from the key cap — the two do not clamp each other", () => {
+    // A value the length of an over-long KEY is an ordinary value; the caps differ because
+    // a value is compared rather than looked up and can legitimately be a URL or a prompt.
+    const keyLengthOver = "x".repeat(MAX_KEY_LENGTH + 1);
+    expect(
+      isValidPredicate({ field: "metadata", key: "session_id", op: "eq", value: keyLengthOver }),
+    ).toBe(true);
+    expect(isValidPredicate({ field: "metadata", key: keyLengthOver, op: "eq", value: "x" })).toBe(
+      false,
+    );
+  });
+
+  it("drops an over-cap predicate from a hand-edited URL, keeping the valid ones", () => {
+    const raw = JSON.stringify([
+      modelFilter,
+      { field: "trace_id", op: "contains", value: overCap },
+      costFilter,
+    ]);
+    expect(parseFiltersParam(raw)).toEqual([modelFilter, costFilter]);
+  });
+
+  it("never emits an over-cap predicate to the URL", () => {
+    // Assert the RAW serialized output rather than laundering it back through
+    // parseFiltersParam, which would re-drop the over-cap predicate itself.
+    const overCapFilter = { field: "trace_id", op: "contains", value: overCap } as Predicate;
+    expect(JSON.parse(serializeFiltersParam([modelFilter, overCapFilter])!)).toEqual([modelFilter]);
+  });
+
+  it("round-trips a filter set whose value sits exactly at the cap", () => {
+    const filters: Predicate[] = [
+      { field: "trace_id", op: "contains", value: atCap },
+      { field: "metadata", key: "session_id", op: "eq", value: atCap },
+      { field: "model_name", op: "in", value: [atCap, "b"] },
+      costFilter,
+    ];
+    expect(parseFiltersParam(serializeFiltersParam(filters))).toEqual(filters);
+  });
+
+  it("equals the backend cap in translate.py, which TypeScript cannot import from Python", () => {
+    const cap = backendCap("MAX_VALUE_LENGTH");
+    expect(cap, `MAX_VALUE_LENGTH is no longer declared in ${TRANSLATE_PATH}`).not.toBeNull();
+    expect(
+      cap,
+      "the backend value-length cap moved — update MAX_VALUE_LENGTH in features/filters/predicate.ts",
+    ).toBe(MAX_VALUE_LENGTH);
+  });
+});
+
+describe("MAX_FILTERS", () => {
+  // Distinct predicates: metadata keys are independent filters, so `n` of them are `n` chips.
+  const manyFilters = (n: number): Predicate[] =>
+    Array.from({ length: n }, (_, i) => ({
+      field: "metadata",
+      key: `key_${i}`,
+      op: "eq" as const,
+      value: `v${i}`,
+    }));
+
+  it("accepts a URL holding exactly MAX_FILTERS predicates", () => {
+    const filters = manyFilters(MAX_FILTERS);
+    expect(parseFiltersParam(JSON.stringify(filters))).toEqual(filters);
+  });
+
+  it("truncates a longer URL array to the cap rather than rejecting it wholesale", () => {
+    // A hand-edited URL past the cap shows most of what it asked for instead of nothing —
+    // the list comes back broader than described rather than not at all.
+    const parsed = parseFiltersParam(JSON.stringify(manyFilters(MAX_FILTERS + 5)));
+    expect(parsed).toEqual(manyFilters(MAX_FILTERS));
+  });
+
+  it("never emits more than MAX_FILTERS predicates to the URL", () => {
+    const raw = serializeFiltersParam(manyFilters(MAX_FILTERS + 5));
+    expect(JSON.parse(raw!)).toEqual(manyFilters(MAX_FILTERS));
+  });
+
+  it("equals the backend cap in translate.py, which TypeScript cannot import from Python", () => {
+    const cap = backendCap("MAX_FILTERS");
+    expect(cap, `MAX_FILTERS is no longer declared in ${TRANSLATE_PATH}`).not.toBeNull();
+    expect(
+      cap,
+      "the backend filter-count cap moved — update MAX_FILTERS in features/filters/predicate.ts",
+    ).toBe(MAX_FILTERS);
   });
 });
 

--- a/frontend/ui/src/features/filters/predicate.ts
+++ b/frontend/ui/src/features/filters/predicate.ts
@@ -1,19 +1,41 @@
 /**
- * Pure helpers for the trace-list filter predicate IR (`{field, op, value}`).
+ * Pure helpers for the trace-list filter predicate IR (`{field, key?, op, value}`).
  *
  * Kept framework-free so the canonicalization, URL serialization, and validation
  * are unit-testable without React or the DOM, and reused by both the query-key
  * builder and the URL-synced state hook.
  */
 import type { Predicate } from "@/types/api";
+import { STATIC_FILTER_FIELDS } from "./registry";
 
 const VALID_OPS = new Set<Predicate["op"]>(["in", "eq", "gt", "gte", "lt", "lte", "contains"]);
+
+// Fields whose predicate carries a key slot. Read off the static registry rather than
+// hard-coded so `requires_key` has one frontend source of truth; the live `/filter-fields`
+// payload can't serve here because URL predicates are validated before any fetch resolves.
+const KEY_REQUIRED_FIELDS = new Set(
+  STATIC_FILTER_FIELDS.filter((f) => f.requires_key).map((f) => f.field),
+);
+
+// Mirrors MAX_KEY_LENGTH in backend/rest/services/filters/translate.py. Rejecting here
+// keeps an over-long key out of state entirely: admitted, it would persist to the URL and
+// to storage and then 422 every list request until the user found and removed it by hand.
+export const MAX_KEY_LENGTH = 256;
 
 /** Shape-guard for a single predicate parsed from untrusted input (e.g. a URL). */
 export function isValidPredicate(p: unknown): p is Predicate {
   if (typeof p !== "object" || p === null) return false;
-  const { field, op, value } = p as Record<string, unknown>;
+  const { field, key, op, value } = p as Record<string, unknown>;
   if (typeof field !== "string" || !VALID_OPS.has(op as Predicate["op"])) return false;
+  // A keyed field needs a non-empty key, and every other field must carry none. Rejecting a
+  // stray key rather than ignoring it keeps the chip, the URL, and the query the backend runs
+  // describing the same filter. Any key VALUE is legal: it binds as a parameter, so an
+  // unrecognized key is an empty result, never a rejection.
+  if (KEY_REQUIRED_FIELDS.has(field)) {
+    if (typeof key !== "string" || key.length === 0 || key.length > MAX_KEY_LENGTH) return false;
+  } else if (key !== undefined) {
+    return false;
+  }
   if (op === "in") {
     // Non-empty list of strings: an empty `in` matches nothing and the backend 422s it,
     // so a hand-edited/degenerate empty-`in` is dropped here rather than sinking the fetch.
@@ -47,7 +69,10 @@ export function canonicalizeFilters(filters?: Predicate[]): string {
       // matched values is order-independent, so hover-prefetch and the list hook must
       // agree on the same cache entry. Scalar values (numbers/strings) are left as-is.
       const value = p.op === "in" && Array.isArray(p.value) ? [...p.value].sort() : p.value;
-      return JSON.stringify({ field: p.field, op: p.op, value });
+      // The key is part of a keyed predicate's identity: `metadata[session_id] = x` and
+      // `metadata[user_id] = x` select different traces. An absent key stringifies away,
+      // so keyless predicates keep the shape their cache entries were written under.
+      return JSON.stringify({ field: p.field, key: p.key, op: p.op, value });
     })
     .sort()
     .join("|");

--- a/frontend/ui/src/features/filters/predicate.ts
+++ b/frontend/ui/src/features/filters/predicate.ts
@@ -22,6 +22,14 @@ const KEY_REQUIRED_FIELDS = new Set(
 // to storage and then 422 every list request until the user found and removed it by hand.
 export const MAX_KEY_LENGTH = 256;
 
+// Mirrors MAX_VALUE_LENGTH in the same backend module, and rejected here for the same reason
+// as the key cap: admitted, an over-long value persists to the URL and 422s every list request
+// until the user removes the chip by hand. Larger than the key cap because a value is compared
+// rather than looked up, so a legitimate one can be a prompt fragment or a URL. Both numbers
+// are duplicated rather than served from the backend because a hand-edited `?filters=` is
+// validated before any fetch resolves; if either moves, the two files move together.
+export const MAX_VALUE_LENGTH = 1024;
+
 /** Shape-guard for a single predicate parsed from untrusted input (e.g. a URL). */
 export function isValidPredicate(p: unknown): p is Predicate {
   if (typeof p !== "object" || p === null) return false;
@@ -39,16 +47,21 @@ export function isValidPredicate(p: unknown): p is Predicate {
   if (op === "in") {
     // Non-empty list of strings: an empty `in` matches nothing and the backend 422s it,
     // so a hand-edited/degenerate empty-`in` is dropped here rather than sinking the fetch.
-    return Array.isArray(value) && value.length > 0 && value.every((v) => typeof v === "string");
+    // Every element is capped, not just the list: the backend caps them individually too.
+    return (
+      Array.isArray(value) &&
+      value.length > 0 &&
+      value.every((v) => typeof v === "string" && v.length <= MAX_VALUE_LENGTH)
+    );
   }
   if (op === "contains") {
-    return typeof value === "string" && value.length > 0;
+    return typeof value === "string" && value.length > 0 && value.length <= MAX_VALUE_LENGTH;
   }
   if (op === "eq") {
     // Numeric equality OR a text exact match — a finite number or a non-empty string.
     return (
       (typeof value === "number" && Number.isFinite(value)) ||
-      (typeof value === "string" && value.length > 0)
+      (typeof value === "string" && value.length > 0 && value.length <= MAX_VALUE_LENGTH)
     );
   }
   // gt/gte/lt/lte: a single FINITE number. Number.isFinite rejects Infinity/NaN — e.g. a

--- a/frontend/ui/src/features/filters/predicate.ts
+++ b/frontend/ui/src/features/filters/predicate.ts
@@ -30,6 +30,12 @@ export const MAX_KEY_LENGTH = 256;
 // validated before any fetch resolves; if either moves, the two files move together.
 export const MAX_VALUE_LENGTH = 1024;
 
+// Mirrors MAX_FILTERS in the same backend module, which 422s an array longer than this. Unlike
+// the two length caps, this one is reachable by clicking alone -- adding one more chip than the
+// backend accepts wedges the list with no paste and no hand-edited URL -- so the ceiling is
+// enforced where the array grows as well as where it is parsed.
+export const MAX_FILTERS = 20;
+
 /** Shape-guard for a single predicate parsed from untrusted input (e.g. a URL). */
 export function isValidPredicate(p: unknown): p is Predicate {
   if (typeof p !== "object" || p === null) return false;
@@ -97,7 +103,7 @@ export function canonicalizeFilters(filters?: Predicate[]): string {
  * in), so a malformed shape — e.g. an empty `in` — can't reach the URL/backend and 422.
  */
 export function serializeFiltersParam(filters?: Predicate[]): string | null {
-  const valid = (filters ?? []).filter(isValidPredicate);
+  const valid = (filters ?? []).filter(isValidPredicate).slice(0, MAX_FILTERS);
   return valid.length === 0 ? null : JSON.stringify(valid);
 }
 
@@ -115,5 +121,9 @@ export function parseFiltersParam(raw: string | null): Predicate[] {
     return [];
   }
   if (!Array.isArray(parsed)) return [];
-  return parsed.filter(isValidPredicate);
+  // Truncating past the cap rather than discarding the whole array keeps a hand-edited URL
+  // showing most of what it asked for instead of nothing, which is the same trade the
+  // per-predicate drops above already make: a filter the backend would reject is dropped,
+  // and the list comes back broader than the URL described rather than not at all.
+  return parsed.filter(isValidPredicate).slice(0, MAX_FILTERS);
 }

--- a/frontend/ui/src/features/filters/registry.test.ts
+++ b/frontend/ui/src/features/filters/registry.test.ts
@@ -1,5 +1,8 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
-import { STATIC_FILTER_FIELDS } from "./registry";
+import { STATIC_FILTER_FIELDS, type FilterFieldDef } from "./registry";
 
 describe("STATIC_FILTER_FIELDS fallback", () => {
   it("covers the trace + membership + aggregate tiers", () => {
@@ -9,11 +12,26 @@ describe("STATIC_FILTER_FIELDS fallback", () => {
         "duration_ms",
         "environment",
         "errors",
+        "metadata",
         "model_name",
         "total_tokens",
         "trace_id",
       ].sort(),
     );
+  });
+
+  it("exposes metadata as ONE keyed field, not one field per key", () => {
+    const keyed = STATIC_FILTER_FIELDS.filter((f) => f.requires_key);
+    expect(keyed.map((f) => f.field)).toEqual(["metadata"]);
+    // String operators only — values are stored stringified, so there is no per-key type
+    // inference and no numeric/boolean comparison to offer.
+    expect(keyed[0].operators).toEqual(["eq", "contains"]);
+  });
+
+  it("leaves every other field unkeyed", () => {
+    for (const f of STATIC_FILTER_FIELDS.filter((f) => f.field !== "metadata")) {
+      expect(f.requires_key).toBeFalsy();
+    }
   });
 
   it("declares the right operator set per field type", () => {
@@ -28,5 +46,103 @@ describe("STATIC_FILTER_FIELDS fallback", () => {
     const model = STATIC_FILTER_FIELDS.find((f) => f.field === "model_name")!;
     expect(model.value_source).toBe("distinct_query");
     expect(model.enum_values).toEqual([]);
+  });
+});
+
+/**
+ * STATIC_FILTER_FIELDS is a hand-maintained copy of the backend `FILTER_COLUMNS` tuple, so
+ * read the Python and compare rather than pin each side to its own hand-typed literals —
+ * which is what let the client ship `level: "SPAN_MEMBERSHIP"` for metadata against the
+ * server's `KEYED_MAP` with both suites green.
+ */
+const COLUMNS_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../../../backend/rest/services/filters/columns.py",
+);
+
+/** columns.py with docstrings and comment lines removed, so prose cannot read as code. */
+const columnsSource = readFileSync(COLUMNS_PATH, "utf8")
+  .replace(/"""[\s\S]*?"""/g, "")
+  .replace(/^[ \t]*#.*$/gm, "");
+
+/** Every `Class.MEMBER` -> serialized value the StrEnums in columns.py declare. */
+const enumValues = new Map<string, string>(
+  [...columnsSource.matchAll(/^class (\w+)\(StrEnum\):\n([\s\S]*?)(?=\n\S)/gm)].flatMap(
+    ([, className, body]) =>
+      [...body.matchAll(/^ {4}([A-Z_]+)\s*=\s*"([^"]*)"/gm)].map(
+        ([, member, value]) => [`${className}.${member}`, value] as const,
+      ),
+  ),
+);
+
+/** Anything unrecoverable becomes a marker that fails the comparison instead of matching. */
+const capture = (source: string, pattern: RegExp) => source.match(pattern)?.[1] ?? "<unparsed>";
+const enumValue = (reference: string) => enumValues.get(reference) ?? `<unparsed ${reference}>`;
+
+/** `operators=` is either a tuple literal or a module-level alias of one (`_NUMERIC_OPS`). */
+function operatorValues(expression: string): string[] {
+  const literal = expression.startsWith("(")
+    ? expression
+    : capture(columnsSource, new RegExp(`^${expression}\\s*=\\s*\\(([^)]*)\\)`, "m"));
+  return [...literal.matchAll(/FilterOperator\.\w+/g)].map((m) => enumValue(m[0]));
+}
+
+const TUPLE_DECLARATION = "FILTER_COLUMNS: tuple[FilterColumn, ...] = (";
+const tupleBody = columnsSource.slice(
+  columnsSource.indexOf(TUPLE_DECLARATION) + TUPLE_DECLARATION.length,
+);
+
+/** Every `FilterColumn(...)` in the FILTER_COLUMNS tuple, in declaration order. */
+const backendColumns = tupleBody
+  .slice(0, tupleBody.indexOf("\n)"))
+  // Split on the constructor, not on balanced parens (`countIf(status = 'ERROR')` nests
+  // parens in a string), then cut at each entry's own closing paren so a kwarg only some
+  // entries declare — `requires_key` — cannot be read across the seam from a neighbour.
+  .split("FilterColumn(")
+  .slice(1)
+  .map((chunk) => chunk.slice(0, chunk.search(/\n\s*\)/)))
+  .map((entry) => ({
+    field: capture(entry, /\bname="([^"]*)"/),
+    label: capture(entry, /\blabel="([^"]*)"/),
+    level: enumValue(capture(entry, /\blevel=(FilterLevel\.\w+)/)),
+    type: enumValue(capture(entry, /\btype=(FilterType\.\w+)/)),
+    operators: operatorValues(capture(entry, /\boperators=(\([^)]*\)|\w+)/)),
+    value_source: enumValue(capture(entry, /\bvalue_source=(ValueSource\.\w+)/)),
+    // Declared, not derived from the level: the backend treats keyed-ness and lowering
+    // scope as independent axes, so a keyed field at a new level must land here as a diff.
+    requires_key: /\brequires_key=True/.test(entry),
+  }));
+
+/** The part of a client entry the backend also declares. */
+const declaredOnBothSides = (field: FilterFieldDef) => ({
+  field: field.field,
+  label: field.label,
+  level: field.level,
+  type: field.type,
+  operators: [...field.operators],
+  value_source: field.value_source,
+  requires_key: field.requires_key ?? false,
+});
+
+describe("STATIC_FILTER_FIELDS mirrors the backend FILTER_COLUMNS registry", () => {
+  it("parses a non-empty registry that declares at least one keyed field", () => {
+    // Guards the guard: a registry the parser can no longer read would leave the
+    // comparison below with nothing to compare and pass silently.
+    expect(
+      backendColumns.length,
+      `no FilterColumn entries parsed from ${COLUMNS_PATH} — the parity check compares nothing`,
+    ).toBeGreaterThan(0);
+    expect(
+      backendColumns.filter((c) => c.requires_key).length,
+      "no keyed field parsed from the backend registry — the requires_key half is vacuous",
+    ).toBeGreaterThan(0);
+  });
+
+  it("declares every field exactly as the backend declares it, in the same order", () => {
+    // Order is the field dropdown's render order, so it is part of the contract.
+    expect(
+      STATIC_FILTER_FIELDS.map(declaredOnBothSides),
+      `STATIC_FILTER_FIELDS disagrees with ${COLUMNS_PATH} — the client is the copy, so update it (or the backend, if the client is right)`,
+    ).toEqual(backendColumns);
   });
 });

--- a/frontend/ui/src/features/filters/registry.ts
+++ b/frontend/ui/src/features/filters/registry.ts
@@ -15,6 +15,13 @@ export interface FilterFieldDef {
   enum_values: string[];
   /** Integer-typed numeric field (tokens/latency/errors) — restrict input to whole numbers. */
   integer?: boolean;
+  /**
+   * The field is parameterized by a key, so its predicate carries a `key` slot and the
+   * builder renders a key control before the operator. `metadata` is the only such field:
+   * its keys are user data, so they are discovered per window rather than being registry
+   * rows, and the registry stays one entry per field.
+   */
+  requires_key?: boolean;
 }
 
 /** GET /traces/filter-fields response. */
@@ -100,5 +107,17 @@ export const STATIC_FILTER_FIELDS: FilterFieldDef[] = [
     value_source: "range",
     enum_values: [],
     integer: true,
+  },
+  {
+    // Values are stored stringified, so string operators only — no per-key type inference.
+    // `free_text` because the value is typed, not picked; the key is the discovered part.
+    field: "metadata",
+    label: "Metadata",
+    type: "text",
+    level: "KEYED_MAP",
+    operators: ["eq", "contains"],
+    value_source: "free_text",
+    enum_values: [],
+    requires_key: true,
   },
 ];

--- a/frontend/ui/src/features/filters/trace-search-filter-input.test.tsx
+++ b/frontend/ui/src/features/filters/trace-search-filter-input.test.tsx
@@ -14,18 +14,40 @@ vi.mock("./hooks", () => ({
       type: "numeric",
       operators: ["eq", "gt", "gte", "lt", "lte"],
     },
+    {
+      field: "metadata",
+      label: "Metadata",
+      type: "text",
+      operators: ["eq", "contains"],
+      requires_key: true,
+    },
   ],
 }));
 
-// Stub the builder: clicking it submits a `cost` predicate, so we can assert the
-// input's add/replace wiring without driving the whole builder.
+// Stub the builder: clicking it submits whatever predicate the test lined up, defaulting
+// to a `cost` one, so the input's add/replace wiring is assertable without driving the
+// whole builder. Held in a mutable box because the module mock is hoisted above it.
+const COST_PREDICATE: Predicate = { field: "cost", op: "gt", value: 1 };
+const submission = vi.hoisted(() => ({
+  predicate: { field: "cost", op: "gt", value: 1 } as Predicate,
+}));
 vi.mock("./filter-builder", () => ({
   FilterBuilder: ({ onSubmit }: { onSubmit: (p: Predicate) => void }) => (
-    <button onClick={() => onSubmit({ field: "cost", op: "gt", value: 1 })}>stub-add-cost</button>
+    <button onClick={() => onSubmit(submission.predicate)}>stub-add</button>
   ),
 }));
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  submission.predicate = COST_PREDICATE;
+});
+
+/** Open the builder and submit the predicate the test lined up. */
+function submitFromBuilder(predicate: Predicate) {
+  submission.predicate = predicate;
+  fireEvent.focus(screen.getByRole("textbox"));
+  fireEvent.click(screen.getByText("stub-add"));
+}
 
 function renderInput(props: Partial<React.ComponentProps<typeof TraceSearchFilterInput>> = {}) {
   return render(
@@ -45,6 +67,44 @@ describe("TraceSearchFilterInput", () => {
     expect(screen.queryByText(/duration_ms/)).toBeNull();
   });
 
+  it("names a keyed predicate's key once on its chip, not twice", () => {
+    // The chip is the only place the three parts of a metadata filter (key, operator,
+    // value) are visible at once, so the key has to read as itself — `metadata.session_id`,
+    // not `metadata.session_id.session_id`.
+    renderInput({ filters: [{ field: "metadata", key: "session_id", op: "eq", value: "s-1" }] });
+    expect(screen.getByText("metadata.session_id = s-1")).toBeTruthy();
+    expect(screen.queryByText(/session_id\.session_id/)).toBeNull();
+  });
+
+  it("names the key once on a keyed chip whose field has a different display label", () => {
+    // The display name and the key are two different strings; only the label is
+    // substituted, and the key is still appended exactly once after it.
+    renderInput({ filters: [{ field: "metadata", key: "tenant", op: "contains", value: "acme" }] });
+    expect(screen.getByText("metadata.tenant contains acme")).toBeTruthy();
+  });
+
+  it("gives two metadata chips distinct labels and distinct remove buttons", () => {
+    renderInput({
+      filters: [
+        { field: "metadata", key: "session_id", op: "eq", value: "s-1" },
+        { field: "metadata", key: "tenant", op: "eq", value: "acme" },
+      ],
+    });
+    expect(screen.getByText("metadata.session_id = s-1")).toBeTruthy();
+    expect(screen.getByText("metadata.tenant = acme")).toBeTruthy();
+    expect(screen.getByLabelText("Remove metadata.session_id filter")).toBeTruthy();
+    expect(screen.getByLabelText("Remove metadata.tenant filter")).toBeTruthy();
+  });
+
+  it("removes the clicked metadata chip and leaves the other key filtered", () => {
+    const onFiltersChange = vi.fn();
+    const session: Predicate = { field: "metadata", key: "session_id", op: "eq", value: "s-1" };
+    const tenant: Predicate = { field: "metadata", key: "tenant", op: "eq", value: "acme" };
+    renderInput({ filters: [session, tenant], onFiltersChange });
+    fireEvent.click(screen.getByLabelText("Remove metadata.tenant filter"));
+    expect(onFiltersChange).toHaveBeenCalledWith([session]);
+  });
+
   it("removes a filter when its chip ✕ is clicked", () => {
     const onFiltersChange = vi.fn();
     renderInput({
@@ -62,11 +122,42 @@ describe("TraceSearchFilterInput", () => {
     const onFiltersChange = vi.fn();
     renderInput({ filters: [{ field: "cost", op: "gte", value: 5 }], onFiltersChange });
     // Builder is closed until the box is focused.
-    expect(screen.queryByText("stub-add-cost")).toBeNull();
-    fireEvent.focus(screen.getByRole("textbox"));
-    fireEvent.click(screen.getByText("stub-add-cost"));
+    expect(screen.queryByText("stub-add")).toBeNull();
+    submitFromBuilder(COST_PREDICATE);
     // The new `gt` supersedes the existing `gte` on the same field (same lower-bound slot).
     expect(onFiltersChange).toHaveBeenCalledWith([{ field: "cost", op: "gt", value: 1 }]);
+  });
+
+  it("a second metadata filter on a DIFFERENT key stacks alongside the first", () => {
+    // A keyed field behaves as one filterable field per key: `metadata.session_id` and
+    // `metadata.tenant` are independent filters that have to coexist, or narrowing by a
+    // second key would silently drop the first.
+    const onFiltersChange = vi.fn();
+    const session: Predicate = { field: "metadata", key: "session_id", op: "eq", value: "s-1" };
+    const tenant: Predicate = { field: "metadata", key: "tenant", op: "eq", value: "acme" };
+    renderInput({ filters: [session], onFiltersChange });
+    submitFromBuilder(tenant);
+    expect(onFiltersChange).toHaveBeenCalledWith([session, tenant]);
+  });
+
+  it("a second metadata filter on the SAME key replaces the first", () => {
+    // Two filters on one key would AND into a contradiction the chips could not explain,
+    // so re-filtering a key is a correction rather than an addition.
+    const onFiltersChange = vi.fn();
+    const first: Predicate = { field: "metadata", key: "session_id", op: "eq", value: "s-1" };
+    const second: Predicate = { field: "metadata", key: "session_id", op: "contains", value: "s-" };
+    renderInput({ filters: [first], onFiltersChange });
+    submitFromBuilder(second);
+    expect(onFiltersChange).toHaveBeenCalledWith([second]);
+  });
+
+  it("adding a metadata filter leaves filters on other fields untouched", () => {
+    const onFiltersChange = vi.fn();
+    const cost: Predicate = { field: "cost", op: "gte", value: 5 };
+    const session: Predicate = { field: "metadata", key: "session_id", op: "eq", value: "s-1" };
+    renderInput({ filters: [cost], onFiltersChange });
+    submitFromBuilder(session);
+    expect(onFiltersChange).toHaveBeenCalledWith([cost, session]);
   });
 
   it("backspace removes the last filter (the box is filter-only, no keyword text)", () => {

--- a/frontend/ui/src/features/filters/trace-search-filter-input.tsx
+++ b/frontend/ui/src/features/filters/trace-search-filter-input.tsx
@@ -15,6 +15,15 @@ import { useFilterFields } from "./hooks";
 import { FilterBuilder } from "./filter-builder";
 import { predicateLabel, upsertPredicate } from "./predicate-ui";
 
+/**
+ * The key of a keyed predicate (metadata), or undefined for the ordinary
+ * field/operator/value ones. Read off the predicate rather than by field name so nothing
+ * here has to know which fields are keyed — the registry's `requires_key` is that answer.
+ */
+function predicateKey(p: Predicate): string | undefined {
+  return p.key;
+}
+
 interface TraceSearchFilterInputProps {
   projectId: string;
   filters: Predicate[];
@@ -36,21 +45,31 @@ export function TraceSearchFilterInput({
   const inputRef = useRef<HTMLInputElement>(null);
   const anchorRef = useRef<HTMLDivElement>(null);
 
-  const addPredicate = (p: Predicate) => {
-    // Merge into the active set: a lower bound (`greater than or equal to`) and an upper
-    // bound (`less than or equal to`) on the same field coexist to form a range (e.g.
-    // latency ≥ 5 and latency ≤ 10, AND-combined by the backend); a same-direction bound,
-    // an exact `equals`, a categorical value, or a contradictory opposite bound that would
-    // make an empty range (e.g. errors ≥ 5 then errors ≤ 3) is superseded by the new one. The
-    // popover stays open and the builder resets, so another filter can be added at once.
-    onFiltersChange(upsertPredicate(filters, p));
-  };
+  // Merge into the active set: a lower bound (`greater than or equal to`) and an upper
+  // bound (`less than or equal to`) on the same field coexist to form a range (e.g.
+  // latency ≥ 5 and latency ≤ 10, AND-combined by the backend); a same-direction bound,
+  // an exact `equals`, a categorical value, or a contradictory opposite bound that would
+  // make an empty range (e.g. errors ≥ 5 then errors ≤ 3) is superseded by the new one.
+  // A keyed field merges per KEY, not per field — `metadata.session_id` and
+  // `metadata.user_id` are independent filters that coexist. The popover stays open and
+  // the builder resets, so another filter can be added at once.
+  const addPredicate = (p: Predicate) => onFiltersChange(upsertPredicate(filters, p));
   const removeAt = (index: number) => onFiltersChange(filters.filter((_, i) => i !== index));
 
   // Chips show the field's display name (its registry label, lowercased — e.g. `latency`
   // rather than the raw `duration_ms`), falling back to the field key if it isn't loaded.
+  // Only the BARE name goes to predicateLabel: the label appends a keyed predicate's own
+  // key itself, so it reads as `metadata.session_id` there. Handing it a name that already
+  // carries the key would spell the key twice.
   const fieldName = (field: string) =>
     fields.find((f) => f.field === field)?.label.toLowerCase() ?? field;
+  // The remove button names the raw field (not its display label) so the accessible name
+  // is stable regardless of whether the registry has loaded; the key is appended so two
+  // metadata chips are distinguishable rather than both reading "Remove metadata filter".
+  const chipRemoveTarget = (p: Predicate) => {
+    const key = predicateKey(p);
+    return key === undefined ? p.field : `${p.field}.${key}`;
+  };
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -79,7 +98,7 @@ export function TraceSearchFilterInput({
           <ListFilter className="mr-1 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
           {filters.map((p, i) => (
             <span
-              key={`${p.field}-${i}`}
+              key={`${p.field}-${predicateKey(p) ?? ""}-${i}`}
               className="flex items-center gap-1 rounded bg-muted/70 py-0.5 pl-1.5 pr-1 text-[12px]"
             >
               <span className="font-medium text-foreground">
@@ -87,7 +106,7 @@ export function TraceSearchFilterInput({
               </span>
               <button
                 type="button"
-                aria-label={`Remove ${p.field} filter`}
+                aria-label={`Remove ${chipRemoveTarget(p)} filter`}
                 onClick={() => removeAt(i)}
                 className="rounded p-0.5 transition-colors hover:bg-muted"
               >
@@ -127,8 +146,9 @@ export function TraceSearchFilterInput({
         // (fixed z-50), so it never overlaps on top of an open detail view.
         // Width is 75% of the search bar (left-aligned, so the right ~25% stays
         // uncovered) with a min floor so the field/operator/value/Add-filter row never
-        // cramps when the bar itself is narrow.
-        className="z-40 w-[calc(var(--radix-popover-trigger-width)*0.75)] min-w-[22rem] p-0"
+        // cramps when the bar itself is narrow. The floor budgets for the widest row —
+        // a keyed field (metadata) inserts a fifth control, and the row stays one line.
+        className="z-40 w-[calc(var(--radix-popover-trigger-width)*0.75)] min-w-[28rem] p-0"
       >
         <FilterBuilder
           projectId={projectId}

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -184,17 +184,22 @@ export interface TraceListResponse {
 }
 
 /**
- * A single trace-list filter predicate `{field, op, value}` — the frontend mirror of the
- * backend predicate IR, serialized into the `?filters=` JSON array. Explicit scalar
+ * A single trace-list filter predicate `{field, key?, op, value}` — the frontend mirror of
+ * the backend predicate IR, serialized into the `?filters=` JSON array. Explicit scalar
  * operators: categorical `in` (a list of strings; the UI selects one),
  * numeric `eq`/`gt`/`gte`/`lt`/`lte` (a single number), and text `eq`/`contains` (a string).
  * A numeric range is two one-sided predicates the backend AND-combines.
+ *
+ * `key` is the metadata key slot: required on a field the registry marks `requires_key`
+ * (`metadata` is the only one), absent on every other field. It reaches ClickHouse as a
+ * bound parameter rather than an identifier, which is why any key the user types is safe
+ * to query and an unrecognized one simply matches nothing.
  */
 export type Predicate =
-  | { field: string; op: "in"; value: string[] }
-  | { field: string; op: "gt" | "gte" | "lt" | "lte"; value: number }
-  | { field: string; op: "eq"; value: number | string }
-  | { field: string; op: "contains"; value: string };
+  | { field: string; key?: string; op: "in"; value: string[] }
+  | { field: string; key?: string; op: "gt" | "gte" | "lt" | "lte"; value: number }
+  | { field: string; key?: string; op: "eq"; value: number | string }
+  | { field: string; key?: string; op: "contains"; value: string };
 
 export interface TraceQueryOptions {
   page?: number;

--- a/tests/rest/test_trace_filter_meta.py
+++ b/tests/rest/test_trace_filter_meta.py
@@ -57,11 +57,7 @@ class TestFilterFields:
         resp = client.get("/api/v1/projects/p1/traces/filter-fields")
         assert resp.status_code == 200
         fields = resp.json()["fields"]
-        # ... except the ones held back by the temporary keyed-field gate in
-        # get_filter_fields, which feat/metadata-filter-ui removes along with this clause.
-        assert {f["field"] for f in fields} == {
-            c.name for c in reg.FILTER_COLUMNS if not c.requires_key
-        }
+        assert {f["field"] for f in fields} == {c.name for c in reg.FILTER_COLUMNS}
 
     def test_serializes_field_shape_from_registry(self, client):
         fields = {
@@ -87,6 +83,27 @@ class TestFilterFields:
         assert fields["errors"]["integer"] is True
         assert cost["integer"] is False
         assert model["integer"] is False
+
+    def test_serializes_requires_key_so_the_builder_renders_a_key_control(self, client):
+        """The client learns which field takes a key from the registry response rather
+        than hard-coding the field name.
+
+        The bit survives on the wire even though the backend derives it from the level,
+        because the level is serialized as an opaque string the client never interprets:
+        without the boolean, deciding whether to render the key control would mean
+        branching on a backend enum's spelling in the UI.
+        """
+        fields = {
+            f["field"]: f
+            for f in client.get("/api/v1/projects/p1/traces/filter-fields").json()["fields"]
+        }
+
+        assert fields["metadata"]["requires_key"] is True
+        assert fields["metadata"]["level"] == "KEYED_MAP"
+        assert fields["metadata"]["operators"] == ["eq", "contains"]
+        assert fields["metadata"]["value_source"] == "free_text"
+        for name in ("model_name", "environment", "cost", "trace_id", "errors"):
+            assert fields[name]["requires_key"] is False
 
 
 class TestFilterValues:


### PR DESCRIPTION
Part of #1824

> [!NOTE]
> Stacked on #1834 (`perf/trace-list-query-bounds`). This is the first PR in the stack
> with a user-visible change.

## Summary

The metadata filter end to end, with the key typed by hand.

- Pick **Metadata** in the filter builder, type a key, pick `=` or `contains`, type a value,
  Add filter. The row stays a single line — the popover's minimum width goes up so the
  fifth control fits.
- `Predicate` gains an optional `key` slot. `isValidPredicate` requires a non-empty key of
  at most 256 characters on a `requires_key` field and rejects a stray key on any other
  field, so a hand-edited URL can never put a filter into state that 422s every subsequent
  list request.
- `canonicalizeFilters` includes the key: `metadata.session_id = x` and
  `metadata.user_id = x` select different traces and must not share a query cache entry. An
  absent key stringifies away, so keyless predicates keep the shape their existing cache
  entries were written under.
- Chips read `metadata.tenant = acme`. The key is appended by `predicateLabel` itself, and
  the remove button names `metadata.tenant` rather than just `metadata`, so two metadata
  chips are distinguishable to assistive tech instead of both reading "Remove metadata
  filter".
- **Chips merge per key, not per field.** `upsertPredicate` slots on field *and* key, so
  `metadata.tenant = acme` and `metadata.feature contains checkout` coexist as two
  independent filters rather than one replacing the other — matching the backend, which
  lowers each metadata predicate as its own condition.
- `STATIC_FILTER_FIELDS` gains the metadata entry with `requires_key`. The static registry
  is the client's source of truth for that flag because URL predicates are validated before
  any `/filter-fields` fetch resolves.
- Metadata gets an icon in the shared domain icon registry.
- **Backend (about 20 lines):** removes the temporary `/filter-fields` gate added in
  #1833, adds `FilterField.requires_key` and serializes it, plus its test.
  `/filter-fields` now advertises metadata, which is exactly when the UI can handle it.

## Type of Change

- [x] feat - A new feature

## Details

**Any key the user types is accepted.** The key reaches ClickHouse as a bound parameter
rather than an identifier, which is what makes an arbitrary key safe to query — an
unrecognized key returns no rows, which is a correct empty result and not a reason to refuse
the filter. Nothing in this PR validates a key against a list.

**The key control here is a plain text input** (`aria-label="metadata key"`, capped at the
mirrored `MAX_KEY_LENGTH`). #1837 replaces it with a combobox that suggests the keys
discovered in the active window; the typed-key path it sits on does not change, and
if the suggestion work is dropped this input is what ships permanently.

The 256-character cap is mirrored from the backend deliberately: admitted into state, an
over-long key would persist into the URL and into storage and then 422 every list request
until the user found and removed it by hand.

## Notes

- Ordering: this PR must merge after #1833, since it removes that PR's gate. The
  two are adjacent in the stack for exactly that reason — every merge point stays
  deployable.
- The predicate, registry, chip, and builder logic all carry their own unit suites in this
  diff.

## Screenshots / Recordings (if applicable)

1. Filter popover open with **Metadata** picked: field dropdown, empty key box, operator
   dropdown, value box and Add filter, all on one row.
2. The same row filled in — key `tenant`, operator `=`, value `acme` — just before Add
   filter.
3. After applying: the chip reading `metadata.tenant = acme` in the filter bar, with the
   narrowed trace list and its result count behind it.
4. Two metadata chips at once (`metadata.tenant = acme` and
   `metadata.feature contains checkout`), showing they coexist rather than replace each
   other.
5. A key that was attached at **span** scope only, applied, matching traces in the list —
   the either-scope behavior, which is the part a reviewer cannot see from the diff.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add metadata key filtering to the trace list. Users can filter by `metadata.<key>` with `=` or `contains`, and the UI/URL enforce backend caps on value length and filter count to avoid 422s.

- **New Features**
  - Filter builder: shows a “metadata key” input when `metadata` is selected (trimmed, Enter applies, max 256 chars). Value is free text; operators: `=` and `contains`. Popover min width increased so the row stays on one line.
  - Chips and labels: `predicateLabel` appends the key (`metadata.session_id = ...`); remove buttons name `metadata.<key>` so multiple metadata chips are distinguishable.
  - Canonicalization and upserts: cache keys include `key`; `upsertPredicate` merges per field+key so different metadata keys coexist, same key replaces. Refuses adding a 21st chip.
  - Registry/API/icons: `STATIC_FILTER_FIELDS` adds `metadata` as `KEYED_MAP` with `requires_key`; `FIELD_ICONS`/`DOMAIN_ICONS` add a `metadata` icon. Backend `GET /traces/filter-fields` now advertises `metadata` and serializes `requires_key`; the temporary keyed-field gate is removed.

- **Validation and limits**
  - `Predicate` supports an optional `key`; keyed fields require a non-empty key and stray keys are rejected.
  - String values are capped at 1024 chars (text `=`/`contains` and each `in` element); the text input clamps this. Keys are capped at 256 chars.
  - Active filters are capped at 20: parse/serialize truncate to 20; `upsertPredicate` rejects additions past the cap but still allows edits that replace an existing one.

<sup>Written for commit 5fd2294e357bbc49ee2b45339cc70eb3e0c312ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

