### PR TITLE
fix(agent): inject current date into system prompt for time-bounded queries

### DIFF
--- a/frontend/packages/agent/src/prompts/__tests__/system.test.ts
+++ b/frontend/packages/agent/src/prompts/__tests__/system.test.ts
@@ -28,10 +28,8 @@ describe("getSystemPrompt", () => {
   });
 
   it("includes current date in UTC", () => {
+    const today = new Date().toISOString().split("T")[0];
     const prompt = getSystemPrompt({ projectId: "proj-123" });
-    const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
-    expect(prompt).toContain("Current date:");
-    expect(prompt).toContain(today);
-    expect(prompt).toContain("UTC");
+    expect(prompt).toContain(`- Current date: ${today} (UTC)`);
   });
 });

--- a/frontend/packages/agent/src/prompts/__tests__/system.test.ts
+++ b/frontend/packages/agent/src/prompts/__tests__/system.test.ts
@@ -26,4 +26,12 @@ describe("getSystemPrompt", () => {
     expect(prompt).toContain("observations table");
     expect(prompt).toContain("GENERATION|SPAN|EVENT");
   });
+
+  it("includes current date in UTC", () => {
+    const prompt = getSystemPrompt({ projectId: "proj-123" });
+    const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+    expect(prompt).toContain("Current date:");
+    expect(prompt).toContain(today);
+    expect(prompt).toContain("UTC");
+  });
 });

--- a/frontend/packages/agent/src/prompts/system.ts
+++ b/frontend/packages/agent/src/prompts/system.ts
@@ -13,11 +13,14 @@ export function getSystemPrompt(ctx: SystemPromptContext): string {
     ? `\n- Currently viewing Session ID: ${ctx.traceSessionId}\n  The user opened the AI assistant from this session's detail view.\n  Call query_sessions with this sessionId to see all traces and their I/O.\n  Call download_session with this sessionId for a full deep-dive across all traces.`
     : "";
 
+  const currentDate = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
+
   return `You are a debugging assistant for TraceRoot, an observability platform for AI agents.
 You help users analyze telemetry data (traces and spans) from their AI agent systems.
 
 ## Current Context
 - Project ID: ${ctx.projectId}${traceContext}${sessionContext}
+- Current date: ${currentDate} (UTC)
 
 ## Available Tools
 


### PR DESCRIPTION
Fixes #1820

## Summary

The agent's system prompt now includes the current UTC date, enabling accurate timestamp computation for time-bounded queries like "today's sessions" or "errors this week". Previously, the agent used stale dates from its training data (e.g., `2025-07-21`), which became problematic after the registry rebind exposed real time-range parameters.

## Type of Change

- [x] fix - A bug fix

## Details

### Changes Made

**Modified `frontend/packages/agent/src/prompts/system.ts`:**

- Added current date calculation at session initialization:

```typescript
  const currentDate = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
```

- Injected date into the "Current Context" section:

```
  - Current date: ${currentDate} (UTC)
```

**Modified `system.test.ts`:**

- Added test case: `"includes current date in UTC"`
- Verifies that `"Current date:"`, today's date (`YYYY-MM-DD`), and `"UTC"` are present in the prompt

### Implementation Details

- **Format:** `2026-08-11 (UTC)`
- **Timing:** Calculated once per agent session start (sufficient for short-lived sessions)
- **Scope:** Applies to both chat sessions and detector RCA runs (same prompt path)
- **Performance:** Optimized with single `Date` object creation, no unnecessary operations

### Example Output

The agent now receives:

```
## Current Context
- Project ID: proj-123
- Current date: 2026-08-11 (UTC)
```

This enables the model to compute accurate `start_after` and `end_before` parameters for time-bounded tool calls.

## Testing

```bash
cd frontend/packages/agent
pnpm test system.test.ts
```

**Results:**

- ✅ All 5 system prompt tests pass (including new date injection test)
- ✅ Full agent test suite: 28/28 tests pass
- ✅ No TypeScript errors

## Screenshots / Recordings (if applicable)

N/A — backend prompt change with test coverage

## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects the current UTC date into the agent’s system prompt so “today”/“this week” queries use correct ranges instead of stale dates. Previously the agent used training-time dates; now it emits “- Current date: YYYY-MM-DD (UTC)” per session.

- Adds the date line to `frontend/packages/agent/src/prompts/system.ts`.
- Updates `system.test.ts` to assert the exact full line (“- Current date: YYYY-MM-DD (UTC)”) to lock format and avoid midnight-boundary false positives.

<sup>Written for commit 67f0c4c058d4683e0b722f46dc98774c07b11652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

