### PR TITLE
feat(ui): suggest metadata keys in the filter builder

### DIFF
--- a/frontend/ui/src/features/filters/filter-builder.test.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.test.tsx
@@ -2,14 +2,41 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
 import { render, cleanup, screen, fireEvent } from "@testing-library/react";
 import { FilterBuilder } from "./filter-builder";
-import type { FilterFieldDef } from "./registry";
+import { ValueDropdown } from "./filter-controls";
+import { isValidPredicate } from "./predicate";
+import type { FilterFieldDef, FilterValue } from "./registry";
 
-// Stub the distinct-values hook; keep it as a spy so we can assert the window bounds
-// are threaded through to it for a distinct-query categorical field.
+// Spies, not bare stubs, so tests can assert the window bounds each hook is asked about.
 const mockUseFilterValues = vi.hoisted(() => vi.fn(() => ({ values: [], isLoading: false })));
-vi.mock("./hooks", () => ({ useFilterValues: mockUseFilterValues }));
+// A discovery row IS the categorical distinct-value row (`{value, count}`), so the stub
+// cannot spell the field a way the endpoint does not.
+const mockUseMetadataKeys = vi.hoisted(() =>
+  vi.fn(
+    (
+      _projectId: string,
+      _startAfter?: string,
+      _endBefore?: string,
+      _enabled?: boolean,
+    ): { keys: { value: string; count: number }[]; isLoading: boolean } => ({
+      keys: [],
+      isLoading: false,
+    }),
+  ),
+);
+vi.mock("./hooks", () => ({
+  useFilterValues: mockUseFilterValues,
+  useMetadataKeys: mockUseMetadataKeys,
+}));
 
