### PR TITLE
refactor(ui): extract the trace list table behind the column registry

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/traces/page.prefetch.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.prefetch.test.tsx
@@ -39,7 +39,11 @@ vi.mock("@/lib/hooks/use-list-page-state", () => ({
     queryOptions: { page: 3, limit: 50, start_after: "S" },
   }),
 }));
-vi.mock("@/lib/hooks/use-local-storage", () => ({ useLocalStorage: () => [autoRefresh, vi.fn()] }));
+// The page's live-view toggle and the trace list's column entry both persist through this
+// hook, so the stub pins the toggle for the test and leaves the columns at their defaults.
+vi.mock("@/lib/hooks/use-local-storage", () => ({
+  useLocalStorage: () => [autoRefresh, vi.fn()],
+}));
 vi.mock("@/lib/auth-client", () => ({
   useSession: () => ({ data: { user: { id: "u1", email: "e" } }, isPending: false }),
 }));

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -11,15 +11,7 @@ import { SearchFilterBar } from "@/components/search-filter-bar";
 import { TraceSearchFilterInput } from "@/features/filters/trace-search-filter-input";
 import { ListPagination } from "@/components/list-pagination";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import {
-  formatDuration,
-  formatDate,
-  formatCost,
-  formatTokenFlow,
-  formatExactTokens,
-  cn,
-  buildUrlWithFilters,
-} from "@/lib/utils";
+import { cn, buildUrlWithFilters } from "@/lib/utils";
 import type { TraceListItem } from "@/types/api";
 import { useTraces, usePrefetchTraces, useTracesExist } from "@/features/traces/hooks";
 import { useRetention } from "@/lib/hooks/use-retention";
@@ -29,7 +21,10 @@ import { useListPageState } from "@/lib/hooks/use-list-page-state";
 import { useLocalStorage } from "@/lib/hooks/use-local-storage";
 import { TraceViewerPanel, GettingStarted } from "@/features/traces/components";
 import { LoadingState } from "@/components/ui/loading-state";
-import { formatContentPreview } from "@/features/traces/utils";
+import { TraceListTable } from "@/features/traces/components/TraceListTable";
+// Imported from the hook's own module, not the feature barrel: the page tests replace that
+// barrel wholesale with a factory mock, and a barrel import here would go missing under it.
+import { useTraceColumns } from "@/features/traces/hooks/use-trace-columns";
 import { useSession as useAuthSession } from "@/lib/auth-client";
 
 // Tab definitions
@@ -88,6 +83,8 @@ export default function TracesPage() {
   );
 
   const prefetchTraces = usePrefetchTraces(projectId);
+
+  const { visibleColumns } = useTraceColumns(projectId);
 
   // Check if project has EVER sent traces — controls onboarding visibility.
   // Uses a dedicated endpoint that bypasses retention gating (returns a
