### PR TITLE
feat(ui): let the trace list choose which columns it shows

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -22,6 +22,7 @@ import { useLocalStorage } from "@/lib/hooks/use-local-storage";
 import { TraceViewerPanel, GettingStarted } from "@/features/traces/components";
 import { LoadingState } from "@/components/ui/loading-state";
 import { TraceListTable } from "@/features/traces/components/TraceListTable";
+import { ColumnPicker } from "@/features/traces/components/ColumnPicker";
 // Imported from the hook's own module, not the feature barrel: the page tests replace that
 // barrel wholesale with a factory mock, and a barrel import here would go missing under it.
 import { useTraceColumns } from "@/features/traces/hooks/use-trace-columns";
@@ -84,7 +85,7 @@ export default function TracesPage() {
 
   const prefetchTraces = usePrefetchTraces(projectId);
 
-  const { visibleColumns } = useTraceColumns(projectId);
+  const { visibleColumns, toggleField, reset: resetColumns } = useTraceColumns(projectId);
 
   // Check if project has EVER sent traces — controls onboarding visibility.
   // Uses a dedicated endpoint that bypasses retention gating (returns a
@@ -140,7 +141,7 @@ export default function TracesPage() {
         {/* Tab navigation — hidden during onboarding or while checking */}
         {!checking && !showGettingStarted && (
           <div className="border-b border-border bg-background">
-            <div className="flex">
+            <div className="flex items-center">
               {tabs.map((tab) => {
                 const Icon = tab.icon;
                 const isActive = tab.id === "traces";
@@ -183,6 +184,13 @@ export default function TracesPage() {
             onCustomRangeChange={updateCustomRange}
             retentionDays={retention.retentionDays}
             onUpgradeClick={retention.onUpgradeClick}
+            beforeDateFilter={
+              <ColumnPicker
+                visibleColumns={visibleColumns}
+                onToggleField={toggleField}
+                onReset={resetColumns}
+              />
+            }
           >
             <button
               type="button"

--- a/frontend/ui/src/components/search-filter-bar.tsx
+++ b/frontend/ui/src/components/search-filter-bar.tsx
@@ -24,6 +24,9 @@ interface SearchFilterBarProps {
   onUpgradeClick?: () => void;
   // Optional additional content (e.g., filter badges)
   children?: React.ReactNode;
+  // Optional control rendered immediately left of the date filter, grouped with it on the
+  // right of the bar rather than with `children` on the left.
+  beforeDateFilter?: React.ReactNode;
 }
 
 export function SearchFilterBar({
@@ -39,6 +42,7 @@ export function SearchFilterBar({
   retentionDays,
   onUpgradeClick,
   children,
+  beforeDateFilter,
 }: SearchFilterBarProps) {
   return (
     <div className="border-b border-border bg-background px-3 py-1.5">
@@ -55,16 +59,20 @@ export function SearchFilterBar({
           </div>
         )}
         {children}
-        <DateFilterSelect
-          className="ml-auto"
-          dateFilter={dateFilter}
-          customStartDate={customStartDate}
-          customEndDate={customEndDate}
-          onDateFilterChange={onDateFilterChange}
-          onCustomRangeChange={onCustomRangeChange}
-          retentionDays={retentionDays}
-          onUpgradeClick={onUpgradeClick}
-        />
+        {/* The auto margin moves to the group so an adjacent control travels with the date
+            filter and wraps with it instead of drifting to the other end of the bar. */}
+        <div className="ml-auto flex items-center gap-2">
+          {beforeDateFilter}
+          <DateFilterSelect
+            dateFilter={dateFilter}
+            customStartDate={customStartDate}
+            customEndDate={customEndDate}
+            onDateFilterChange={onDateFilterChange}
+            onCustomRangeChange={onCustomRangeChange}
+            retentionDays={retentionDays}
+            onUpgradeClick={onUpgradeClick}
+          />
+        </div>
       </div>
     </div>
   );

--- a/frontend/ui/src/features/traces/components/ColumnPicker.test.tsx
+++ b/frontend/ui/src/features/traces/components/ColumnPicker.test.tsx
@@ -1,0 +1,273 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { render, cleanup, screen, fireEvent, within } from "@testing-library/react";
+import { ColumnPicker } from "./ColumnPicker";
+import { FIXED_COLUMNS, visibleFixedColumns, type FixedColumnId } from "@/features/traces/columns";
+
+// Radix's popover positioning observes its anchor, and jsdom ships no ResizeObserver.
+beforeAll(() => {
+  if (!("ResizeObserver" in globalThis)) {
+    (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+afterEach(cleanup);
+
+/** Every column the picker lists, in row order. Written out rather than derived from the
+ * registry so that adding, removing or reordering a column fails here and gets looked at. */
+const ALL_COLUMN_LABELS = [
+  "Timestamp",
+  "Name",
+  "Trace ID",
+  "Errors",
+  "Spans",
+  "Input",
+  "Output",
+  "User ID",
+  "Session ID",
+  "Input usage",
+  "Output usage",
+  "Total usage",
+  "Tokens",
+  "Cost",
+  "Latency",
+];
+
+/** The ones that are off for a user who has never opened the picker. */
+const DEFAULT_OFF_LABELS = ["User ID", "Session ID", "Input usage", "Output usage", "Total usage"];
+
+/** The badge reads shown out of available. Both sides come from the registry so that adding a
+ * column moves these expectations with it instead of leaving them quietly wrong. */
+const TOTAL_COLUMN_COUNT = FIXED_COLUMNS.length;
+const DEFAULT_SHOWN_COUNT = visibleFixedColumns([]).length;
+const columnRatio = (shownCount: number) => `${shownCount}/${TOTAL_COLUMN_COUNT}`;
+
+const LAST_COLUMN_TITLE = "The list needs at least one column";
+
+interface PickerProps {
+  visibleColumns?: FixedColumnId[];
+  onToggleField?: (id: FixedColumnId) => void;
+  onReset?: () => void;
+}
+
+function renderPicker(props: PickerProps = {}) {
+  const onToggleField = props.onToggleField ?? vi.fn();
+  const onReset = props.onReset ?? vi.fn();
+  render(
+    <ColumnPicker
+      // The default is the resolved default-on set, the state the picker actually opens in
+      // for a new user — an empty list would be the guarded last-column case instead.
+      visibleColumns={props.visibleColumns ?? visibleFixedColumns([])}
+      onToggleField={onToggleField}
+      onReset={onReset}
+    />,
+  );
+  return { onToggleField, onReset };
+}
+
+/** A parent that owns the column state the way the hook does, storing flips from the registry
+ * defaults: without it a toggle changes nothing on screen and no check state can be observed. */
+function ControlledPicker({ initialFlips = [] }: { initialFlips?: FixedColumnId[] }) {
+  const [flipped, setFlipped] = useState<FixedColumnId[]>(initialFlips);
+  return (
+    <ColumnPicker
+      visibleColumns={visibleFixedColumns(flipped)}
+      onToggleField={(id) =>
+        setFlipped((current) =>
+          current.includes(id) ? current.filter((entry) => entry !== id) : [...current, id],
+        )
+      }
+      onReset={() => setFlipped([])}
+    />
+  );
+}
+
+const getTrigger = () => screen.getByRole("button", { name: /^Columns/ });
+
+function openPicker(): HTMLElement {
+  fireEvent.click(getTrigger());
+  return screen.getByRole("dialog", { name: "Choose columns" });
+}
+
+/** The column toggles, in DOM order. `Reset to default` is an action, not a column. */
+function columnToggles(): HTMLButtonElement[] {
+  return within(screen.getByRole("dialog", { name: "Choose columns" }))
+    .getAllByRole("button")
+    .filter((button) => button.textContent !== "Reset to default") as HTMLButtonElement[];
+}
+
+const columnLabels = () => columnToggles().map((button) => button.textContent);
+
+function columnToggle(label: string): HTMLButtonElement {
+  return screen.getByRole("button", { name: label }) as HTMLButtonElement;
+}
+
+/** Which columns read as shown, by the state assistive technology is given. */
+const pressedLabels = () =>
+  columnToggles()
+    .filter((button) => button.getAttribute("aria-pressed") === "true")
+    .map((button) => button.textContent);
+
+describe("ColumnPicker trigger", () => {
+  it("labels the trigger Columns and says what it does", () => {
+    renderPicker();
+    expect(getTrigger().textContent).toContain("Columns");
+    expect(getTrigger().getAttribute("title")).toBe("Choose which fields appear as columns");
+  });
+
+  it("reads the default-on count over the registry total, where the user has turned nothing off", () => {
+    // A ratio, not a hidden-count: a fresh install must not read as the user hiding columns.
+    renderPicker();
+    expect(within(getTrigger()).getByText(columnRatio(DEFAULT_SHOWN_COUNT))).toBeTruthy();
+  });
+
+  it("lowers the shown side when a default column is turned off", () => {
+    renderPicker({ visibleColumns: visibleFixedColumns(["cost"]) });
+    expect(within(getTrigger()).getByText(columnRatio(DEFAULT_SHOWN_COUNT - 1))).toBeTruthy();
+  });
+
+  it("raises the shown side when an opt-in column is turned on", () => {
+    // Turning a column on shows one more of the same total, so the ratio must move for it.
+    render(<ControlledPicker />);
+    expect(within(getTrigger()).getByText(columnRatio(DEFAULT_SHOWN_COUNT))).toBeTruthy();
+    openPicker();
+    fireEvent.click(columnToggle("User ID"));
+    expect(within(getTrigger()).getByText(columnRatio(DEFAULT_SHOWN_COUNT + 1))).toBeTruthy();
+  });
+});
+
+describe("ColumnPicker contents", () => {
+  it("lists every column in the order the row renders them", () => {
+    renderPicker();
+    openPicker();
+    expect(columnLabels()).toEqual(ALL_COLUMN_LABELS);
+  });
+
+  it("checks the columns shown by default and leaves the opt-in columns unchecked", () => {
+    renderPicker();
+    openPicker();
+    expect(pressedLabels()).toEqual(
+      ALL_COLUMN_LABELS.filter((label) => !DEFAULT_OFF_LABELS.includes(label)),
+    );
+  });
+
+  it("reflects a hidden default and a shown opt-in column in the check state", () => {
+    renderPicker({ visibleColumns: visibleFixedColumns(["input", "user_id"]) });
+    openPicker();
+    expect(columnToggle("Input").getAttribute("aria-pressed")).toBe("false");
+    expect(columnToggle("User ID").getAttribute("aria-pressed")).toBe("true");
+  });
+});
+
+describe("ColumnPicker toggling", () => {
+  it("reports the column a click toggles", () => {
+    const { onToggleField } = renderPicker();
+    openPicker();
+    fireEvent.click(columnToggle("Input"));
+    expect(onToggleField).toHaveBeenCalledWith("input");
+  });
+
+  it("unchecks a default column that is turned off", () => {
+    render(<ControlledPicker />);
+    openPicker();
+    fireEvent.click(columnToggle("Input"));
+    expect(columnToggle("Input").getAttribute("aria-pressed")).toBe("false");
+    expect(pressedLabels()).not.toContain("Input");
+  });
+
+  it("checks an opt-in column that is turned on", () => {
+    render(<ControlledPicker />);
+    openPicker();
+    fireEvent.click(columnToggle("Session ID"));
+    expect(columnToggle("Session ID").getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("keeps the popover open so several columns can be changed in one visit", () => {
+    render(<ControlledPicker />);
+    openPicker();
+    fireEvent.click(columnToggle("Input"));
+    fireEvent.click(columnToggle("Output"));
+    expect(screen.getByRole("dialog", { name: "Choose columns" })).toBeTruthy();
+    expect(pressedLabels()).toEqual(
+      ALL_COLUMN_LABELS.filter(
+        (label) => ![...DEFAULT_OFF_LABELS, "Input", "Output"].includes(label),
+      ),
+    );
+  });
+
+  it("keeps the columns listed in registry order after a toggle", () => {
+    // The list is the registry, not a shown-first ordering that reshuffles under the click.
+    render(<ControlledPicker />);
+    openPicker();
+    fireEvent.click(columnToggle("Timestamp"));
+    expect(columnLabels()).toEqual(ALL_COLUMN_LABELS);
+  });
+});
+
+describe("ColumnPicker last remaining column", () => {
+  it("cannot turn off the only column left", () => {
+    // A table with no columns has no rows to click and no header to recover from, so the
+    // picker must not be able to produce one.
+    const { onToggleField } = renderPicker({ visibleColumns: ["timestamp"] });
+    openPicker();
+    const lastColumn = columnToggle("Timestamp");
+    expect(lastColumn.disabled).toBe(true);
+    expect(lastColumn.getAttribute("title")).toBe(LAST_COLUMN_TITLE);
+
+    fireEvent.click(lastColumn);
+    expect(onToggleField).not.toHaveBeenCalled();
+  });
+
+  it("still lets every hidden column be turned on while one column is left", () => {
+    // The guard is on the last column standing, not on the picker as a whole.
+    const { onToggleField } = renderPicker({ visibleColumns: ["timestamp"] });
+    openPicker();
+    const others = columnToggles().filter((button) => button.textContent !== "Timestamp");
+    expect(others).toHaveLength(ALL_COLUMN_LABELS.length - 1);
+    others.forEach((button) => expect(button.disabled).toBe(false));
+
+    fireEvent.click(columnToggle("Latency"));
+    expect(onToggleField).toHaveBeenCalledWith("latency");
+  });
+
+  it("guards whichever column is the last one, not a privileged one", () => {
+    renderPicker({ visibleColumns: ["latency"] });
+    openPicker();
+    expect(columnToggle("Latency").disabled).toBe(true);
+    expect(columnToggle("Timestamp").disabled).toBe(false);
+  });
+
+  it("releases the guard as soon as a second column is shown", () => {
+    render(<ControlledPicker initialFlips={visibleFixedColumns([]).slice(1)} />);
+    openPicker();
+    expect(columnToggle("Timestamp").disabled).toBe(true);
+
+    fireEvent.click(columnToggle("Cost"));
+
+    expect(columnToggle("Timestamp").disabled).toBe(false);
+    expect(columnToggle("Cost").disabled).toBe(false);
+  });
+});
+
+describe("ColumnPicker reset", () => {
+  it("offers Reset to default as an action beside the columns, not as one of them", () => {
+    renderPicker();
+    const content = openPicker();
+    expect(within(content).getByRole("button", { name: "Reset to default" })).toBeTruthy();
+    expect(columnLabels()).not.toContain("Reset to default");
+  });
+
+  it("puts a hidden default back and drops an opt-in column on reset", () => {
+    render(<ControlledPicker initialFlips={["input", "user_id"]} />);
+    const content = openPicker();
+    fireEvent.click(within(content).getByRole("button", { name: "Reset to default" }));
+    expect(pressedLabels()).toEqual(
+      ALL_COLUMN_LABELS.filter((label) => !DEFAULT_OFF_LABELS.includes(label)),
+    );
+  });
+});

--- a/frontend/ui/src/features/traces/components/ColumnPicker.tsx
+++ b/frontend/ui/src/features/traces/components/ColumnPicker.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+// Column picker for the trace list: every fixed column in `columns.ts`, checked when shown.
+// Fields only, and the only way a column reaches the list.
+import type { JSX } from "react";
+import { Check, Columns3 } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { FIXED_COLUMNS, type FixedColumnId } from "@/features/traces/columns";
+import { cn } from "@/lib/utils";
+
+const LAST_COLUMN_TITLE = "The list needs at least one column";
+
+interface ColumnPickerProps {
+  /** Fixed columns currently shown, in registry order. */
+  visibleColumns: FixedColumnId[];
+  onToggleField: (id: FixedColumnId) => void;
+  onReset: () => void;
+}
+
+export function ColumnPicker({
+  visibleColumns,
+  onToggleField,
+  onReset,
+}: ColumnPickerProps): JSX.Element {
+  // Shown out of available, not a count of what is hidden: a ratio tells the user there is
+  // more to turn on.
+  const shownCount = visibleColumns.length;
+  const totalCount = FIXED_COLUMNS.length;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          title="Choose which fields appear as columns"
+          // Sits beside the date filter in the filter bar, so it matches that control's
+          // width and height (h-8) exactly rather than reading as a smaller sibling.
+          className="flex h-8 min-w-[140px] items-center justify-between gap-2 rounded-md border border-border px-2.5 text-[12px] text-foreground transition-colors hover:border-foreground/40 hover:bg-muted"
+        >
+          <span className="flex items-center gap-1.5">
+            <Columns3 className="h-3.5 w-3.5 text-muted-foreground" />
+            Columns
+          </span>
+          <span className="rounded bg-muted px-1 text-[11px] text-muted-foreground">
+            {shownCount}/{totalCount}
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" aria-label="Choose columns" className="w-[18rem] p-1">
+        <div className="flex flex-col">
+          {FIXED_COLUMNS.map((column) => {
+            const isVisible = visibleColumns.includes(column.id);
+            // A table with no columns has no rows to click, so the last one cannot be hidden.
+            const isLastVisible = isVisible && visibleColumns.length === 1;
+            return (
+              <button
+                key={column.id}
+                type="button"
+                // `aria-pressed` carries the state; the check mark alone is invisible to AT.
+                aria-pressed={isVisible}
+                disabled={isLastVisible}
+                title={isLastVisible ? LAST_COLUMN_TITLE : undefined}
+                onClick={() => onToggleField(column.id)}
+                className={cn(
+                  "flex items-center gap-2 rounded px-2 py-1 text-left text-[13px] transition-colors",
+                  isVisible && "bg-muted/40",
+                  isLastVisible ? "cursor-not-allowed opacity-50" : "hover:bg-muted/50",
+                )}
+              >
+                <Check
+                  aria-hidden="true"
+                  className={cn(
+                    "h-3.5 w-3.5 shrink-0",
+                    isVisible ? "text-foreground" : "text-transparent",
+                  )}
+                />
+                <span className="flex-1 truncate" title={column.label}>
+                  {column.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        <div className="mt-1 border-t border-border pt-1">
+          <button
+            type="button"
+            onClick={onReset}
+            className="w-full rounded px-2 py-1 text-left text-[12px] text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            Reset to default
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/ui/src/features/traces/components/index.ts
+++ b/frontend/ui/src/features/traces/components/index.ts
@@ -8,6 +8,7 @@ export { SpanTreeView } from "./SpanTreeView";
 export { JsonRenderer } from "./JsonRenderer";
 export { ContentRenderer } from "./ContentRenderer";
 export { SpanInfoPanel } from "./SpanInfoPanel";
+export { ColumnPicker } from "./ColumnPicker";
 export { TraceListTable } from "./TraceListTable";
 export { TraceViewerPanel } from "./TraceViewerPanel";
 export { SessionDetailPanel } from "./SessionDetailPanel";


### PR DESCRIPTION
Part of #1825

> [!NOTE]
> Stacked on #1838 (`refactor/trace-list-table`).

## Summary

The Columns control #1825 asks for.

- `ColumnPicker` — a popover listing every registry column, checked when shown, toggled on
  click. The trigger carries a shown/total count rather than a count of what is hidden,
  because a ratio tells the user there is more to turn on.
- Grouped with the date filter: `SearchFilterBar` gains a `beforeDateFilter` slot, and the
  auto margin moves from the date filter onto the group, so an adjacent control travels and
  wraps with it instead of drifting to the other end of the bar.
- **The last visible column cannot be turned off** — a table with no columns has no rows to
  click. That entry is disabled and carries a title saying why.
- Reset to default clears the stored flips in one click.
- `aria-pressed` carries each entry's state; the check mark alone is invisible to assistive
  tech.
- The trigger matches the date filter's height exactly rather than reading as a smaller
  sibling next to it.

## Type of Change

- [x] feat - A new feature

## Details

The picker offers fields only, and it is the only way a column reaches the list. Nothing
else — a filter included — puts a column on screen.

Tests cover the rendered list against the registry, toggle and reset dispatching to the
hook, the checked state and its `aria-pressed`, the shown/total count, and the last-column
guard being disabled rather than merely ignored on click.

## Notes

- With this PR the issue's core is delivered: the ten defaults are unchanged for every
  existing user, and five non-default fields can now be turned on per project. The sixth
  non-default field #1825 names — metadata — is #1840, since it needs the backend to
  surface the map.

## Screenshots / Recordings (if applicable)

1. The filter bar with the Columns control closed, sitting immediately left of the date
   filter, reading 10/15.
2. The picker open: the full column list, the ten defaults checked, the five non-defaults
   unchecked.
3. User ID toggled on — the trigger reading 11/15 and the new column rendered in the table
   behind it, in registry order.
4. All five non-defaults on, showing the table scrolling horizontally in its container
   rather than crushing Input and Output.
5. Everything off except one column: the remaining entry disabled, with its "The list needs
   at least one column" title visible.
6. After Reset to default: back to 10/15 and the original ten columns.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Columns picker to the trace list so users can choose which columns are visible. The control sits next to the date filter, shows a shown/total count, and prevents hiding the last column. Addresses #1825.

- **New Features**
  - Added `ColumnPicker` popover listing all fixed registry columns with `aria-pressed` toggle state, a Reset to default action, and a guard that disables turning off the last visible column (with tooltip).
  - Integrated into `TracesPage` via `SearchFilterBar`’s new `beforeDateFilter` slot; grouped with the date filter so they wrap together, and the trigger matches the date filter’s height.
  - Trace list renders only selected fields; defaults stay the same for existing users, and opt-in fields can be enabled per project.
  - Added tests for registry order, toggle/reset behavior, accessibility state, shown/total badge updates, popover staying open for multi-changes, and the last-column guard.

<sup>Written for commit ceb20e4d2f10bd31ed740e80ed9108ad991beec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

