### PR TITLE
feat(ui): a metadata column for the trace list

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -598,6 +598,14 @@
             ],
             "title": "Input"
           },
+          "metadata_map": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {},
+            "title": "Metadata Map",
+            "type": "object"
+          },
           "name": {
             "title": "Name",
             "type": "string"

--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -91,6 +91,13 @@ class TraceListItem(BaseModel):
     total_input_tokens: int | None = 0
     total_output_tokens: int | None = 0
     total_cost: float | None = 0.0
+    # Trace-level metadata, one entry per key — what the list's single Metadata cell
+    # renders from, and its only source: ``TraceListItem`` carries no ``metadata`` string
+    # sibling to fall back to, so dropping this field would empty that cell rather than
+    # degrade it. Empty for traces that carry no metadata. Filters match any span, so a
+    # row's cell can differ from what its filter matched — see the comment on the list
+    # query in ``trace_reader.list_traces``.
+    metadata_map: dict[str, str] = {}
 
 
 class TraceListResponse(BaseModel):

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -276,11 +276,15 @@ class TraceReaderService:
                 -- THEN order by start time for pagination.
                 SELECT
                     trace_id, project_id, name, trace_start_time,
-                    user_id, session_id, input, output
+                    user_id, session_id, input, output, metadata_map
                 FROM (
+                    -- metadata_map is the TRACE row's metadata, and it is what the list's
+                    -- single default-off Metadata cell renders. A metadata FILTER also
+                    -- matches span-level keys, so a matched row can still show a blank
+                    -- cell here; the span detail panel is the reconciliation point.
                     SELECT
                         t.trace_id, t.project_id, t.name, t.trace_start_time,
-                        t.user_id, t.session_id, t.input, t.output
+                        t.user_id, t.session_id, t.input, t.output, t.metadata_map
                     FROM traces AS t
                     WHERE {where_clause}
                     ORDER BY t.ch_update_time DESC
@@ -327,7 +331,8 @@ class TraceReaderService:
                 p.output,
                 sa.total_input_tokens,
                 sa.total_output_tokens,
-                sa.total_cost
+                sa.total_cost,
+                p.metadata_map
             FROM page AS p
             LEFT JOIN span_agg AS sa ON p.trace_id = sa.trace_id
             ORDER BY p.trace_start_time DESC
@@ -373,6 +378,7 @@ class TraceReaderService:
                     "total_input_tokens": int(row[11]) if row[11] is not None else 0,
                     "total_output_tokens": int(row[12]) if row[12] is not None else 0,
                     "total_cost": float(row[13]) if row[13] is not None else 0.0,
+                    "metadata_map": dict(row[14]) if row[14] else {},
                 }
             )
 

--- a/frontend/ui/src/features/traces/columns.ts
+++ b/frontend/ui/src/features/traces/columns.ts
@@ -7,6 +7,7 @@ export type FixedColumnId =
   | "spans"
   | "input"
   | "output"
+  | "metadata"
   | "user_id"
   | "session_id"
   | "input_usage"
