### PR TITLE
feat(rest): expose metadata keys for filter discovery

### DIFF
--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -26,6 +26,7 @@ from rest.routers.deps import RateLimitedProjectAccess
 from rest.schemas.traces import (
     FilterFieldsResponse,
     FilterValuesResponse,
+    MetadataKeysResponse,
     SpanIOResponse,
     TraceDetailResponse,
     TraceListResponse,
@@ -215,6 +216,60 @@ async def get_filter_values(
         project_id=project_id, column=column.name, start_after=start_after, end_before=end_before
     )
     return {"field": field, "values": values}
+
+
+@router.get("/metadata-keys", response_model=MetadataKeysResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def get_metadata_keys(
+    request: Request,
+    response: Response,
+    project_id: str,
+    _access: RateLimitedProjectAccess,  # Validates access + sets rate-limit identity
+    start_after: datetime | None = Query(
+        None,
+        description="Only consider traces and spans starting at or after this timestamp",
+    ),
+    end_before: datetime | None = Query(
+        None, description="Only consider traces and spans starting before this timestamp"
+    ),
+):
+    """Metadata keys seen on the window's traces and spans, by descending frequency.
+
+    The discovery answer behind the metadata filter's key combobox, its one consumer. It
+    covers both scopes the SDK can attach metadata at: a key set on the trace and a key
+    set on a span are disjoint key spaces, so answering from one table alone would leave
+    the other's keys unsuggestable, while a filter on either is equally valid. Unlike
+    ``/filter-values/{field}`` there is no field to resolve and nothing to reject: a key
+    binds as a parameter, so this list only suggests, and an unlisted key stays filterable
+    by typing it.
+
+    Args:
+        project_id (str): Project that owns the traces and spans; server-bound for
+            isolation.
+        _access (RateLimitedProjectAccess): Validates access and sets rate-limit identity.
+        start_after (datetime | None): Lower bound on trace and span start time (active
+            window). An omitted bound is defaulted to a fixed lookback, never scanned
+            all-time.
+        end_before (datetime | None): Upper bound on trace and span start time (active
+            window), symmetric with ``start_after`` so keys match the list's window.
+
+    Returns:
+        MetadataKeysResponse: Keys with occurrence counts, by descending frequency.
+    """
+    start_after, end_before = clamp_retention_window(_access.billing_plan, start_after, end_before)
+    service = get_trace_discovery_service()
+    # Off the event loop, same reasoning as the trace list: the key scan arrayJoins over
+    # mapKeys on both tables' base rows, so it is the heaviest of the discovery reads, and
+    # the 30s cache does not protect the first caller.
+    keys = await asyncio.to_thread(
+        service.get_distinct_metadata_keys,
+        project_id=project_id,
+        start_after=start_after,
+        end_before=end_before,
+    )
+    return {"keys": keys}
 
 
 @router.get("/{trace_id}", response_model=TraceDetailResponse)

--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -163,3 +163,16 @@ class FilterValuesResponse(BaseModel):
 
     field: str
     values: list[FilterValueCount]
+
+
+class MetadataKeysResponse(BaseModel):
+    """Metadata keys observed in a window, by frequency — the discovery answer.
+
+    Feeds one surface: the metadata filter's key combobox. The trace list's column picker
+    is not a consumer — it offers fixed fields only, and metadata reaches the list as a
+    single blob cell rather than a column per key. Rows reuse ``FilterValueCount``
+    (``value``/``count``) because a key with an occurrence count is the same shape as a
+    categorical value with one, and both are rendered by the same suggestion list.
+    """
+
+    keys: list[FilterValueCount]

--- a/backend/rest/services/trace_discovery.py
+++ b/backend/rest/services/trace_discovery.py
@@ -1,7 +1,7 @@
-"""Option discovery for the filter UI: the distinct values a column takes.
+"""Option discovery for the filter UI: distinct column values and metadata keys.
 
 Every read here answers "what could the user pick?", never "what matches?". Suggestion is
-not permission — a value that falls outside an answer here stays filterable.
+not permission — a value or key that falls outside an answer here stays filterable.
 """
 
 import time
@@ -13,9 +13,9 @@ from rest.services.trace_reader import customer_traffic_only, default_lookback_s
 from rest.sql_utils import to_utc_naive
 
 # Every discovery answer: cap the option list and cache briefly. A picker only needs the
-# frequent entries, and the GROUP BY over spans is the heavy part. The cap bounds each
-# option list; the cache bounds all of them together, since they share one dict keyed by
-# namespace.
+# frequent entries, and the GROUP BY over spans is the heavy part. The cap bounds the
+# distinct-value lists and the metadata key list alike; the cache bounds all of them
+# together, since they share one dict keyed by namespace.
 DISCOVERY_LIMIT = 100
 DISCOVERY_CACHE_TTL_SECONDS = 30
 DISCOVERY_CACHE_MAX = 256
@@ -26,6 +26,11 @@ DISCOVERY_CACHE_MAX = 256
 # to expire or spill at different points. The rationale for each setting lives in that
 # module. Note for this module in particular: the 30s discovery cache does not protect the
 # FIRST caller, which is the one max_execution_time bounds.
+
+# Cache namespace for metadata key discovery. Every cache key leads with a namespace — the
+# scanned table for a column enumeration, this constant for key discovery — which is what
+# keeps the two answer spaces apart.
+_METADATA_KEYS_NAMESPACE = "metadata_keys"
 
 
 def _floor_minute(dt: datetime | None) -> datetime | None:
@@ -48,11 +53,11 @@ def _discovery_cache_key(
 
     Args:
         namespace (str): Which discovery answer space the key belongs to — the scanned
-            table for a column enumeration. Two answers can only collide if they share
-            this.
+            table for a column enumeration, ``_METADATA_KEYS_NAMESPACE`` for key
+            discovery. Two answers can only collide if they share this.
         project_id (str): Project the answer is scoped to.
         subject (str): What was enumerated within the namespace — a registry-resolved
-            column name.
+            column name, or the map column key discovery reads.
         normalized_start (datetime): Naive-UTC lower window bound.
         normalized_end (datetime | None): Naive-UTC upper window bound, or ``None``.
 
@@ -260,7 +265,7 @@ class TraceDiscoveryService:
         """Shared distinct-values scan: dedup, group, count, cache.
 
         Window resolution and the scan's WHERE clause come from ``_resolve_scan_window``
-        and ``_window_scan``, shared by every discovery query.
+        and ``_window_scan``, the same pair metadata key discovery uses.
 
         Args:
             table (str): Source table (``spans`` or ``traces``) — a literal chosen by
@@ -302,6 +307,101 @@ class TraceDiscoveryService:
                 LIMIT 1 BY {dedup_keys}
             )
             WHERE value IS NOT NULL AND value != ''
+            GROUP BY value
+            ORDER BY n DESC
+            LIMIT {DISCOVERY_LIMIT}
+        """
+        result = self._client.query(query, parameters=params, settings=READ_QUERY_SETTINGS)
+        rows = [{"value": str(row[0]), "count": int(row[1])} for row in result.result_rows]
+        self._cache_put(cache_key, rows)
+        return rows
+
+    def get_distinct_metadata_keys(
+        self,
+        project_id: str,
+        start_after: datetime | None = None,
+        end_before: datetime | None = None,
+    ) -> list[dict]:
+        """Distinct metadata keys on traces and spans in the active window, by frequency.
+
+        The discovery answer behind the metadata filter's key combobox, its one consumer.
+        It covers BOTH key spaces, which are disjoint by construction — a trace-level key
+        arrives on the ``traceroot.trace.`` attribute prefix and can never reach a span —
+        so scanning one table would leave the other's keys unsuggestable, and either half's
+        keys are equally filterable. The two halves' counts are summed per key before the
+        frequency order and the cap are applied. Otherwise the same machinery as
+        ``get_distinct_span_values``.
+
+        Args:
+            project_id (str): Project that scopes both scans (tenant isolation).
+            start_after (datetime | None): Lower bound on ``span_start_time`` and
+                ``trace_start_time``; prunes monthly partitions. ``None`` defaults to a
+                fixed lookback rather than scanning all time.
+            end_before (datetime | None): Upper bound on the same two columns (exclusive),
+                symmetric with the trace list's window so the suggestions never include
+                keys seen only on traces newer than the active window's end.
+
+        Returns:
+            list[dict]: ``[{"value": str, "count": int}]`` — the key and the number of
+            trace and span rows carrying it — ordered by descending frequency and capped
+            at ``DISCOVERY_LIMIT``. Same row shape as ``get_distinct_span_values`` so
+            both discovery surfaces render one list type.
+        """
+        normalized_start, normalized_end = _resolve_scan_window(start_after, end_before)
+        cache_key = _discovery_cache_key(
+            _METADATA_KEYS_NAMESPACE,
+            project_id,
+            "metadata_map",
+            normalized_start,
+            normalized_end,
+        )
+        cached = self._cache_get(cache_key)
+        if cached is not None:
+            return cached
+
+        span_where, span_params = _window_scan(
+            "span_start_time", project_id, normalized_start, normalized_end
+        )
+        trace_where, trace_params = _window_scan(
+            "trace_start_time", project_id, normalized_start, normalized_end
+        )
+        # Both halves scan the same project over the same window, so they bind the same
+        # parameter names to the same values.
+        params = {**span_params, **trace_params}
+
+        # In each half the key fan-out sits in its OWN layer ABOVE the dedup: LIMIT 1 BY is
+        # applied after the SELECT expressions are evaluated, so an arrayJoin inside the
+        # deduped sub-query would collapse back to one surviving row per source row and every
+        # row would contribute exactly one of its keys.
+        #
+        # The two halves are UNION ALLed BELOW the aggregation so one GROUP BY sums a key's
+        # trace and span occurrences and the ordering and LIMIT apply to the merged answer.
+        # Capping each half first would drop a key that is frequent overall but top of
+        # neither list.
+        query = f"""
+            SELECT value, count() AS n
+            FROM (
+                SELECT arrayJoin(mapKeys(metadata_map)) AS value
+                FROM (
+                    SELECT project_id, trace_id, span_id, metadata_map
+                    FROM spans
+                    WHERE {span_where}
+                    ORDER BY ch_update_time DESC
+                    LIMIT 1 BY project_id, trace_id, span_id
+                )
+
+                UNION ALL
+
+                SELECT arrayJoin(mapKeys(metadata_map)) AS value
+                FROM (
+                    SELECT project_id, trace_id, metadata_map
+                    FROM traces
+                    WHERE {trace_where}
+                    ORDER BY ch_update_time DESC
+                    LIMIT 1 BY project_id, trace_id
+                )
+            )
+            WHERE value != ''
             GROUP BY value
             ORDER BY n DESC
             LIMIT {DISCOVERY_LIMIT}

--- a/tests/rest/test_trace_filter_meta.py
+++ b/tests/rest/test_trace_filter_meta.py
@@ -1,20 +1,34 @@
 """Unit tests for the trace-filter meta endpoints and the discovery queries.
 
-Covers ``GET /traces/filter-fields`` (registry serialization) and
-``GET /traces/filter-values/{field}`` (distinct categorical values), plus the
+Covers ``GET /traces/filter-fields`` (registry serialization),
+``GET /traces/filter-values/{field}`` (distinct categorical values) and
+``GET /traces/metadata-keys`` (metadata key discovery), plus the
 ``TraceDiscoveryService`` queries + cache behind them. Uses TestClient with mocked
 dependencies — no ClickHouse needed.
 """
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
 
 from rest.main import app
 from rest.routers.deps import ProjectAccessInfo, get_project_access
 from rest.services.filters import columns as reg
+
+
+def _now_naive() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _free_clamp_floor() -> datetime:
+    """Lower edge a clamped free-plan (15-day retention) start must land at or after.
+
+    Allows generous slack for the cutoff's 1h buffer and the test's own runtime.
+    """
+    return _now_naive() - timedelta(days=15, hours=2)
 
 
 def _client_for_plan(mock_discovery, billing_plan: str) -> TestClient:
@@ -48,6 +62,17 @@ def client(mock_discovery):
 
     original = traces_mod.get_trace_discovery_service
     yield _client_for_plan(mock_discovery, "enterprise")
+    traces_mod.get_trace_discovery_service = original
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def free_plan_client(mock_discovery):
+    """Free plan (15-day retention) — exercises the retention clamp path."""
+    import rest.routers.traces as traces_mod
+
+    original = traces_mod.get_trace_discovery_service
+    yield _client_for_plan(mock_discovery, "free")
     traces_mod.get_trace_discovery_service = original
     app.dependency_overrides.clear()
 
@@ -411,6 +436,434 @@ class TestGetDistinctTraceValues:
         second = svc.get_distinct_trace_values(project_id="p1", column="environment")
         assert first == second
         mock_client.query.assert_called_once()
+
+
+class TestMetadataKeys:
+    """``GET /traces/metadata-keys`` — the one discovery answer behind the filter's key
+    combobox and the trace list's metadata column picker."""
+
+    _URL = "/api/v1/projects/p1/traces/metadata-keys"
+
+    def test_returns_keys_with_counts_in_the_service_order(self, client, mock_discovery):
+        mock_discovery.get_distinct_metadata_keys.return_value = [
+            {"value": "tenant_id", "count": 120},
+            {"value": "release", "count": 8},
+        ]
+
+        resp = client.get(self._URL)
+
+        assert resp.status_code == 200
+        assert resp.json()["keys"] == [
+            {"value": "tenant_id", "count": 120},
+            {"value": "release", "count": 8},
+        ]
+        assert mock_discovery.get_distinct_metadata_keys.call_args.kwargs["project_id"] == "p1"
+
+    def test_window_params_are_threaded_to_the_service(self, client, mock_discovery):
+        mock_discovery.get_distinct_metadata_keys.return_value = []
+
+        resp = client.get(
+            f"{self._URL}?start_after=2026-06-01T00:00:00&end_before=2026-06-02T00:00:00"
+        )
+
+        assert resp.status_code == 200
+        kw = mock_discovery.get_distinct_metadata_keys.call_args.kwargs
+        assert kw["start_after"] == datetime(2026, 6, 1, 0, 0, 0)
+        assert kw["end_before"] == datetime(2026, 6, 2, 0, 0, 0)
+
+    def test_response_carries_only_the_keys(self, client, mock_discovery):
+        """The response is the key list and nothing else. It used to echo the window back,
+        which no consumer read, and which meant resolving the window twice — once in the
+        router and once in the service — with only convention keeping the echoed bounds
+        equal to the scanned ones."""
+        mock_discovery.get_distinct_metadata_keys.return_value = []
+
+        body = client.get(
+            f"{self._URL}?start_after=2026-06-01T00:00:00&end_before=2026-06-02T00:00:00"
+        ).json()
+
+        assert set(body) == {"keys"}
+        assert "start_after" not in body
+        assert "end_before" not in body
+
+    def test_omitted_bounds_reach_the_service_as_none(self, client, mock_discovery):
+        """The router does not resolve the window: an open-ended request passes ``None``
+        through and the service applies the one discovery window rule (which defaults the
+        lower bound rather than scanning all time — asserted on the service itself)."""
+        mock_discovery.get_distinct_metadata_keys.return_value = []
+
+        resp = client.get(self._URL)
+
+        assert resp.status_code == 200
+        kw = mock_discovery.get_distinct_metadata_keys.call_args.kwargs
+        assert kw["start_after"] is None
+        assert kw["end_before"] is None
+
+    def test_out_of_window_start_is_clamped_for_limited_plan(
+        self, free_plan_client, mock_discovery
+    ):
+        """A window reaching past the plan's retention is pulled up to the cutoff, exactly
+        as ``/filter-values/{field}`` clamps it. Without this a caller could enumerate the
+        metadata key names of data the plan no longer grants access to — key names carry
+        customer vocabulary (tenant, customer and account identifiers), so the leak is real
+        even though no values come back with them."""
+        mock_discovery.get_distinct_metadata_keys.return_value = []
+        old = (_now_naive() - timedelta(days=365)).isoformat()
+
+        resp = free_plan_client.get(f"{self._URL}?start_after={old}")
+
+        assert resp.status_code == 200
+        clamped = mock_discovery.get_distinct_metadata_keys.call_args.kwargs["start_after"]
+        assert clamped > datetime(2020, 1, 2)  # not the ancient input
+        assert clamped >= _free_clamp_floor()  # pulled up to ~ now - 15 days
+
+    def test_missing_start_is_clamped_for_limited_plan(self, free_plan_client, mock_discovery):
+        """An omitted lower bound would otherwise reach the service as ``None`` and be
+        defaulted to a lookback that owes nothing to the plan; the clamp bounds it first."""
+        mock_discovery.get_distinct_metadata_keys.return_value = []
+
+        resp = free_plan_client.get(self._URL)
+
+        assert resp.status_code == 200
+        clamped = mock_discovery.get_distinct_metadata_keys.call_args.kwargs["start_after"]
+        assert clamped is not None
+        assert clamped >= _free_clamp_floor()
+
+    def test_the_clamp_matches_the_sibling_filter_values_endpoint(
+        self, free_plan_client, mock_discovery
+    ):
+        """Same plan, same requested window, same resulting lower bound on both discovery
+        endpoints — one clamp reused, not two implementations that could drift."""
+        mock_discovery.get_distinct_metadata_keys.return_value = []
+        mock_discovery.get_distinct_span_values.return_value = []
+        old = (_now_naive() - timedelta(days=365)).isoformat()
+
+        free_plan_client.get(f"{self._URL}?start_after={old}")
+        keys_start = mock_discovery.get_distinct_metadata_keys.call_args.kwargs["start_after"]
+        free_plan_client.get(
+            f"/api/v1/projects/p1/traces/filter-values/model_name?start_after={old}"
+        )
+        values_start = mock_discovery.get_distinct_span_values.call_args.kwargs["start_after"]
+
+        assert abs((keys_start - values_start).total_seconds()) < 2
+
+    def test_unlimited_plan_window_reaches_the_service_verbatim(self, client, mock_discovery):
+        """The clamp is a retention gate, not a window rewrite: an unlimited plan's
+        requested bounds pass through untouched."""
+        mock_discovery.get_distinct_metadata_keys.return_value = []
+
+        resp = client.get(f"{self._URL}?start_after=2020-01-01T00:00:00")
+
+        assert resp.status_code == 200
+        kw = mock_discovery.get_distinct_metadata_keys.call_args.kwargs
+        assert kw["start_after"] == datetime(2020, 1, 1, 0, 0, 0)
+
+    def test_denied_project_access_is_not_answered(self, mock_discovery):
+        """Discovery reads another tenant's spans if it skips the access check, so it
+        carries the same dependency as every other trace route."""
+
+        async def deny_access(project_id: str, x_user_id=None):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="No access")
+
+        app.dependency_overrides[get_project_access] = deny_access
+        import rest.routers.traces as traces_mod
+
+        original = traces_mod.get_trace_discovery_service
+        traces_mod.get_trace_discovery_service = lambda: mock_discovery
+        try:
+            resp = TestClient(app).get(self._URL)
+        finally:
+            traces_mod.get_trace_discovery_service = original
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 403
+        mock_discovery.get_distinct_metadata_keys.assert_not_called()
+
+    def test_route_is_registered_with_the_shared_read_limiter(self):
+        """Discovery is a full-project GROUP BY, so it must share the per-workspace read
+        budget rather than ship undecorated."""
+        from rest.rate_limit import limiter
+
+        assert "rest.routers.traces.get_metadata_keys" in limiter._dynamic_route_limits
+
+    def test_success_returns_200_with_headers_when_limiter_enabled(
+        self, client, mock_discovery, monkeypatch
+    ):
+        """With the limiter enabled (cloud), the route must still 200 and carry the
+        X-RateLimit-* headers — i.e. it declares the ``response`` param slowapi needs for
+        header injection (missing it 500s every call). The test env disables the limiter,
+        so this drives the real route through an enabled module limiter."""
+        import rest.rate_limit as rate_limit
+
+        monkeypatch.setattr(rate_limit.limiter, "enabled", True)
+        mock_discovery.get_distinct_metadata_keys.return_value = []
+
+        resp = client.get(self._URL)
+
+        assert resp.status_code == 200, resp.text
+        assert "X-RateLimit-Limit" in resp.headers
+
+
+class TestGetDistinctMetadataKeys:
+    """Metadata key discovery reuses the distinct-values machinery wholesale: the same
+    defaulted-and-both-ends window, dedup before counting, frequency order, cap and
+    minute-floored cache. A suggested key must obey the same rule as a suggested value —
+    the active window must never be the reason a suggested option returns zero rows.
+
+    It answers for BOTH surfaces it feeds: the filter's key combobox and the trace list's
+    column picker. A tag can be attached at trace scope or span scope and the two key
+    spaces are disjoint, so scanning one table would leave the other's keys unsuggestable."""
+
+    def _service(self, monkeypatch, mock_client):
+        import rest.services.trace_discovery as discovery_mod
+
+        monkeypatch.setattr(discovery_mod, "get_clickhouse_client", lambda: mock_client)
+        return discovery_mod.TraceDiscoveryService()
+
+    def test_returns_keys_with_counts_in_frequency_order(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = [("tenant_id", 120), ("release", 8)]
+        svc = self._service(monkeypatch, mock_client)
+
+        out = svc.get_distinct_metadata_keys(project_id="p1")
+
+        assert out == [
+            {"value": "tenant_id", "count": 120},
+            {"value": "release", "count": 8},
+        ]
+        assert "ORDER BY n DESC" in mock_client.query.call_args[0][0]
+
+    def test_enumerates_map_keys_from_project_scoped_spans_and_traces(self, monkeypatch):
+        """Both key spaces or neither: a trace-level key can never reach a span, so a
+        spans-only scan would offer the column picker nothing to pick."""
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_metadata_keys(project_id="p1")
+
+        sql, kwargs = mock_client.query.call_args
+        query_text = sql[0]
+        assert query_text.count("arrayJoin(mapKeys(metadata_map))") == 2
+        assert "FROM spans" in query_text
+        assert "FROM traces" in query_text
+        assert query_text.count("project_id = {project_id:String}") == 2
+        assert "GROUP BY value" in query_text
+        assert kwargs["parameters"]["project_id"] == "p1"
+
+    def test_counts_are_summed_per_key_across_both_tables(self, monkeypatch):
+        """One GROUP BY over the union, not one per half: a key carried by both a trace
+        row and its spans is one suggestion whose count is everything carrying it."""
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = [("tenant_id", 9)]
+        svc = self._service(monkeypatch, mock_client)
+
+        out = svc.get_distinct_metadata_keys(project_id="p1")
+
+        query_text = mock_client.query.call_args[0][0]
+        assert "UNION ALL" in query_text
+        assert query_text.count("GROUP BY value") == 1
+        assert query_text.index("UNION ALL") < query_text.index("GROUP BY value")
+        assert out == [{"value": "tenant_id", "count": 9}]
+
+    def test_frequency_order_and_the_cap_apply_to_the_unioned_result(self, monkeypatch):
+        """Capping each half first would let a key that is frequent overall fall off both
+        lists while a key frequent in only one survives."""
+        from rest.services.trace_discovery import DISCOVERY_LIMIT
+
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_metadata_keys(project_id="p1")
+
+        query_text = mock_client.query.call_args[0][0]
+        assert query_text.count("ORDER BY n DESC") == 1
+        assert query_text.count(f"LIMIT {DISCOVERY_LIMIT}") == 1
+        assert query_text.index("UNION ALL") < query_text.index("ORDER BY n DESC")
+        assert query_text.index("UNION ALL") < query_text.index(f"LIMIT {DISCOVERY_LIMIT}")
+
+    def test_dedups_each_table_before_the_key_fanout(self, monkeypatch):
+        """LIMIT 1 BY is applied after the SELECT expressions are evaluated, so the
+        arrayJoin has to sit in a layer ABOVE the dedup — otherwise every row would
+        contribute exactly one of its keys and multi-key rows would lose the rest. Each
+        half dedups on its own table's logical row identity."""
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_metadata_keys(project_id="p1")
+
+        lines = [line.strip() for line in mock_client.query.call_args[0][0].splitlines()]
+        fanouts = [
+            i for i, line in enumerate(lines) if line.startswith("SELECT arrayJoin(mapKeys(")
+        ]
+        dedups = [i for i, line in enumerate(lines) if line.startswith("LIMIT 1 BY")]
+
+        assert {lines[i] for i in dedups} == {
+            "LIMIT 1 BY project_id, trace_id, span_id",  # a span is one logical row
+            "LIMIT 1 BY project_id, trace_id",  # so is a trace
+        }
+        assert len(fanouts) == len(dedups) == 2
+        assert all(fanout < dedup for fanout, dedup in zip(fanouts, dedups))
+
+    def test_window_bounds_both_halves_at_both_ends(self, monkeypatch):
+        """A discovery scan stands alone — no trace-level semi-join above it re-filters
+        what it admits — so neither half may offer keys from outside the active window."""
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_metadata_keys(
+            project_id="p1",
+            start_after=datetime(2026, 6, 1),
+            end_before=datetime(2026, 6, 2),
+        )
+
+        sql, kwargs = mock_client.query.call_args
+        assert "span_start_time >= {start_after:DateTime64(3)}" in sql[0]
+        assert "span_start_time < {end_before:DateTime64(3)}" in sql[0]
+        assert "trace_start_time >= {start_after:DateTime64(3)}" in sql[0]
+        assert "trace_start_time < {end_before:DateTime64(3)}" in sql[0]
+        assert kwargs["parameters"]["start_after"] == datetime(2026, 6, 1)
+        assert kwargs["parameters"]["end_before"] == datetime(2026, 6, 2)
+
+    def test_detector_self_traces_are_excluded_from_both_halves(self, monkeypatch):
+        """A suggestion list is customer-facing, and internal telemetry carries keys the
+        customer never set and cannot act on."""
+        from rest.services.trace_reader import customer_traffic_only
+
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_metadata_keys(project_id="p1")
+
+        assert mock_client.query.call_args[0][0].count(customer_traffic_only()) == 2
+
+    def test_no_window_defaults_a_lookback_bound_on_both_halves(self, monkeypatch):
+        from rest.services.trace_reader import DEFAULT_SPAN_SCAN_LOOKBACK_HOURS
+
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        before = datetime.now(UTC).replace(tzinfo=None)
+        svc.get_distinct_metadata_keys(project_id="p1")
+        after = datetime.now(UTC).replace(tzinfo=None)
+
+        sql, kwargs = mock_client.query.call_args
+        assert "span_start_time >= {start_after:DateTime64(3)}" in sql[0]
+        assert "trace_start_time >= {start_after:DateTime64(3)}" in sql[0]
+        lookback = timedelta(hours=DEFAULT_SPAN_SCAN_LOOKBACK_HOURS)
+        assert before - lookback <= kwargs["parameters"]["start_after"] <= after - lookback
+        # One binding serves both halves, so they cannot drift onto different windows.
+        assert "start_after" in kwargs["parameters"]
+
+    def test_end_before_only_defaults_start_relative_to_it(self, monkeypatch):
+        from rest.services.trace_reader import DEFAULT_SPAN_SCAN_LOOKBACK_HOURS
+
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        end = datetime(2026, 6, 2, 12, 0, 0)
+        svc.get_distinct_metadata_keys(project_id="p1", end_before=end)
+
+        params = mock_client.query.call_args.kwargs["parameters"]
+        assert params["start_after"] == end - timedelta(hours=DEFAULT_SPAN_SCAN_LOOKBACK_HOURS)
+
+    def test_query_excludes_empty_keys_and_respects_the_cap(self, monkeypatch):
+        from rest.services.trace_discovery import DISCOVERY_LIMIT
+
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_metadata_keys(project_id="p1")
+
+        query_text = mock_client.query.call_args[0][0]
+        assert "value != ''" in query_text  # blanks aren't offered as suggestions
+        assert f"LIMIT {DISCOVERY_LIMIT}" in query_text
+
+    def test_results_are_cached_per_project_and_window(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = [("tenant_id", 3)]
+        svc = self._service(monkeypatch, mock_client)
+
+        first = svc.get_distinct_metadata_keys(project_id="p1")
+        second = svc.get_distinct_metadata_keys(project_id="p1")
+
+        assert first == second
+        mock_client.query.assert_called_once()  # second call served from cache
+
+    @pytest.mark.parametrize(
+        "second_time,expected_calls",
+        [((0, 0, 45), 1), ((0, 1, 5), 2)],
+        ids=["same-minute-reuses-the-cache", "a-new-minute-is-a-fresh-answer"],
+    )
+    def test_the_cache_key_is_floored_to_the_whole_minute(
+        self, monkeypatch, second_time, expected_calls
+    ):
+        """Sub-minute jitter (the UI recomputes "now - duration" every render) must not force
+        a fresh full-project GROUP BY, while a genuinely new minute must."""
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = [("tenant_id", 3)]
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_metadata_keys(project_id="p1", start_after=datetime(2026, 6, 1, 0, 0, 5))
+        svc.get_distinct_metadata_keys(
+            project_id="p1", start_after=datetime(2026, 6, 1, *second_time)
+        )
+
+        assert mock_client.query.call_count == expected_calls
+
+    def test_key_discovery_does_not_share_a_cache_entry_with_a_column(self, monkeypatch):
+        """Both answers live in one cache; a collision would serve model names as keys."""
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = [("gpt-4", 3)]
+        svc = self._service(monkeypatch, mock_client)
+        window = {"start_after": datetime(2026, 6, 1), "end_before": datetime(2026, 6, 2)}
+
+        svc.get_distinct_span_values(project_id="p1", column="model_name", **window)
+        svc.get_distinct_metadata_keys(project_id="p1", **window)
+
+        assert mock_client.query.call_count == 2
+        assert "arrayJoin(mapKeys(metadata_map))" in mock_client.query.call_args[0][0]
+
+
+class TestDiscoveryWindowRuleIsShared:
+    """Every discovery surface answers over the same window, because there is one window
+    rule rather than one per surface. A dropdown that defaulted a different lookback from
+    the key combobox beside it would offer options over a range the user never chose, and
+    the drift would be invisible until someone compared two suggestion lists."""
+
+    def _service(self, monkeypatch, mock_client):
+        import rest.services.trace_discovery as discovery_mod
+
+        monkeypatch.setattr(discovery_mod, "get_clickhouse_client", lambda: mock_client)
+        return discovery_mod.TraceDiscoveryService()
+
+    def _bound_window(self, mock_client) -> dict:
+        """The window parameters the last query actually bound."""
+        params = mock_client.query.call_args.kwargs["parameters"]
+        return {k: v for k, v in params.items() if k in ("start_after", "end_before")}
+
+    def test_a_value_dropdown_and_key_discovery_default_the_same_lower_bound(self, monkeypatch):
+        """An absent lower bound is defaulted, never left open, and defaulted identically:
+        both anchor the same lookback to the window's end."""
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+        end = datetime(2026, 6, 2, 12, 0, 0)
+
+        svc.get_distinct_span_values(project_id="p1", column="model_name", end_before=end)
+        dropdown_window = self._bound_window(mock_client)
+        svc.get_distinct_metadata_keys(project_id="p1", end_before=end)
+        keys_window = self._bound_window(mock_client)
+
+        assert dropdown_window == keys_window
+        assert dropdown_window["start_after"] < end  # defaulted, not left open
 
 
 class TestGetTraceDiscoveryService:

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -664,6 +664,17 @@ class TestBlockingReadsRunOffTheEventLoop:
         assert response.status_code == 200
         assert ran_on_loop == [False]
 
+    def test_metadata_keys_reads_off_the_loop(self, client, mock_trace_discovery):
+        ran_on_loop: list[bool] = []
+        mock_trace_discovery.get_distinct_metadata_keys.side_effect = self._loop_visible_to(
+            ran_on_loop, []
+        )
+
+        response = client.get("/api/v1/projects/test-project/traces/metadata-keys")
+
+        assert response.status_code == 200
+        assert ran_on_loop == [False]
+
     def test_a_read_that_raises_in_the_worker_thread_still_maps_to_500(
         self, client, mock_trace_reader
     ):


### PR DESCRIPTION
Part of #1824

> [!NOTE]
> Stacked on #1835 (`feat/metadata-filter-ui`).

## Summary

`GET /projects/{project_id}/traces/metadata-keys` → `{"keys": [{"value", "count"}]}`, the
discovery answer behind the metadata filter's key control.

- **Both scopes.** A trace-level key can never reach a span, so the two key spaces are
  disjoint and scanning one table alone would leave the other's keys unsuggestable while a
  filter on either is equally valid.
- The two halves are `UNION ALL`ed **below** the aggregation, so one `GROUP BY` sums a key's
  trace and span occurrences and the ordering and the cap apply to the merged answer.
  Capping each half first would drop a key that is frequent overall but top of neither list.
- The key fan-out (`arrayJoin(mapKeys(metadata_map))`) sits in its own layer **above** the
  ReplacingMergeTree dedup. Inside the deduped sub-query, `LIMIT 1 BY` applies after the
  SELECT expressions are evaluated, so every row would contribute exactly one of its keys.
- Window-bounded through the same `_resolve_scan_window` / `_window_scan` pair the
  distinct-value scans use: a defaulted lookback rather than an all-time scan, an exclusive
  upper bound symmetric with the list's window, detector self-traces excluded.
- Capped at 100, cached for 30s in its own cache namespace, and run off the event loop —
  it arrayJoins over `mapKeys` on both tables' base rows, so it is the heaviest of the
  discovery reads, and the cache does not protect the first caller.
- Retention clamping, rate-limit bucket, and project access exactly as the sibling
  discovery endpoints.

## Type of Change

- [x] feat - A new feature

## Details

**Suggestion is not permission.** Unlike `/filter-values/{field}` there is no field to
resolve and nothing to reject: the key binds as a query parameter, so this endpoint only
suggests, and a key absent from its answer stays filterable by typing it. That is stated in
the endpoint docstring so a future reader does not mistake it for a whitelist.

The response reuses `FilterValueCount` (`value` / `count`) rather than defining a parallel
row type — a key with an occurrence count is the same shape as a categorical value with one,
and the same suggestion list renders both.

Tests cover the endpoint (both scopes contributing, frequency order, the cap, the cache, the
window default, retention clamping) and that the read runs off the event loop.

## Notes

- No UI consumer in this PR; the combobox that calls it is #1837. The trace list's
  column picker is explicitly not a consumer — it offers fixed fields only, and metadata
  reaches the list as a single cell rather than a column per key.

## Screenshots / Recordings (if applicable)

Not applicable — backend only, no UI consumer yet.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