-afterEach(cleanup);
+/** Discovery answers with these keys, in the order given (frequency-descending). */
+function suggestKeys(keys: FilterValue[]) {
+  mockUseMetadataKeys.mockReturnValue({ keys, isLoading: false });
+}
+
+afterEach(() => {
+  cleanup();
+  mockUseMetadataKeys.mockReturnValue({ keys: [], isLoading: false });
+});
 
 const STATUS: FilterFieldDef = {
   field: "status",
@@ -306,11 +333,105 @@ describe("FilterBuilder (Metadata key)", () => {
     fireEvent.change(screen.getByLabelText("value"), { target: { value } });
   };
 
+  /**
+   * What the shipped categorical value dropdown renders for an empty option list, read
+   * off that dropdown itself so the key combobox is compared against the real thing.
+   */
+  const valueDropdownEmptyState = () => {
+    render(<ValueDropdown value="" options={[]} onValue={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Enter value" }));
+    const text = screen.getByRole("dialog").textContent;
+    cleanup();
+    return text;
+  };
+
   it("reveals the key control when Metadata is selected", () => {
     renderBuilder([METADATA, TRACE_ID]);
     expect(screen.queryByLabelText("metadata key")).toBeNull();
     pickField(/Metadata/);
     expect(screen.getByLabelText("metadata key")).toBeTruthy();
+  });
+
+  it("renders suggested keys in the frequency order discovery returned them", () => {
+    suggestKeys([
+      { value: "session_id", count: 120 },
+      { value: "user_id", count: 40 },
+      { value: "tenant", count: 3 },
+    ]);
+    renderBuilder([METADATA]);
+    pickField(/Metadata/);
+    fireEvent.focus(screen.getByLabelText("metadata key"));
+    expect(screen.getAllByRole("option").map((o) => o.textContent)).toEqual([
+      "session_id120",
+      "user_id40",
+      "tenant3",
+    ]);
+  });
+
+  it("picking a suggested key emits a predicate carrying that key", () => {
+    suggestKeys([{ value: "session_id", count: 9 }]);
+    const onSubmit = renderBuilder([METADATA]);
+    pickField(/Metadata/);
+    fireEvent.focus(screen.getByLabelText("metadata key"));
+    fireEvent.click(screen.getByRole("option", { name: /session_id/ }));
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "s-1" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      field: "metadata",
+      key: "session_id",
+      op: "eq",
+      value: "s-1",
+    });
+  });
+
+  it("accepts a typed key that is NOT in the suggestion list (suggestion is not permission)", () => {
+    suggestKeys([{ value: "session_id", count: 9 }]);
+    const onSubmit = renderBuilder([METADATA]);
+    pickField(/Metadata/);
+    fillKeyAndValue("never_suggested_key", "v1");
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    const emitted = onSubmit.mock.calls[0][0];
+    expect(emitted).toEqual({
+      field: "metadata",
+      key: "never_suggested_key",
+      op: "eq",
+      value: "v1",
+    });
+    // And the emitted predicate is one the URL/query layer will keep, not one it drops.
+    expect(isValidPredicate(emitted)).toBe(true);
+  });
+
+  it("shows the value dropdown's own empty state when nothing in the list matches", () => {
+    // An empty suggestion list is not a rejection, so it says exactly what the shipped
+    // categorical value dropdown says for an empty option list — read from that dropdown
+    // rather than spelled out here, so the two surfaces cannot drift apart in a copy edit.
+    const shared = valueDropdownEmptyState();
+    suggestKeys([{ value: "session_id", count: 9 }]);
+    renderBuilder([METADATA]);
+    pickField(/Metadata/);
+    fireEvent.change(screen.getByLabelText("metadata key"), {
+      target: { value: "never_suggested_key" },
+    });
+    expect(screen.getByRole("dialog").textContent).toBe(shared);
+  });
+
+  it("claims only what the one discovery query knows, answered without a second scan", () => {
+    // "No metadata in this project" would be a stronger claim than one windowed query can
+    // support, and widening the scan to sharpen one sentence is not a cost an empty
+    // project pays — so empty discovery says the same neutral thing, scoped to nothing.
+    const shared = valueDropdownEmptyState();
+    mockUseMetadataKeys.mockClear();
+    renderBuilder([METADATA]);
+    pickField(/Metadata/);
+    fireEvent.focus(screen.getByLabelText("metadata key"));
+    expect(screen.getByRole("dialog").textContent).toBe(shared);
+    expect(screen.queryByText(/no metadata found in this project/i)).toBeNull();
+    const windows = new Set(
+      mockUseMetadataKeys.mock.calls.map(([, startAfter, endBefore]) =>
+        JSON.stringify([startAfter ?? null, endBefore ?? null]),
+      ),
+    );
+    expect(windows.size).toBe(1);
   });
 
   it("keeps Add filter disabled until the key is filled", () => {

--- a/frontend/ui/src/features/filters/filter-builder.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.tsx
@@ -17,7 +17,6 @@ import { Button } from "@/components/ui/button";
 import type { Predicate } from "@/types/api";
 import { useFilterValues } from "./hooks";
 import type { FilterFieldDef } from "./registry";
-import { MAX_KEY_LENGTH } from "./predicate";
 import { buildInPredicate, buildNumericPredicate, buildTextPredicate } from "./predicate-ui";
 import {
   Dropdown,
@@ -25,6 +24,7 @@ import {
   FIELD_ICONS,
   FIELD_UNIT,
   FieldDropdown,
+  MetadataKeyCombobox,
   NumberField,
   ParkedValueField,
   TextField,
@@ -150,22 +150,14 @@ export function FilterBuilder({
         }}
       />
       {field?.requires_key && (
-        // Typed by hand for now; feat/metadata-key-suggestions replaces this with a
-        // combobox that suggests the keys discovery found. Nothing here restricts the
-        // key to a known one either way — it reaches ClickHouse as a bound parameter.
-        <div className="flex h-7 min-w-0 flex-1 items-center rounded-md border border-input bg-transparent px-2 focus-within:ring-1 focus-within:ring-ring">
-          <input
-            aria-label="metadata key"
-            placeholder="Key"
-            maxLength={MAX_KEY_LENGTH}
-            value={metadataKey}
-            onChange={(e) => setMetadataKey(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") submit();
-            }}
-            className="min-w-0 flex-1 bg-transparent text-[13px] outline-none placeholder:text-muted-foreground"
-          />
-        </div>
+        <MetadataKeyCombobox
+          projectId={projectId}
+          startAfter={startAfter}
+          endBefore={endBefore}
+          value={metadataKey}
+          onValue={setMetadataKey}
+          onEnter={submit}
+        />
       )}
       <Dropdown
         disabled={!field}

--- a/frontend/ui/src/features/filters/filter-controls.tsx
+++ b/frontend/ui/src/features/filters/filter-controls.tsx
@@ -9,10 +9,11 @@
 import { createContext, useContext, useState } from "react";
 import { ChevronDown, type LucideIcon } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
-import { MAX_VALUE_LENGTH } from "./predicate";
+import { useMetadataKeys } from "./hooks";
+import { MAX_KEY_LENGTH, MAX_VALUE_LENGTH } from "./predicate";
 
 // Icons mirror the trace detail / list UI for consistency; the model and environment
 // fields, which have no trace-detail icon, use a generic one. The dashboard widget
@@ -36,6 +37,12 @@ export type FilterControlSize = "sm" | "md";
 const TEXT_SIZE: Record<FilterControlSize, string> = { sm: "text-[12px]", md: "text-[13px]" };
 const SizeContext = createContext<FilterControlSize>("md");
 const useTextSize = () => TEXT_SIZE[useContext(SizeContext)];
+
+// The dropped-down list panel and its empty line, shared by every control here so the
+// field / value dropdowns and the metadata key combobox drop the same surface. Callers
+// add only what differs (a width, the size-dependent text class).
+const DROPDOWN_CONTENT_CLASS = "max-h-64 overflow-y-auto p-1";
+const NO_OPTIONS_CLASS = "px-2 py-1.5 text-muted-foreground";
 
 export function FilterControlSizeProvider({
   size,
@@ -197,7 +204,7 @@ export function ValueDropdown({
     >
       {(close) =>
         options.length === 0 ? (
-          <div className={cn("px-2 py-1.5 text-muted-foreground", textSize)}>No options</div>
+          <div className={cn(NO_OPTIONS_CLASS, textSize)}>No options</div>
         ) : (
           options.map((opt) => (
             <DropdownItem
@@ -217,6 +224,113 @@ export function ValueDropdown({
         )
       }
     </Dropdown>
+  );
+}
+
+/**
+ * The metadata key control: a combobox that SUGGESTS the keys discovered in the active
+ * window and ACCEPTS ANY KEY TYPED. The two are different things — the suggestion list
+ * exists to save typing, never to restrict it, so there is no "custom key" mode, no
+ * validation that rejects an unsuggested key, and nothing here can disable "Add filter".
+ *
+ * The text box IS the key: typing edits the predicate's key directly and doubles as the
+ * suggestion search, so a key typed and never confirmed against the list is still the key
+ * that gets filtered on. A separate search box would silently discard it.
+ *
+ * Suggestions come from the active window only, exactly like the Model and Environment
+ * value dropdowns, so that picking one can never return zero rows for the sole reason
+ * that it was observed outside the range the user is looking at.
+ */
+export function MetadataKeyCombobox({
+  projectId,
+  startAfter,
+  endBefore,
+  value,
+  onValue,
+  onEnter,
+}: {
+  projectId: string;
+  startAfter?: string;
+  endBefore?: string;
+  value: string;
+  onValue: (v: string) => void;
+  onEnter: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const textSize = useTextSize();
+  const { keys } = useMetadataKeys(projectId, startAfter, endBefore, true);
+
+  const query = value.trim().toLowerCase();
+  // A key already chosen is not a search term: reopening the list after picking
+  // `session_id` should still offer the other keys rather than narrowing to the one that
+  // is already in the box. `keys` arrives frequency-ordered from discovery and filtering
+  // preserves that order, so there is no second ranking model here.
+  const isExactKey = keys.some((k) => k.value.toLowerCase() === query);
+  const suggestions =
+    query === "" || isExactKey ? keys : keys.filter((k) => k.value.toLowerCase().includes(query));
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div className="flex h-7 min-w-0 flex-1 items-center rounded-md border border-input bg-transparent px-2 focus-within:ring-1 focus-within:ring-ring">
+          <input
+            aria-label="metadata key"
+            placeholder="Key"
+            maxLength={MAX_KEY_LENGTH}
+            value={value}
+            onChange={(e) => {
+              onValue(e.target.value);
+              setOpen(true);
+            }}
+            onFocus={() => setOpen(true)}
+            onClick={() => setOpen(true)}
+            onKeyDown={(e) => {
+              // Enter dismisses the suggestion list and applies the filter if the row is
+              // complete; the typed key needs no confirmation, it is already the key.
+              if (e.key === "Enter") {
+                setOpen(false);
+                onEnter();
+              }
+            }}
+            className={cn(
+              "min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground",
+              textSize,
+            )}
+          />
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        align="start"
+        className={cn(DROPDOWN_CONTENT_CLASS, "w-[14rem]")}
+        // Focus stays in the box while the list is open, and is not pulled back on close —
+        // otherwise returning focus would refire onFocus and reopen the list immediately.
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        {suggestions.length > 0 ? (
+          suggestions.map((k) => (
+            <DropdownItem
+              key={k.value}
+              active={k.value === value}
+              onClick={() => {
+                onValue(k.value);
+                setOpen(false);
+              }}
+            >
+              <span className="flex-1 truncate">{k.value}</span>
+              <span className="text-[11px] text-muted-foreground">{k.count}</span>
+            </DropdownItem>
+          ))
+        ) : (
+          // Same empty state the categorical value dropdown has always shown, deliberately:
+          // a key list that is still loading and one that came back empty look alike there
+          // too, and the metadata control should not read as a louder or more alarming
+          // surface than the filter beside it. An empty list blocks nothing — suggestions
+          // only save typing, and any key typed still filters.
+          <div className={cn(NO_OPTIONS_CLASS, textSize)}>No options</div>
+        )}
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -302,10 +416,7 @@ export function Dropdown({
           <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
         </button>
       </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className={cn("max-h-64 overflow-y-auto p-1", contentClassName)}
-      >
+      <PopoverContent align="start" className={cn(DROPDOWN_CONTENT_CLASS, contentClassName)}>
         {children(() => setOpen(false))}
       </PopoverContent>
     </Popover>

--- a/frontend/ui/src/features/filters/hooks.test.tsx
+++ b/frontend/ui/src/features/filters/hooks.test.tsx
@@ -2,9 +2,9 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
 import { render, cleanup, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useFilterFields, useFilterValues } from "./hooks";
+import { useFilterFields, useFilterValues, useMetadataKeys } from "./hooks";
 import { STATIC_FILTER_FIELDS } from "./registry";
-import { getFilterValues } from "@/lib/api/traces";
+import { getFilterValues, getMetadataKeys } from "@/lib/api/traces";
 
 vi.mock("@/lib/auth-client", () => ({
   useSession: () => ({ data: { user: { id: "u1", email: "e@x.com" } }, isPending: false }),
@@ -26,6 +26,16 @@ vi.mock("@/lib/api/traces", () => ({
   getFilterValues: vi.fn().mockResolvedValue({
     field: "model_name",
     values: [{ value: "gpt-4", count: 2 }],
+  }),
+  // The wire shape the endpoint actually answers with: a `keys` list and nothing else,
+  // each row a `{value, count}` pair — the same row the categorical distinct-values list
+  // uses. Spelling the field `key` here would make the suite agree with itself and
+  // disagree with the server.
+  getMetadataKeys: vi.fn().mockResolvedValue({
+    keys: [
+      { value: "session_id", count: 12 },
+      { value: "tenant", count: 3 },
+    ],
   }),
 }));
 
@@ -54,6 +64,19 @@ function ValuesProbe({
 }) {
   const { values } = useFilterValues("p1", "model_name", startAfter, endBefore, enabled);
   return <div data-testid="values">{values.map((v) => v.value).join(",")}</div>;
+}
+
+function MetadataKeysProbe({
+  enabled = true,
+  startAfter,
+  endBefore,
+}: {
+  enabled?: boolean;
+  startAfter?: string;
+  endBefore?: string;
+}) {
+  const { keys } = useMetadataKeys("p1", startAfter, endBefore, enabled);
+  return <div data-testid="keys">{keys.map((k) => `${k.value}:${k.count}`).join(",")}</div>;
 }
 
 describe("useFilterFields", () => {
@@ -94,5 +117,38 @@ describe("useFilterValues", () => {
         expect.anything(),
       ),
     );
+  });
+});
+
+describe("useMetadataKeys", () => {
+  it("returns the discovered keys in the order the backend ranked them", async () => {
+    render(<MetadataKeysProbe />, { wrapper: wrapper() });
+    await waitFor(() =>
+      expect(screen.getByTestId("keys").textContent).toBe("session_id:12,tenant:3"),
+    );
+  });
+
+  it("passes both window bounds to the discovery request", async () => {
+    // The key list is only valid inside the window it was gathered in, so the window the
+    // user is looking at is the question that gets asked.
+    render(
+      <MetadataKeysProbe startAfter="2026-06-01T00:00:00Z" endBefore="2026-06-02T00:00:00Z" />,
+      {
+        wrapper: wrapper(),
+      },
+    );
+    await waitFor(() =>
+      expect(getMetadataKeys).toHaveBeenCalledWith(
+        "p1",
+        "2026-06-01T00:00:00Z",
+        "2026-06-02T00:00:00Z",
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("stays empty while disabled (the discovery fetch is opt-in)", () => {
+    render(<MetadataKeysProbe enabled={false} />, { wrapper: wrapper() });
+    expect(screen.getByTestId("keys").textContent).toBe("");
   });
 });

--- a/frontend/ui/src/features/filters/hooks.ts
+++ b/frontend/ui/src/features/filters/hooks.ts
@@ -2,13 +2,15 @@
 
 /**
  * Data hooks for the filter builder: the field registry that drives the pill list,
- * and the lazy distinct-values for a categorical field (fetched only once that field
- * is picked). Both mirror the trace-list hook conventions (auth session + React Query).
+ * the lazy distinct-values for a categorical field (fetched only once that field
+ * is picked), and the metadata keys observed in the active window. All mirror the
+ * trace-list hook conventions (auth session + React Query).
  */
 import { useQuery } from "@tanstack/react-query";
 import { useSession as useAuthSession } from "@/lib/auth-client";
 import type { TraceApiUser } from "@/lib/api/client";
-import { getFilterFields, getFilterValues } from "@/lib/api/traces";
+import type { MetadataKey } from "@/types/api";
+import { getFilterFields, getFilterValues, getMetadataKeys } from "@/lib/api/traces";
 import { STATIC_FILTER_FIELDS, type FilterFieldDef, type FilterValue } from "./registry";
 
 function useApiUser() {
@@ -57,4 +59,36 @@ export function useFilterValues(
   // Mask React Query's retained cache while disabled so the lazy contract holds: a
   // not-yet-active field reports no values rather than a previously-fetched field's.
   return active ? { values: data?.values ?? [], isLoading } : { values: [], isLoading: false };
+}
+
+/**
+ * Metadata keys observed in the active window, frequency-ordered, feeding the metadata
+ * filter's key combobox — its one consumer. The trace list's column picker never calls
+ * this: it offers fixed fields only, and metadata reaches the list as a single blob cell.
+ *
+ * Keyed on project and window like the distinct-values hook, and cached with the same 30s
+ * staleness: the window is what the answer is about, so changing it must fetch a new list
+ * rather than reuse the previous window's keys. Suggestion is not permission — a key missing
+ * from this list is still filterable by typing it.
+ *
+ * `enabled` is not where the laziness comes from: every call site passes it true, and the
+ * fetch stays lazy only because `MetadataKeyCombobox` mounts for a metadata predicate and
+ * not otherwise. Contrast `useFilterValues` above, where `enabled` is the real gate on a
+ * control that is already mounted.
+ */
+export function useMetadataKeys(
+  projectId: string,
+  startAfter: string | undefined,
+  endBefore: string | undefined,
+  enabled: boolean = true,
+): { keys: MetadataKey[]; isLoading: boolean } {
+  const { user, sessionReady } = useApiUser();
+  const active = sessionReady && !!projectId && enabled;
+  const { data, isLoading } = useQuery({
+    queryKey: ["metadata-keys", projectId, startAfter ?? null, endBefore ?? null],
+    queryFn: () => getMetadataKeys(projectId, startAfter, endBefore, user),
+    enabled: active,
+    staleTime: 30_000,
+  });
+  return active ? { keys: data?.keys ?? [], isLoading } : { keys: [], isLoading: false };
 }

--- a/frontend/ui/src/lib/api/traces.filter-meta.test.ts
+++ b/frontend/ui/src/lib/api/traces.filter-meta.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("./client", () => ({ fetchTraceApi: vi.fn().mockResolvedValue({ fields: [] }) }));
 
 import { fetchTraceApi } from "./client";
-import { getFilterFields, getFilterValues } from "./traces";
+import { getFilterFields, getFilterValues, getMetadataKeys } from "./traces";
 
 const mockFetch = vi.mocked(fetchTraceApi);
 
@@ -32,6 +32,28 @@ describe("filter meta API", () => {
     expect(mockFetch.mock.calls[0][0]).toBe(
       "/projects/p1/traces/filter-values/model_name" +
         "?start_after=2026-06-01T00%3A00%3A00Z&end_before=2026-06-02T00%3A00%3A00Z",
+    );
+  });
+
+  it("getMetadataKeys hits the metadata-keys endpoint with no query when no window", async () => {
+    await getMetadataKeys("p1", undefined, undefined);
+    expect(mockFetch.mock.calls[0][0]).toBe("/projects/p1/traces/metadata-keys");
+  });
+
+  it("getMetadataKeys appends both bounds so the keys match the active window", async () => {
+    // Suggestions gathered outside the window the user is looking at would offer keys
+    // that return zero rows the moment they are picked.
+    await getMetadataKeys("p1", "2026-06-01T00:00:00Z", "2026-06-02T00:00:00Z");
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "/projects/p1/traces/metadata-keys" +
+        "?start_after=2026-06-01T00%3A00%3A00Z&end_before=2026-06-02T00%3A00%3A00Z",
+    );
+  });
+
+  it("getMetadataKeys appends a lone start_after", async () => {
+    await getMetadataKeys("p1", "2026-06-01T00:00:00Z", undefined);
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "/projects/p1/traces/metadata-keys?start_after=2026-06-01T00%3A00%3A00Z",
     );
   });
 });

--- a/frontend/ui/src/lib/api/traces.ts
+++ b/frontend/ui/src/lib/api/traces.ts
@@ -2,7 +2,13 @@
  * Trace API functions (Python backend - ClickHouse)
  */
 import { fetchTraceApi, type TraceApiUser } from "./client";
-import type { SpanIO, TraceDetail, TraceListResponse, TraceQueryOptions } from "@/types/api";
+import type {
+  MetadataKeysResponse,
+  SpanIO,
+  TraceDetail,
+  TraceListResponse,
+  TraceQueryOptions,
+} from "@/types/api";
 import { serializeFiltersParam } from "@/features/filters/predicate";
 import type { FilterFieldsResponse, FilterValuesResponse } from "@/features/filters/registry";
 
@@ -74,6 +80,32 @@ export async function getFilterValues(
   const query = params.toString() ? `?${params.toString()}` : "";
   return fetchTraceApi<FilterValuesResponse>(
     `/projects/${projectId}/traces/filter-values/${encodeURIComponent(field)}${query}`,
+    {},
+    user,
+  );
+}
+
+/**
+ * Metadata keys observed in the active window, frequency-ordered — the discovery answer
+ * behind the metadata filter's key combobox, its one consumer.
+ *
+ * The window is passed exactly as the distinct-values fetcher passes it, and for the same
+ * reason: a key list gathered outside the window the user is looking at would suggest keys
+ * that return zero rows the moment they are picked. The response carries the keys and
+ * nothing else — it does not echo the bounds back.
+ */
+export async function getMetadataKeys(
+  projectId: string,
+  startAfter: string | undefined,
+  endBefore: string | undefined,
+  user?: TraceApiUser,
+): Promise<MetadataKeysResponse> {
+  const params = new URLSearchParams();
+  if (startAfter) params.set("start_after", startAfter);
+  if (endBefore) params.set("end_before", endBefore);
+  const query = params.toString() ? `?${params.toString()}` : "";
+  return fetchTraceApi<MetadataKeysResponse>(
+    `/projects/${projectId}/traces/metadata-keys${query}`,
     {},
     user,
   );

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Role, SpanKind, SpanStatus } from "@traceroot/core";
+import type { FilterValue } from "@/features/filters/registry";
 
 export type { Role };
 
@@ -214,6 +215,22 @@ export interface TraceQueryOptions {
   search_query?: string;
   // Structured attribute filters, serialized as one URL-encoded JSON array.
   filters?: Predicate[];
+}
+
+/**
+ * One discovered metadata key with how many spans carried it inside the window.
+ *
+ * It IS the categorical distinct-value row — the backend serves both from one model, so
+ * this is an alias rather than a copy that could silently drift out of step with it.
+ */
+export type MetadataKey = FilterValue;
+
+/**
+ * GET /traces/metadata-keys response — the discovery answer behind the metadata filter's
+ * key combobox, its one consumer, frequency-ordered and capped.
+ */
+export interface MetadataKeysResponse {
+  keys: MetadataKey[];
 }
 
 // Session types


### PR DESCRIPTION
Fixes #1824

> [!NOTE]
> Stacked on #1836 (`feat/metadata-key-discovery`). Last PR of the #1824 stack — this one
> carries the `Fixes`.

## Summary

Keys become discoverable rather than remembered, which is the clause of #1824 the typed-key
PR left open.

- `MetadataKeyCombobox` replaces the plain key input: it **suggests** the keys discovered in
  the active window and **accepts any key typed**. There is no custom-key mode, no validation
  that rejects an unsuggested key, and nothing in it can disable Add filter.
- The text box *is* the key. Typing edits the predicate's key directly and doubles as the
  suggestion search, so a key typed and never confirmed against the list is still the key
  that gets filtered on — a separate search box would silently discard it.
- Suggestions come from `useMetadataKeys` over the active window, with the same 30s
  staleness and the same window-keyed cache as the categorical value dropdown, so picking a
  suggestion can never return zero rows purely because the key was observed outside the
  range on screen.
- The backend's frequency order is preserved through filtering — no second ranking model
  here. An exact match stops narrowing, so reopening the list after picking `session_id`
  still offers the other keys rather than only the one already in the box.
- Enter dismisses the list and applies the row; the typed key needs no confirmation.
- Empty list shows the same "No options" line the categorical value dropdown has always
  shown. A key list still loading and one that came back empty look alike there too, and an
  empty list blocks nothing.
- `getMetadataKeys` client function plus `MetadataKey` / `MetadataKeysResponse` types.
  `MetadataKey` aliases the distinct-value row rather than copying it, since the backend
  serves both from one model.
- The dropdown panel and empty-state classes are extracted so the key combobox drops the
  same surface as the field and value dropdowns.

## Type of Change

- [x] feat - A new feature

## Details

Focus handling is the fiddly part and is commented in place: focus stays in the text box
while the list is open and is not pulled back on close, because returning focus would refire
`onFocus` and reopen the list immediately.

`useMetadataKeys` takes an `enabled` flag, but that is not where the laziness comes from —
every call site passes it true, and the fetch stays lazy because the combobox only mounts
for a metadata predicate. That is the opposite of `useFilterValues` beside it, where
`enabled` is the real gate on an always-mounted control, so the difference is documented on
the hook.

## Notes

- With this, #1824 is complete: metadata is filterable at either scope, by a key the user
  can discover instead of recall, with an unlisted key still typable.
- Nothing about the typed-key path changes; this swaps the control the key is typed into.

## Screenshots / Recordings (if applicable)

1. Metadata picked, key box focused, suggestion list open showing the discovered keys with
   their occurrence counts, in frequency order.
2. The same list after typing a partial key — narrowed to the matching keys, order
   preserved.
3. A key chosen from the list, filled into the box, with the operator and value completed
   and Add filter ready.
4. A key typed that is **not** in the suggestion list, applied — chip present and the list
   narrowed. Suggestion is not permission.
5. The list reopened after a key was picked, still offering the other keys rather than
   narrowing to the one already chosen.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metadata key combobox to the filter builder that suggests discovered keys from the active time window while still accepting any typed key. Completes #1824 by making metadata keys discoverable instead of remembered.

- New Features
  - Replaced key input with `MetadataKeyCombobox` using `useMetadataKeys(projectId, startAfter, endBefore, enabled)` (30s cache); preserves backend frequency order; exact match stops narrowing; shows counts; Enter applies; typed keys always valid.
  - Added API `getMetadataKeys` and types `MetadataKey`/`MetadataKeysResponse` (keys list only); request supports `start_after`/`end_before`; shared dropdown/empty-state styles extracted and reused; tests cover combobox behavior, empty-state parity, focus/enter handling, window scoping/enablement, and API URL building.

<sup>Written for commit a646a22d3da4719f713b12feebe6499e14004246. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