@@ -30,6 +31,7 @@ export const FIXED_COLUMNS: readonly FixedColumn[] = [
   { id: "spans", label: "Spans", isDefaultOn: true },
   { id: "input", label: "Input", isDefaultOn: true },
   { id: "output", label: "Output", isDefaultOn: true },
+  { id: "metadata", label: "Metadata", isDefaultOn: false },
   { id: "user_id", label: "User ID", isDefaultOn: false },
   { id: "session_id", label: "Session ID", isDefaultOn: false },
   { id: "input_usage", label: "Input usage", isDefaultOn: false },

--- a/frontend/ui/src/features/traces/components/ColumnPicker.test.tsx
+++ b/frontend/ui/src/features/traces/components/ColumnPicker.test.tsx
@@ -28,6 +28,7 @@ const ALL_COLUMN_LABELS = [
   "Spans",
   "Input",
   "Output",
+  "Metadata",
   "User ID",
   "Session ID",
   "Input usage",
@@ -39,7 +40,14 @@ const ALL_COLUMN_LABELS = [
 ];
 
 /** The ones that are off for a user who has never opened the picker. */
-const DEFAULT_OFF_LABELS = ["User ID", "Session ID", "Input usage", "Output usage", "Total usage"];
+const DEFAULT_OFF_LABELS = [
+  "Metadata",
+  "User ID",
+  "Session ID",
+  "Input usage",
+  "Output usage",
+  "Total usage",
+];
 
 /** The badge reads shown out of available. Both sides come from the registry so that adding a
  * column moves these expectations with it instead of leaving them quietly wrong. */
@@ -161,6 +169,18 @@ describe("ColumnPicker contents", () => {
     openPicker();
     expect(columnToggle("Input").getAttribute("aria-pressed")).toBe("false");
     expect(columnToggle("User ID").getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("lists the Metadata column but never enumerates metadata keys", () => {
+    // A per-key column is a consequence of filtering on that key, so the picker offers no
+    // second way in: no search box, no key list, and the fixed Metadata column is one toggle
+    // for the whole payload rather than a per-key one.
+    renderPicker();
+    openPicker();
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(columnLabels()).toEqual(ALL_COLUMN_LABELS);
+    expect(columnLabels()).toContain("Metadata");
   });
 });
 

--- a/frontend/ui/src/features/traces/components/ColumnPicker.tsx
+++ b/frontend/ui/src/features/traces/components/ColumnPicker.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 // Column picker for the trace list: every fixed column in `columns.ts`, checked when shown.
-// Fields only, and the only way a column reaches the list.
+// Fields only, and the only way a column reaches the list — metadata is one column holding
+// the whole map, never one column per key.
 import type { JSX } from "react";
 import { Check, Columns3 } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";

--- a/frontend/ui/src/features/traces/components/MetadataJson.test.tsx
+++ b/frontend/ui/src/features/traces/components/MetadataJson.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { afterEach, describe, it, expect } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MetadataJson } from "./MetadataJson";
+import type { MetadataEntry } from "../utils/metadata";
+
+afterEach(cleanup);
+
+const entry = (key: string, rawValue: unknown): MetadataEntry => ({
+  key,
+  value: typeof rawValue === "string" ? rawValue : JSON.stringify(rawValue),
+  rawValue,
+  isFilterable: typeof rawValue === "string",
+});
+
+/** The rendered document as text, which is what the reader is being shown. */
+function renderText(entries: MetadataEntry[]): string {
+  const { container } = render(<MetadataJson entries={entries} />);
+  const root = container.firstElementChild;
+  if (root === null) throw new Error("MetadataJson rendered nothing");
+  return Array.from(root.children)
+    .map((line) => line.textContent)
+    .join("\n");
+}
+
+describe("MetadataJson", () => {
+  it("frames the entries in braces on their own lines", () => {
+    const text = renderText([entry("service", "api")]);
+    expect(text).toBe('{\n"service": "api"\n}');
+  });
+
+  it("separates entries with a comma but does not trail one after the last", () => {
+    const text = renderText([entry("a", "1"), entry("b", "2"), entry("c", "3")]);
+    expect(text).toBe('{\n"a": "1",\n"b": "2",\n"c": "3"\n}');
+  });
+
+  it("renders each value in its JSON spelling, so only strings are quoted", () => {
+    const text = renderText([
+      entry("quality", 0.9),
+      entry("policy_pass", true),
+      entry("owner", null),
+      entry("note", "hi"),
+    ]);
+    expect(text).toBe('{\n"quality": 0.9,\n"policy_pass": true,\n"owner": null,\n"note": "hi"\n}');
+  });
+
+  it("escapes a key that contains a quote instead of printing it raw", () => {
+    // Rendered as-is this would close the key early and stop being valid JSON.
+    expect(renderText([entry('a"b', "v")])).toBe('{\n"a\\"b": "v"\n}');
+  });
+
+  it("escapes a value that contains a quote", () => {
+    expect(renderText([entry("k", 'say "hi"')])).toBe('{\n"k": "say \\"hi\\""\n}');
+  });
+
+  describe("truncation", () => {
+    it("leaves a value that fits exactly as JSON.stringify would write it", () => {
+      const fits = "a".repeat(42);
+      expect(renderText([entry("k", fits)])).toBe(`{\n"k": "${fits}"\n}`);
+    });
+
+    it("puts the ellipsis inside the closing quote so the value still reads as a string", () => {
+      const long = "a".repeat(60);
+      expect(renderText([entry("k", long)])).toBe(`{\n"k": "${"a".repeat(42)}…"\n}`);
+    });
+
+    it("does not split a surrogate pair when the cut lands on one", () => {
+      // Slicing the serialized text by UTF-16 unit would keep half the emoji and render U+FFFD.
+      const text = renderText([entry("k", `${"a".repeat(41)}😀tail`)]);
+      expect(text).not.toContain("�");
+      expect(text).toBe(`{\n"k": "${"a".repeat(41)}😀…"\n}`);
+    });
+
+    it("does not leave a half-written escape sequence at the cut", () => {
+      // Serializing first would put a lone backslash before the ellipsis.
+      const text = renderText([entry("k", `${"a".repeat(41)}"tail`)]);
+      expect(text).toBe(`{\n"k": "${"a".repeat(41)}\\"…"\n}`);
+    });
+
+    it("shortens a structured value without pretending it is a string", () => {
+      const text = renderText([entry("k", { note: "b".repeat(60) })]);
+      expect(text).toMatch(/^\{\n"k": \{"note":"b+…\n\}$/);
+    });
+  });
+
+  it("renders nothing but the braces when there are no entries", () => {
+    expect(renderText([])).toBe("{\n}");
+  });
+
+  it("colours keys apart from values, and never in the palette the project bars", () => {
+    const { container } = render(<MetadataJson entries={[entry("service", "api")]} />);
+    expect(screen.getByText('"service"').className).toContain("text-blue-600");
+    expect(container.innerHTML).not.toContain("purple");
+  });
+});

--- a/frontend/ui/src/features/traces/components/MetadataJson.tsx
+++ b/frontend/ui/src/features/traces/components/MetadataJson.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * A trace's metadata as a JSON document — braces, quoted keys, separating commas — rather
+ * than the tree `JsonRenderer` draws, which wraps its values and truncates a string only at
+ * 500 characters, enough to fill this 22rem popover several times over, and leaves keys
+ * unquoted where these are `JSON.stringify`'d. Metadata is one level deep by construction
+ * (the map's values are text), so there is nothing to collapse and no depth to indent for,
+ * and reading it as the document it is beats reading a rendering of it.
+ */
+import { cn } from "@/lib/utils";
+import type { MetadataEntry } from "../utils/metadata";
+
+/** Long enough for a version, a slug, or an id; short enough that no line wraps. */
+const MAX_VALUE_CHARS = 42;
+
+/** Cuts on code points, so a slice can never leave half a surrogate pair behind. */
+function shorten(text: string): string {
+  const chars = Array.from(text);
+  return chars.length <= MAX_VALUE_CHARS ? text : chars.slice(0, MAX_VALUE_CHARS).join("");
+}
+
+/** The value in its JSON spelling, shortened inside the quotes so a string still reads as one. */
+function valueText(rawValue: unknown): string {
+  if (typeof rawValue === "string") {
+    // Shorten first, then serialize: escaping text that is already short cannot produce a
+    // half-written escape sequence, which slicing the serialized form can.
+    const shortened = shorten(rawValue);
+    const serialized = JSON.stringify(shortened);
+    return shortened === rawValue ? serialized : `${serialized.slice(0, -1)}…"`;
+  }
+  const serialized = JSON.stringify(rawValue) ?? "null";
+  const shortened = shorten(serialized);
+  return shortened === serialized ? serialized : `${shortened}…`;
+}
+
+interface MetadataJsonProps {
+  entries: readonly MetadataEntry[];
+  className?: string;
+}
+
+export function MetadataJson({ entries, className }: MetadataJsonProps) {
+  return (
+    <div className={cn("font-mono text-[11px] leading-[1.7] text-foreground", className)}>
+      <div>{"{"}</div>
+      {entries.map((entry, index) => (
+        <div key={entry.key} className="whitespace-nowrap pl-4">
+          {/* Serialized, not wrapped in literal quotes: a key holding a quote or a backslash
+              has to appear escaped, or the line stops being the document it claims to be. */}
+          <span className="text-blue-600 dark:text-blue-400">{JSON.stringify(entry.key)}</span>
+          <span className="text-muted-foreground">: </span>
+          <span>{valueText(entry.rawValue)}</span>
+          {index < entries.length - 1 && <span className="text-muted-foreground">,</span>}
+        </div>
+      ))}
+      <div>{"}"}</div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/traces/components/TraceListTable.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceListTable.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, screen, fireEvent, within } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { act, render, cleanup, screen, fireEvent, within } from "@testing-library/react";
 import type { TraceListItem } from "@/types/api";
 import { visibleFixedColumns, type FixedColumnId } from "@/features/traces/columns";
 import { TraceListTable } from "./TraceListTable";
@@ -21,6 +21,8 @@ const DEFAULT_COLUMNS = [
   "Latency",
 ];
 
+// Rows arrive with `metadata_map`, the parsed map the list query selects — the cells
+// read that, not the legacy `metadata` JSON blob.
 function makeTrace(overrides: Partial<TraceListItem> & { trace_id: string }): TraceListItem {
   return {
     project_id: "p-1",
@@ -88,8 +90,11 @@ describe("TraceListTable default columns", () => {
   it("renders exactly the ten default columns, in registry order, when nothing has been changed", () => {
     // `toEqual` on the whole array is deliberate: it pins the set and the order together,
     // which is what "unchanged for existing users" means now that every column is togglable.
-    renderTable({ traces: [makeTrace({ trace_id: "t-1" })] });
+    renderTable({
+      traces: [makeTrace({ trace_id: "t-1", metadata_map: { session_id: "s-1" } })],
+    });
     expect(headerNames()).toEqual(DEFAULT_COLUMNS);
+    expect(screen.queryByText("s-1")).toBeNull();
   });
 
   it("renders neither the header nor the cell for a default column turned off", () => {
@@ -219,5 +224,162 @@ describe("TraceListTable row-ending divider", () => {
     expect(hasRowDivider(headerCell("Total usage"))).toBe(false);
     // The body row walks the same column list, so its last cell has to agree with the header.
     expect(hasRowDivider(cellAt("t-1", "Total usage"))).toBe(false);
+  });
+});
+
+/**
+ * The Metadata column: one truncated line per row, the whole payload revealed on hover or
+ * keyboard activation. It is off by default, so every assertion names it in `visibleColumns`.
+ *
+ * A warning for whoever adds a row-wide button count: this cell is a control, so a query over
+ * a whole row finds one button no other cell accounts for. That is why the assertions about
+ * the other cells' inertness stay cell-scoped.
+ */
+describe("TraceListTable metadata reveal", () => {
+  // Radix's popover positioning observes its anchor, and jsdom ships no ResizeObserver.
+  beforeAll(() => {
+    if (!("ResizeObserver" in globalThis)) {
+      (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+    }
+  });
+
+  /** A payload the collapsed line provably cannot show in full: the preview is capped at 80
+   * characters, so the trailing keys of these five pairs exist only in the reveal. */
+  const WIDE_METADATA = {
+    tenant: "acme",
+    region: "eu-west-1",
+    deployment: "canary-2026-06-01",
+    release: "v4.12.0-rc3",
+    operator: "scheduled-backfill",
+  };
+
+  /** A key that falls outside the cap, and the value under it. */
+  const CUT_OFF_KEY = "operator";
+  const CUT_OFF_VALUE = "scheduled-backfill";
+
+  function renderMetadataColumn(metadataMap?: Record<string, string>) {
+    const rendered = renderTable({
+      traces: [makeTrace({ trace_id: "t-1", metadata_map: metadataMap })],
+      visibleColumns: visibleFixedColumns(["metadata"]),
+    });
+    return { ...rendered, cell: cellAt("t-1", "Metadata") };
+  }
+
+  /** The collapsed line, which is also the control that opens the reveal. */
+  const metadataTrigger = (cell: HTMLElement) => within(cell).getByRole("button");
+
+  const revealSurface = () => screen.getByRole("dialog", { name: "Metadata" });
+  const queryRevealSurface = () => screen.queryByRole("dialog", { name: "Metadata" });
+
+  it("shows the payload as one truncated line and hangs nothing off a title attribute", () => {
+    // A `title` was the old reveal, rendering the payload as one unformatted unselectable run,
+    // so its absence is part of the feature rather than an oversight.
+    const { cell } = renderMetadataColumn(WIDE_METADATA);
+    const trigger = metadataTrigger(cell);
+    const preview = trigger.textContent ?? "";
+    expect(preview).toContain("tenant");
+    expect(preview.endsWith("...")).toBe(true);
+    expect(preview).not.toContain(CUT_OFF_KEY);
+    // One line: the collapsed cell shows the compact spelling, never the pretty-printed one.
+    expect(preview).not.toContain("\n");
+    expect(trigger.hasAttribute("title")).toBe(false);
+    expect(cell.querySelector("[title]")).toBeNull();
+  });
+
+  it("opens the reveal on hover with the metadata keys in it", () => {
+    const { cell } = renderMetadataColumn(WIDE_METADATA);
+    expect(queryRevealSurface()).toBeNull();
+
+    fireEvent.pointerEnter(metadataTrigger(cell));
+
+    const surface = revealSurface();
+    for (const key of Object.keys(WIDE_METADATA)) {
+      expect(surface.textContent).toContain(key);
+    }
+    // The pair the collapsed line had no room for is in the reveal, which is its whole point.
+    expect(surface.textContent).toContain(CUT_OFF_VALUE);
+  });
+
+  it("renders a dash and opens nothing for a trace carrying no metadata", () => {
+    // An empty object would read as metadata the trace recorded; the dash reads as the
+    // missing value it is, and a cell with nothing to reveal carries no control at all.
+    const { cell } = renderMetadataColumn();
+    expect(cell.textContent).toBe("-");
+    expect(within(cell).queryByRole("button")).toBeNull();
+
+    fireEvent.pointerEnter(cell);
+
+    expect(queryRevealSurface()).toBeNull();
+  });
+
+  it("does not select the row when the trigger is clicked", () => {
+    // The row opens the trace, so revealing metadata must not also navigate — and the
+    // reveal has to survive the click that Radix would otherwise read as a toggle-shut.
+    const { cell, onSelectTrace } = renderMetadataColumn(WIDE_METADATA);
+    const trigger = metadataTrigger(cell);
+    fireEvent.pointerEnter(trigger);
+    expect(revealSurface()).toBeTruthy();
+
+    fireEvent.click(trigger, { detail: 1 });
+
+    expect(onSelectTrace).not.toHaveBeenCalled();
+    expect(revealSurface()).toBeTruthy();
+  });
+
+  it("does not select the row when the surface itself is clicked", () => {
+    // The surface is portaled out of the row, but React events bubble through the component
+    // tree rather than the DOM tree, so a click in it still reaches the row's handler.
+    const { cell, onSelectTrace } = renderMetadataColumn(WIDE_METADATA);
+    fireEvent.pointerEnter(metadataTrigger(cell));
+    const surface = revealSurface();
+
+    fireEvent.click(surface);
+
+    expect(onSelectTrace).not.toHaveBeenCalled();
+    expect(revealSurface()).toBeTruthy();
+  });
+
+  it("opens on keyboard activation and moves focus into the surface", () => {
+    // Enter and Space arrive as a click with no originating pointer, which `detail: 0`
+    // reproduces. Focus has to follow, or the surface is unreachable without a mouse.
+    const { cell, onSelectTrace } = renderMetadataColumn(WIDE_METADATA);
+
+    fireEvent.click(metadataTrigger(cell), { detail: 0 });
+
+    expect(revealSurface().contains(document.activeElement)).toBe(true);
+    expect(onSelectTrace).not.toHaveBeenCalled();
+  });
+
+  it("stays open while the pointer crosses from the trigger into the surface", () => {
+    // The surface is placed clear of the trigger, so closing on the first pointerleave would
+    // put the revealed document out of reach: the gap has to be crossable.
+    vi.useFakeTimers();
+    try {
+      const { cell } = renderMetadataColumn(WIDE_METADATA);
+      const trigger = metadataTrigger(cell);
+      fireEvent.pointerEnter(trigger);
+      const surface = revealSurface();
+
+      fireEvent.pointerLeave(trigger);
+      fireEvent.pointerEnter(surface);
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(revealSurface()).toBeTruthy();
+
+      fireEvent.pointerLeave(surface);
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(queryRevealSurface()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/ui/src/features/traces/components/TraceListTable.tsx
+++ b/frontend/ui/src/features/traces/components/TraceListTable.tsx
@@ -13,6 +13,8 @@ import {
   cn,
 } from "@/lib/utils";
 import { formatContentPreview } from "../utils";
+import { traceMetadataEntries } from "../utils/metadata";
+import { TraceMetadataCell } from "./TraceMetadataCell";
 import { fixedColumnLabel, isDefaultOnColumn, type FixedColumnId } from "@/features/traces/columns";
 
 // Below this the default columns crush each other once any column is added, so the table
@@ -211,6 +213,11 @@ const FIXED_CELLS: Record<FixedColumnId, (props: FixedCellProps) => ReactElement
         {formatContentPreview(trace.output)}
       </span>
     </td>
+  ),
+  // The whole payload, shaped like Input and Output. Display-only: a blob is not a value the
+  // filter registry can be handed, so a click here could only build a filter matching nothing.
+  metadata: ({ trace, borderClassName }) => (
+    <TraceMetadataCell entries={traceMetadataEntries(trace)} borderClassName={borderClassName} />
   ),
   user_id: ({ trace, borderClassName }) => (
     <FixedFieldCell value={trace.user_id} borderClassName={borderClassName} />

--- a/frontend/ui/src/features/traces/components/TraceMetadataCell.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceMetadataCell.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { parseMetadataEntries } from "@/features/traces/utils/metadata";
+import { TraceMetadataCell } from "./TraceMetadataCell";
+
+afterEach(cleanup);
+
+/**
+ * Who owns focus when the metadata reveal opens and closes. The governing rule is that an
+ * interaction which did not take focus must not give it away, and one which did take it must
+ * give it back — so the same close has to behave two different ways depending on how the open
+ * started, and neither answer may be reached by asking "was a pointer involved at all".
+ *
+ * These render the cell on its own beside a text field rather than through `TraceListTable`,
+ * because every assertion here needs somewhere real for focus to have been and to return to;
+ * the table's own tests are about which columns it draws and are cell-agnostic.
+ */
+describe("TraceMetadataCell focus ownership", () => {
+  // Radix's popover positioning observes its anchor, and jsdom ships no ResizeObserver.
+  beforeAll(() => {
+    if (!("ResizeObserver" in globalThis)) {
+      (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+    }
+  });
+
+  // Both closes are deferred — the hover close behind its grace period, and the focus Radix
+  // hands back behind a task of its own — so every test here runs the clock out by hand.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const METADATA = { tenant: "acme", region: "eu-west-1" };
+
+  /** The rest of the page, reduced to the one part of it that can hold focus. */
+  const FIELD_LABEL = "Filter";
+
+  function renderCell() {
+    render(
+      <>
+        <input aria-label={FIELD_LABEL} defaultValue="" />
+        <table>
+          <tbody>
+            <tr>
+              <TraceMetadataCell
+                entries={parseMetadataEntries(METADATA)}
+                borderClassName="border-r"
+              />
+            </tr>
+          </tbody>
+        </table>
+      </>,
+    );
+    return {
+      trigger: screen.getByRole("button"),
+      field: screen.getByRole("textbox", { name: FIELD_LABEL }) as HTMLInputElement,
+    };
+  }
+
+  const revealSurface = () => screen.getByRole("dialog", { name: "Metadata" });
+  const queryRevealSurface = () => screen.queryByRole("dialog", { name: "Metadata" });
+
+  /**
+   * Runs the clock out twice over. The grace period ends in a state update, and the focus
+   * Radix hands back on close is deferred behind a task that is only scheduled once that
+   * update has torn the surface down — so one advance closes the surface and a second one
+   * delivers the focus. Advancing once leaves the restoration permanently pending, which
+   * would make "focus did not move" true of every one of these tests for the wrong reason.
+   */
+  function settle() {
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+  }
+
+  /**
+   * Types the way a keyboard does — into whatever holds focus, not into a chosen element — so
+   * a keystroke the user aimed at the field lands nowhere once focus has moved off it. That
+   * is what makes the field's value, rather than `document.activeElement` alone, the proof
+   * that a stolen focus is something the user loses work to.
+   */
+  function typeWhereFocusIs(text: string) {
+    for (const character of text) {
+      const target = document.activeElement;
+      if (!(target instanceof HTMLInputElement)) continue;
+      fireEvent.change(target, { target: { value: target.value + character } });
+    }
+  }
+
+  it("leaves the user's typing where it was when the pointer opens and then leaves the reveal", () => {
+    // The pointer took nothing, so it has nothing to give back: pulling focus onto the trigger
+    // on the way out drops the keystrokes that were still coming.
+    const { trigger, field } = renderCell();
+    field.focus();
+    typeWhereFocusIs("sess");
+
+    fireEvent.pointerEnter(trigger);
+
+    expect(revealSurface()).toBeTruthy();
+    expect(document.activeElement).toBe(field);
+
+    fireEvent.pointerLeave(trigger);
+    settle();
+
+    expect(queryRevealSurface()).toBeNull();
+    // The field's value is asserted before its focus because the value is the damage: a
+    // reveal that takes focus on the way out reads to the user as keystrokes going missing.
+    typeWhereFocusIs("ion");
+    expect(field.value).toBe("session");
+    expect(document.activeElement).toBe(field);
+  });
+
+  it("returns focus to the collapsed line when Escape dismisses a keyboard-opened reveal", () => {
+    // Enter and Space arrive as a click with no originating pointer, which `detail: 0`
+    // reproduces. This open moved focus into the surface, so this close owes it back — and
+    // whatever suppresses the restoration in the hover case must not reach this one.
+    const { trigger } = renderCell();
+    trigger.focus();
+
+    fireEvent.click(trigger, { detail: 0 });
+
+    const surface = revealSurface();
+    expect(surface.contains(document.activeElement)).toBe(true);
+
+    fireEvent.keyDown(surface, { key: "Escape" });
+    settle();
+
+    expect(queryRevealSurface()).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("returns focus to the collapsed line when the keyboard takes over a reveal the pointer opened", () => {
+    // A pointer opened this one, but the keyboard activation that followed moved focus into
+    // the surface, so the close owes it back all the same. Asking only "did a pointer open
+    // this?" answers yes here and strands focus on `document.body`.
+    const { trigger } = renderCell();
+    trigger.focus();
+    fireEvent.pointerEnter(trigger);
+    const surface = revealSurface();
+    expect(surface.contains(document.activeElement)).toBe(false);
+
+    fireEvent.click(trigger, { detail: 0 });
+
+    expect(surface.contains(document.activeElement)).toBe(true);
+
+    fireEvent.keyDown(surface, { key: "Escape" });
+    settle();
+
+    expect(queryRevealSurface()).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("returns focus to the collapsed line when the pointer only brushes a keyboard-opened reveal", () => {
+    // The keyboard opened this one and holds its focus. A pointer arriving afterwards is not
+    // a second opening, so it cannot hand ownership of the focus to a hover that never had it.
+    const { trigger } = renderCell();
+    trigger.focus();
+    fireEvent.click(trigger, { detail: 0 });
+    const surface = revealSurface();
+    expect(surface.contains(document.activeElement)).toBe(true);
+
+    fireEvent.pointerEnter(trigger);
+    fireEvent.pointerLeave(trigger);
+    settle();
+
+    expect(queryRevealSurface()).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+});

--- a/frontend/ui/src/features/traces/components/TraceMetadataCell.tsx
+++ b/frontend/ui/src/features/traces/components/TraceMetadataCell.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * The row's metadata map as one truncated line, revealed in full on hover or keyboard. A
+ * popover rather than a `title` or tooltip because the reveal is a scrollable JSON document
+ * and has to be keyboard-reachable.
+ */
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { MetadataJson } from "./MetadataJson";
+import { cn } from "@/lib/utils";
+import { formatContentPreview } from "../utils";
+import { stringifyMetadataEntries, type MetadataEntry } from "../utils/metadata";
+
+/** The surface sits clear of the trigger; this grace period covers the pointer crossing. */
+const HOVER_CLOSE_DELAY_MS = 120;
+
+const PREVIEW_TEXT = "block truncate font-mono text-[11px] text-muted-foreground";
+
+interface TraceMetadataCellProps {
+  entries: readonly MetadataEntry[];
+  borderClassName: string | false;
+}
+
+export function TraceMetadataCell({ entries, borderClassName }: TraceMetadataCellProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  // How the open started: a hover must not pull focus away, but a keyboard open must move
+  // focus into the surface or its scrolling and its Escape are unreachable.
+  const isOpenedByPointerRef = useRef(false);
+
+  const cancelScheduledClose = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleClose = useCallback(() => {
+    cancelScheduledClose();
+    closeTimerRef.current = setTimeout(() => setIsOpen(false), HOVER_CLOSE_DELAY_MS);
+  }, [cancelScheduledClose]);
+
+  const openByPointer = useCallback(() => {
+    cancelScheduledClose();
+    isOpenedByPointerRef.current = true;
+    setIsOpen(true);
+  }, [cancelScheduledClose]);
+
+  // A row can unmount mid-hover when the list refetches; a pending close must not outlive it.
+  useEffect(() => cancelScheduledClose, [cancelScheduledClose]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      // A queued hover-close would otherwise fire after a later reopen and shut it again.
+      cancelScheduledClose();
+      setIsOpen(nextOpen);
+    },
+    [cancelScheduledClose],
+  );
+
+  const handleTriggerClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      // The row itself opens the trace, so revealing metadata must not also select the row.
+      event.stopPropagation();
+      // Enter and Space arrive as a click with no originating pointer.
+      const isKeyboardActivation = event.detail === 0;
+      // Radix toggles the trigger, so a click on a hover-opened surface would close it.
+      if (isOpen) {
+        event.preventDefault();
+        if (isKeyboardActivation) contentRef.current?.focus();
+        return;
+      }
+      isOpenedByPointerRef.current = !isKeyboardActivation;
+    },
+    [isOpen],
+  );
+
+  const cellClassName = cn("max-w-[180px]", borderClassName, "px-3 py-1.5");
+
+  if (entries.length === 0) {
+    return (
+      <td className={cellClassName}>
+        <span className={PREVIEW_TEXT}>{formatContentPreview(null)}</span>
+      </td>
+    );
+  }
+
+  // The preview line reads from the same serialization the popover documents.
+  const payload = stringifyMetadataEntries(entries);
+
+  return (
+    <td className={cellClassName}>
+      <Popover open={isOpen} onOpenChange={handleOpenChange}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            onPointerEnter={openByPointer}
+            onPointerLeave={scheduleClose}
+            onFocus={cancelScheduledClose}
+            onClick={handleTriggerClick}
+            className={cn(
+              PREVIEW_TEXT,
+              "w-full text-left transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            )}
+          >
+            {formatContentPreview(payload)}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          ref={contentRef}
+          align="start"
+          aria-label="Metadata"
+          // Portaled and fixed, so it cannot widen the table; these keep it in the viewport.
+          collisionPadding={8}
+          className="w-[22rem] max-w-[calc(100vw-2rem)] p-0"
+          onOpenAutoFocus={(event) => {
+            if (isOpenedByPointerRef.current) event.preventDefault();
+          }}
+          onPointerEnter={cancelScheduledClose}
+          onPointerLeave={scheduleClose}
+          onClick={(event) => {
+            // React events bubble the component tree, so a portaled click still reaches the row.
+            event.stopPropagation();
+          }}
+        >
+          {/* No title bar: the braces already say what this is, and a header would put a
+              label above a document that reads as one thing. */}
+          <div className="max-h-64 overflow-auto px-3 py-2">
+            <MetadataJson entries={entries} />
+          </div>
+        </PopoverContent>
+      </Popover>
+    </td>
+  );
+}

--- a/frontend/ui/src/features/traces/components/TraceMetadataCell.tsx
+++ b/frontend/ui/src/features/traces/components/TraceMetadataCell.tsx
@@ -44,9 +44,11 @@ export function TraceMetadataCell({ entries, borderClassName }: TraceMetadataCel
 
   const openByPointer = useCallback(() => {
     cancelScheduledClose();
-    isOpenedByPointerRef.current = true;
+    // Only an open that starts here belongs to the pointer; brushing the trigger of an
+    // already-open surface must not relabel a keyboard open that holds the focus.
+    if (!isOpen) isOpenedByPointerRef.current = true;
     setIsOpen(true);
-  }, [cancelScheduledClose]);
+  }, [cancelScheduledClose, isOpen]);
 
   // A row can unmount mid-hover when the list refetches; a pending close must not outlive it.
   useEffect(() => cancelScheduledClose, [cancelScheduledClose]);
@@ -69,7 +71,12 @@ export function TraceMetadataCell({ entries, borderClassName }: TraceMetadataCel
       // Radix toggles the trigger, so a click on a hover-opened surface would close it.
       if (isOpen) {
         event.preventDefault();
-        if (isKeyboardActivation) contentRef.current?.focus();
+        // Focus moves into the surface here, so the close owes it back to the trigger even
+        // though the pointer opened this one.
+        if (isKeyboardActivation) {
+          isOpenedByPointerRef.current = false;
+          contentRef.current?.focus();
+        }
         return;
       }
       isOpenedByPointerRef.current = !isKeyboardActivation;
@@ -116,6 +123,12 @@ export function TraceMetadataCell({ entries, borderClassName }: TraceMetadataCel
           collisionPadding={8}
           className="w-[22rem] max-w-[calc(100vw-2rem)] p-0"
           onOpenAutoFocus={(event) => {
+            if (isOpenedByPointerRef.current) event.preventDefault();
+          }}
+          // Radix hands focus to the trigger on every close. A hover-opened surface never
+          // took focus, so that would pull it out of whatever the user was typing in; the
+          // keyboard open, which did take it, still needs the way back.
+          onCloseAutoFocus={(event) => {
             if (isOpenedByPointerRef.current) event.preventDefault();
           }}
           onPointerEnter={cancelScheduledClose}

--- a/frontend/ui/src/features/traces/utils/metadata.test.ts
+++ b/frontend/ui/src/features/traces/utils/metadata.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+import type { TraceListItem } from "@/types/api";
+import {
+  parseMetadataEntries,
+  stringifyMetadataEntries,
+  traceMetadataEntries,
+  unstructuredMetadataText,
+} from "./metadata";
+
+// Minimal list row — only the metadata carrier matters here. The list payload carries
+// `metadata_map`, the map the list query selects, not the legacy `metadata` JSON blob.
+function makeTrace(metadataMap: Record<string, string>): TraceListItem {
+  return {
+    trace_id: "t-1",
+    project_id: "p-1",
+    name: "run",
+    trace_start_time: "2026-06-01T00:00:00.000Z",
+    user_id: null,
+    session_id: null,
+    span_count: 1,
+    duration_ms: 10,
+    error_count: 0,
+    input: null,
+    output: null,
+    metadata_map: metadataMap,
+  };
+}
+
+/** A displayed row whose value is the stored text, so clicking it can filter. */
+const filterable = (key: string, value: string) => ({
+  key,
+  value,
+  rawValue: value,
+  isFilterable: true,
+});
+/** A displayed row rendered by us rather than read from storage: shown, not clickable. `raw`
+ * is the value as parsed, which is what a copy of the document must reproduce. */
+const displayOnly = (key: string, value: string, raw: unknown) => ({
+  key,
+  value,
+  rawValue: raw,
+  isFilterable: false,
+});
+
+describe("parseMetadataEntries", () => {
+  it("turns a JSON object blob into key/value rows in payload order", () => {
+    const entries = parseMetadataEntries('{"session_id":"s-1","tenant":"acme"}');
+    expect(entries).toEqual([filterable("session_id", "s-1"), filterable("tenant", "acme")]);
+  });
+
+  it("accepts an already-parsed map as well as a blob", () => {
+    expect(parseMetadataEntries({ session_id: "s-1" })).toEqual([filterable("session_id", "s-1")]);
+  });
+
+  it("strips traceroot's internal span keys", () => {
+    const entries = parseMetadataEntries(
+      '{"traceroot.span.id":"abc","traceroot.span.parent":"def","session_id":"s-1"}',
+    );
+    expect(entries).toEqual([filterable("session_id", "s-1")]);
+  });
+
+  it("strips every traceroot key, not only the span ones", () => {
+    // SDK identity rides on nearly every span, so leaving it in would put two keys
+    // nobody filters on above every real one in a frequency-ordered list.
+    const entries = parseMetadataEntries(
+      '{"traceroot.sdk.name":"python","traceroot.sdk.version":"0.1.0","service":"api"}',
+    );
+    expect(entries).toEqual([filterable("service", "api")]);
+  });
+
+  it("keeps a user key that merely mentions traceroot without the namespace prefix", () => {
+    expect(parseMetadataEntries('{"my.traceroot.note":"keep","traceroot":"keep"}')).toEqual([
+      filterable("my.traceroot.note", "keep"),
+      filterable("traceroot", "keep"),
+    ]);
+  });
+
+  // INVARIANT: a filterable row renders the text storage holds, because a click builds an
+  // exact-match filter against the stored `metadata_map` value — the two spellings must agree
+  // byte-for-byte or the filter silently matches nothing. A string value IS that text, so
+  // re-quoting it, escaping it to unicode sequences, or rewriting separators inside it would
+  // each build a filter for text storage never held.
+  it.each([
+    ['{"note": "a, b: c"}', [filterable("note", "a, b: c")]],
+    [
+      '{"city": "café", "note": "naïve — 東京"}',
+      [filterable("city", "café"), filterable("note", "naïve — 東京")],
+    ],
+    [
+      '{"note": "a { b", "tpl": "{\\"k\\": 1}"}',
+      [filterable("note", "a { b"), filterable("tpl", '{"k": 1}')],
+    ],
+  ])("passes a string value through verbatim: %s", (source, expected) => {
+    expect(parseMetadataEntries(source)).toEqual(expected);
+  });
+
+  it("renders a non-string scalar readably but does not offer it as a filter", () => {
+    // The stored spelling of a non-string value is the server's, not this one's, so the
+    // row shows the value and withholds the click rather than guessing.
+    expect(parseMetadataEntries('{"n":3,"ok":true,"nothing":null}')).toEqual([
+      displayOnly("n", "3", 3),
+      displayOnly("ok", "true", true),
+      displayOnly("nothing", "null", null),
+    ]);
+  });
+
+  it("renders a structured value readably but does not offer it as a filter", () => {
+    expect(parseMetadataEntries('{"nested": {"x": 1}, "many": ["a", "b"]}')).toEqual([
+      displayOnly("nested", '{"x":1}', { x: 1 }),
+      displayOnly("many", '["a","b"]', ["a", "b"]),
+    ]);
+  });
+
+  it("renders an empty object and an empty array as themselves", () => {
+    expect(parseMetadataEntries('{"nothing": {}, "none": []}')).toEqual([
+      displayOnly("nothing", "{}", {}),
+      displayOnly("none", "[]", []),
+    ]);
+  });
+
+  it("yields no entries for absent, malformed, or non-object metadata", () => {
+    expect(parseMetadataEntries(null)).toEqual([]);
+    expect(parseMetadataEntries(undefined)).toEqual([]);
+    expect(parseMetadataEntries("not json")).toEqual([]);
+    expect(parseMetadataEntries("[1,2]")).toEqual([]);
+    expect(parseMetadataEntries('"a string"')).toEqual([]);
+  });
+});
+
+describe("unstructuredMetadataText", () => {
+  it("returns the verbatim text of a blob that is not a JSON object", () => {
+    expect(unstructuredMetadataText("plain note")).toBe("plain note");
+    expect(unstructuredMetadataText("[1,2]")).toBe("[1,2]");
+  });
+
+  it("returns null for a structured object, so it renders as rows instead", () => {
+    expect(unstructuredMetadataText('{"a":"b"}')).toBeNull();
+  });
+
+  it("returns null for absent or blank metadata", () => {
+    expect(unstructuredMetadataText(null)).toBeNull();
+    expect(unstructuredMetadataText("   ")).toBeNull();
+  });
+});
+
+describe("stringifyMetadataEntries", () => {
+  it("re-serializes the displayed rows as pretty JSON", () => {
+    expect(stringifyMetadataEntries([filterable("a", "b")])).toBe('{\n  "a": "b"\n}');
+  });
+
+  // A copy has to be the document, not a description of it: building the JSON from display
+  // text quotes every value, turning 0.9 into "0.9" and true into "true".
+  it("round-trips a mixed document back to its source values", () => {
+    const source = '{"quality":0.9,"policy_pass":true,"tags":["a"],"note":"hi"}';
+    expect(JSON.parse(stringifyMetadataEntries(parseMetadataEntries(source)))).toEqual(
+      JSON.parse(source),
+    );
+  });
+
+  it("omits internal keys from a copied document", () => {
+    const copied = stringifyMetadataEntries(
+      parseMetadataEntries('{"traceroot.sdk.name":"python","service":"api"}'),
+    );
+    expect(JSON.parse(copied)).toEqual({ service: "api" });
+  });
+});
+
+describe("traceMetadataEntries", () => {
+  // A thin read of `metadata_map`, so the stripping and verbatim-value invariants above hold
+  // here too; what is pinned below is the source field it reads and how it reads an absent one.
+  it("reads trace-level metadata off a list row", () => {
+    expect(traceMetadataEntries(makeTrace({ session_id: "s-1" }))).toEqual([
+      filterable("session_id", "s-1"),
+    ]);
+  });
+
+  it("reads a row from an older server that carries no metadata field as having none", () => {
+    const { metadata_map, ...withoutMetadataMap } = makeTrace({ session_id: "s-1" });
+    void metadata_map;
+    expect(traceMetadataEntries(withoutMetadataMap)).toEqual([]);
+  });
+
+  it("ignores the legacy metadata blob, which the list payload no longer carries", () => {
+    // A row that only has the old blob field reads as no metadata: the column source
+    // is `metadata_map`, so a server that stopped sending it must show blank cells
+    // rather than the frontend quietly falling back to a field with different contents.
+    const legacyRow = {
+      ...makeTrace({}),
+      metadata: '{"session_id":"s-1"}',
+    } as TraceListItem;
+    expect(traceMetadataEntries(legacyRow)).toEqual([]);
+  });
+});

--- a/frontend/ui/src/features/traces/utils/metadata.ts
+++ b/frontend/ui/src/features/traces/utils/metadata.ts
@@ -1,0 +1,63 @@
+import type { TraceListItem } from "@/types/api";
+
+/** The whole `traceroot.` namespace is ours, not the user's; storage strips it too. */
+const INTERNAL_METADATA_PREFIX = "traceroot.";
+
+export interface MetadataEntry {
+  key: string;
+  /** Display text. Structured values are rendered as JSON and are not filterable. */
+  value: string;
+  /** The value as parsed, so round-tripping to JSON reproduces the source exactly. */
+  rawValue: unknown;
+  isFilterable: boolean;
+}
+
+type MetadataSource = string | Record<string, unknown> | null | undefined;
+
+// Only a string is the stored text verbatim. Re-serializing a structured value here produces
+// text that will not match what is stored, so it renders readably but is not filterable.
+function displayMetadataValue(value: unknown): { value: string; isFilterable: boolean } {
+  if (typeof value === "string") return { value, isFilterable: true };
+  try {
+    const serialized = JSON.stringify(value);
+    return { value: serialized ?? "", isFilterable: false };
+  } catch {
+    return { value: String(value), isFilterable: false };
+  }
+}
+
+export function parseMetadataEntries(source: MetadataSource): MetadataEntry[] {
+  if (!source) return [];
+  let parsed: unknown = source;
+  if (typeof source === "string") {
+    try {
+      parsed = JSON.parse(source);
+    } catch {
+      return [];
+    }
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return [];
+  return Object.entries(parsed as Record<string, unknown>)
+    .filter(([key]) => !key.startsWith(INTERNAL_METADATA_PREFIX))
+    .map(([key, value]) => ({ key, rawValue: value, ...displayMetadataValue(value) }));
+}
+
+export function unstructuredMetadataText(source: MetadataSource): string | null {
+  if (typeof source !== "string" || source.trim() === "") return null;
+  try {
+    const parsed: unknown = JSON.parse(source);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed) ? null : source;
+  } catch {
+    return source;
+  }
+}
+
+// Serializes rawValue, not the display text: a number displays as "0.9" but must copy back
+// as 0.9, and stringifying the display text would quote every value in the document.
+export function stringifyMetadataEntries(entries: readonly MetadataEntry[]): string {
+  return JSON.stringify(Object.fromEntries(entries.map((e) => [e.key, e.rawValue])), null, 2);
+}
+
+export function traceMetadataEntries(trace: TraceListItem): MetadataEntry[] {
+  return parseMetadataEntries(trace.metadata_map);
+}

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -110,6 +110,14 @@ export interface TraceListItem {
   total_input_tokens?: number;
   total_output_tokens?: number;
   total_cost?: number;
+  /**
+   * Trace-level metadata as an already-parsed map, the source for the list's single
+   * Metadata cell.
+   * Named for the ClickHouse column the backend selects (`metadata_map`), not the legacy
+   * JSON blob (`metadata`) it is derived from. Optional so a payload from an older server
+   * reads as "no metadata to show" rather than breaking the row.
+   */
+  metadata_map?: Record<string, string>;
 }
 
 export interface Span {

--- a/tests/rest/test_trace_reader.py
+++ b/tests/rest/test_trace_reader.py
@@ -572,3 +572,37 @@ class TestHasTraces:
         service.has_traces("c")
         assert "a" not in service._has_traces_cache
         assert "c" in service._has_traces_cache
+
+
+class TestListTracesRows:
+    def test_trace_rows_carry_the_trace_level_metadata_map(self):
+        """The list projects the TRACE row's metadata as a map so the UI can render one
+        column per key. A trace with no metadata yields an empty map, not null."""
+        base = [
+            "t1",
+            "p1",
+            "trace",
+            datetime(2026, 6, 1),
+            "u1",
+            None,
+            3,
+            1500,
+            0,
+            "in",
+            "out",
+            10,
+            20,
+            0.5,
+        ]
+        results = iter(
+            [
+                _rows([base + [{"tenant_id": "acme-corp"}], base + [None]]),
+                _rows([[2]]),
+            ]
+        )
+        service, _ = _make_service(lambda *a, **kw: next(results))
+
+        result = service.list_traces(project_id="p1")
+
+        assert result["data"][0]["metadata_map"] == {"tenant_id": "acme-corp"}
+        assert result["data"][1]["metadata_map"] == {}


### PR DESCRIPTION
Fixes #1825

> [!IMPORTANT]
> Stacked on #1839 (`feat/trace-column-picker`), and it also needs the `metadata_map`
> migration from #1830 (`feat/metadata-map-column`) to be in `main` — without that column
> the list query does not compile. Do not merge this before that migration.
> Last PR of the #1825 stack — this one carries the `Fixes`.

## Summary

The sixteenth column, end to end — the last of the six non-default fields #1825 names.

- **Backend surfacing:** `metadata_map` is selected in both layers of the list query,
  carried into the row dict, and added to `TraceListItem`. It is the cell's only source —
  the list item carries no `metadata` blob sibling to fall back to.
- **Registry:** a `metadata` entry, default off, so no existing user's list changes.
- **`TraceMetadataCell`** renders the map as one truncated line shaped like Input and
  Output, revealed in full on hover or from the keyboard.
- The reveal is a popover rather than a `title` or a tooltip because the document scrolls
  and has to be keyboard-reachable. The details that took the work: a hover open does not
  pull focus, a keyboard open moves focus into the surface so Escape and scrolling reach it,
  the trigger click does not also select the row, a portaled click does not bubble the
  component tree into the row handler, and a queued hover-close cannot outlive a row that
  unmounts when the list refetches.
- **`MetadataJson`** prints the entries as a JSON document — braces, serialized keys,
  separating commas — rather than the tree renderer, which truncates strings only at 500
  characters (enough to fill this popover several times) and leaves keys unquoted. Values
  are shortened at 42 characters, cut on code points so a slice cannot leave half a
  surrogate pair, and strings are shortened *before* serialization so a cut cannot leave
  half an escape sequence.
- **`utils/metadata.ts`** — parsing that strips the `traceroot.` namespace, keeps the raw
  parsed value beside the display text so a round trip reproduces the source exactly, and
  marks a value filterable only when it is the stored text verbatim.

## Type of Change

- [x] feat - A new feature

## Details

**A row matched by a span-scope metadata key can show an empty Metadata cell.** The cell
renders the **trace-level** map only, while a metadata filter matches a key attached at
either scope. So a filtered list can contain a row whose Metadata cell is blank, and it will
look like a rendering bug the first time anyone sees it. It is not: reconciling the two at
this level would mean duplicating every span-level key onto the trace row, which inflates the
largest table to answer a question the query layer already answers. The span detail panel is
where a span's own metadata is visible, and it is the reconciliation point. The list query
carries a comment saying so.

The cell is display-only. A blob is not a value the filter registry can be handed, so a click
here could only build a filter that matches nothing.

**Public API.** `TraceListItem` is inherited by `PublicTraceListItem`, so the field reaches
the public API-key list response as well — that is the `openapi/public.json` hunk. This
follows how the usage fields (`total_cost`, `total_input_tokens`, `total_output_tokens`)
arrived there: added to the internal list item for the list's columns, inherited by the
public model, with the spec diff carried in the same PR. Flagging it because a public-surface
change should be a thing the reviewer sees rather than something noticed later, and because
it is the part of this PR that is not freely revisable after merge. Say the word if you would
rather the public model narrowed instead.

Migration dependency: 009 must be applied for the column to exist, and 010 for
pre-migration history to answer with anything but an empty map.

## Notes

- Tests ride along for all of it: the metadata utils, the cell (including the hover/keyboard
  and row-selection interactions), the JSON renderer, the table's metadata cell, and the
  backend row test that a trace row carries its trace-level map.

## Screenshots / Recordings (if applicable)

1. The picker open with **Metadata** unchecked among the non-defaults — the default-off state
   every existing user lands on.
2. Metadata turned on: the column in the table, with one-line truncated previews on the rows
   that carry metadata.
3. A row whose trace carries no metadata, showing the same placeholder the other preview
   columns use.
4. The hover reveal open over a row: the JSON document with quoted keys, scrolled if it is
   long enough.
5. The keyboard path: the cell reached with Tab and opened with Enter, focus inside the
   popover.
6. The disclosure above, shown rather than described — a trace matched by a span-scope key
   with an empty Metadata cell in the list, beside the span panel open on the span that
   actually carries the key.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a non-default “Metadata” column to the trace list backed by `metadata_map`, with a one-line preview and an accessible popover; also exposes `metadata_map` in the public list API (fixes #1825).

- **New Features**
  - Backend/API: adds `metadata_map` to list queries and `TraceListItem`; OpenAPI updated; returns `{}` when absent; the table reads only this field.
  - UI: adds “Metadata” (default off) with a truncated preview and a popover that shows compact JSON; the column picker offers a single “Metadata” toggle, never per‑key.

- **Bug Fixes**
  - Focus/accessibility: hover-opened reveals neither take nor restore focus; keyboard opens move focus into the surface and Escape returns it; hover↔keyboard handoffs fixed; queued hover-close is canceled on unmount.
  - Interaction: trigger and surface clicks don’t select the row; the reveal stays open on trigger click; a short grace period keeps it open while moving from trigger to surface.

<sup>Written for commit 21eb8309f06b3d299ead3bb7033335e3737f47d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