@@ -258,110 +255,12 @@ export default function TracesPage() {
           ) : (
             <div className="flex h-full flex-col">
               <div className="flex-1 overflow-auto">
-                <table className="w-full">
-                  <thead className="sticky top-0 bg-background">
-                    <tr className="border-b border-border bg-muted/50">
-                      <th className="w-[140px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Timestamp
-                      </th>
-                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Name
-                      </th>
-                      <th className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Trace ID
-                      </th>
-                      <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Errors
-                      </th>
-                      <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Spans
-                      </th>
-                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Input
-                      </th>
-                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Output
-                      </th>
-                      <th className="w-[100px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Tokens
-                      </th>
-                      <th className="w-[80px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Cost
-                      </th>
-                      <th className="px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Latency
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {traces.map((trace: TraceListItem) => (
-                      <tr
-                        key={trace.trace_id}
-                        onClick={() => {
-                          setSelectedTraceId(trace.trace_id);
-                        }}
-                        className={cn(
-                          "cursor-pointer border-b border-border/50 transition-colors last:border-0",
-                          selectedTraceId === trace.trace_id ? "bg-muted" : "hover:bg-muted/50",
-                        )}
-                      >
-                        <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
-                          {formatDate(trace.trace_start_time)}
-                        </td>
-                        <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
-                          {trace.name}
-                        </td>
-                        <td className="min-w-[280px] max-w-[400px] whitespace-nowrap border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
-                          <span className="block truncate" title={trace.trace_id}>
-                            {trace.trace_id}
-                          </span>
-                        </td>
-                        <td className="border-r border-border/50 px-3 py-1.5 text-center">
-                          {trace.error_count > 0 ? (
-                            <span className="inline-flex min-w-5 justify-center rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
-                              {trace.error_count}
-                            </span>
-                          ) : (
-                            <span className="text-[12px] text-muted-foreground">0</span>
-                          )}
-                        </td>
-                        <td className="border-r border-border/50 px-3 py-1.5 text-center text-[12px] text-muted-foreground">
-                          {trace.span_count}
-                        </td>
-                        <td className="max-w-[180px] border-r border-border/50 px-3 py-1.5">
-                          <span className="block truncate font-mono text-[11px] text-muted-foreground">
-                            {formatContentPreview(trace.input)}
-                          </span>
-                        </td>
-                        <td className="max-w-[180px] border-r border-border/50 px-3 py-1.5">
-                          <span className="block truncate font-mono text-[11px] text-muted-foreground">
-                            {formatContentPreview(trace.output)}
-                          </span>
-                        </td>
-                        <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
-                          {(trace.total_input_tokens ?? 0) + (trace.total_output_tokens ?? 0) >
-                          0 ? (
-                            <span
-                              title={`${formatExactTokens(trace.total_input_tokens)} → ${formatExactTokens(trace.total_output_tokens)} (${formatExactTokens((trace.total_input_tokens ?? 0) + (trace.total_output_tokens ?? 0))})`}
-                            >
-                              {formatTokenFlow(trace.total_input_tokens, trace.total_output_tokens)}
-                            </span>
-                          ) : (
-                            "-"
-                          )}
-                        </td>
-                        <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
-                          {trace.total_cost && trace.total_cost > 0
-                            ? formatCost(trace.total_cost)
-                            : "-"}
-                        </td>
-                        <td className="whitespace-nowrap px-3 py-1.5 text-[12px] text-foreground">
-                          {formatDuration(trace.duration_ms)}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                <TraceListTable
+                  traces={traces}
+                  selectedTraceId={selectedTraceId}
+                  onSelectTrace={setSelectedTraceId}
+                  visibleColumns={visibleColumns}
+                />
               </div>
 
               <ListPagination

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.user-filter.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.user-filter.test.tsx
@@ -30,7 +30,11 @@ vi.mock("@/lib/hooks/use-list-page-state", () => ({
     queryOptions: { page: 1, limit: 50 },
   }),
 }));
-vi.mock("@/lib/hooks/use-local-storage", () => ({ useLocalStorage: () => [false, vi.fn()] }));
+// The page's live-view toggle and the trace list's column entry both persist through this
+// hook, so the stub pins the toggle for the test and leaves the columns at their defaults.
+vi.mock("@/lib/hooks/use-local-storage", () => ({
+  useLocalStorage: () => [false, vi.fn()],
+}));
 vi.mock("@/lib/auth-client", () => ({
   useSession: () => ({ data: { user: { id: "u1", email: "e" } }, isPending: false }),
 }));

--- a/frontend/ui/src/features/traces/components/TraceListTable.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceListTable.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen, fireEvent, within } from "@testing-library/react";
+import type { TraceListItem } from "@/types/api";
+import { visibleFixedColumns, type FixedColumnId } from "@/features/traces/columns";
+import { TraceListTable } from "./TraceListTable";
+
+afterEach(cleanup);
+
+// The ten columns a user who never touches the picker sees. Nothing added, nothing hidden.
+const DEFAULT_COLUMNS = [
+  "Timestamp",
+  "Name",
+  "Trace ID",
+  "Errors",
+  "Spans",
+  "Input",
+  "Output",
+  "Tokens",
+  "Cost",
+  "Latency",
+];
+
+function makeTrace(overrides: Partial<TraceListItem> & { trace_id: string }): TraceListItem {
+  return {
+    project_id: "p-1",
+    name: "run",
+    trace_start_time: "2026-06-01T00:00:00.000Z",
+    user_id: null,
+    session_id: null,
+    span_count: 2,
+    duration_ms: 120,
+    error_count: 0,
+    input: "in",
+    output: "out",
+    ...overrides,
+  };
+}
+
+interface TableProps {
+  traces: TraceListItem[];
+  visibleColumns?: FixedColumnId[];
+  onSelectTrace?: (traceId: string) => void;
+}
+
+function renderTable(props: TableProps) {
+  const onSelectTrace = props.onSelectTrace ?? vi.fn();
+  render(
+    <TraceListTable
+      traces={props.traces}
+      selectedTraceId={null}
+      onSelectTrace={onSelectTrace}
+      // The resolved default-on set, never an empty list: empty is the "no columns selected"
+      // table, which would quietly pass assertions about columns nobody rendered.
+      visibleColumns={props.visibleColumns ?? visibleFixedColumns([])}
+    />,
+  );
+  return { onSelectTrace };
+}
+
+const headerNames = () => screen.getAllByRole("columnheader").map((th) => th.textContent);
+
+function headerCell(name: string): HTMLElement {
+  const header = screen.getAllByRole("columnheader").find((th) => th.textContent === name);
+  if (!header) throw new Error(`no column header named ${name}`);
+  return header;
+}
+
+/** The cell under the named column for a row, located the way a reader locates it. */
+function cellAt(traceId: string, columnName: string): HTMLElement {
+  const columnIndex = headerNames().indexOf(columnName);
+  if (columnIndex === -1) throw new Error(`no column header named ${columnName}`);
+  const row = screen.getByText(traceId).closest("tr");
+  if (!row) throw new Error(`no row for ${traceId}`);
+  return row.querySelectorAll("td")[columnIndex] as HTMLElement;
+}
+
+const classesOf = (element: Element) => element.className.split(/\s+/);
+
+/** The Tailwind sizing classes on a cell, which are what fix a column's width. */
+const widthClassesOf = (element: Element) =>
+  classesOf(element).filter((name) => /^(?:w|min-w|max-w)-/.test(name));
+
+/** The right-hand divider, present on every cell except the one that ends the row. */
+const hasRowDivider = (element: Element) => classesOf(element).includes("border-r");
+
+describe("TraceListTable default columns", () => {
+  it("renders exactly the ten default columns, in registry order, when nothing has been changed", () => {
+    // `toEqual` on the whole array is deliberate: it pins the set and the order together,
+    // which is what "unchanged for existing users" means now that every column is togglable.
+    renderTable({ traces: [makeTrace({ trace_id: "t-1" })] });
+    expect(headerNames()).toEqual(DEFAULT_COLUMNS);
+  });
+
+  it("renders neither the header nor the cell for a default column turned off", () => {
+    renderTable({
+      traces: [makeTrace({ trace_id: "t-1", input: "the-input" })],
+      visibleColumns: visibleFixedColumns(["input"]),
+    });
+    expect(headerNames()).toEqual(DEFAULT_COLUMNS.filter((name) => name !== "Input"));
+    expect(screen.queryByText("the-input")).toBeNull();
+  });
+
+  it("renders an opt-in column turned on alongside the ten", () => {
+    renderTable({
+      traces: [makeTrace({ trace_id: "t-1", session_id: "s-1" })],
+      visibleColumns: visibleFixedColumns(["session_id"]),
+    });
+    expect(headerNames()).toContain("Session ID");
+    expect(cellAt("t-1", "Session ID").textContent).toBe("s-1");
+  });
+
+  it("says so rather than rendering an empty grid when no column is left", () => {
+    // Reachable only through storage, since the picker guards the last column — but a row
+    // per trace with no cells in it collapses the table and reads as "no traces".
+    renderTable({ traces: [makeTrace({ trace_id: "t-1" })], visibleColumns: [] });
+    expect(screen.queryAllByRole("columnheader")).toHaveLength(0);
+    expect(screen.getByText("No columns selected. Choose one from the Columns menu.")).toBeTruthy();
+    expect(screen.queryByText("t-1")).toBeNull();
+  });
+});
+
+describe("TraceListTable opt-in field columns", () => {
+  it("places an opt-in column after Output and before Tokens", () => {
+    renderTable({
+      traces: [makeTrace({ trace_id: "t-1", user_id: "u-1" })],
+      visibleColumns: visibleFixedColumns(["user_id"]),
+    });
+    const names = headerNames();
+    expect(names.indexOf("User ID")).toBeGreaterThan(names.indexOf("Output"));
+    expect(names.indexOf("User ID")).toBeLessThan(names.indexOf("Tokens"));
+  });
+
+  it("renders the opt-in columns in registry order whatever order they were turned on in", () => {
+    // Turning Session ID on before User ID does not put Session ID first: the resolved list
+    // is registry order, so the two columns land in the order `FIXED_COLUMNS` lists them.
+    renderTable({
+      traces: [makeTrace({ trace_id: "t-1", user_id: "u-1", session_id: "s-1" })],
+      visibleColumns: visibleFixedColumns(["session_id", "user_id"]),
+    });
+    const names = headerNames();
+    expect(names.indexOf("User ID")).toBeLessThan(names.indexOf("Session ID"));
+    expect(names.indexOf("User ID")).toBe(names.indexOf("Output") + 1);
+    expect(names.indexOf("Tokens")).toBe(names.indexOf("Session ID") + 1);
+  });
+
+  it("renders the row's value as plain text", () => {
+    renderTable({
+      traces: [makeTrace({ trace_id: "t-1", user_id: "u-1" })],
+      visibleColumns: visibleFixedColumns(["user_id"]),
+    });
+    const cell = cellAt("t-1", "User ID");
+    expect(cell.textContent).toBe("u-1");
+    expect(within(cell).queryByRole("button")).toBeNull();
+  });
+
+  // A payload that never carries the key reaches the cell as undefined rather than null, and a
+  // null-only placeholder check renders it as a blank gap instead of the table's "-".
+  it.each([["null", null] as const, ["undefined", undefined] as const])(
+    "renders a dash when the row's field is %s",
+    (_case, value) => {
+      renderTable({
+        traces: [makeTrace({ trace_id: "t-1", user_id: value, session_id: "s-1" })],
+        visibleColumns: visibleFixedColumns(["user_id", "session_id"]),
+      });
+      expect(cellAt("t-1", "User ID").textContent).toBe("-");
+      expect(cellAt("t-1", "Session ID").textContent).toBe("s-1");
+    },
+  );
+
+  it("opens the trace when a fixed cell is clicked", () => {
+    const { onSelectTrace } = renderTable({
+      traces: [makeTrace({ trace_id: "t-1", user_id: "u-1" })],
+      visibleColumns: visibleFixedColumns(["user_id"]),
+    });
+    fireEvent.click(screen.getByText("u-1"));
+    expect(onSelectTrace).toHaveBeenCalledWith("t-1");
+  });
+});
+
+describe("TraceListTable header widths", () => {
+  // A header sizes one of two ways, and the split is exactly "a default-on column keeps its
+  // own registered width; an opted-in one takes the shared added-column width".
+  it("sizes a default-on column with its own registered width", () => {
+    renderTable({ traces: [makeTrace({ trace_id: "t-1" })] });
+    expect(widthClassesOf(headerCell("Timestamp"))).toEqual(["w-[140px]"]);
+    expect(widthClassesOf(headerCell("Tokens"))).toEqual(["w-[100px]"]);
+  });
+
+  it("sizes an opt-in field column with the shared added-column width", () => {
+    // Sizing an opted-in column from the width table instead would leave it unconstrained,
+    // since that table holds entries for the default-on columns only.
+    renderTable({
+      traces: [makeTrace({ trace_id: "t-1", user_id: "u-1" })],
+      visibleColumns: visibleFixedColumns(["user_id"]),
+    });
+    expect(widthClassesOf(headerCell("User ID"))).toEqual(["w-[140px]", "max-w-[180px]"]);
+  });
+});
+
+describe("TraceListTable row-ending divider", () => {
+  // The divider is positional: whichever column the user leaves ending the row goes without
+  // one, so hiding the columns that used to end it leaves no stray rule against the edge.
+  it("draws no divider on a default column that ends the row", () => {
+    renderTable({ traces: [makeTrace({ trace_id: "t-1" })] });
+    expect(hasRowDivider(headerCell("Cost"))).toBe(true);
+    expect(hasRowDivider(headerCell("Latency"))).toBe(false);
+    expect(hasRowDivider(cellAt("t-1", "Latency"))).toBe(false);
+  });
+
+  it("draws no divider on an opt-in field column that ends the row", () => {
+    // Every column that used to follow it is hidden, so an opted-in one now ends the row.
+    renderTable({
+      traces: [makeTrace({ trace_id: "t-1", total_input_tokens: 4, total_output_tokens: 6 })],
+      visibleColumns: visibleFixedColumns(["tokens", "cost", "latency", "total_usage"]),
+    });
+    expect(headerNames().at(-1)).toBe("Total usage");
+    expect(hasRowDivider(headerCell("Output"))).toBe(true);
+    expect(hasRowDivider(headerCell("Total usage"))).toBe(false);
+    // The body row walks the same column list, so its last cell has to agree with the header.
+    expect(hasRowDivider(cellAt("t-1", "Total usage"))).toBe(false);
+  });
+});

--- a/frontend/ui/src/features/traces/components/TraceListTable.tsx
+++ b/frontend/ui/src/features/traces/components/TraceListTable.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+// The trace list table: one column per visible registry entry. Header and body rows map the
+// same column list, so they cannot disagree about column order.
+import type { ReactElement } from "react";
+import type { TraceListItem } from "@/types/api";
+import {
+  formatDuration,
+  formatDate,
+  formatCost,
+  formatTokenFlow,
+  formatExactTokens,
+  cn,
+} from "@/lib/utils";
+import { formatContentPreview } from "../utils";
+import { fixedColumnLabel, isDefaultOnColumn, type FixedColumnId } from "@/features/traces/columns";
+
+// Below this the default columns crush each other once any column is added, so the table
+// scrolls horizontally in its container instead of squeezing Input/Output to nothing.
+const ADDED_COLUMN_TABLE_MIN_WIDTH = "min-w-[72rem]";
+
+// The right-hand divider, carried by every cell except the one that ends the row. Positional
+// rather than pinned to Latency, so hiding the last column leaves no divider on the edge.
+const CELL_BORDER = "border-r border-border/50";
+
+const HEADER_CELL = "px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground";
+
+const ADDED_COLUMN_WIDTH = "w-[140px] max-w-[180px]";
+
+// Default-on columns only. An opted-in column always sizes with ADDED_COLUMN_WIDTH, so an
+// entry here for one would never be read. Absent means unconstrained: the column takes what
+// is left.
+const HEADER_WIDTH: Partial<Record<FixedColumnId, string>> = {
+  timestamp: "w-[140px]",
+  trace_id: "min-w-[280px] max-w-[400px]",
+  errors: "w-[60px]",
+  spans: "w-[60px]",
+  tokens: "w-[100px]",
+  cost: "w-[80px]",
+};
+
+interface TraceListTableProps {
+  traces: TraceListItem[];
+  selectedTraceId: string | null;
+  onSelectTrace: (traceId: string) => void;
+  /** Fixed columns to show, already resolved and in registry order. */
+  visibleColumns: FixedColumnId[];
+}
+
+export function TraceListTable({
+  traces,
+  selectedTraceId,
+  onSelectTrace,
+  visibleColumns,
+}: TraceListTableProps) {
+  const hasAddedColumns = visibleColumns.some((id) => !isDefaultOnColumn(id));
+  const hasColumns = visibleColumns.length > 0;
+
+  return (
+    <table className={cn("w-full", hasAddedColumns && ADDED_COLUMN_TABLE_MIN_WIDTH)}>
+      {/* Every column can be hidden, so the header row is omitted rather than left empty. */}
+      {hasColumns && (
+        <thead className="sticky top-0 bg-background">
+          <tr className="border-b border-border bg-muted/50">
+            {visibleColumns.map((id, position) => (
+              <ColumnHeader key={id} id={id} isLast={position === visibleColumns.length - 1} />
+            ))}
+          </tr>
+        </thead>
+      )}
+      <tbody>
+        {hasColumns ? (
+          traces.map((trace) => (
+            <TraceRow
+              key={trace.trace_id}
+              trace={trace}
+              isSelected={selectedTraceId === trace.trace_id}
+              onSelect={onSelectTrace}
+              columns={visibleColumns}
+            />
+          ))
+        ) : (
+          <tr>
+            <td className="px-3 py-6 text-center text-[12px] text-muted-foreground">
+              No columns selected. Choose one from the Columns menu.
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+}
+
+function ColumnHeader({ id, isLast }: { id: FixedColumnId; isLast: boolean }) {
+  const label = fixedColumnLabel(id);
+  const isDefaultOn = isDefaultOnColumn(id);
+  const className = cn(
+    isDefaultOn ? HEADER_WIDTH[id] : ADDED_COLUMN_WIDTH,
+    !isLast && CELL_BORDER,
+    HEADER_CELL,
+  );
+  // An opted-in column is narrow enough for its label to outrun it, so that one truncates
+  // and keeps the full text in a title; the defaults are sized to fit theirs.
+  if (isDefaultOn) return <th className={className}>{label}</th>;
+  return (
+    <th className={className} title={label}>
+      <span className="block truncate">{label}</span>
+    </th>
+  );
+}
+
+function TraceRow({
+  trace,
+  isSelected,
+  onSelect,
+  columns,
+}: {
+  trace: TraceListItem;
+  isSelected: boolean;
+  onSelect: (traceId: string) => void;
+  /** The same column list the header row walked, so the two cannot fall out of step. */
+  columns: readonly FixedColumnId[];
+}) {
+  return (
+    <tr
+      onClick={() => onSelect(trace.trace_id)}
+      className={cn(
+        "cursor-pointer border-b border-border/50 transition-colors last:border-0",
+        isSelected ? "bg-muted" : "hover:bg-muted/50",
+      )}
+    >
+      {columns.map((id, position) => {
+        const Cell = FIXED_CELLS[id];
+        return (
+          <Cell
+            key={id}
+            trace={trace}
+            borderClassName={position === columns.length - 1 ? false : CELL_BORDER}
+          />
+        );
+      })}
+    </tr>
+  );
+}
+
+interface FixedCellProps {
+  trace: TraceListItem;
+  /** The row divider, or false on the column that ends the row. */
+  borderClassName: string | false;
+}
+
+// One cell renderer per registry id, never keyed by a `TraceListItem` field name: `tokens`
+// sums two fields and `latency` reads `duration_ms`, so no id can index the row. The total
+// `Record` makes a new or renamed registry id a compile error rather than a missing column.
+const FIXED_CELLS: Record<FixedColumnId, (props: FixedCellProps) => ReactElement> = {
+  timestamp: ({ trace, borderClassName }) => (
+    <td
+      className={cn(
+        "whitespace-nowrap",
+        borderClassName,
+        "px-3 py-1.5 text-[12px] text-muted-foreground",
+      )}
+    >
+      {formatDate(trace.trace_start_time)}
+    </td>
+  ),
+  name: ({ trace, borderClassName }) => (
+    <td className={cn(borderClassName, "px-3 py-1.5 text-[12px] text-foreground")}>{trace.name}</td>
+  ),
+  trace_id: ({ trace, borderClassName }) => (
+    <td
+      className={cn(
+        "min-w-[280px] max-w-[400px] whitespace-nowrap",
+        borderClassName,
+        "px-3 py-1.5 font-mono text-[11px] text-muted-foreground",
+      )}
+    >
+      <span className="block truncate" title={trace.trace_id}>
+        {trace.trace_id}
+      </span>
+    </td>
+  ),
+  errors: ({ trace, borderClassName }) => (
+    <td className={cn(borderClassName, "px-3 py-1.5 text-center")}>
+      {trace.error_count > 0 ? (
+        <span className="inline-flex min-w-5 justify-center rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
+          {trace.error_count}
+        </span>
+      ) : (
+        <span className="text-[12px] text-muted-foreground">0</span>
+      )}
+    </td>
+  ),
+  spans: ({ trace, borderClassName }) => (
+    <td
+      className={cn(borderClassName, "px-3 py-1.5 text-center text-[12px] text-muted-foreground")}
+    >
+      {trace.span_count}
+    </td>
+  ),
+  input: ({ trace, borderClassName }) => (
+    <td className={cn("max-w-[180px]", borderClassName, "px-3 py-1.5")}>
+      <span className="block truncate font-mono text-[11px] text-muted-foreground">
+        {formatContentPreview(trace.input)}
+      </span>
+    </td>
+  ),
+  output: ({ trace, borderClassName }) => (
+    <td className={cn("max-w-[180px]", borderClassName, "px-3 py-1.5")}>
+      <span className="block truncate font-mono text-[11px] text-muted-foreground">
+        {formatContentPreview(trace.output)}
+      </span>
+    </td>
+  ),
+  user_id: ({ trace, borderClassName }) => (
+    <FixedFieldCell value={trace.user_id} borderClassName={borderClassName} />
+  ),
+  session_id: ({ trace, borderClassName }) => (
+    <FixedFieldCell value={trace.session_id} borderClassName={borderClassName} />
+  ),
+  // The three quantities the Tokens chip compresses into `in → out (total)`, each exact.
+  input_usage: ({ trace, borderClassName }) => (
+    <UsageCell value={trace.total_input_tokens} borderClassName={borderClassName} />
+  ),
+  output_usage: ({ trace, borderClassName }) => (
+    <UsageCell value={trace.total_output_tokens} borderClassName={borderClassName} />
+  ),
+  total_usage: ({ trace, borderClassName }) => (
+    <UsageCell value={traceTotalTokens(trace)} borderClassName={borderClassName} />
+  ),
+  tokens: ({ trace, borderClassName }) => {
+    // The chip is a shape, not a value: a trace that reported nothing has none to draw.
+    const totalTokens = traceTotalTokens(trace) ?? 0;
+    return (
+      <td
+        className={cn(
+          "whitespace-nowrap",
+          borderClassName,
+          "px-3 py-1.5 text-[12px] text-muted-foreground",
+        )}
+      >
+        {totalTokens > 0 ? (
+          <span
+            title={`${formatExactTokens(trace.total_input_tokens)} → ${formatExactTokens(trace.total_output_tokens)} (${formatExactTokens(totalTokens)})`}
+          >
+            {formatTokenFlow(trace.total_input_tokens, trace.total_output_tokens)}
+          </span>
+        ) : (
+          "-"
+        )}
+      </td>
+    );
+  },
+  cost: ({ trace, borderClassName }) => (
+    <td className={cn(borderClassName, "px-3 py-1.5 text-[12px] text-foreground")}>
+      {trace.total_cost && trace.total_cost > 0 ? formatCost(trace.total_cost) : "-"}
+    </td>
+  ),
+  latency: ({ trace, borderClassName }) => (
+    <td
+      className={cn(
+        "whitespace-nowrap",
+        borderClassName,
+        "px-3 py-1.5 text-[12px] text-foreground",
+      )}
+    >
+      {formatDuration(trace.duration_ms)}
+    </td>
+  ),
+};
+
+/**
+ * The row's total usage, or null when the trace reported neither side. One definition for the
+ * Tokens chip and the Total usage column. An unreported side counts as zero; null renders "-".
+ */
+function traceTotalTokens(trace: TraceListItem): number | null {
+  const { total_input_tokens: input, total_output_tokens: output } = trace;
+  if (input == null && output == null) return null;
+  return (input ?? 0) + (output ?? 0);
+}
+
+/**
+ * One token count, exact. Absent renders "-" and a recorded zero renders "0"; the split has
+ * to happen here because `formatExactTokens` folds null into "0".
+ */
+function UsageCell({
+  value,
+  borderClassName,
+}: {
+  value: number | null | undefined;
+  borderClassName: string | false;
+}) {
+  return (
+    <td
+      className={cn(
+        "whitespace-nowrap",
+        borderClassName,
+        "px-3 py-1.5 text-[12px] text-muted-foreground",
+      )}
+    >
+      {value == null ? "-" : formatExactTokens(value)}
+    </td>
+  );
+}
+
+// A fixed field's cell. Never click-to-filter: the filter registry holds no entry for these
+// fields, so a clickable value would offer a filter that cannot be built.
+function FixedFieldCell({
+  value,
+  borderClassName,
+}: {
+  value: string | null | undefined;
+  borderClassName: string | false;
+}) {
+  if (value == null || value === "") {
+    return (
+      <td className={cn(borderClassName, "px-3 py-1.5 text-[12px] text-muted-foreground")}>-</td>
+    );
+  }
+  return (
+    <td className={cn("max-w-[180px]", borderClassName, "px-3 py-1.5")}>
+      <span className="block truncate font-mono text-[11px] text-muted-foreground" title={value}>
+        {value}
+      </span>
+    </td>
+  );
+}

--- a/frontend/ui/src/features/traces/components/index.ts
+++ b/frontend/ui/src/features/traces/components/index.ts
@@ -8,6 +8,7 @@ export { SpanTreeView } from "./SpanTreeView";
 export { JsonRenderer } from "./JsonRenderer";
 export { ContentRenderer } from "./ContentRenderer";
 export { SpanInfoPanel } from "./SpanInfoPanel";
+export { TraceListTable } from "./TraceListTable";
 export { TraceViewerPanel } from "./TraceViewerPanel";
 export { SessionDetailPanel } from "./SessionDetailPanel";
 export { GettingStarted } from "./GettingStarted";


### PR DESCRIPTION
Part of #1825

> [!NOTE]
> Stacked on #1831 (`feat/trace-column-registry`).

## Summary

**No visible change.** The list renders the same ten default columns, in the same order,
with the same markup — this moves where they come from.

- The inline `<table>` in `app/projects/[projectId]/traces/page.tsx` becomes
  `features/traces/components/TraceListTable.tsx`, driven by the visible column list. The
  header row and the body rows map the same list, so they cannot disagree about column
  order.
- One cell renderer per registry id, in a total `Record<FixedColumnId, ...>`: a new or
  renamed registry id is a compile error rather than a silently missing column. Renderers
  are keyed by registry id and never by a `TraceListItem` field name, because `tokens` sums
  two fields and `latency` reads `duration_ms` — no id can index the row.
- The right-hand divider is positional rather than pinned to Latency, so hiding the last
  column leaves no divider on the row's edge; the header row is omitted rather than left
  empty if every column is hidden.
- Once any non-default column is on, the table takes a minimum width and scrolls
  horizontally in its container instead of squeezing Input and Output to nothing.
- The page wires `useTraceColumns`. The hook is imported from its own module rather than the
  feature barrel, because the page tests replace that barrel wholesale with a factory mock
  and a barrel import would go missing under it.
- The five non-default cells land with the table: User ID and Session ID (truncated with a
  title, `-` when absent) and the three usage columns (exact counts; `-` when the trace
  reported neither side, `0` when it reported zero — `formatExactTokens` folds null into
  "0", so the split has to happen in the cell).

## Type of Change

- [x] refactor - A code change that neither fixes a bug nor adds a feature

## Details

Nothing can enable the five non-default columns yet — the picker is #1839. They exist
in this diff because the table is where a column is rendered, and shipping the renderers
with the extraction keeps the picker PR to the control itself.

`page.tsx` loses about 120 lines of markup and six formatting imports. The page's existing
prefetch and user-filter suites are updated for the new component boundary;
`TraceListTable.test.tsx` covers the column-driven header/body, row selection, the
positional divider, the no-columns case, and the usage/fixed-field cells.

## Notes

- The column-order contract is registry order, not the order ids appear in storage — storage
  holds flips, not a sequence.

## Screenshots / Recordings (if applicable)

Optional, and worth attaching precisely because the claim is "nothing changed":

1. The trace list before this PR, at a fixed window and page size.
2. The same list after, same window and page size — the ten default columns identical in
   order, width, and content.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
