### PR TITLE
feat(evaluations): version-scoped test-case Experiments tab + dataset detail

### DIFF
--- a/frontend/packages/core/prisma/migrations/20260720234159_add_offline_eval/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260720234159_add_offline_eval/migration.sql
@@ -35,7 +35,6 @@ CREATE TABLE "test_cases" (
     "project_id" VARCHAR NOT NULL,
     "input" TEXT NOT NULL,
     "expected" TEXT,
-    "recorded_output" TEXT,
     "metadata" JSONB,
     "review" VARCHAR NOT NULL DEFAULT 'needs_review',
     "capture_reason" VARCHAR NOT NULL DEFAULT 'manual',

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -515,7 +515,6 @@ model TestCase {
   projectId        String   @map("project_id") @db.VarChar
   input            String   @db.Text
   expected         String?  @db.Text
-  recordedOutput   String?  @map("recorded_output") @db.Text
   metadata         Json?    @map("metadata") @db.JsonB
   review           String   @default("needs_review") @db.VarChar // "needs_review"|"ready"
   captureReason    String   @default("manual") @map("capture_reason") @db.VarChar // "manual"|"error"|"failed_tool"|"negative_feedback"

--- a/frontend/packages/core/src/__tests__/eval-contract-shape.json
+++ b/frontend/packages/core/src/__tests__/eval-contract-shape.json
@@ -623,12 +623,6 @@
           "required": false,
           "nullable": true
         },
-        "recorded_output": {
-          "type": "string",
-          "max_length": 1000000,
-          "required": false,
-          "nullable": true
-        },
         "metadata": {
           "type": "json_object",
           "required": false,

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -393,7 +393,6 @@ export const CreateTestCaseRequestSchema = z
   .object({
     input: z.string().max(EVAL_PAYLOAD_TEXT_MAX),
     expected: z.string().max(EVAL_PAYLOAD_TEXT_MAX).nullable().optional(),
-    recorded_output: z.string().max(EVAL_PAYLOAD_TEXT_MAX).nullable().optional(),
     metadata: MetadataSchema.nullable().optional(),
     review: ReviewStatusSchema.default("needs_review"),
     capture_reason: CaptureReasonSchema.default("manual"),

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/route.ts
@@ -96,3 +96,48 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     throw err;
   }
 }
+
+// DELETE — remove a test case. Like PATCH, this publishes a NEW dataset version
+// with the case dropped; earlier snapshots (and any run pinned to them) keep it,
+// so a delete is recoverable by viewing/branching an older version.
+export async function DELETE(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, datasetId, testCaseId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId, Role.MEMBER);
+  if (accessResult.error) return accessResult.error;
+
+  // Guard before publishing so deleting a missing case never creates a no-op version.
+  const dataset = await prisma.dataset.findFirst({
+    where: { id: datasetId, projectId },
+    select: { currentVersionId: true },
+  });
+  if (!dataset) return errorResponse("Dataset not found", 404);
+  const exists = dataset.currentVersionId
+    ? await prisma.testCase.findFirst({
+        where: { datasetVersionId: dataset.currentVersionId, testCaseId },
+        select: { id: true },
+      })
+    : null;
+  if (!exists) return errorResponse("Test case not found in the current version", 404);
+
+  try {
+    const result = await publishDatasetVersion({
+      datasetId,
+      projectId,
+      createdBy: authResult.user.email ?? null,
+      note: `Deleted test case ${testCaseId}`,
+      transform: (current) => ({
+        focusTestCaseId: "",
+        cases: current.filter((seed) => seed.testCaseId !== testCaseId),
+      }),
+    });
+    return successResponse(result, 201);
+  } catch (err) {
+    if (err instanceof DatasetNotFound) return errorResponse("Dataset not found", 404);
+    if (err instanceof VersionConflict) {
+      return errorResponse("The dataset changed while deleting; please retry", 409);
+    }
+    throw err;
+  }
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.test.ts
@@ -7,7 +7,7 @@
 import { it, expect, vi, beforeEach } from "vitest";
 
 const prismaMock = vi.hoisted(() => ({
-  evaluationResult: { findMany: vi.fn() },
+  evaluationResult: { findMany: vi.fn(), groupBy: vi.fn() },
 }));
 const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
 
@@ -43,6 +43,8 @@ function resultRow(over: Record<string, unknown> = {}) {
       runNumber: 2,
       candidateVersion: "sonnet",
       startedAt: new Date("2026-07-21T00:00:00Z"),
+      datasetVersionId: "dv1",
+      caseCount: 3,
       evaluation: { name: "ticket-routing" },
     },
     ...over,
@@ -57,10 +59,15 @@ beforeEach(() => {
   vi.clearAllMocks();
   auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
   auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+  prismaMock.evaluationResult.groupBy.mockResolvedValue([]);
 });
 
-it("flattens each result into a run row with the run's identity and this case's score", async () => {
+it("flattens each result into a run row with the run's identity, version, score and run-level totals", async () => {
   prismaMock.evaluationResult.findMany.mockResolvedValue([resultRow()]);
+  // Run-level totals summed over all of run_2's cases (not just this one).
+  prismaMock.evaluationResult.groupBy.mockResolvedValue([
+    { runId: "run_2", _sum: { cost: 0.03, durationMs: 1500 } },
+  ]);
 
   const res = await GET({} as never, params);
   expect(res.status).toBe(200);
@@ -70,10 +77,14 @@ it("flattens each result into a run row with the run's identity and this case's 
     runNumber: 2,
     candidateVersion: "sonnet",
     evaluationName: "ticket-routing",
+    datasetVersionId: "dv1",
     ranAt: "2026-07-21T00:00:00.000Z",
     score: 1,
     status: "passed",
     change: "improved",
+    caseCount: 3,
+    cost: 0.03,
+    elapsedMs: 1500,
   });
 });
 

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.ts
@@ -35,23 +35,47 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
           runNumber: true,
           candidateVersion: true,
           startedAt: true,
+          datasetVersionId: true,
+          // Declared case count — the SAME denominator the Experiments list uses for
+          // Avg Cost / Avg Duration, so the two surfaces agree even on partial runs.
+          caseCount: true,
           evaluation: { select: { name: true } },
         },
       },
     },
   });
 
-  const data = results.map((r) => ({
-    resultId: r.id,
-    runId: r.run.id,
-    runNumber: r.run.runNumber,
-    candidateVersion: r.run.candidateVersion,
-    evaluationName: r.run.evaluation.name,
-    ranAt: r.run.startedAt.toISOString(),
-    score: r.mainScore,
-    status: r.status,
-    change: r.change,
-  }));
+  // Run-level cost/duration, summed over ALL of each run's results (not just this
+  // case) — the same aggregation the runs list uses, so the panel's Cost / Duration
+  // (and the averages over the declared caseCount) match the Experiments list.
+  const runIds = [...new Set(results.map((r) => r.run.id))];
+  const runAgg = runIds.length
+    ? await prisma.evaluationResult.groupBy({
+        by: ["runId"],
+        where: { runId: { in: runIds } },
+        _sum: { cost: true, durationMs: true },
+      })
+    : [];
+  const aggByRun = new Map(runAgg.map((a) => [a.runId, a]));
+
+  const data = results.map((r) => {
+    const agg = aggByRun.get(r.run.id);
+    return {
+      resultId: r.id,
+      runId: r.run.id,
+      runNumber: r.run.runNumber,
+      candidateVersion: r.run.candidateVersion,
+      evaluationName: r.run.evaluation.name,
+      datasetVersionId: r.run.datasetVersionId,
+      ranAt: r.run.startedAt.toISOString(),
+      score: r.mainScore,
+      status: r.status,
+      change: r.change,
+      caseCount: r.run.caseCount,
+      cost: agg?._sum.cost ?? null,
+      elapsedMs: agg?._sum.durationMs ?? null,
+    };
+  });
 
   return successResponse({ data });
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
@@ -83,7 +83,6 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
             input: encodeJsonValue(c.input),
             expected:
               c.expected === null || c.expected === undefined ? null : encodeJsonValue(c.expected),
-            recordedOutput: c.recorded_output ?? null,
             metadata: (c.metadata ?? null) as Record<string, unknown> | null,
             review: c.review,
             captureReason: c.capture_reason,

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/dataset-case/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/dataset-case/route.test.ts
@@ -60,7 +60,6 @@ beforeEach(() => {
     projectId: PROJECT_ID,
     input: "orig input",
     expected: "orig expected",
-    recordedOutput: null,
     metadata: null,
     review: "ready",
     captureReason: "manual",
@@ -123,14 +122,14 @@ describe("result → dataset: update_existing_case", () => {
 });
 
 describe("result → dataset: save_new_case", () => {
-  it("saves a new case into another dataset with result provenance; candidate stays separate", async () => {
+  it("saves a new case into another dataset with result provenance; candidate never becomes expected", async () => {
     const res = await POST(req({ action: "save_new_case", dataset_id: "ds2" }), params("res1"));
     expect(res.status).toBe(201);
     const cases = casesIn(currentVersionId("ds2"));
     expect(cases).toHaveLength(1);
     const c = cases[0];
-    // Candidate output is recorded separately and is NEVER the expected output.
-    expect(c.recordedOutput).toBe("the CANDIDATE answer");
+    // Candidate output is NEVER the expected output; it isn't stored on the case
+    // either — the source run/result links preserve what actually happened.
     expect(c.expected).toBeNull();
     // Result provenance is captured.
     expect(c.sourceRunId).toBe("run1");
@@ -154,7 +153,6 @@ describe("result → dataset: save_new_case", () => {
     expect(res.status).toBe(201);
     const c = casesIn(currentVersionId("ds2"))[0];
     expect(c.expected).toBe("the CANDIDATE answer");
-    expect(c.recordedOutput).toBe("the CANDIDATE answer");
   });
 });
 

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts
@@ -89,7 +89,7 @@ it("derives regressedCaseCount + trustworthy delta + elapsedMs for a listed run"
     startedAt: new Date("2026-07-21T00:00:00Z"),
     completedAt: new Date("2026-07-21T00:00:05Z"),
     evaluation: { name: "ticket-routing" },
-    datasetVersion: { label: "v1" },
+    datasetVersion: { label: "v1", createTime: new Date("2026-07-16T00:00:00Z"), versionNumber: 1 },
   };
   const baselineRun = {
     id: "run_b",
@@ -203,7 +203,7 @@ it("shows null comparison fields for a run with no baseline", async () => {
       startedAt: new Date("2026-07-21T00:00:00Z"),
       completedAt: null,
       evaluation: { name: "e" },
-      datasetVersion: { label: "v1" },
+      datasetVersion: { label: "v1", createTime: new Date("2026-07-16T00:00:00Z"), versionNumber: 1 },
     },
   ]);
   prismaMock.evaluationRun.count.mockResolvedValue(1);
@@ -244,7 +244,7 @@ it("derives per-status counts for a listed run", async () => {
     startedAt: new Date("2026-07-21T00:00:00Z"),
     completedAt: new Date("2026-07-21T00:00:05Z"),
     evaluation: { name: "ticket-routing" },
-    datasetVersion: { label: "v1" },
+    datasetVersion: { label: "v1", createTime: new Date("2026-07-16T00:00:00Z"), versionNumber: 1 },
   };
   prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run]);
   prismaMock.evaluationRun.count.mockResolvedValue(1);
@@ -284,7 +284,7 @@ it("returns the pass rate, derived from the same counts", async () => {
       startedAt: new Date("2026-07-21T00:00:00Z"),
       completedAt: new Date("2026-07-21T00:00:05Z"),
       evaluation: { name: "ticket-routing" },
-      datasetVersion: { label: "v1" },
+      datasetVersion: { label: "v1", createTime: new Date("2026-07-16T00:00:00Z"), versionNumber: 1 },
     },
   ]);
   prismaMock.evaluationRun.count.mockResolvedValue(1);
@@ -326,7 +326,7 @@ it("returns a null pass rate for an all-errored run, never 0", async () => {
       startedAt: new Date("2026-07-21T00:00:00Z"),
       completedAt: new Date("2026-07-21T00:00:05Z"),
       evaluation: { name: "ticket-routing" },
-      datasetVersion: { label: "v1" },
+      datasetVersion: { label: "v1", createTime: new Date("2026-07-16T00:00:00Z"), versionNumber: 1 },
     },
   ]);
   prismaMock.evaluationRun.count.mockResolvedValue(1);
@@ -362,7 +362,7 @@ it("reports a running duration for a mid-flight run with no completedAt", async 
       startedAt: new Date("2026-07-21T00:00:00Z"),
       completedAt: null,
       evaluation: { name: "ticket-routing" },
-      datasetVersion: { label: "v1" },
+      datasetVersion: { label: "v1", createTime: new Date("2026-07-16T00:00:00Z"), versionNumber: 1 },
     },
   ]);
   prismaMock.evaluationRun.count.mockResolvedValue(1);
@@ -402,7 +402,7 @@ it("reports zero counts for a run with no results, without extra queries", async
     startedAt: new Date("2026-07-21T00:00:00Z"),
     completedAt: null,
     evaluation: { name: "ticket-routing" },
-    datasetVersion: { label: "v1" },
+    datasetVersion: { label: "v1", createTime: new Date("2026-07-16T00:00:00Z"), versionNumber: 1 },
   };
   prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run]);
   prismaMock.evaluationRun.count.mockResolvedValue(1);
@@ -440,7 +440,7 @@ it("prefers the derived counts over a stored scoredCount that disagrees", async 
     startedAt: new Date("2026-07-21T00:00:00Z"),
     completedAt: new Date("2026-07-21T00:00:05Z"),
     evaluation: { name: "ticket-routing" },
-    datasetVersion: { label: "v1" },
+    datasetVersion: { label: "v1", createTime: new Date("2026-07-16T00:00:00Z"), versionNumber: 1 },
   };
   prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run]);
   prismaMock.evaluationRun.count.mockResolvedValue(1);
@@ -481,7 +481,7 @@ function run(overrides: Partial<Record<string, unknown>> = {}) {
     startedAt: new Date("2026-07-21T00:00:00Z"),
     completedAt: new Date("2026-07-21T00:00:05Z"),
     evaluation: { name: "ticket-routing" },
-    datasetVersion: { label: "v1" },
+    datasetVersion: { label: "v1", createTime: new Date("2026-07-16T00:00:00Z"), versionNumber: 1 },
     ...overrides,
   };
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
@@ -107,7 +107,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
 
   const include = {
     evaluation: { select: { name: true } },
-    datasetVersion: { select: { label: true } },
+    datasetVersion: { select: { label: true, createTime: true, versionNumber: true } },
   };
 
   let runs: Awaited<ReturnType<typeof prisma.evaluationRun.findMany<{ include: typeof include }>>>;
@@ -307,6 +307,10 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
       evaluationName: r.evaluation.name,
       datasetName: datasetName.get(r.datasetId) ?? null,
       datasetVersionLabel: r.datasetVersion.label,
+      // Raw fields for the UI's time-sortable dataset-version snowflake (see
+      // lib/eval/snowflake); the list shows "<snowflake> <dataset name>".
+      datasetVersionCreatedAt: r.datasetVersion.createTime.toISOString(),
+      datasetVersionNumber: r.datasetVersion.versionNumber,
       cost,
       // Delta + regressed-case count only when trustworthy; otherwise null (UI shows —),
       // never a misleading number beside an incompatible baseline.

--- a/frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts
@@ -103,7 +103,6 @@ export async function POST(request: Request, { params }: RouteParams) {
             input: ch.input !== undefined ? encodeJsonValue(ch.input) : (prev?.input ?? ""),
             expected:
               ch.expected === undefined ? (prev?.expected ?? null) : encodeJsonValue(ch.expected),
-            recordedOutput: prev?.recordedOutput ?? null,
             metadata: ch.metadata !== undefined ? ch.metadata : (prev?.metadata ?? null),
             review: prev?.review ?? "needs_review",
             captureReason: prev?.captureReason ?? "manual",

--- a/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
+++ b/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { useRouter } from "next/navigation";
 import { Check, Copy, Database, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/toast";
@@ -29,6 +30,7 @@ export function NewDatasetPanel({
   onOpenChange: (open: boolean) => void;
 }) {
   const { toast } = useToast();
+  const router = useRouter();
   const create = useCreateDataset(projectId);
   const [state, setState] = React.useState<DatasetFormState>(emptyDatasetForm());
 
@@ -56,9 +58,11 @@ export function NewDatasetPanel({
     create.mutate(
       { name: state.name.trim(), description: state.description.trim() || null },
       {
-        onSuccess: () => {
+        onSuccess: (data) => {
           toast({ title: "Dataset created", tone: "success" });
           onOpenChange(false);
+          // Jump straight into the dataset that was just created.
+          router.push(`/projects/${projectId}/datasets/${data.dataset.id}`);
         },
         onError: (e) =>
           toast({ title: "Could not create dataset", description: String(e), tone: "warning" }),
@@ -67,40 +71,56 @@ export function NewDatasetPanel({
   };
 
   return (
-    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
-      <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
-        <h2 className="text-[13px] font-semibold">New dataset</h2>
-        <button
-          type="button"
-          onClick={() => onOpenChange(false)}
-          aria-label="Close"
-          className="rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
-        >
-          <X className="h-4 w-4" />
-        </button>
-      </div>
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
+      {/* Dimmed backdrop; clicking it closes the modal. */}
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={() => onOpenChange(false)}
+        aria-hidden
+      />
+      {/* Centered modal (matches the "Add to datasets" modal), not a side drawer. */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="new-dataset-title"
+        className="relative z-10 flex max-h-[90vh] w-[min(560px,94vw)] flex-col rounded-lg border border-border bg-background shadow-xl"
+      >
+        <div className="flex shrink-0 items-center justify-between border-b border-border px-5 py-3">
+          <h2 id="new-dataset-title" className="text-[13px] font-semibold">
+            New dataset
+          </h2>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            aria-label="Close"
+            className="rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
 
-      <div className="min-h-0 flex-1 overflow-auto p-4">
-        <DatasetFormFields state={state} onChange={setState} />
-      </div>
+        <div className="min-h-0 flex-1 overflow-auto px-5 py-4">
+          <DatasetFormFields state={state} onChange={setState} />
+        </div>
 
-      <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border px-4 py-3">
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 text-[12px]"
-          onClick={() => onOpenChange(false)}
-        >
-          Cancel
-        </Button>
-        <Button
-          size="sm"
-          className="h-7 text-[12px]"
-          onClick={handleCreate}
-          disabled={!canCreate || create.isPending}
-        >
-          {create.isPending ? "Creating…" : "Create dataset"}
-        </Button>
+        <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border px-5 py-3">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-[12px]"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            className="h-7 text-[12px]"
+            onClick={handleCreate}
+            disabled={!canCreate || create.isPending}
+          >
+            {create.isPending ? "Creating…" : "Create"}
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/ui/src/features/evaluations/components/delete-test-case-dialog.tsx
+++ b/frontend/ui/src/features/evaluations/components/delete-test-case-dialog.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Confirms deleting a single dataset row. Unlike deleting a whole dataset, this
+ * only publishes a new version without the row — earlier snapshots keep it — so
+ * it's recoverable and doesn't need a type-to-confirm gate, just a plain confirm.
+ */
+export function DeleteTestCaseDialog({
+  rowLabel,
+  isOpen,
+  onClose,
+  onConfirm,
+  isDeleting,
+}: {
+  rowLabel: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isDeleting?: boolean;
+}) {
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle className="text-[13px] font-semibold">Delete row</DialogTitle>
+        </DialogHeader>
+        <div className="mt-1 space-y-4">
+          <p className="text-[12px] text-muted-foreground">
+            This removes <span className="font-medium text-foreground">{rowLabel}</span> from the
+            current version by publishing a new one. Earlier versions still contain it, so any run
+            that scored it is unaffected.
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 text-[12px]"
+              onClick={onClose}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              className="h-7 text-[12px]"
+              disabled={isDeleting}
+              onClick={onConfirm}
+            >
+              {isDeleting ? "Deleting…" : "Delete"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
+++ b/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import * as React from "react";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/toast";
+import { EditableValueBlock } from "@/features/offline-eval/components";
+import { useSaveTestCase, useUpdateTestCase } from "../hooks";
+
+/**
+ * Create / edit a dataset row (test case). "+ Row" opens it empty; the row action
+ * menu opens it seeded from the case. Input / Expected / Metadata are the same
+ * editable, line-numbered fields the trace "Add to datasets" flow uses — a blank
+ * row is authored here rather than inserted empty and edited later. Saving
+ * publishes a new immutable dataset version (older snapshots are untouched).
+ */
+export type TestCaseEditorMode =
+  | { kind: "create" }
+  | {
+      kind: "edit";
+      testCaseId: string;
+      input: string;
+      expected: string | null;
+      metadata: unknown;
+    };
+
+function metadataToText(metadata: unknown): string {
+  if (metadata === null || metadata === undefined) return "";
+  if (typeof metadata === "object" && Object.keys(metadata as object).length === 0) return "";
+  return JSON.stringify(metadata, null, 2);
+}
+
+export function TestCaseEditorModal({
+  projectId,
+  datasetId,
+  mode,
+  onClose,
+  onSaved,
+}: {
+  projectId: string;
+  datasetId: string;
+  mode: TestCaseEditorMode;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const { toast } = useToast();
+  const save = useSaveTestCase(projectId, datasetId);
+  const update = useUpdateTestCase(projectId, datasetId);
+  const isEdit = mode.kind === "edit";
+
+  const [input, setInput] = React.useState(isEdit ? mode.input : "");
+  const [expected, setExpected] = React.useState(isEdit ? (mode.expected ?? "") : "");
+  const [metadata, setMetadata] = React.useState(isEdit ? metadataToText(mode.metadata) : "");
+
+  // Close on Escape (capture phase, so a nested popover can pre-empt it).
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onClose]);
+
+  // Metadata must be empty or a JSON object; surfaced so a half-typed value blocks
+  // Save rather than being silently dropped.
+  const metadataError = React.useMemo(() => {
+    const trimmed = metadata.trim();
+    if (trimmed === "") return null;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return null;
+      return 'Metadata must be a JSON object, e.g. {"key": "value"}.';
+    } catch {
+      return "Metadata isn't valid JSON.";
+    }
+  }, [metadata]);
+
+  const pending = save.isPending || update.isPending;
+  const canSave = !metadataError && !pending;
+
+  const handleSave = () => {
+    if (!canSave) return;
+    const metadataObj: Record<string, unknown> | null = metadata.trim()
+      ? (JSON.parse(metadata) as Record<string, unknown>)
+      : null;
+    const onSuccess = () => {
+      toast({
+        title: isEdit ? "Row saved — new version published" : "Row added",
+        tone: "success",
+      });
+      onSaved();
+      onClose();
+    };
+    const onError = (e: unknown) =>
+      toast({ title: "Could not save the row", description: String(e), tone: "warning" });
+
+    if (mode.kind === "edit") {
+      update.mutate(
+        {
+          testCaseId: mode.testCaseId,
+          patch: { input, expected: expected.trim() || null, metadata: metadataObj },
+        },
+        { onSuccess, onError },
+      );
+    } else {
+      save.mutate(
+        { input, expected: expected.trim() || null, metadata: metadataObj },
+        { onSuccess, onError },
+      );
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} aria-hidden />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="test-case-editor-title"
+        className="relative z-10 flex max-h-[90vh] w-[min(1080px,94vw)] flex-col rounded-lg border border-border bg-background shadow-xl"
+      >
+        <div className="flex shrink-0 items-center justify-between border-b border-border px-5 py-3">
+          <h2 id="test-case-editor-title" className="text-[13px] font-semibold">
+            {isEdit ? "Edit Row" : "New Row"}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 space-y-4 overflow-auto px-5 py-4 text-[12px]">
+          <EditableValueBlock
+            label="Input"
+            text={input}
+            onChange={setInput}
+            copyable
+            autoDetectKind
+            boxed
+            minRows={3}
+          />
+          <EditableValueBlock
+            label="Expected"
+            text={expected}
+            onChange={setExpected}
+            copyable
+            autoDetectKind
+            boxed
+            minRows={3}
+          />
+          <EditableValueBlock
+            label="Metadata"
+            text={metadata}
+            onChange={setMetadata}
+            defaultKind="pretty"
+            copyable
+            autoDetectKind
+            boxed
+            minRows={2}
+          />
+          {metadataError && (
+            <p className="text-[11px] leading-snug text-amber-700 dark:text-amber-300">
+              {metadataError}
+            </p>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border px-5 py-3">
+          <Button variant="outline" size="sm" className="h-7 text-[12px]" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button size="sm" className="h-7 text-[12px]" onClick={handleSave} disabled={!canSave}>
+            {pending ? "Saving…" : isEdit ? "Save changes" : "Save"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -3,9 +3,8 @@
 import * as React from "react";
 import Link from "next/link";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { ArrowDown, ArrowUp, ArrowUpRight, Database, Info, Plus, X } from "lucide-react";
+import { ArrowUpRight, Database, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -13,30 +12,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { CopyButton } from "@/components/ui/copy-button";
 import { cn } from "@/lib/utils";
 import { getTrace } from "@/lib/api/traces";
-import { SpanKindIcon, useSpanIO } from "@/features/traces";
+import { useSpanIO } from "@/features/traces";
 import { FormCard, EditableValueBlock, Timestamp } from "@/features/offline-eval/components";
 import { tokenizeCode } from "@/features/offline-eval/components/syntax";
 import { useProject } from "@/features/projects/hooks";
-import {
-  CAPTURE_REASON_LABEL,
-  SPAN_KIND_LABEL,
-  type CaptureReason,
-} from "@/features/offline-eval/types";
 import type { Span } from "@/types/api";
-import {
-  useDatasets,
-  useCreateDataset,
-  useTraceEvaluationResults,
-  useTraceTestCases,
-} from "../hooks";
-
-/** Sentinel dataset-select value for "create a new dataset". */
-const NEW_DATASET = "__new__";
+import { useDatasets, useTraceEvaluationResults, useTraceTestCases } from "../hooks";
 
 /** Root = the span with no parent (the application / evaluation-item root). */
 function rootSpan(spans: Span[]): Span | undefined {
@@ -55,19 +40,6 @@ function prettyJson(raw: string | null | undefined): string {
   } catch {
     return raw;
   }
-}
-
-/** One short line explaining what a case sourced from this span actually tests. */
-function boundaryHint(displayKind: string, spanName: string): string {
-  const name = spanName.toLowerCase();
-  if (displayKind === "trace" || displayKind === "AGENT")
-    return "This tests the application from this input.";
-  if (displayKind === "LLM") return "This tests this model or prompt step.";
-  if (displayKind === "TOOL")
-    return "This tests the tool using these arguments. To test whether the agent selected the correct tool, choose its parent agent or LLM span.";
-  if (/retriev|search|recall|policy|vector|embed/.test(name))
-    return "This tests retrieval from this query.";
-  return "This tests this step from its input.";
 }
 
 /**
@@ -103,18 +75,14 @@ export function SaveTestCaseDrawer({
   });
 
   const [datasetId, setDatasetId] = React.useState("");
-  const [newDatasetName, setNewDatasetName] = React.useState("");
   const [selectedSpanId, setSelectedSpanId] = React.useState<string | undefined>(spanId);
   const [input, setInput] = React.useState("");
   const [metadata, setMetadata] = React.useState("");
-  const [attachSource, setAttachSource] = React.useState(true);
-  // The single editable Output field. It seeds from the recorded output; editing it
-  // makes the edit the EXPECTED outcome future runs are graded against, while the
-  // untouched recorded output is still stored separately. Left as-is, expected ==
-  // recorded — but all three fields (input, expected, recorded_output) are persisted.
-  // Whether it's been edited is DERIVED (see `outputEdited` below), not a flag set by
-  // the field's `onChange` — the field normalises JSON on seed (see EditableValueBlock),
-  // and that normalisation must never itself read as an edit.
+  // The single editable Output field. It seeds from the span's production output;
+  // whatever it holds at Save becomes the EXPECTED outcome future runs are graded
+  // against (the field normalises JSON on seed — see EditableValueBlock). The raw
+  // production output isn't stored separately: to see what actually happened, follow
+  // the case's source trace/span link (matching the dataset-item model).
   const [output, setOutput] = React.useState("");
   const [duplicate, setDuplicate] = React.useState<{ datasetId: string } | null>(null);
   const [feedback, setFeedback] = React.useState<{
@@ -127,8 +95,6 @@ export function SaveTestCaseDrawer({
   React.useEffect(() => {
     if (open) {
       setDatasetId("");
-      setNewDatasetName("");
-      setAttachSource(true);
       setDuplicate(null);
       setFeedback(null);
     }
@@ -148,7 +114,6 @@ export function SaveTestCaseDrawer({
     if (!trace) return undefined;
     return selectedSpanId ? spans.find((s) => s.span_id === selectedSpanId) : root;
   }, [trace, selectedSpanId, spans, root]);
-  const isRoot = !!span && !span.parent_span_id;
 
   // The trace-detail response OMITS span input/output/metadata — they are fetched
   // per span on demand (getSpanIO), so read them from that hook, not the span.
@@ -233,7 +198,6 @@ export function SaveTestCaseDrawer({
     return () => root.removeEventListener("keydown", onKey);
   }, [open, onOpenChange]);
 
-  const createDataset = useCreateDataset(projectId);
   const save = useMutation({
     mutationFn: async (vars: { datasetId: string; body: Record<string, unknown> }) => {
       const res = await fetch(`/api/projects/${projectId}/datasets/${vars.datasetId}/test-cases`, {
@@ -256,22 +220,6 @@ export function SaveTestCaseDrawer({
 
   if (!open || !traceId) return null;
 
-  const creatingNew = datasetId === NEW_DATASET;
-  const dataset = datasets.find((item) => item.id === datasetId);
-  const displayKind = isRoot ? "trace" : (span?.span_kind ?? "SPAN");
-  // Normalised the same way the Output field's seed is (see the effect above), so
-  // this is byte-for-byte what an untouched Output field holds.
-  const recordedOutput = spanIOReady ? prettyJson(spanIO?.output) : "";
-  // Derived, not a flag `onChange` sets — a same-content reformat (the field's own
-  // JSON pretty-print on seed) must never itself read as an edit.
-  const outputEdited = output !== recordedOutput;
-  const currentIndex = span ? spans.findIndex((s) => s.span_id === span.span_id) : -1;
-  const canNavigateUp = currentIndex > 0;
-  const canNavigateDown = currentIndex >= 0 && currentIndex < spans.length - 1;
-
-  const inferredReason: CaptureReason =
-    span?.status === "ERROR" ? (displayKind === "TOOL" ? "failed_tool" : "error") : "manual";
-
   // Metadata must parse to a JSON object (or be empty) to be persisted at all — see
   // CreateTestCaseRequestSchema.metadata. Validated here (surfaced below) rather than
   // only at submit time, so an array/scalar/invalid value blocks Save instead of
@@ -288,53 +236,28 @@ export function SaveTestCaseDrawer({
     }
   })();
 
-  const canSave =
-    !!span &&
-    spanIOReady &&
-    !metadataError &&
-    (creatingNew ? newDatasetName.trim() !== "" : datasetId !== "") &&
-    !save.isPending;
-
-  const navigate = (dir: "up" | "down") => {
-    if (currentIndex < 0) return;
-    const next = dir === "up" ? currentIndex - 1 : currentIndex + 1;
-    if (next >= 0 && next < spans.length) setSelectedSpanId(spans[next].span_id);
-  };
+  const canSave = !!span && spanIOReady && !metadataError && datasetId !== "" && !save.isPending;
 
   const handleSave = async () => {
     if (!span || !canSave) return;
     setFeedback(null);
     try {
-      let dsId = datasetId;
-      if (creatingNew) {
-        const created = await createDataset.mutateAsync({ name: newDatasetName.trim() });
-        dsId = created.dataset.id;
-        setDatasetId(dsId);
-      }
       // canSave already required metadataError === null, so this is either empty or a
       // valid JSON object — never silently dropped.
       const metadataObj: Record<string, unknown> | null = metadata.trim()
         ? (JSON.parse(metadata) as Record<string, unknown>)
         : null;
-      // The Output field IS the expected outcome (edited or not); the recorded output
-      // is always stored separately. Unedited → expected == recorded output.
+      // The Output field IS the expected outcome (edited or not).
       const res = await save.mutateAsync({
-        datasetId: dsId,
+        datasetId,
         body: {
           input,
           expected: output.trim() || null,
-          recorded_output: recordedOutput || null,
           metadata: metadataObj,
-          review: "needs_review",
-          capture_reason: inferredReason,
-          source_trace_id: attachSource ? traceId : null,
-          source_span_id: attachSource ? span.span_id : null,
-          source_span_name: attachSource ? span.name : null,
-          source_span_kind: attachSource ? displayKind : null,
         },
       });
       if (res.duplicate) {
-        setDuplicate({ datasetId: dsId });
+        setDuplicate({ datasetId });
         return;
       }
       setFeedback({ tone: "success", text: "Saved — published as a new dataset version." });
@@ -345,247 +268,154 @@ export function SaveTestCaseDrawer({
   };
 
   return (
-    <div
-      ref={rootRef}
-      role="dialog"
-      aria-labelledby="save-test-case-title"
-      className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl"
-    >
-      <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
-        <h2
-          id="save-test-case-title"
-          ref={headingRef}
-          tabIndex={-1}
-          className="text-[13px] font-semibold focus:outline-none"
-        >
-          Save as test case
-        </h2>
-        <button
-          type="button"
-          onClick={() => onOpenChange(false)}
-          aria-label="Close"
-          className="rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
-        >
-          <X className="h-4 w-4" />
-        </button>
-      </div>
-
-      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-auto px-4 py-3">
-        <FormCard label="Dataset">
-          <Select
-            value={datasetId}
-            onValueChange={(value) => {
-              setDatasetId(value);
-              setDuplicate(null);
-            }}
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
+      {/* Dimmed backdrop; clicking it closes the modal. */}
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={() => onOpenChange(false)}
+        aria-hidden
+      />
+      {/* Centered modal panel: a wide sheet with Input/Output
+          side by side, rather than a narrow right-side drawer. */}
+      <div
+        ref={rootRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="save-test-case-title"
+        className="relative z-10 flex max-h-[90vh] w-[min(1080px,94vw)] flex-col rounded-lg border border-border bg-background shadow-xl"
+      >
+        <div className="flex shrink-0 items-center justify-between border-b border-border px-5 py-3">
+          <h2
+            id="save-test-case-title"
+            ref={headingRef}
+            tabIndex={-1}
+            className="text-[13px] font-semibold focus:outline-none"
           >
-            <SelectTrigger className="h-7 text-[13px]">
-              <SelectValue placeholder="Select dataset" />
-            </SelectTrigger>
-            <SelectContent>
-              {datasets.map((item) => (
-                <SelectItem key={item.id} value={item.id} className="text-[12px]">
-                  {item.name}
-                </SelectItem>
-              ))}
-              <SelectItem
-                value={NEW_DATASET}
-                icon={<Plus className="h-4 w-4" />}
-                className="mt-1 border-t border-border text-[12px]"
-              >
-                New dataset
-              </SelectItem>
-            </SelectContent>
-          </Select>
-          {creatingNew && (
-            <Input
-              value={newDatasetName}
-              onChange={(event) => setNewDatasetName(event.target.value)}
-              placeholder="New dataset name"
-              autoFocus
-              className="mt-2 h-7 text-[13px]"
-            />
-          )}
-          {duplicate && (
-            <p className="mt-1.5 text-[11px] text-muted-foreground">
-              This span is already a test case in this dataset. Open it instead of adding another
-              row.
-            </p>
-          )}
-        </FormCard>
+            Add to datasets
+          </h2>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            aria-label="Close"
+            className="rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
 
-        <FormCard label="Selected span">
-          <div className="flex items-center gap-2">
-            <SpanKindIcon kind={displayKind} inTree />
-            <span className="text-[13px] font-medium">{span?.name ?? "Loading trace…"}</span>
-            <span className="text-[11px] text-muted-foreground">
-              {SPAN_KIND_LABEL[displayKind as keyof typeof SPAN_KIND_LABEL] ?? displayKind}
-            </span>
-            <span className="ml-auto flex items-center gap-1">
-              <button
-                type="button"
-                onClick={() => navigate("up")}
-                disabled={!canNavigateUp}
-                aria-label="Previous span"
-                className="rounded border border-border p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
-              >
-                <ArrowUp className="h-3.5 w-3.5" />
-              </button>
-              <button
-                type="button"
-                onClick={() => navigate("down")}
-                disabled={!canNavigateDown}
-                aria-label="Next span"
-                className="rounded border border-border p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
-              >
-                <ArrowDown className="h-3.5 w-3.5" />
-              </button>
-            </span>
-          </div>
-          <p className="mt-2 flex items-start gap-1.5 text-[11px] text-muted-foreground">
-            <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
-            {boundaryHint(displayKind, span?.name ?? "")}
-          </p>
-          <p className="mt-1.5 text-[11px] text-muted-foreground">
-            Capture reason:{" "}
-            <span className="font-medium text-foreground">
-              {CAPTURE_REASON_LABEL[inferredReason]}
-            </span>
-          </p>
-        </FormCard>
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto px-5 py-4">
+          <FormCard label="Dataset">
+            <Select
+              value={datasetId}
+              onValueChange={(value) => {
+                setDatasetId(value);
+                setDuplicate(null);
+              }}
+            >
+              <SelectTrigger className="h-7 text-[13px]">
+                <SelectValue placeholder="Select dataset" />
+              </SelectTrigger>
+              <SelectContent>
+                {datasets.map((item) => (
+                  <SelectItem key={item.id} value={item.id} className="text-[12px]">
+                    {item.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {duplicate && (
+              <p className="mt-1.5 text-[11px] text-muted-foreground">
+                This span is already a test case in this dataset. Open it instead of adding another
+                row.
+              </p>
+            )}
+          </FormCard>
 
-        <EditableValueBlock
-          label="Input"
-          text={input}
-          onChange={setInput}
-          copyable
-          // Read + hand-edited most, and usually the most nested → expand it.
-          seedJson="expanded"
-          boxed
-          minRows={2}
-          collapsible
-          collapseResetKey={String(seedGeneration)}
-        />
+          {/* Stacked Dataset → Input → Output → Metadata (mirrors the trace detail
+              panel this modal is launched from); each field is only as tall as its
+              content, so a short input never leaves a tall empty box. */}
+          <EditableValueBlock
+            label="Input"
+            text={input}
+            onChange={setInput}
+            copyable
+            formatSwitcher={false}
+            // Read + hand-edited most, and usually the most nested → expand it.
+            seedJson="expanded"
+            boxed
+            minRows={3}
+            maxRows={16}
+            collapseResetKey={String(seedGeneration)}
+          />
 
-        <div>
           <EditableValueBlock
             label="Output"
             text={output}
             onChange={setOutput}
             copyable
+            formatSwitcher={false}
             // Read and possibly hand-corrected — expand it like Input.
             seedJson="expanded"
             boxed
-            minRows={2}
-            collapsible
+            minRows={3}
+            maxRows={16}
             collapseResetKey={String(seedGeneration)}
           />
-          <p className="mt-1 flex items-start gap-1.5 text-[11px] text-muted-foreground">
-            <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
-            {outputEdited ? (
-              <span>
-                Edited — your version becomes the{" "}
-                <span className="font-medium text-foreground">expected outcome</span>; the original
-                recorded output is still stored.
-              </span>
-            ) : (
-              <span>
-                The recorded production output. Leave it to grade against it, or edit to set a
-                corrected <span className="font-medium text-foreground">expected outcome</span> —
-                the recorded output is kept either way.
-              </span>
-            )}
-          </p>
-        </div>
 
-        <div>
-          <EditableValueBlock
-            label="Metadata"
-            text={metadata}
-            onChange={setMetadata}
-            copyable
-            // Incidental context, usually one or two short keys → keep it inline
-            // (seedFormat expands it anyway once it stops fitting on one line).
-            seedJson="compact"
-            boxed
-            minRows={2}
-            collapsible
-            collapseResetKey={String(seedGeneration)}
-          />
-          {metadataError && <p className="mt-1 text-[11px] text-destructive">{metadataError}</p>}
-        </div>
-
-        <div className="border border-border">
-          <div className="flex items-center justify-between border-b border-border bg-muted/50 px-3 py-1.5">
-            <span className="text-[12px] font-medium text-muted-foreground">Source</span>
-            <Switch checked={attachSource} onCheckedChange={setAttachSource} />
+          <div>
+            <EditableValueBlock
+              label="Metadata"
+              text={metadata}
+              onChange={setMetadata}
+              copyable
+              formatSwitcher={false}
+              // Incidental context, usually one or two short keys → keep it inline
+              // (seedFormat expands it anyway once it stops fitting on one line).
+              seedJson="compact"
+              boxed
+              minRows={3}
+              maxRows={12}
+              collapseResetKey={String(seedGeneration)}
+            />
+            {metadataError && <p className="mt-1 text-[11px] text-destructive">{metadataError}</p>}
           </div>
-          {attachSource ? (
-            <div className="p-3">
-              <dl className="flex flex-col gap-1 text-[11px]">
-                <div className="flex justify-between gap-3">
-                  <dt className="text-muted-foreground">Source trace</dt>
-                  <dd className="font-mono text-muted-foreground">{traceId}</dd>
-                </div>
-                <div className="flex justify-between gap-3">
-                  <dt className="text-muted-foreground">Source span</dt>
-                  <dd className="font-mono text-muted-foreground">{span?.span_id ?? "—"}</dd>
-                </div>
-              </dl>
-            </div>
+        </div>
+
+        <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border px-5 py-3">
+          {feedback && (
+            <span
+              className={cn(
+                "mr-auto text-[11px]",
+                feedback.tone === "error"
+                  ? "text-destructive"
+                  : "text-emerald-600 dark:text-emerald-400",
+              )}
+            >
+              {feedback.text}
+            </span>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-[12px]"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          {duplicate ? (
+            <Link
+              href={`/projects/${projectId}/datasets/${duplicate.datasetId}`}
+              className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
+              Open existing test case
+            </Link>
           ) : (
-            <div className="p-3">
-              <p className="text-[11px] text-muted-foreground">
-                Added as a manual case — no source trace or span is linked.
-              </p>
-            </div>
+            <Button size="sm" className="h-7 text-[12px]" onClick={handleSave} disabled={!canSave}>
+              Save
+            </Button>
           )}
         </div>
-
-        <p className="text-[11px] text-muted-foreground">
-          This case will start as <span className="font-medium text-foreground">Needs review</span>.
-          Review it from the dataset row.
-        </p>
-      </div>
-
-      <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border px-4 py-3">
-        {feedback && (
-          <span
-            className={cn(
-              "mr-auto text-[11px]",
-              feedback.tone === "error"
-                ? "text-destructive"
-                : "text-emerald-600 dark:text-emerald-400",
-            )}
-          >
-            {feedback.text}
-          </span>
-        )}
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 text-[12px]"
-          onClick={() => onOpenChange(false)}
-        >
-          Cancel
-        </Button>
-        {duplicate ? (
-          <Link
-            href={`/projects/${projectId}/datasets/${duplicate.datasetId}`}
-            className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-          >
-            <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
-            Open existing test case
-          </Link>
-        ) : (
-          <Button size="sm" className="h-7 text-[12px]" onClick={handleSave} disabled={!canSave}>
-            {creatingNew
-              ? "Create dataset & save"
-              : datasetId
-                ? `Save to ${dataset?.name ?? "dataset"}`
-                : "Save"}
-          </Button>
-        )}
       </div>
     </div>
   );

--- a/frontend/ui/src/features/evaluations/dataset-panels.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/dataset-panels.smoke.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 /**
- * View-mount smoke for the New-dataset and Edit-dataset slide-in panels, driven
- * from the real Datasets list (the only place they open from) against a stubbed
- * fetch. Covers the shared DatasetFormFields — including the schema toggles that
- * only appear once switched on — and the create/update round trips.
+ * View-mount smoke for the New-dataset (centered modal) and Edit-dataset panels,
+ * driven from the real Datasets list (the only place they open from) against a
+ * stubbed fetch. Covers the shared DatasetFormFields (Name + Description) and the
+ * create/update round trips.
  */
 import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
 import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
@@ -38,11 +38,14 @@ let requests: Array<{ url: string; method: string; body: unknown }> = [];
 /** Flipped by a test to make every write fail, exercising the error toasts. */
 let writesFail = false;
 
-function payloadFor(url: string): unknown {
+function payloadFor(url: string, method: string): unknown {
   if (url.includes("/evaluations")) {
     return { data: [{ id: "eval1", name: "Billing routing", datasetId: "ds1" }] };
   }
   if (url.includes("/datasets")) {
+    // Creating a dataset returns the created row (the panel navigates into it);
+    // the list GET returns the paged collection.
+    if (method === "POST") return { dataset: DATASET };
     return { data: [DATASET], meta: { page: 0, limit: 50, total: 1 } };
   }
   return {};
@@ -69,7 +72,7 @@ beforeEach(() => {
     if (writesFail && method !== "GET") {
       return { ok: false, status: 500, json: async () => ({ error: "server exploded" }) };
     }
-    return { ok: true, status: 200, json: async () => payloadFor(String(url)) };
+    return { ok: true, status: 200, json: async () => payloadFor(String(url), method) };
   }) as unknown as typeof fetch;
 });
 afterEach(() => cleanup());
@@ -96,17 +99,17 @@ describe("New dataset panel", () => {
     mount();
     fireEvent.click(await screen.findByRole("button", { name: "New Dataset" }));
 
-    const create = screen.getByRole("button", { name: "Create dataset" });
+    const create = screen.getByRole("button", { name: "Create" });
     expect(create.hasAttribute("disabled")).toBe(true);
 
-    fireEvent.change(screen.getByPlaceholderText("e.g. Billing routing"), {
+    fireEvent.change(screen.getByLabelText("Name"), {
       target: { value: "  Refund routing  " },
     });
-    fireEvent.change(screen.getByPlaceholderText("What this collection of test cases is for"), {
+    fireEvent.change(screen.getByLabelText("Description"), {
       target: { value: "Refund tickets" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Create dataset" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
     expect(await screen.findByText("Dataset created")).toBeDefined();
 
     const post = requests.find((r) => r.method === "POST");
@@ -119,48 +122,15 @@ describe("New dataset panel", () => {
   it("an empty description persists as null, never as an empty string", async () => {
     mount();
     fireEvent.click(await screen.findByRole("button", { name: "New Dataset" }));
-    fireEvent.change(screen.getByPlaceholderText("e.g. Billing routing"), {
+    fireEvent.change(screen.getByLabelText("Name"), {
       target: { value: "Refund routing" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Create dataset" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
     await waitFor(() => expect(requests.some((r) => r.method === "POST")).toBe(true));
     expect(requests.find((r) => r.method === "POST")?.body).toEqual({
       name: "Refund routing",
       description: null,
     });
-  });
-
-  it("the schema cards reveal an editable JSON block only once switched on", async () => {
-    mount();
-    fireEvent.click(await screen.findByRole("button", { name: "New Dataset" }));
-
-    expect(screen.queryByLabelText("Input schema JSON")).toBeNull();
-    const [inputSwitch, expectedSwitch] = screen.getAllByRole("switch");
-
-    fireEvent.click(inputSwitch);
-    const inputSchema = (await screen.findByLabelText("Input schema JSON")) as HTMLTextAreaElement;
-    expect(inputSchema.value).toContain('"required": ["input"]');
-    fireEvent.change(inputSchema, { target: { value: '{"type":"string"}' } });
-    expect((screen.getByLabelText("Input schema JSON") as HTMLTextAreaElement).value).toContain(
-      '{"type":"string"}',
-    );
-
-    fireEvent.click(expectedSwitch);
-    expect(
-      ((await screen.findByLabelText("Expected output schema JSON")) as HTMLTextAreaElement).value,
-    ).toContain('"required": ["expected"]');
-
-    // Toggling back off hides the block again.
-    fireEvent.click(inputSwitch);
-    await waitFor(() => expect(screen.queryByLabelText("Input schema JSON")).toBeNull());
-  });
-
-  it("accepts free-form metadata", async () => {
-    mount();
-    fireEvent.click(await screen.findByRole("button", { name: "New Dataset" }));
-    const metadata = screen.getByLabelText("Metadata") as HTMLTextAreaElement;
-    fireEvent.change(metadata, { target: { value: '{"team":"support"}' } });
-    expect((screen.getByLabelText("Metadata") as HTMLTextAreaElement).value).toContain("support");
   });
 
   it("closes on Cancel, on the X, and on Escape", async () => {
@@ -177,8 +147,8 @@ describe("New dataset panel", () => {
 
     fireEvent.click(open);
     await screen.findByText("New dataset");
-    // The panel is a Radix drawer, which listens for Escape on the document via its
-    // dismissable layer — an event dispatched straight at `window` never reaches it.
+    // The modal listens for Escape via a window capture-phase keydown listener; a
+    // keydown dispatched at `document` reaches it during the capture phase.
     fireEvent.keyDown(document, { key: "Escape" });
     await waitFor(() => expect(screen.queryByText("New dataset")).toBeNull());
   });
@@ -187,10 +157,10 @@ describe("New dataset panel", () => {
     writesFail = true;
     mount();
     fireEvent.click(await screen.findByRole("button", { name: "New Dataset" }));
-    fireEvent.change(screen.getByPlaceholderText("e.g. Billing routing"), {
+    fireEvent.change(screen.getByLabelText("Name"), {
       target: { value: "Refund routing" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Create dataset" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
     expect(await screen.findByText("Could not create dataset")).toBeDefined();
     expect(screen.getByText("New dataset")).toBeDefined();
   });
@@ -202,10 +172,10 @@ describe("Edit dataset panel", () => {
     await rowAction("Edit");
 
     // Seeded from the dataset row.
-    const name = (await screen.findByPlaceholderText("e.g. Billing routing")) as HTMLInputElement;
+    const name = (await screen.findByLabelText("Name")) as HTMLInputElement;
     expect(name.value).toBe("Billing routing");
     expect(
-      (screen.getByPlaceholderText("What this collection of test cases is for") as HTMLInputElement)
+      (screen.getByLabelText("Description") as HTMLInputElement)
         .value,
     ).toBe("Routing tickets");
 

--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -10,10 +10,12 @@
  * slide-in case panel (details / runs / edit + save), the review drawer, the
  * pull-code drawer, and the Evaluation history tab.
  */
+import type { ReactNode } from "react";
 import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
 import { render, cleanup, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastProvider } from "@/components/ui/toast";
+import { versionSnowflake } from "@/lib/eval/snowflake";
 
 /** Mutable so a test can exercise the ?case=<id> deep link. */
 let searchParams = new URLSearchParams();
@@ -27,6 +29,16 @@ vi.mock("next/navigation", () => ({
 }));
 // ProjectBreadcrumb pulls layout/workspace context we don't mount here.
 vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+// react-resizable-panels needs a real ResizeObserver (absent in jsdom); the panel
+// split is pure layout, so stub it to plain divs like the trace-viewer tests do.
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => null,
+}));
+vi.mock("@/features/ai-assistant/components/ai-assistant-panel", () => ({
+  AiAssistantPanel: () => <div data-testid="ai-assistant" />,
+}));
 
 import { DatasetDetailView } from "./views/dataset-detail-view";
 import { caseDisplayId } from "@/features/offline-eval/utils";
@@ -68,7 +80,6 @@ function testCase(over: Partial<Record<string, unknown>> = {}) {
     projectId: "p1",
     input: "I was charged twice for my July invoice",
     expected: "billing",
-    recordedOutput: null,
     metadata: null,
     review: "needs_review",
     captureReason: "manual",
@@ -89,9 +100,8 @@ const CASES = [
     testCaseId: "tc_2",
     input: "Reset my password please",
     expected: "account-management",
-    // Exercises the metadata preview + the recorded-output block + a real source span.
+    // Exercises the metadata preview + a real source span.
     metadata: { channel: "email", priority: "high" },
-    recordedOutput: "escalation",
     review: "ready",
     captureReason: "detector",
     sourceTraceId: "tr_9",
@@ -151,10 +161,14 @@ const CASE_RUNS = [
     runNumber: 27,
     candidateVersion: "git:4a91c02",
     evaluationName: "Billing routing nightly",
+    datasetVersionId: "dv2",
     ranAt: "2026-07-17T10:24:00Z",
     score: 1,
     status: "passed",
     change: "improved",
+    caseCount: 3,
+    cost: 0.42,
+    elapsedMs: 360000,
   },
 ];
 
@@ -242,16 +256,14 @@ async function openCase(text: string | RegExp) {
 }
 
 describe("Dataset detail view renders server data", () => {
-  it("shows the dataset name, its id, and every test case of the current version", async () => {
+  it("shows every test case of the current version", async () => {
+    // The dataset name + id live in the top breadcrumb bar (ProjectBreadcrumb),
+    // which this harness mocks out; here we assert the rows themselves.
     mountDetail();
-    expect(await screen.findByText("Billing routing")).toBeDefined();
-    expect(screen.getAllByText("ds1").length).toBeGreaterThan(0);
-    expect(screen.getByText(/charged twice/)).toBeDefined();
+    expect(await screen.findByText(/charged twice/)).toBeDefined();
     expect(screen.getByText("Reset my password please")).toBeDefined();
     // The metadata preview renders the flat key: value join.
     expect(screen.getByText(/channel: email/)).toBeDefined();
-    // Tab counts come from the loaded data.
-    expect(screen.getByRole("tab", { name: /Test cases/ }).textContent).toContain("3");
   });
 
   it("renders a loading state before the dataset resolves", () => {
@@ -276,34 +288,26 @@ describe("Dataset detail — versions", () => {
   it("switching to an older version loads its snapshot read-only", async () => {
     mountDetail();
     await screen.findByText(/charged twice/);
-    // The current version is preselected and its immutable id is shown.
-    expect(screen.getAllByText("dv2").length).toBeGreaterThan(0);
-    expect(screen.queryByText(/— read only/)).toBeNull();
 
     fireEvent.click(screen.getByRole("combobox"));
-    fireEvent.click(await screen.findByRole("option", { name: /v1/ }));
+    // Options now read "<number> <snowflake>" (no "v" prefix); pick v1 by its
+    // derived snowflake, which also asserts the snowflake id is rendered.
+    const v1Snow = versionSnowflake(V1.createTime, V1.versionNumber);
+    fireEvent.click(await screen.findByRole("option", { name: new RegExp(v1Snow) }));
 
-    // The banner names the version being viewed, not just "an older version".
-    expect(await screen.findByText(/Viewing v1.*— read only/)).toBeDefined();
+    // The older snapshot's content loads (no read-only banner — that was removed).
     expect(await screen.findByText("seeded ticket")).toBeDefined();
     // Editing branches from the current version, so adding a row is disabled here.
     expect(screen.getByRole("button", { name: /Row/ }).hasAttribute("disabled")).toBe(true);
     // The request carried the requested snapshot.
     expect(requests.some((r) => r.url.includes("version_id=dv1"))).toBe(true);
   });
-
-  it("copies the selected version id", async () => {
-    mountDetail();
-    await screen.findByText(/charged twice/);
-    fireEvent.click(screen.getByTitle("Copy version ID"));
-    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith("dv2"));
-  });
 });
 
 describe("Dataset detail — filtering and adding rows", () => {
   it("the keyword filter matches input and expected, and shows a no-match empty state", async () => {
     mountDetail();
-    const search = await screen.findByPlaceholderText("Search cases...");
+    const search = await screen.findByPlaceholderText("Search...");
 
     fireEvent.change(search, { target: { value: "password" } });
     expect(screen.queryByText(/charged twice/)).toBeNull();
@@ -330,44 +334,71 @@ describe("Dataset detail — filtering and adding rows", () => {
       },
     })) as unknown as typeof fetch;
     mountDetail();
-    expect(await screen.findByText(/No test cases yet/)).toBeDefined();
+    expect(await screen.findByText(/To populate this dataset/)).toBeDefined();
   });
 
-  it("Row posts an empty, needs-review test case and toasts", async () => {
+  it("Row opens the editor and POSTs the authored row", async () => {
     mountDetail();
     await screen.findByText(/charged twice/);
-    fireEvent.click(screen.getByRole("button", { name: /Row/ }));
-    expect(await screen.findByText("Empty row added")).toBeDefined();
-    const post = requests.find((r) => r.method === "POST");
-    expect(post?.body).toEqual({ input: "", review: "needs_review", capture_reason: "manual" });
+    fireEvent.click(screen.getByRole("button", { name: "Row" }));
+    // Opens the editor rather than inserting a blank row.
+    expect(await screen.findByText("New Row")).toBeDefined();
+    fireEvent.change(screen.getByLabelText("Input"), { target: { value: "a new question" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(await screen.findByText("Row added")).toBeDefined();
+    const post = requests.find((r) => r.method === "POST" && r.url.includes("/test-cases"));
+    expect(post?.body).toMatchObject({ input: "a new question", expected: null, metadata: null });
+  });
+
+  it("the row action menu edits a row (PATCH)", async () => {
+    mountDetail();
+    await screen.findByText(/charged twice/);
+    fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
+    fireEvent.click(await screen.findByText("Edit"));
+    // Seeded from the row.
+    expect(await screen.findByText("Edit Row")).toBeDefined();
+    const input = screen.getByLabelText("Input") as HTMLTextAreaElement;
+    expect(input.value).toContain("charged twice");
+    fireEvent.change(input, { target: { value: "edited question" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(await screen.findByText(/Row saved/)).toBeDefined();
+    const patch = requests.find((r) => r.method === "PATCH");
+    expect(patch?.url).toContain("/datasets/ds1/test-cases/tc_1");
+    expect(patch?.body).toMatchObject({ input: "edited question" });
+  });
+
+  it("the row action menu deletes a row (DELETE) after confirming", async () => {
+    mountDetail();
+    await screen.findByText(/charged twice/);
+    fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
+    fireEvent.click(await screen.findByText("Delete"));
+    // Confirmation first — nothing is deleted until the dialog's Delete is clicked.
+    await screen.findByText("Delete row");
+    expect(requests.some((r) => r.method === "DELETE")).toBe(false);
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete" }).at(-1)!);
+    expect(await screen.findByText("Row deleted")).toBeDefined();
+    expect(
+      requests.some((r) => r.method === "DELETE" && r.url.includes("/test-cases/tc_1")),
+    ).toBe(true);
   });
 });
 
 describe("Dataset detail — the slide-in case panel", () => {
-  it("opens a case, shows its identity, source, and capture reason", async () => {
+  it("opens a case read-only, rendering its content like the trace-detail panel", async () => {
     mountDetail();
     await openCase("Reset my password please");
-    // The opened row carries a real source span and a detector capture reason.
-    expect(screen.getByText("handle_ticket")).toBeDefined();
-    expect(screen.getByText("Captured:")).toBeDefined();
-    // Editable value blocks are seeded from the case, each addressed by its label.
-    expect((screen.getByLabelText("Input") as HTMLTextAreaElement).value).toContain(
-      "Reset my password please",
-    );
-    expect((screen.getByLabelText("Expected") as HTMLTextAreaElement).value).toContain(
-      "account-management",
-    );
-    // The recorded production output is a separate, read-only block.
-    const recorded = screen.getByLabelText("What happened in production") as HTMLTextAreaElement;
-    expect(recorded.value).toContain("escalation");
-    expect(recorded.readOnly).toBe(true);
-    expect((screen.getByLabelText("Metadata") as HTMLTextAreaElement).value).toContain("channel");
-  });
-
-  it("a manually added case shows the manual source chip", async () => {
-    mountDetail();
-    await openCase(/charged twice/);
-    expect(screen.getByText("Added manually")).toBeDefined();
+    const dialog = screen.getByRole("dialog");
+    // Read-only view (in-panel editing is deferred): no editable textareas, and
+    // the Input/Expected/Metadata sections render the case's content directly.
+    expect(screen.queryByLabelText("Input")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
+    expect(within(dialog).getAllByText(/Reset my password please/).length).toBeGreaterThan(0);
+    expect(within(dialog).getAllByText(/account-management/).length).toBeGreaterThan(0);
+    // The Metadata section shows the case's metadata.
+    expect(within(dialog).getAllByText(/channel/).length).toBeGreaterThan(0);
+    // No separate "what happened in production" block — the source span link
+    // preserves the actual output (the dataset-item model).
+    expect(screen.queryByLabelText("What happened in production")).toBeNull();
   });
 
   it("navigates between cases with the up/down controls", async () => {
@@ -390,21 +421,25 @@ describe("Dataset detail — the slide-in case panel", () => {
     expect(window.open).toHaveBeenCalledWith("/projects/p1/datasets/ds1", "_blank");
   });
 
-  it("the Runs view lists every evaluation run that measured the case", async () => {
+  it("the Experiments view lists every evaluation run that measured the case", async () => {
     mountDetail();
     await openCase(/charged twice/);
-    fireEvent.click(screen.getByRole("button", { name: /Runs/ }));
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: /Experiments/ }));
     expect(await screen.findByText("Billing routing nightly")).toBeDefined();
-    expect(screen.getByText(/Run #27 ·/)).toBeDefined();
+    // Run Name column: candidate version + run number.
+    expect(screen.getByText("git:4a91c02")).toBeDefined();
+    expect(screen.getByText("#27")).toBeDefined();
     // Clicking a run navigates to its detail.
     fireEvent.click(screen.getByText("Billing routing nightly"));
     expect(mockPush).toHaveBeenCalledWith("/projects/p1/evaluations/run1");
-    // Back to Details.
-    fireEvent.click(screen.getByRole("button", { name: /Details/ }));
-    expect(await screen.findByLabelText("Input")).toBeDefined();
+    // Back to the Row tab — the read-only view shows the Input section. Scoped to
+    // the dialog since "Row" also names the toolbar's "+ Row" button.
+    fireEvent.click(within(dialog).getByRole("button", { name: "Row" }));
+    expect(await within(dialog).findByText("Input")).toBeDefined();
   });
 
-  it("shows an empty Runs state when nothing has measured the case", async () => {
+  it("shows an empty Experiments state when nothing has measured the case", async () => {
     global.fetch = vi.fn(async (url: RequestInfo | URL) => ({
       ok: true,
       status: 200,
@@ -419,166 +454,20 @@ describe("Dataset detail — the slide-in case panel", () => {
     })) as unknown as typeof fetch;
     mountDetail();
     await openCase(/charged twice/);
-    fireEvent.click(screen.getByRole("button", { name: /Runs/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Experiments/ }));
     expect(
-      await screen.findByText(/No evaluation run has measured this test case yet/),
+      await screen.findByText(/No run has measured this row on the dataset version/),
     ).toBeDefined();
   });
 
-  it("editing a field reveals Save, which PATCHes and publishes a new version", async () => {
-    mountDetail();
-    await openCase(/charged twice/);
-    // Nothing is dirty yet.
-    expect(screen.queryByRole("button", { name: "Save changes" })).toBeNull();
-
-    fireEvent.change(screen.getByLabelText("Input"), { target: { value: "edited input" } });
-    fireEvent.change(screen.getByLabelText("Expected"), { target: { value: "" } });
-
-    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
-    expect(await screen.findByText(/Saved — new dataset version published/)).toBeDefined();
-
-    const patch = requests.find((r) => r.method === "PATCH");
-    expect(patch?.url).toContain("/datasets/ds1/test-cases/tc_1");
-    // A cleared Expected persists as null, never as "".
-    expect(patch?.body).toEqual({ input: "edited input", expected: null });
-  });
-
-  it("only persists metadata once it parses back to an object", async () => {
-    mountDetail();
-    await openCase("Reset my password please");
-    const metadataBox = screen.getByLabelText("Metadata");
-
-    // Half-typed JSON leaves the stored metadata untouched — the patch is empty,
-    // so nothing is sent at all rather than blowing the value away.
-    fireEvent.change(metadataBox, { target: { value: "{ not json" } });
-    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
-    expect(requests.some((r) => r.method === "PATCH")).toBe(false);
-
-    // ...and valid JSON is sent through.
-    fireEvent.change(metadataBox, { target: { value: '{"channel":"chat"}' } });
-    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
-    await waitFor(() =>
-      expect(
-        requests
-          .filter((r) => r.method === "PATCH")
-          .some((r) => {
-            const body = r.body as { metadata?: Record<string, unknown> };
-            return body.metadata?.channel === "chat";
-          }),
-      ).toBe(true),
-    );
-  });
+  // In-panel editing (Edit → line-numbered fields → Save/PATCH) is deferred;
+  // its tests will return with the feature.
 
   it("closes the panel", async () => {
     mountDetail();
     await openCase(/charged twice/);
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
     await waitFor(() => expect(screen.queryByTitle("Copy ID")).toBeNull());
-  });
-});
-
-describe("Dataset detail — review drawer", () => {
-  it("Mark ready PATCHes the review and toasts", async () => {
-    mountDetail();
-    await openCase(/charged twice/);
-    fireEvent.click(screen.getByRole("button", { name: "Review" }));
-
-    const drawer = await screen.findByText("Review test case");
-    expect(drawer).toBeDefined();
-    // The drawer names the case it is reviewing.
-    expect(screen.getByText(`${caseDisplayId("tc_1")} · Billing routing`)).toBeDefined();
-
-    // "Mark ready" is gated on every verification check.
-    screen.getAllByRole("checkbox").forEach((b) => fireEvent.click(b));
-
-    fireEvent.click(screen.getByRole("button", { name: "Mark ready" }));
-    await waitFor(() => expect(requests.some((r) => r.method === "PATCH")).toBe(true));
-    expect(requests.find((r) => r.method === "PATCH")?.body).toEqual({ review: "ready" });
-    expect(await screen.findByText(/Review saved — new dataset version published/)).toBeDefined();
-  });
-
-  it("a corrected expected outcome is sent alongside the review", async () => {
-    mountDetail();
-    await openCase(/charged twice/);
-    fireEvent.click(screen.getByRole("button", { name: "Review" }));
-    fireEvent.change(await screen.findByLabelText(/Correct the expected outcome/), {
-      target: { value: "  refunds  " },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Needs work" }));
-    await waitFor(() => expect(requests.some((r) => r.method === "PATCH")).toBe(true));
-    expect(requests.find((r) => r.method === "PATCH")?.body).toEqual({
-      review: "needs_review",
-      expected: "refunds",
-    });
-  });
-
-  it("a case with no expected outcome says a scorer judges the output", async () => {
-    mountDetail();
-    // Row 3 has a null expected; its Input cell renders as "-", so open by created time.
-    await openCase(/charged twice/);
-    fireEvent.click(screen.getByTitle("Next row"));
-    fireEvent.click(screen.getByTitle("Next row"));
-    fireEvent.click(await screen.findByRole("button", { name: "Review" }));
-    expect(
-      await screen.findByText(/Not required — a scorer judges the output directly/),
-    ).toBeDefined();
-  });
-});
-
-describe("Dataset detail — pull code", () => {
-  it("opens the drawer with the dataset's real id in both languages", async () => {
-    mountDetail();
-    await screen.findByText(/charged twice/);
-    fireEvent.click(screen.getByRole("button", { name: /Pull code/ }));
-
-    const drawer = await screen.findByText("Pull this dataset in code");
-    const panel = drawer.closest("div.fixed") as HTMLElement;
-    // The Python snippet pulls this dataset by its real id.
-    expect(panel.textContent).toContain('pull_dataset("ds1")');
-
-    fireEvent.click(screen.getByRole("button", { name: "TypeScript" }));
-    await waitFor(() => expect(panel.textContent).toContain('await pullDataset("ds1")'));
-    expect(panel.textContent).not.toContain("pull_dataset");
-  });
-});
-
-describe("Dataset detail — evaluation history tab", () => {
-  it("lists the runs against this dataset and opens one", async () => {
-    mountDetail();
-    fireEvent.click(await screen.findByRole("tab", { name: /Evaluation history/ }));
-    expect(await screen.findByText("Billing routing nightly")).toBeDefined();
-    expect(screen.getByText(/Run #27 ·/)).toBeDefined();
-    fireEvent.click(screen.getByText("Billing routing nightly"));
-    expect(mockPush).toHaveBeenCalledWith("/projects/p1/evaluations/run1");
-  });
-
-  it("filters the history and falls back to a search-specific empty state", async () => {
-    mountDetail();
-    fireEvent.click(await screen.findByRole("tab", { name: /Evaluation history/ }));
-    const search = await screen.findByPlaceholderText("Search evaluations...");
-    fireEvent.change(search, { target: { value: "nightly" } });
-    expect(screen.getByText("Billing routing nightly")).toBeDefined();
-    fireEvent.change(search, { target: { value: "zzz" } });
-    expect(await screen.findByText("No evaluations match your search.")).toBeDefined();
-  });
-
-  it("names the dataset when nothing has been run against it", async () => {
-    global.fetch = vi.fn(async (url: RequestInfo | URL) => ({
-      ok: true,
-      status: 200,
-      json: async () => {
-        const s = String(url);
-        if (s.includes("/evaluations/runs")) {
-          return { data: [], meta: { page: 0, limit: 50, total: 0 } };
-        }
-        return detail(null);
-      },
-    })) as unknown as typeof fetch;
-    mountDetail();
-    fireEvent.click(await screen.findByRole("tab", { name: /Evaluation history/ }));
-    expect(
-      await screen.findByText(/Nothing has been run against Billing routing yet/),
-    ).toBeDefined();
   });
 });
 
@@ -589,7 +478,6 @@ describe("Dataset detail — deep link", () => {
     // The panel opens on the matching stable testCaseId, not the per-version row id.
     expect(await screen.findByTitle("Copy ID")).toBeDefined();
     expect(await screen.findByText(caseDisplayId("tc_2"))).toBeDefined();
-    expect(screen.getByText("handle_ticket")).toBeDefined();
   });
 
   it("ignores a ?case that no row matches", async () => {
@@ -600,23 +488,3 @@ describe("Dataset detail — deep link", () => {
   });
 });
 
-describe("Dataset detail — tabs behave as an ARIA tablist", () => {
-  it("arrow keys move between the two tabs", async () => {
-    mountDetail();
-    const cases = await screen.findByRole("tab", { name: /Test cases/ });
-    const list = screen.getByRole("tablist");
-    cases.focus();
-    fireEvent.keyDown(list, { key: "ArrowRight" });
-    expect(
-      screen.getByRole("tab", { name: /Evaluation history/ }).getAttribute("aria-selected"),
-    ).toBe("true");
-    fireEvent.keyDown(list, { key: "End" });
-    fireEvent.keyDown(list, { key: "Home" });
-    expect(screen.getByRole("tab", { name: /Test cases/ }).getAttribute("aria-selected")).toBe(
-      "true",
-    );
-    // A key the tablist doesn't own is ignored.
-    fireEvent.keyDown(list, { key: "a" });
-    expect(within(list).getAllByRole("tab").length).toBe(2);
-  });
-});

--- a/frontend/ui/src/features/evaluations/save-test-case-drawer.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-test-case-drawer.smoke.test.tsx
@@ -1,10 +1,9 @@
 // @vitest-environment jsdom
 /**
- * The real Save-as-test-case drawer exposes the full capture flow:
- * dataset picker (with a "New dataset" option), selected span + capture reason,
- * read-only Recorded output, the three-way Expected outcome, Metadata, and the
- * Source toggle. This mounts it against a stubbed trace + datasets and asserts
- * those details are present (the earlier version was missing most of them).
+ * The "Add to datasets" modal is intentionally minimal: pick an existing dataset,
+ * then Input / Output / Metadata. This mounts it against a stubbed trace + datasets
+ * and asserts those four sections render and that an edited Output saves as
+ * `expected` while the recorded output is retained.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
@@ -28,10 +27,10 @@ vi.mock("@/lib/api/traces", () => ({
   })),
 }));
 
-// The recorded output the drawer seeds Output from and, unedited, would send
-// back as both `expected` and `recorded_output`. Stable identity (vi.hoisted)
-// so the drawer's re-seed effect (keyed on this object) doesn't refire and
-// clobber an in-progress edit — see save-test-case-format.smoke.test.tsx.
+// The span's production output the drawer seeds Output from and, unedited, sends
+// back as `expected`. Stable identity (vi.hoisted) so the drawer's re-seed effect
+// (keyed on this object) doesn't refire and clobber an in-progress edit — see
+// save-test-case-format.smoke.test.tsx.
 const spanIO = vi.hoisted(() => ({
   data: {
     // `span_id` must match the selected span: the drawer only seeds from I/O it can
@@ -108,54 +107,41 @@ function mount(node: React.ReactNode) {
   return render(<QueryClientProvider client={qc}>{node}</QueryClientProvider>);
 }
 
-describe("Save as test case drawer", () => {
-  it("renders every drawer detail", async () => {
+describe("Add to datasets drawer", () => {
+  it("renders the four capture sections", async () => {
     mount(<SaveTestCaseDrawer projectId="p1" traceId="t1" open onOpenChange={() => {}} />);
-    // Header + the selected span derived from the fetched trace.
-    expect(screen.getByText("Save as test case")).toBeDefined();
-    expect(await screen.findByText("support-ticket-triage")).toBeDefined();
-    // The details the earlier stripped version was missing. The single editable Output
-    // field replaced the read-only Recorded output + three-way Expected outcome.
+    // Header + the four fields (no Selected-span / Source / Capture-reason clutter).
+    expect(screen.getByText("Add to datasets")).toBeDefined();
+    await screen.findByDisplayValue("I was charged twice");
+    expect(screen.getByText("Dataset")).toBeDefined();
+    expect(screen.getByText("Input")).toBeDefined();
     expect(screen.getByText("Output")).toBeDefined();
-    expect(
-      screen.getByText(/becomes the outcome future runs are evaluated against|expected outcome/i),
-    ).toBeDefined();
-    expect(screen.getByText("Source")).toBeDefined();
-    expect(screen.getByText(/Capture reason/)).toBeDefined();
+    expect(screen.getByText("Metadata")).toBeDefined();
   });
 });
 
 // ---------------------------------------------------------------------------
-// The headline behaviour ("Save as test case retains the recorded output
-// while an edit becomes the expected output") was previously unasserted: no
-// test in this file fired a change event on Output or submitted, and the
-// stubbed fetch's call arguments were never read. Per trace-integration.tsx:
-// the Output field IS the expected outcome (edited or not); the recorded
-// output — a separate source (`spanIO?.output`) — is always stored alongside
-// it, gated by the `outputEdited` flag that stops a re-seed from clobbering
-// an in-progress edit.
+// The headline behaviour: the Output field IS the expected outcome (edited or
+// not). Following the dataset-item model, the raw production output is
+// NOT copied onto the case — to see what actually happened, follow the source
+// trace/span link. So the payload carries `expected` (+ input/metadata) and
+// never a separate `recorded_output`.
 //
-// Mutation check: any of the following pass every existing test in this
-// suite, but are caught below —
-//   1. sending `recorded_output: output` (collapsing the two fields and
-//      destroying the provenance the drawer's own copy promises), or
-//   2. dropping `recorded_output` from the payload entirely, or
-//   3. deleting the `outputEdited` flag (trace-integration.tsx:116, read at
-//      :396) so an edit is indistinguishable from the untouched seed.
+// Mutation check: sending `recorded_output` in the payload (reviving the
+// dropped column) is caught below.
 // ---------------------------------------------------------------------------
 describe("Save as test case drawer — submit", () => {
-  it("submits an edited Output as `expected`, keeping the original recorded output separate", async () => {
+  it("submits an edited Output as `expected`, with no separate recorded output", async () => {
     const fetchMock = stubFetch();
     mount(<SaveTestCaseDrawer projectId="p1" traceId="t1" open onOpenChange={() => {}} />);
-    await screen.findByText("support-ticket-triage");
+    await screen.findByDisplayValue("I was charged twice");
 
     fireEvent.change(screen.getByLabelText("Dataset"), { target: { value: "ds1" } });
-    // The recorded output seeds Output at "billing"; correct it, which is what
-    // marks it edited (trace-integration.tsx `onChange` sets `outputEdited`).
+    // The span's production output seeds Output at "billing"; correct it.
     fireEvent.change(screen.getByLabelText("Output"), {
       target: { value: "billing (corrected: two charges refunded)" },
     });
-    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(fetchMock.mock.calls.some(([, init]) => init?.method === "POST")).toBe(true);
@@ -163,20 +149,18 @@ describe("Save as test case drawer — submit", () => {
     const [url, init] = fetchMock.mock.calls.find(([, i]) => i?.method === "POST")!;
     expect(url).toBe("/api/projects/p1/datasets/ds1/test-cases");
     const body = JSON.parse(init!.body as string);
-    // The edit becomes the expected outcome...
+    // The edit becomes the expected outcome; nothing is stored as recorded output.
     expect(body.expected).toBe("billing (corrected: two charges refunded)");
-    // ...while the ORIGINAL recorded output (the mocked span's real output) is
-    // still persisted, untouched, alongside it.
-    expect(body.recorded_output).toBe("billing");
+    expect(body.recorded_output).toBeUndefined();
   });
 
-  it("submits an unedited Output as both `expected` and `recorded_output`", async () => {
+  it("submits an unedited Output as `expected`", async () => {
     const fetchMock = stubFetch();
     mount(<SaveTestCaseDrawer projectId="p1" traceId="t1" open onOpenChange={() => {}} />);
-    await screen.findByText("support-ticket-triage");
+    await screen.findByDisplayValue("I was charged twice");
 
     fireEvent.change(screen.getByLabelText("Dataset"), { target: { value: "ds1" } });
-    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(fetchMock.mock.calls.some(([, init]) => init?.method === "POST")).toBe(true);
@@ -184,6 +168,6 @@ describe("Save as test case drawer — submit", () => {
     const [, init] = fetchMock.mock.calls.find(([, i]) => i?.method === "POST")!;
     const body = JSON.parse(init!.body as string);
     expect(body.expected).toBe("billing");
-    expect(body.recorded_output).toBe("billing");
+    expect(body.recorded_output).toBeUndefined();
   });
 });

--- a/frontend/ui/src/features/evaluations/save-test-case-format.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-test-case-format.smoke.test.tsx
@@ -9,7 +9,7 @@
  * text is normalised to match, so what is saved is canonical.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, cleanup, screen } from "@testing-library/react";
+import { render, cleanup, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 vi.mock("@/lib/api/traces", () => ({
@@ -82,7 +82,7 @@ const valueOf = (label: string) =>
 describe("save-as-test-case seed formats", () => {
   it("expands Input even though it was captured compact", async () => {
     mount();
-    await screen.findByText("support-ticket-triage");
+    await waitFor(() => expect(valueOf("Input")).toContain("I was charged twice"));
     const input = valueOf("Input");
     expect(input).toContain("\n"); // pretty, not the captured one-liner
     expect(input).toContain('  "message": "I was charged twice"');
@@ -90,13 +90,13 @@ describe("save-as-test-case seed formats", () => {
 
   it("keeps Metadata on one line even though it was captured indented", async () => {
     mount();
-    await screen.findByText("support-ticket-triage");
+    await waitFor(() => expect(valueOf("Input")).toContain("I was charged twice"));
     expect(valueOf("Metadata")).toBe('{"suite":"smoke"}');
   });
 
   it("expands Output — the editable field that becomes the expected outcome", async () => {
     mount();
-    await screen.findByText("support-ticket-triage");
+    await waitFor(() => expect(valueOf("Input")).toContain("I was charged twice"));
     const output = valueOf("Output");
     expect(output).toContain("\n");
     expect(output).toContain('  "route": "billing"');

--- a/frontend/ui/src/features/evaluations/save-test-case-span-sync.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-test-case-span-sync.smoke.test.tsx
@@ -33,17 +33,26 @@ vi.mock("@/lib/api/traces", () => ({
   })),
 }));
 
-// Distinct I/O per span, so the "Selected span" swap is observable.
+// Distinct I/O per span, so the retarget is observable via the seeded Input.
+// Cached per span (a fresh object each render would refire the drawer's seed
+// effect — which bumps seedGeneration — into an infinite loop).
+const spanIOCache = new Map<string, { data: unknown }>();
 vi.mock("@/features/traces", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/features/traces")>();
   return {
     ...actual,
-    useSpanIO: (_p: string, _t: string, spanId: string | null) => ({
-      data:
-        spanId === "llm"
-          ? { input: "llm-input", metadata: null }
-          : { input: "root-input", metadata: null },
-    }),
+    useSpanIO: (_p: string, _t: string, spanId: string | null) => {
+      if (!spanId) return { data: undefined };
+      if (!spanIOCache.has(spanId)) {
+        spanIOCache.set(spanId, {
+          data:
+            spanId === "llm"
+              ? { span_id: "llm", input: "llm-input", metadata: null }
+              : { span_id: "root", input: "root-input", metadata: null },
+        });
+      }
+      return spanIOCache.get(spanId)!;
+    },
   };
 });
 
@@ -78,8 +87,11 @@ function renderDrawer(spanId: string | undefined) {
 
 describe("drawer follows the tree selection", () => {
   it("retargets the selected span when the spanId prop changes while open", async () => {
+    // The drawer no longer shows a "Selected span" card, so the retarget is observed
+    // through the seeded Input (each span has distinct I/O), not a span-name label.
     const { rerender } = renderDrawer("root");
-    expect(await screen.findByText("triage-agent")).toBeDefined();
+    // Regex, not an exact string: LineNumberedTextarea keeps a trailing newline.
+    expect(await screen.findByDisplayValue(/root-input/)).toBeDefined();
 
     // Simulate a click on the LLM span in the tree (page pushes the new spanId).
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -88,7 +100,7 @@ describe("drawer follows the tree selection", () => {
         <SaveTestCaseDrawer projectId="p1" traceId="t1" spanId="llm" open onOpenChange={() => {}} />
       </QueryClientProvider>,
     );
-    expect(await screen.findByText("anthropic.messages")).toBeDefined();
-    expect(screen.queryByText("triage-agent")).toBeNull();
+    expect(await screen.findByDisplayValue(/llm-input/)).toBeDefined();
+    expect(screen.queryByDisplayValue(/root-input/)).toBeNull();
   });
 });

--- a/frontend/ui/src/features/evaluations/trace-integration.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/trace-integration.smoke.test.tsx
@@ -194,33 +194,28 @@ function savePayload() {
 describe("SaveTestCaseDrawer — save round trip", () => {
   it("renders nothing without a trace id", () => {
     mount(<SaveTestCaseDrawer projectId="p1" traceId={null} open onOpenChange={vi.fn()} />);
-    expect(screen.queryByText("Save as test case")).toBeNull();
+    expect(screen.queryByText("Add to datasets")).toBeNull();
   });
 
   it("cannot save until a dataset is picked, then posts the captured case", async () => {
     const onOpenChange = mountDrawer();
-    await screen.findByText("support-ticket-triage");
+    await screen.findByDisplayValue("I was charged twice for my July invoice");
 
     // No dataset yet: the button is generic and disabled.
     const before = screen.getByRole("button", { name: "Save" });
     expect(before.hasAttribute("disabled")).toBe(true);
 
     await pickDataset("Billing routing");
-    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(savePayload()).toBeDefined());
+    // Only the three fields the drawer captures — no recorded output, review,
+    // capture-reason, or source.
     expect(savePayload()).toMatchObject({
       input: "I was charged twice for my July invoice",
       // Untouched, the Output field is still the expected outcome.
       expected: "billing",
-      recorded_output: "billing",
       metadata: null,
-      review: "needs_review",
-      capture_reason: "manual",
-      source_trace_id: "t1",
-      source_span_id: "root",
-      source_span_name: "support-ticket-triage",
-      source_span_kind: "trace",
     });
 
     expect(await screen.findByText(/Saved — published as a new dataset version/)).toBeDefined();
@@ -230,83 +225,20 @@ describe("SaveTestCaseDrawer — save round trip", () => {
 
   it("an edited Output is what future runs are graded against", async () => {
     mountDrawer();
-    await screen.findByText("support-ticket-triage");
+    await screen.findByDisplayValue("I was charged twice for my July invoice");
     fireEvent.change(screen.getByLabelText("Output"), { target: { value: "refunds" } });
     await pickDataset("Billing routing");
-    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save" }));
     await waitFor(() => expect(savePayload()).toBeDefined());
-    expect(savePayload()).toMatchObject({ expected: "refunds", recorded_output: "billing" });
-  });
-
-  it("walking to a failed tool span changes the span, kind, and capture reason", async () => {
-    mountDrawer();
-    await screen.findByText("support-ticket-triage");
-    expect(screen.getByLabelText("Previous span").hasAttribute("disabled")).toBe(true);
-
-    fireEvent.click(screen.getByLabelText("Next span"));
-    expect(await screen.findByText("lookup_invoice")).toBeDefined();
-    expect(screen.getByLabelText("Next span").hasAttribute("disabled")).toBe(true);
-
-    await pickDataset("Billing routing");
-    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
-    await waitFor(() => expect(savePayload()).toBeDefined());
-    expect(savePayload()).toMatchObject({
-      capture_reason: "failed_tool",
-      source_span_id: "child",
-      source_span_kind: "TOOL",
-    });
-
-    // And back up to the root.
-    fireEvent.click(screen.getByLabelText("Previous span"));
-    expect(await screen.findByText("support-ticket-triage")).toBeDefined();
-  });
-
-  it("turning Source off saves the case with no trace or span linked", async () => {
-    mountDrawer();
-    await screen.findByText("support-ticket-triage");
-    // The source block lists the trace and span it would attach.
-    expect(screen.getByText("Source trace")).toBeDefined();
-
-    fireEvent.click(screen.getByRole("switch"));
-    expect(await screen.findByText(/Added as a manual case/)).toBeDefined();
-
-    await pickDataset("Billing routing");
-    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
-    await waitFor(() => expect(savePayload()).toBeDefined());
-    expect(savePayload()).toMatchObject({
-      source_trace_id: null,
-      source_span_id: null,
-      source_span_name: null,
-      source_span_kind: null,
-    });
-  });
-
-  it("creating a dataset inline creates it first, then saves into it", async () => {
-    mountDrawer();
-    await screen.findByText("support-ticket-triage");
-
-    await pickDataset("New dataset");
-    fireEvent.change(await screen.findByPlaceholderText("New dataset name"), {
-      target: { value: "  Refund routing  " },
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Create dataset & save" }));
-    await waitFor(() => expect(savePayload()).toBeDefined());
-
-    const create = requests.find((r) => r.method === "POST" && r.url.endsWith("/datasets"));
-    expect(create?.body).toEqual({ name: "Refund routing" });
-    // The case lands in the dataset that was just created.
-    expect(
-      requests.find((r) => r.method === "POST" && r.url.endsWith("/test-cases"))?.url,
-    ).toContain("/datasets/ds_new/test-cases");
+    expect(savePayload()).toMatchObject({ expected: "refunds" });
   });
 
   it("a duplicate span offers the existing case instead of adding another row", async () => {
     saveResponse = { duplicate: true };
     mountDrawer();
-    await screen.findByText("support-ticket-triage");
+    await screen.findByDisplayValue("I was charged twice for my July invoice");
     await pickDataset("Billing routing");
-    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save" }));
 
     expect(await screen.findByText(/already a test case in this dataset/)).toBeDefined();
     const link = screen.getByText("Open existing test case").closest("a") as HTMLAnchorElement;
@@ -318,9 +250,9 @@ describe("SaveTestCaseDrawer — save round trip", () => {
   it("surfaces a failed save without closing", async () => {
     saveFails = true;
     const onOpenChange = mountDrawer();
-    await screen.findByText("support-ticket-triage");
+    await screen.findByDisplayValue("I was charged twice for my July invoice");
     await pickDataset("Billing routing");
-    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save" }));
 
     expect(await screen.findByText("Could not save test case.")).toBeDefined();
     expect(onOpenChange).not.toHaveBeenCalled();
@@ -330,10 +262,10 @@ describe("SaveTestCaseDrawer — save round trip", () => {
     spanIO.data.metadata = "not json at all";
     try {
       mountDrawer();
-      await screen.findByText("support-ticket-triage");
+      await screen.findByDisplayValue("I was charged twice for my July invoice");
       await pickDataset("Billing routing");
       expect(
-        screen.getByRole("button", { name: "Save to Billing routing" }).hasAttribute("disabled"),
+        screen.getByRole("button", { name: "Save" }).hasAttribute("disabled"),
       ).toBe(true);
       expect(
         screen.getByText(/Metadata isn't valid JSON|Metadata must be a JSON object/),
@@ -345,7 +277,7 @@ describe("SaveTestCaseDrawer — save round trip", () => {
 
   it("closes from the X, from Cancel, and from Escape", async () => {
     const onOpenChange = mountDrawer();
-    await screen.findByText("support-ticket-triage");
+    await screen.findByDisplayValue("I was charged twice for my July invoice");
 
     fireEvent.click(screen.getByLabelText("Close"));
     expect(onOpenChange).toHaveBeenCalledWith(false);

--- a/frontend/ui/src/features/evaluations/types.ts
+++ b/frontend/ui/src/features/evaluations/types.ts
@@ -90,9 +90,6 @@ export interface TestCaseRow {
   projectId: string;
   input: string;
   expected: string | null;
-  /** Recorded production output — kept on the row until the dataset-detail rework
-   *  that drops it (removed in the dataset-detail PR alongside the schema column). */
-  recordedOutput: string | null;
   metadata: unknown;
   review: ReviewStatus;
   captureReason: string;

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -6,10 +6,8 @@ import { useRouter, useSearchParams } from "next/navigation";
 import {
   ArrowDown,
   ArrowUp,
-  ChevronRight,
   Database,
   Expand,
-  FileCode,
   FileText,
   History,
   Plus,
@@ -19,51 +17,34 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/components/ui/toast";
 import { useLayout } from "@/components/layout/app-layout";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
+import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import { SpanKindIcon } from "@/features/traces";
 import { cn } from "@/lib/utils";
 import {
+  DatasetActionsMenu,
   EmptyState,
   EvalBody,
   EvalPageHeader,
-  ReviewBadge,
-  EditableValueBlock,
   Timestamp,
-  TestCaseReviewDrawer,
-  type TestCaseReviewTarget,
 } from "@/features/offline-eval/components";
-import { CAPTURE_REASON_LABEL, type ReviewStatus } from "@/features/offline-eval/types";
-import { RunStatusBadge, ScoreValue, formatCost, formatElapsed } from "./evaluations-view";
-import { PassRate } from "../components/pass-rate";
+import { TraceIOSection } from "@/features/traces/components/TraceIOValue";
+import { ScoreValue, formatCost, formatElapsed } from "./evaluations-view";
+import { caseDisplayId, truncate } from "@/features/offline-eval/utils";
+import { versionSnowflake } from "@/lib/eval/snowflake";
+import { useDataset, useTestCaseRuns, useDeleteTestCase } from "../hooks";
 import {
-  caseDisplayId,
-  datasetPullCode,
-  datasetPullCodeTs,
-  datasetPullVersionCode,
-  datasetPullVersionCodeTs,
-  truncate,
-} from "@/features/offline-eval/utils";
-import {
-  useDataset,
-  useSaveTestCase,
-  useUpdateTestCase,
-  useEvaluationRuns,
-  useTestCaseRuns,
-} from "../hooks";
+  TestCaseEditorModal,
+  type TestCaseEditorMode,
+} from "../components/test-case-editor-modal";
+import { DeleteTestCaseDialog } from "../components/delete-test-case-dialog";
 import type { TestCaseRow } from "../types";
-import { PullCodeDrawer, type PullOption } from "../components/pull-code-drawer";
 
 /** A dash for the list; empty reads as a placeholder, not a blank cell. */
 function orDash(value: string | null): React.ReactNode {
@@ -106,7 +87,6 @@ export function DatasetDetailView({
   datasetId: string;
 }) {
   const { toast } = useToast();
-  const router = useRouter();
   const searchParams = useSearchParams();
   // null = the current version. Selecting an older version loads its snapshot
   // (read-only — editing always branches from the current version).
@@ -116,8 +96,11 @@ export function DatasetDetailView({
     datasetId,
     selectedVersionId,
   );
-  const save = useSaveTestCase(projectId, datasetId);
-  const update = useUpdateTestCase(projectId, datasetId);
+  const del = useDeleteTestCase(projectId, datasetId);
+
+  // "+ Row" and the row action menu open the editor; delete opens a confirm.
+  const [editorMode, setEditorMode] = React.useState<TestCaseEditorMode | null>(null);
+  const [deleteRow, setDeleteRow] = React.useState<TestCaseRow | null>(null);
 
   // Hold the stable lineage id (testCaseId), not the per-version row id — a
   // save/review publishes a new version with fresh row ids, and the row id
@@ -137,13 +120,10 @@ export function DatasetDetailView({
       handledCaseParam.current = caseParam;
     }
   }, [searchParams, data]);
-  const [reviewCaseId, setReviewCaseId] = React.useState<string | null>(null);
   // Mirrors CasePanel's dirty flag so the table can prompt before discarding an
   // unsaved edit on row-click, without lifting the whole edit buffer up.
   const dirtyRef = React.useRef(false);
   const [keyword, setKeyword] = React.useState("");
-  const [historyKeyword, setHistoryKeyword] = React.useState("");
-  const [codeOpen, setCodeOpen] = React.useState(false);
 
   const dataset = data?.dataset ?? null;
   const versions = React.useMemo(() => data?.versions ?? [], [data]);
@@ -166,73 +146,23 @@ export function DatasetDetailView({
     );
   }, [allCases, keyword]);
 
-  const evaluations = useEvaluationRuns(projectId, { dataset_id: datasetId });
-  const runs = React.useMemo(() => evaluations.data?.data ?? [], [evaluations.data]);
-  const visibleRuns = React.useMemo(() => {
-    const q = historyKeyword.trim().toLowerCase();
-    if (!q) return runs;
-    return runs.filter(
-      (r) =>
-        r.evaluationName.toLowerCase().includes(q) ||
-        (r.mainScoreName ?? "").toLowerCase().includes(q),
-    );
-  }, [runs, historyKeyword]);
-
   // Resolved against allCases (not the keyword-filtered `cases`) and keyed on the
   // stable testCaseId — otherwise typing in the search box, or a save publishing
   // a new version's row ids, would silently unmount the open panel.
   const openCase = openCaseId ? (allCases.find((c) => c.testCaseId === openCaseId) ?? null) : null;
-  const reviewCase = reviewCaseId
-    ? (allCases.find((c) => c.testCaseId === reviewCaseId) ?? null)
-    : null;
-
-  const reviewTarget = React.useMemo<TestCaseReviewTarget | null>(() => {
-    if (!reviewCase || !dataset) return null;
-    return {
-      contextLabel: `${caseDisplayId(reviewCase.testCaseId)} · ${dataset.name}`,
-      input: reviewCase.input,
-      expected: reviewCase.expected,
-      currentReview: reviewCase.review,
-    };
-  }, [reviewCase, dataset]);
-
-  const submitReview = (result: { review: ReviewStatus; correctedExpected?: string }) => {
-    if (!reviewCase) return;
-    update.mutate(
-      {
-        testCaseId: reviewCase.testCaseId,
-        patch: {
-          review: result.review,
-          ...(result.correctedExpected ? { expected: result.correctedExpected } : {}),
-        },
+  const confirmDelete = () => {
+    if (!deleteRow) return;
+    const target = deleteRow;
+    del.mutate(target.testCaseId, {
+      onSuccess: () => {
+        toast({ title: "Row deleted", tone: "success" });
+        setDeleteRow(null);
+        // Close the slide-in if it was showing the row we just removed.
+        if (openCaseId === target.testCaseId) setOpenCaseId(null);
       },
-      {
-        onSuccess: () => {
-          toast({ title: "Review saved — new dataset version published", tone: "success" });
-          // Follow the version just published rather than leaving the view
-          // pinned to whatever was selected before the save.
-          setSelectedVersionId(null);
-          setReviewCaseId(null);
-        },
-        onError: (e) =>
-          toast({
-            title: "Could not save this review",
-            description: String(e),
-            tone: "warning",
-          }),
-      },
-    );
-  };
-
-  const addEmptyRow = () => {
-    save.mutate(
-      { input: "", review: "needs_review", capture_reason: "manual" },
-      {
-        onSuccess: () => toast({ title: "Empty row added", tone: "success" }),
-        onError: (e) =>
-          toast({ title: "Could not add row", description: String(e), tone: "warning" }),
-      },
-    );
+      onError: (e) =>
+        toast({ title: "Could not delete the row", description: String(e), tone: "warning" }),
+    });
   };
 
   if (isLoading && !data) {
@@ -293,126 +223,79 @@ export function DatasetDetailView({
 
   return (
     <>
-      <ProjectBreadcrumb projectId={projectId} />
+      {/* The dataset name rides in the top breadcrumb bar (Workspace / Project /
+          Datasets / <name>) rather than a separate title row, so the page starts
+          straight at the toolbar. */}
+      <ProjectBreadcrumb
+        projectId={projectId}
+        trail={[{ label: "Datasets", href: `/projects/${projectId}/datasets` }]}
+        current={dataset.name}
+      />
       <div className="flex h-full flex-col text-[13px]">
-        <EvalPageHeader
-          parent={{ label: "Datasets", href: `/projects/${projectId}/datasets` }}
-          title={
-            <span className="flex flex-wrap items-center gap-2">
-              <span>{dataset.name}</span>
-              <span className="font-mono text-xs font-normal text-muted-foreground">
-                {dataset.id}
-              </span>
-              <CopyButton
-                value={dataset.id}
-                className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                title="Copy dataset ID"
-              />
-            </span>
-          }
-        />
-
-        {/* Version bar — pick a snapshot to view (previous versions are read-only),
-            with its immutable version id + copy. Hidden entirely on a freshly
-            created dataset: there is nothing to select yet. */}
-        {hasVersions && (
-          <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 py-1.5 text-[12px]">
-            <span className="text-muted-foreground">Version</span>
-            <Select
-              value={selectedVersion?.id ?? ""}
-              onValueChange={(v) => setSelectedVersionId(v)}
-            >
-              <SelectTrigger className="h-7 w-[240px] text-[12px]">
-                <SelectValue placeholder="Current version" />
-              </SelectTrigger>
-              <SelectContent>
-                {versions.map((v) => (
-                  <SelectItem key={v.id} value={v.id} className="text-[12px]">
-                    v{v.versionNumber}
-                    {v.id === dataset.currentVersionId ? " (current)" : ""}
-                    {v.label ? ` · ${v.label}` : ""}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {selectedVersion && (
-              <>
-                <span className="font-mono text-[11px] text-muted-foreground">
-                  {selectedVersion.id}
-                </span>
-                <CopyButton
-                  value={selectedVersion.id}
-                  className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                  title="Copy version ID"
-                />
-              </>
-            )}
-            {!isCurrentVersion && (
-              <span
-                role="status"
-                className="ml-auto rounded border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-700 dark:text-amber-300"
-              >
-                Viewing v{selectedVersion?.versionNumber}
-                {selectedVersion?.label ? ` · ${selectedVersion.label}` : ""} — read only.{" "}
-                <button
-                  type="button"
-                  // null = follow the LIVE current pointer. Pinning the current version's
-                  // id would strand the page on a now-historical version after the next edit.
-                  onClick={() => setSelectedVersionId(null)}
-                  className="underline underline-offset-2"
-                >
-                  Back to current
-                </button>
-              </span>
-            )}
-          </div>
-        )}
-
-        <Tabs defaultValue="cases" className="flex min-h-0 flex-1 flex-col">
-          <TabsList className="shrink-0 px-4 pt-2" aria-label="Dataset views">
-            <TabsTrigger value="cases" count={cases.length}>
-              Test cases
-            </TabsTrigger>
-            <TabsTrigger value="history" count={runs.length}>
-              Evaluation history
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="cases" className="flex min-h-0 flex-1 flex-col">
-            {/* Toolbar — the standard SearchFilterBar (search + actions). No date
-                filter: nothing here reads it — a rendered-but-inert filter chip
-                falsely implies the table is scoped to it. */}
+        <div className="flex min-h-0 flex-1 flex-col">
+            {/* Single toolbar row: search on the left; the Row action and the
+                version selector pushed to the right (version farthest). The version
+                id lives inside the dropdown, not spelled out in the bar. No date
+                filter: nothing here reads one. */}
             <SearchFilterBar
               searchValue={keyword}
               onSearchChange={setKeyword}
-              searchPlaceholder="Search cases..."
+              searchPlaceholder="Search..."
             >
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 gap-1.5 text-[12px]"
-                onClick={addEmptyRow}
-                disabled={save.isPending || !isCurrentVersion}
-              >
-                <Plus className="h-3.5 w-3.5" aria-hidden />
-                Row
-              </Button>
-
-              {/* Spacer keeps the dataset-level actions flush right. */}
-              <span className="flex-1" aria-hidden />
-
-              {/* Dataset-level actions (no dropdown). */}
-              <span className="flex items-center gap-1">
+              <div className="ml-auto flex items-center gap-2">
                 <Button
-                  variant="ghost"
+                  variant="outline"
                   size="sm"
-                  className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-                  onClick={() => setCodeOpen(true)}
+                  className="h-7 gap-1.5 text-[12px]"
+                  onClick={() => setEditorMode({ kind: "create" })}
+                  disabled={!isCurrentVersion}
                 >
-                  <FileCode className="h-3.5 w-3.5" aria-hidden />
-                  Pull code
+                  <Plus className="h-3.5 w-3.5" aria-hidden />
+                  Row
                 </Button>
-              </span>
+                {hasVersions && (
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-[12px] text-muted-foreground">Version</span>
+                    <Select
+                      value={selectedVersion?.id ?? ""}
+                      onValueChange={(v) => setSelectedVersionId(v)}
+                    >
+                      {/* Trigger shows the time-sortable snowflake id;
+                          the dropdown pairs each version NUMBER with its snowflake so
+                          both the ordering and the exact version id are visible. w-auto
+                          hugs the id (no dead gap before the chevron); the dropdown grows
+                          to fit its wider "<n>  <snowflake>" rows on its own. */}
+                      <SelectTrigger
+                        className="h-7 w-auto gap-2 text-[12px]"
+                        title="Dataset version"
+                      >
+                        <span className="whitespace-nowrap font-mono text-[12px]">
+                          {selectedVersion
+                            ? versionSnowflake(
+                                selectedVersion.createTime,
+                                selectedVersion.versionNumber,
+                              )
+                            : "Current version"}
+                        </span>
+                      </SelectTrigger>
+                      <SelectContent align="end">
+                        {versions.map((v) => (
+                          <SelectItem key={v.id} value={v.id} className="text-[12px]">
+                            <span className="flex items-center gap-2">
+                              <span className="tabular-nums text-muted-foreground">
+                                {v.versionNumber}
+                              </span>
+                              <span className="font-mono">
+                                {versionSnowflake(v.createTime, v.versionNumber)}
+                              </span>
+                            </span>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+              </div>
             </SearchFilterBar>
 
             {/* Table + focused-case slide-in panel */}
@@ -421,7 +304,7 @@ export function DatasetDetailView({
                 <EmptyState>
                   {keyword
                     ? "No cases match your search."
-                    : "No test cases yet — use Row to add one, or open a trace, select the root or a span, and save it as a test case."}
+                    : "To populate this dataset, manually create a row or insert data programmatically."}
                 </EmptyState>
               ) : (
                 <Table>
@@ -431,6 +314,7 @@ export function DatasetDetailView({
                       <Th>Input</Th>
                       <Th>Expected</Th>
                       <Th>Metadata</Th>
+                      <Th className="w-[70px] text-right">Actions</Th>
                     </TRHead>
                   </THead>
                   <TBody>
@@ -466,6 +350,22 @@ export function DatasetDetailView({
                           <Td className="max-w-[320px] truncate">{orDash(tc.input || null)}</Td>
                           <Td className="max-w-[320px] truncate">{orDash(tc.expected)}</Td>
                           <Td className="max-w-[240px] truncate">{metadataPreview(tc.metadata)}</Td>
+                          <Td className="text-right">
+                            {isCurrentVersion && (
+                              <DatasetActionsMenu
+                                onEdit={() =>
+                                  setEditorMode({
+                                    kind: "edit",
+                                    testCaseId: tc.testCaseId,
+                                    input: tc.input,
+                                    expected: tc.expected,
+                                    metadata: tc.metadata,
+                                  })
+                                }
+                                onDelete={() => setDeleteRow(tc)}
+                              />
+                            )}
+                          </Td>
                         </TR>
                       );
                     })}
@@ -473,79 +373,7 @@ export function DatasetDetailView({
                 </Table>
               )}
             </div>
-          </TabsContent>
-
-          <TabsContent value="history" className="flex min-h-0 flex-1 flex-col">
-            <SearchFilterBar
-              searchValue={historyKeyword}
-              onSearchChange={setHistoryKeyword}
-              searchPlaceholder="Search evaluations..."
-            />
-            <EvalBody>
-              {visibleRuns.length === 0 ? (
-                <EmptyState>
-                  {historyKeyword
-                    ? "No evaluations match your search."
-                    : `Nothing has been run against ${dataset.name} yet.`}
-                </EmptyState>
-              ) : (
-                <Table>
-                  <THead>
-                    <TRHead>
-                      <Th>Evaluation / Run</Th>
-                      <Th>Dataset</Th>
-                      <Th className="w-[110px] text-right">Main score</Th>
-                      <Th className="w-[100px] text-right">Passed</Th>
-                      <Th className="w-[100px] text-right">Cost</Th>
-                      <Th className="w-[90px] text-right">Duration</Th>
-                      <Th className="w-[150px]">Status</Th>
-                      <Th className="w-[130px] text-right">Timestamp</Th>
-                    </TRHead>
-                  </THead>
-                  <TBody>
-                    {visibleRuns.map((run) => (
-                      <TR
-                        key={run.id}
-                        interactive
-                        onClick={() => router.push(`/projects/${projectId}/evaluations/${run.id}`)}
-                      >
-                        <Td>
-                          <div className="font-medium">{run.evaluationName}</div>
-                          <div className="text-[11px] text-muted-foreground">
-                            Run #{run.runNumber} ·{" "}
-                            <span className="font-mono">{run.candidateVersion}</span>
-                          </div>
-                        </Td>
-                        <Td className="text-muted-foreground">
-                          <div>{run.datasetName}</div>
-                          <div className="text-[11px]">{run.datasetVersionLabel}</div>
-                        </Td>
-                        <Td className="text-right tabular-nums">
-                          <ScoreValue value={run.mainScore} />
-                        </Td>
-                        <Td className="text-right tabular-nums">
-                          <PassRate counts={run} />
-                        </Td>
-                        <Td className="text-right tabular-nums text-muted-foreground">
-                          {formatCost(run.cost)}
-                        </Td>
-                        <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
-                          {formatElapsed(run.elapsedMs)}
-                        </Td>
-                        <Td>
-                          <RunStatusBadge status={run.status} />
-                        </Td>
-                        <Td className="whitespace-nowrap text-right text-muted-foreground">
-                          <Timestamp iso={run.startedAt} />
-                        </Td>
-                      </TR>
-                    ))}
-                  </TBody>
-                </Table>
-              )}
-            </EvalBody>
-          </TabsContent>
-        </Tabs>
+        </div>
       </div>
 
       {/* Focused case — slides in from the right like a trace. */}
@@ -554,12 +382,9 @@ export function DatasetDetailView({
           testCase={openCase}
           projectId={projectId}
           datasetId={datasetId}
-          datasetName={dataset.name}
-          readOnly={!isCurrentVersion}
+          versionId={selectedVersion?.id ?? null}
           dirtyRef={dirtyRef}
           onClose={() => setOpenCaseId(null)}
-          onReview={() => setReviewCaseId(openCase.testCaseId)}
-          onSaved={() => setSelectedVersionId(null)}
           onNavigate={(dir) => {
             const idx = cases.findIndex((c) => c.testCaseId === openCase.testCaseId);
             const next = dir === "up" ? idx - 1 : idx + 1;
@@ -572,51 +397,28 @@ export function DatasetDetailView({
         />
       )}
 
-      {/* Pull code — the shared drawer: one snippet that fetches the dataset. */}
-      <PullCodeDrawer
-        title="Pull this dataset in code"
-        subtitle={
-          <>
-            Fetch <span className="font-medium text-foreground">{dataset.name}</span> to run an
-            evaluation against. Only the dataset is pullable — an evaluation or run id isn&apos;t.
-          </>
-        }
-        options={
-          // While pinned to an older, read-only snapshot, swap in the exact
-          // version so "pull code" reproduces what's actually on screen instead
-          // of the dataset's (different) current version. Swap, not add — the
-          // drawer's contract is a single option, resolved to whichever version
-          // is in view.
-          (selectedVersion && !isCurrentVersion
-            ? [
-                {
-                  id: "version",
-                  label: `Pull v${selectedVersion.versionNumber}`,
-                  note: "This exact immutable snapshot — never changes.",
-                  py: datasetPullVersionCode(selectedVersion.id),
-                  ts: datasetPullVersionCodeTs(selectedVersion.id),
-                },
-              ]
-            : [
-                {
-                  id: "latest",
-                  label: "Pull dataset",
-                  note: "Fetches the dataset's current published version when the run starts.",
-                  py: datasetPullCode(dataset.id),
-                  ts: datasetPullCodeTs(dataset.id),
-                },
-              ]) satisfies PullOption[]
-        }
-        open={codeOpen}
-        onOpenChange={setCodeOpen}
-      />
+      {/* New / edit row editor. Keyed so switching between rows (or create↔edit)
+          remounts it, re-seeding the fields from the fresh target. */}
+      {editorMode && (
+        <TestCaseEditorModal
+          key={editorMode.kind === "edit" ? `edit-${editorMode.testCaseId}` : "create"}
+          projectId={projectId}
+          datasetId={datasetId}
+          mode={editorMode}
+          onClose={() => setEditorMode(null)}
+          onSaved={() => setSelectedVersionId(null)}
+        />
+      )}
 
-      <TestCaseReviewDrawer
-        target={reviewTarget}
-        open={reviewCaseId !== null}
-        onOpenChange={(open) => !open && setReviewCaseId(null)}
-        onSubmit={submitReview}
-      />
+      {deleteRow && (
+        <DeleteTestCaseDialog
+          rowLabel={caseDisplayId(deleteRow.testCaseId)}
+          isOpen
+          onClose={() => setDeleteRow(null)}
+          onConfirm={confirmDelete}
+          isDeleting={del.isPending}
+        />
+      )}
     </>
   );
 }
@@ -624,20 +426,17 @@ export function DatasetDetailView({
 /**
  * Slide-in case panel, matching the trace/span detail panel: a header with an
  * icon, the row id, a copy button and the up/down/fullscreen/open-in-new-tab/
- * close controls; then the created date; then Source / Captured chips (in place
- * of a span kind). Input, expected, and metadata render as editable value
- * blocks; saving any edit publishes a new immutable dataset version.
+ * close controls; then the created date; then a Details/Runs toggle. Input,
+ * expected, and metadata render read-only through the same ExpandableSection +
+ * ContentRenderer chrome the trace detail uses. In-panel editing is deferred.
  */
 function CasePanel({
   testCase,
   projectId,
   datasetId,
-  datasetName,
-  readOnly = false,
+  versionId,
   dirtyRef,
   onClose,
-  onReview,
-  onSaved,
   onNavigate,
   canNavigateUp,
   canNavigateDown,
@@ -645,123 +444,61 @@ function CasePanel({
   testCase: TestCaseRow;
   projectId: string;
   datasetId: string;
-  datasetName: string;
-  /** Viewing an older snapshot: fields and Save are disabled (editing branches
-   * from the current version, not this one). */
-  readOnly?: boolean;
-  /** Mirrors `dirty` for the parent, which can't see this component's state
-   * directly (e.g. to confirm before switching rows). */
+  /** The dataset version being viewed; runs that measured a different version of
+   *  this row are hidden (their input/expected association differs). */
+  versionId: string | null;
+  /** Reset to false by this (read-only) panel; kept so the parent can reintroduce
+   * an unsaved-changes guard when in-panel editing returns. */
   dirtyRef: React.MutableRefObject<boolean>;
   onClose: () => void;
-  onReview: () => void;
-  /** Called after a save publishes a new version, so the parent can stop
-   * pinning an older/explicit version selection and follow the new current. */
-  onSaved: () => void;
   onNavigate: (direction: "up" | "down") => void;
   canNavigateUp: boolean;
   canNavigateDown: boolean;
 }) {
-  const { toast } = useToast();
   const router = useRouter();
-  const { sidebarCollapsed } = useLayout();
-  const update = useUpdateTestCase(projectId, datasetId);
+  const {
+    sidebarCollapsed,
+    aiPanelOpen,
+    setAiPanelOpen,
+    setAiContext,
+    setAiInitialSessionId,
+    registerAiHost,
+  } = useLayout();
   const caseRuns = useTestCaseRuns(projectId, datasetId, testCase.testCaseId);
-  const runs = caseRuns.data?.data ?? [];
+  // Only runs that measured THIS version of the row — a run on a different dataset
+  // version scored a different input/expected, so lumping it in would mislead. When
+  // the viewed version is unknown, don't filter.
+  const runs = React.useMemo(() => {
+    const all = caseRuns.data?.data ?? [];
+    return versionId ? all.filter((r) => r.datasetVersionId === versionId) : all;
+  }, [caseRuns.data, versionId]);
   const [fullscreen, setFullscreen] = React.useState(false);
   const [view, setView] = React.useState<"details" | "runs">("details");
 
-  // Editable buffers, seeded from the case and re-seeded when it changes.
-  // Input/expected are plain strings; metadata is edited as JSON and parsed back.
-  const initialMetadata = React.useMemo(() => {
+  // Metadata renders as pretty JSON, matching the trace-detail metadata section.
+  const metadataJson = React.useMemo(() => {
     const record = asRecord(testCase.metadata);
     return Object.keys(record).length ? JSON.stringify(record, null, 2) : "";
   }, [testCase.metadata]);
-  const [inputText, setInputText] = React.useState(testCase.input);
-  const [expectedText, setExpectedText] = React.useState(testCase.expected ?? "");
-  const [metadataText, setMetadataText] = React.useState(initialMetadata);
 
-  // Re-seed on the per-version ROW id, not the stable testCaseId. A save or a
-  // snapshot switch publishes a NEW version — same testCaseId, new row id and values —
-  // so keying on the row id refreshes the buffer to the just-saved/selected values
-  // (otherwise a successful metadata save looks lost). A same-version background
-  // refetch keeps the same row id, so it still can't stomp in-progress typing.
+  const copyToClipboard = (value: string) => void navigator.clipboard?.writeText(value);
+
+  // Read-only for now (in-panel editing is deferred), so the parent never needs
+  // to guard row switches against unsaved changes.
   React.useEffect(() => {
-    setInputText(testCase.input);
-    setExpectedText(testCase.expected ?? "");
-    setMetadataText(initialMetadata);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [testCase.id]);
+    dirtyRef.current = false;
+  }, [dirtyRef]);
 
-  const dirty =
-    !readOnly &&
-    (inputText !== testCase.input ||
-      expectedText !== (testCase.expected ?? "") ||
-      metadataText !== initialMetadata);
+  // Claim the AI slot so AppLayout's project rail steps aside and the assistant
+  // renders INSIDE this panel (same as the trace viewer). The returned cleanup
+  // runs on unmount, handing the rail back.
+  React.useEffect(() => registerAiHost(), [registerAiHost]);
 
-  React.useEffect(() => {
-    dirtyRef.current = dirty;
-  }, [dirty, dirtyRef]);
-
-  const confirmDiscard = () => !dirty || window.confirm("Discard unsaved changes to this case?");
-
-  // Metadata only persists when it parses to an object; a half-typed edit keeps
-  // the prior value rather than blowing it away.
-  const parseMetadata = (): Record<string, unknown> | null | undefined => {
-    if (metadataText.trim() === "") return null;
-    try {
-      const parsed = JSON.parse(metadataText);
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        return parsed as Record<string, unknown>;
-      }
-    } catch {
-      /* invalid JSON mid-edit */
-    }
-    return undefined; // leave stored metadata untouched
-  };
-
-  // Surfaces the same parse failure `parseMetadata` swallows, so a half-typed
-  // edit is visibly unsaveable instead of silently dropped on Save.
-  const metadataInvalid = React.useMemo(() => {
-    if (metadataText.trim() === "") return false;
-    try {
-      const parsed = JSON.parse(metadataText);
-      return parsed === null || typeof parsed !== "object" || Array.isArray(parsed);
-    } catch {
-      return true;
-    }
-  }, [metadataText]);
-
-  const saveEdits = () => {
-    const patch: {
-      input?: string;
-      expected?: string | null;
-      metadata?: Record<string, unknown> | null;
-    } = {};
-    if (inputText !== testCase.input) patch.input = inputText;
-    if (expectedText !== (testCase.expected ?? "")) {
-      patch.expected = expectedText.trim() === "" ? null : expectedText;
-    }
-    if (metadataText !== initialMetadata) {
-      const parsed = parseMetadata();
-      if (parsed !== undefined) patch.metadata = parsed;
-    }
-    if (Object.keys(patch).length === 0) return;
-    update.mutate(
-      { testCaseId: testCase.testCaseId, patch },
-      {
-        onSuccess: () => {
-          toast({ title: "Saved — new dataset version published", tone: "success" });
-          onSaved();
-        },
-        onError: (e) =>
-          toast({
-            title: "Could not save this test case",
-            description: String(e),
-            tone: "warning",
-          }),
-      },
-    );
-  };
+  // Close the assistant when this panel closes. Otherwise, once the panel gives
+  // up the AI host slot on unmount, a still-open `aiPanelOpen` would strand the
+  // assistant as an empty ~400px panel in the app rail — the "white gap" on the
+  // right of the dataset page. Runs before the host-release cleanup above.
+  React.useEffect(() => () => setAiPanelOpen(false), [setAiPanelOpen]);
 
   const panelRef = React.useRef<HTMLDivElement>(null);
   const previousFocusRef = React.useRef<HTMLElement | null>(null);
@@ -776,26 +513,17 @@ function CasePanel({
     };
   }, []);
 
-  const guardedClose = () => {
-    if (confirmDiscard()) onClose();
-  };
-  const guardedNavigate = (direction: "up" | "down") => {
-    if (confirmDiscard()) onNavigate(direction);
-  };
-
-  // Close on Escape, unless a nested Radix overlay (the value-block format
-  // popover) already consumed it in the capture phase — defaultPrevented means
-  // "already handled, leave this panel open".
+  // Close on Escape, unless a nested Radix overlay already consumed it in the
+  // capture phase — defaultPrevented means "already handled, leave this open".
   React.useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
       if (e.defaultPrevented) return;
-      guardedClose();
+      onClose();
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onClose, dirty]);
+  }, [onClose]);
 
   return (
     <div
@@ -810,12 +538,11 @@ function CasePanel({
           ? sidebarCollapsed
             ? "top-14 w-[calc(100%-3.5rem)]"
             : "top-14 w-[calc(100%-12rem)]"
-          : "top-0 w-[45%] min-w-[520px] max-w-[94vw]",
+          : "top-0 w-[70%]",
       )}
     >
-      {/* Header — same shape as the trace/span detail panel. */}
-      <div className="shrink-0 border-b border-border bg-muted/30 px-4 py-3">
-        <div className="flex items-start justify-between gap-2">
+      {/* Header — same h-12 chrome as the trace/span detail panel. */}
+      <div className="flex h-12 shrink-0 items-center justify-between gap-2 border-b border-border bg-muted/30 px-4">
           <div className="flex min-w-0 items-center gap-2">
             <Database className="h-4 w-4 shrink-0 text-muted-foreground" />
             <span className="text-sm font-medium">Row</span>
@@ -832,7 +559,7 @@ function CasePanel({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => guardedNavigate("up")}
+              onClick={() => onNavigate("up")}
               disabled={!canNavigateUp}
               className="h-7 w-7 p-0"
               title="Previous row"
@@ -842,7 +569,7 @@ function CasePanel({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => guardedNavigate("down")}
+              onClick={() => onNavigate("down")}
               disabled={!canNavigateDown}
               className="h-7 w-7 p-0"
               title="Next row"
@@ -867,50 +594,36 @@ function CasePanel({
             >
               <SquareArrowOutUpRight className="h-4 w-4" />
             </Button>
+            <div className="w-2" />
+            {/* AI Assistant — mirrors the trace-detail panel. Seeds the case's source
+                trace as context when it has one; otherwise a plain project-scoped chat. */}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setAiContext(testCase.sourceTraceId ? { traceId: testCase.sourceTraceId } : null);
+                setAiInitialSessionId(undefined);
+                setAiPanelOpen(!aiPanelOpen);
+              }}
+              className="h-7 w-7 p-0"
+              title="AI Assistant"
+            >
+              <DOMAIN_ICONS.assistant className="h-4 w-4" />
+            </Button>
             <Button
               variant="ghost"
               size="sm"
               className="h-7 w-7 p-0"
-              onClick={guardedClose}
+              onClick={onClose}
               aria-label="Close"
             >
               <X className="h-4 w-4" />
             </Button>
           </div>
-        </div>
-
-        <Timestamp iso={testCase.createTime} className="mt-1 block text-xs text-muted-foreground" />
-
-        <div className="mt-2 flex flex-wrap items-center gap-2">
-          <ReviewBadge status={testCase.review} />
-          {testCase.sourceTraceId ? (
-            <Link
-              href={`/projects/${projectId}/traces?traceId=${testCase.sourceTraceId}&fullscreen=1`}
-              className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 py-1 pl-2.5 pr-1.5 text-xs transition-colors hover:bg-muted"
-            >
-              <span className="text-muted-foreground">Source:</span>
-              <SpanKindIcon kind={(testCase.sourceSpanKind ?? "SPAN") as never} />
-              <span className="font-medium">{testCase.sourceSpanName ?? "trace"}</span>
-              <ChevronRight className="h-3 w-3 text-muted-foreground" />
-            </Link>
-          ) : (
-            <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
-              <span className="text-muted-foreground">Source:</span>
-              <span className="font-medium">Added manually</span>
-            </span>
-          )}
-          {/* Why this case was captured — read-only context. */}
-          <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
-            <span className="text-muted-foreground">Captured:</span>
-            <span className="font-medium">
-              {CAPTURE_REASON_LABEL[testCase.captureReason as keyof typeof CAPTURE_REASON_LABEL] ??
-                testCase.captureReason}
-            </span>
-          </span>
-        </div>
       </div>
 
-      {/* View toggle — Details / Runs, where a trace shows Tree / Timeline. */}
+      {/* View toggle — Row / Experiments, where a trace shows Tree / Timeline. The
+          `details`/`runs` state keys stay internal. */}
       <div className="flex h-10 shrink-0 items-center border-b border-border px-2">
         <button
           type="button"
@@ -922,7 +635,7 @@ function CasePanel({
               : "text-muted-foreground hover:text-foreground",
           )}
         >
-          <FileText className="h-3.5 w-3.5" /> Details
+          <FileText className="h-3.5 w-3.5" /> Row
         </button>
         <button
           type="button"
@@ -934,7 +647,7 @@ function CasePanel({
               : "text-muted-foreground hover:text-foreground",
           )}
         >
-          <History className="h-3.5 w-3.5" /> Runs
+          <History className="h-3.5 w-3.5" /> Experiments
           {runs.length > 0 && (
             <span className="rounded bg-muted px-1 text-[10px] tabular-nums text-muted-foreground">
               {runs.length}
@@ -943,137 +656,132 @@ function CasePanel({
         </button>
       </div>
 
-      {view === "details" ? (
-        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 text-[12px]">
-          <EditableValueBlock
-            key={`input-${testCase.id}`}
-            label="Input"
-            text={inputText}
-            onChange={setInputText}
-            copyable
-            autoDetectKind
-            boxed
-            minRows={2}
-            collapsible
-            readOnly={readOnly}
-          />
-          <EditableValueBlock
-            key={`expected-${testCase.id}`}
-            label="Expected"
-            text={expectedText}
-            onChange={setExpectedText}
-            copyable
-            autoDetectKind
-            boxed
-            minRows={2}
-            collapsible
-            readOnly={readOnly}
-          />
-          {/* Recorded production output — read-only, kept separate from Expected. */}
-          {testCase.recordedOutput !== null && (
-            <EditableValueBlock
-              key={`recorded-${testCase.id}`}
-              label="What happened in production"
-              text={testCase.recordedOutput}
-              onChange={() => {}}
-              copyable
-              autoDetectKind
-              boxed
-              minRows={2}
-              collapsible
-              readOnly
-            />
-          )}
-          <EditableValueBlock
-            key={`metadata-${testCase.id}`}
-            label="Metadata"
-            text={metadataText}
-            defaultKind="pretty"
-            onChange={setMetadataText}
-            copyable
-            autoDetectKind
-            boxed
-            minRows={2}
-            collapsible
-            readOnly={readOnly}
-          />
-          {metadataInvalid && (
-            <p className="text-[11px] leading-snug text-amber-700 dark:text-amber-300">
-              Metadata must be a JSON object — this edit won&apos;t be saved until it is.
-            </p>
-          )}
-          <p className="text-[11px] leading-snug text-muted-foreground">
-            Saving publishes a new dataset version — it changes what future runs are compared
-            against and never rewrites a snapshot an earlier run used.
-          </p>
-        </div>
-      ) : (
-        <div className="min-h-0 flex-1 overflow-auto p-4">
-          {runs.length === 0 ? (
-            <EmptyState>
-              No evaluation run has measured this test case yet. Runs appear here once your
-              application or CI reports them.
-            </EmptyState>
-          ) : (
-            <Table>
-              <THead>
-                <TRHead>
-                  <Th>Evaluation / Run</Th>
-                  <Th>Dataset</Th>
-                  <Th className="w-[110px] text-right">Main score</Th>
-                  <Th className="w-[130px] text-right">Timestamp</Th>
-                </TRHead>
-              </THead>
-              <TBody>
-                {runs.map((r) => (
-                  <TR
-                    key={r.resultId}
-                    interactive
-                    onClick={() => router.push(`/projects/${projectId}/evaluations/${r.runId}`)}
-                  >
-                    <Td>
-                      <div className="font-medium">{r.evaluationName}</div>
-                      <div className="text-[11px] text-muted-foreground">
-                        Run #{r.runNumber} · <span className="font-mono">{r.candidateVersion}</span>
-                      </div>
-                    </Td>
-                    <Td className="text-muted-foreground">{datasetName}</Td>
-                    <Td className="text-right tabular-nums">
-                      <ScoreValue value={r.score} />
-                    </Td>
-                    <Td className="whitespace-nowrap text-right text-muted-foreground">
-                      <Timestamp iso={r.ranAt} />
-                    </Td>
-                  </TR>
-                ))}
-              </TBody>
-            </Table>
-          )}
-        </div>
-      )}
+      {/* Content area split: [ details/runs | AI assistant (optional) ], exactly
+          like the trace viewer, so the agent button opens an in-panel chat. */}
+      <div className="relative flex min-h-0 flex-1 overflow-hidden">
+        <ResizablePanelGroup orientation="horizontal" className="h-full min-w-0">
+          <ResizablePanel id="case-main" minSize="360px" className="min-w-0 overflow-hidden">
+            {view === "details" ? (
+              // Read-only view — same chrome as the trace/span detail panel: a plain
+              // block-flow scroll region (space-y, NOT flex) so each section keeps its
+              // full height and the panel scrolls, instead of the sections compressing.
+              <div className="h-full space-y-3 overflow-y-auto p-4">
+                <TraceIOSection
+                  key={`input-${testCase.id}`}
+                  title="Input"
+                  content={testCase.input}
+                  onCopy={testCase.input ? () => copyToClipboard(testCase.input) : undefined}
+                />
+                <TraceIOSection
+                  key={`expected-${testCase.id}`}
+                  title="Expected"
+                  content={testCase.expected}
+                  onCopy={testCase.expected ? () => copyToClipboard(testCase.expected!) : undefined}
+                />
+                <TraceIOSection
+                  key={`metadata-${testCase.id}`}
+                  title="Metadata"
+                  content={metadataJson || null}
+                  onCopy={metadataJson ? () => copyToClipboard(metadataJson) : undefined}
+                />
+              </div>
+            ) : runs.length === 0 ? (
+              <div className="h-full overflow-auto p-4">
+                <EmptyState>
+                  No run has measured this row on the dataset version you’re viewing. Runs that
+                  measured a different version aren’t shown here.
+                </EmptyState>
+              </div>
+            ) : (
+              // Edge-to-edge table (no inset padding), so it reads like the Experiments
+              // list page rather than a boxed card floating in whitespace.
+              <div className="h-full overflow-auto">
+                <Table>
+                  <THead>
+                    <TRHead>
+                      <Th className="w-[150px]">Timestamp</Th>
+                      <Th>Experiment Name</Th>
+                      <Th>Run Name</Th>
+                      <Th className="w-[90px] text-right">Score</Th>
+                      <Th className="w-[90px] text-right">Cost</Th>
+                      <Th className="w-[90px] text-right">Avg Cost</Th>
+                      <Th className="w-[90px] text-right">Duration</Th>
+                      <Th className="w-[100px] text-right">Avg Duration</Th>
+                    </TRHead>
+                  </THead>
+                  <TBody>
+                    {runs.map((r) => {
+                      // Run-level averages, same math as the Experiments list.
+                      const avgCost = r.cost != null && r.caseCount > 0 ? r.cost / r.caseCount : null;
+                      const avgDurationMs =
+                        r.elapsedMs != null && r.caseCount > 0
+                          ? Math.round(r.elapsedMs / r.caseCount)
+                          : null;
+                      return (
+                        <TR
+                          key={r.resultId}
+                          interactive
+                          onClick={() =>
+                            router.push(`/projects/${projectId}/evaluations/${r.runId}`)
+                          }
+                        >
+                          <Td className="whitespace-nowrap text-muted-foreground">
+                            <Timestamp iso={r.ranAt} />
+                          </Td>
+                          <Td className="text-foreground">{r.evaluationName}</Td>
+                          <Td className="whitespace-nowrap">
+                            <span className="font-mono">{r.candidateVersion}</span>{" "}
+                            <span className="tabular-nums text-muted-foreground">
+                              #{r.runNumber}
+                            </span>
+                          </Td>
+                          <Td className="text-right tabular-nums">
+                            <ScoreValue value={r.score} />
+                          </Td>
+                          <Td className="text-right tabular-nums text-muted-foreground">
+                            {formatCost(r.cost)}
+                          </Td>
+                          <Td className="text-right tabular-nums text-muted-foreground">
+                            {formatCost(avgCost)}
+                          </Td>
+                          <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
+                            {formatElapsed(r.elapsedMs)}
+                          </Td>
+                          <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
+                            {formatElapsed(avgDurationMs)}
+                          </Td>
+                        </TR>
+                      );
+                    })}
+                  </TBody>
+                </Table>
+              </div>
+            )}
+          </ResizablePanel>
 
-      {/* Save (when edited) + Review — primary actions, at the bottom. */}
-      <div className="flex shrink-0 items-center gap-2 border-t border-border p-3">
-        {dirty && (
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-8 flex-1 text-[12px]"
-            disabled={update.isPending || metadataInvalid}
-            onClick={saveEdits}
-          >
-            Save changes
-          </Button>
-        )}
-        <Button
-          size="sm"
-          className="h-8 flex-1 text-[12px]"
-          onClick={onReview}
-          disabled={readOnly}
-          title={readOnly ? "Switch to the current version to review this case" : undefined}
-        >
-          Review
-        </Button>
+          {aiPanelOpen && (
+            <>
+              <ResizableHandle />
+              <ResizablePanel
+                id="case-ai-chat"
+                defaultSize="31%"
+                minSize="320px"
+                maxSize="45%"
+                className="min-w-0 border-l border-border bg-background"
+              >
+                <AiAssistantPanel
+                  projectId={projectId}
+                  compact
+                  onClose={() => {
+                    setAiPanelOpen(false);
+                    setAiContext(null);
+                    setAiInitialSessionId(undefined);
+                  }}
+                />
+              </ResizablePanel>
+            </>
+          )}
+        </ResizablePanelGroup>
       </div>
     </div>
   );

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as React from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { SearchFilterBar } from "@/components/search-filter-bar";
@@ -10,14 +9,11 @@ import { useUrlPagination } from "@/lib/hooks/use-url-pagination";
 import { useToast } from "@/components/ui/toast";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { DatasetActionsMenu, Timestamp } from "@/features/offline-eval/components";
+import { Table, TBody, Td, Th, THead, TR, TRHead, TableEmpty } from "@/components/ui/table";
 import { useDatasets, useDeleteDataset, useEvaluations } from "../hooks";
 import type { DatasetRow } from "../types";
 import { NewDatasetPanel, DatasetEditPanel } from "../components/dataset-panels";
 import { DeleteDatasetDialog } from "../components/delete-dataset-dialog";
-
-const TH =
-  "h-7 whitespace-nowrap border-r border-border/50 px-3 text-left text-[12px] font-medium text-muted-foreground";
-const TD = "border-r border-border/50 px-3 py-1.5 text-[12px]";
 
 /**
  * Dataset list — the dataset library, wired to the server: tracing-style
@@ -84,31 +80,29 @@ export function DatasetsView({ projectId }: { projectId: string }) {
       <SearchFilterBar
         searchValue={keyword}
         onSearchChange={setKeyword}
-        searchPlaceholder="Search datasets..."
+        searchPlaceholder="Search..."
       >
         <span className="flex-1" aria-hidden />
       </SearchFilterBar>
 
       <div className="min-h-0 flex-1 overflow-auto">
-        <table className="w-full">
-          <thead className="sticky top-0 bg-background">
-            <tr className="border-b border-border bg-muted/50">
-              <th className={`${TH} w-[170px]`}>Last updated</th>
-              <th className={`${TH} w-[240px]`}>Dataset ID</th>
-              <th className={TH}>Name</th>
-              <th className={`${TH} w-[110px] text-right`}>Test cases</th>
-              <th className={`${TH} w-[90px] text-right`}>Versions</th>
-              <th className={`${TH} w-[110px] text-right`}>Evaluations</th>
-              <th className="w-[56px] px-2 py-1.5 text-right text-[12px] font-medium text-muted-foreground">
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody>
+        <Table>
+          <THead>
+            <TRHead>
+              <Th className="w-[170px]">Updated At</Th>
+              <Th>Name</Th>
+              <Th className="w-[240px]">Dataset ID</Th>
+              <Th className="w-[110px] text-right">Items</Th>
+              <Th className="w-[90px] text-right">Versions</Th>
+              <Th className="w-[110px] text-right">Evaluations</Th>
+              <Th className="w-[56px] text-right">Actions</Th>
+            </TRHead>
+          </THead>
+          <TBody>
             {isLoading ? (
-              <RowMessage>Loading datasets...</RowMessage>
+              <TableEmpty colSpan={7}>Loading datasets...</TableEmpty>
             ) : error ? (
-              <RowMessage tone="destructive">
+              <TableEmpty colSpan={7}>
                 Error loading datasets.{" "}
                 <button
                   type="button"
@@ -117,62 +111,53 @@ export function DatasetsView({ projectId }: { projectId: string }) {
                 >
                   Try again
                 </button>
-              </RowMessage>
+              </TableEmpty>
             ) : datasets.length === 0 ? (
-              <RowMessage>
+              <TableEmpty colSpan={7}>
                 {keyword
                   ? "No datasets match your search."
                   : "No datasets yet — save a trace or span as a test case to start one."}
-              </RowMessage>
+              </TableEmpty>
             ) : (
               datasets.map((dataset) => {
                 const href = `/projects/${projectId}/datasets/${dataset.id}`;
                 return (
-                  <tr
-                    key={dataset.id}
-                    onClick={() => router.push(href)}
-                    className="cursor-pointer border-b border-border/50 transition-colors last:border-0 hover:bg-muted/50"
-                  >
-                    <td className={`${TD} whitespace-nowrap text-muted-foreground`}>
+                  <TR key={dataset.id} interactive onClick={() => router.push(href)}>
+                    <Td className="whitespace-nowrap text-muted-foreground">
                       <Timestamp iso={dataset.updateTime} />
-                    </td>
-                    <td
-                      className={`${TD} max-w-[240px] truncate font-mono text-[11px] text-muted-foreground`}
+                    </Td>
+                    {/* Name is the row's primary identifier — dark like the detector
+                        list's name cell — but NOT a separate link: the whole row is the
+                        single click target (keyboard-reachable via the interactive TR),
+                        so there's no competing name link. */}
+                    <Td className="text-foreground">{dataset.name}</Td>
+                    <Td
+                      className="max-w-[240px] truncate font-mono text-[11px] text-muted-foreground"
                       title={dataset.id}
                     >
                       {dataset.id}
-                    </td>
-                    <td className={`${TD} font-medium`}>
-                      {/* A real link, not just a clickable <tr>: keyboard-reachable,
-                          and middle-click / open-in-new-tab / copy-link all work.
-                          The row's onClick above stays as a mouse convenience. */}
-                      <Link
-                        href={href}
-                        className="rounded outline-none hover:underline focus-visible:ring-1 focus-visible:ring-ring"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        {dataset.name}
-                      </Link>
-                    </td>
-                    <td className={`${TD} text-right tabular-nums`}>{dataset.caseCount}</td>
-                    <td className={`${TD} text-right tabular-nums text-muted-foreground`}>
+                    </Td>
+                    <Td className="text-right tabular-nums text-muted-foreground">
+                      {dataset.caseCount}
+                    </Td>
+                    <Td className="text-right tabular-nums text-muted-foreground">
                       {dataset.versionCount}
-                    </td>
-                    <td className={`${TD} text-right tabular-nums text-muted-foreground`}>
+                    </Td>
+                    <Td className="text-right tabular-nums text-muted-foreground">
                       {evalCountByDataset.get(dataset.id) ?? 0}
-                    </td>
-                    <td className="px-2 text-right">
+                    </Td>
+                    <Td className="text-right">
                       <DatasetActionsMenu
                         onEdit={() => setEditing(dataset)}
                         onDelete={() => setDeleteTarget(dataset)}
                       />
-                    </td>
-                  </tr>
+                    </Td>
+                  </TR>
                 );
               })
             )}
-          </tbody>
-        </table>
+          </TBody>
+        </Table>
       </div>
 
       {meta && meta.total > 0 && (
@@ -204,20 +189,5 @@ export function DatasetsView({ projectId }: { projectId: string }) {
         />
       )}
     </div>
-  );
-}
-
-function RowMessage({ children, tone }: { children: React.ReactNode; tone?: "destructive" }) {
-  return (
-    <tr>
-      <td
-        colSpan={7}
-        className={`px-3 py-10 text-center text-[12px] ${
-          tone ? "text-destructive" : "text-muted-foreground"
-        }`}
-      >
-        {children}
-      </td>
-    </tr>
   );
 }

--- a/frontend/ui/src/features/offline-eval/components/code.test.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.test.tsx
@@ -271,6 +271,7 @@ describe("EditableValueBlock", () => {
     return (
       <EditableValueBlock
         label="Input"
+        formatSwitcher
         {...props}
         text={text}
         onChange={(t) => {
@@ -345,6 +346,7 @@ describe("EditableValueBlock", () => {
         text={'{"a":1}'}
         onChange={onChange}
         seedJson="expanded"
+        formatSwitcher
         readOnly
       />,
     );
@@ -371,7 +373,15 @@ describe("EditableValueBlock", () => {
 
   it("reformats a read-only field locally", async () => {
     const onChange = vi.fn();
-    render(<EditableValueBlock label="Input" text={'{"a":1}'} onChange={onChange} readOnly />);
+    render(
+      <EditableValueBlock
+        label="Input"
+        text={'{"a":1}'}
+        onChange={onChange}
+        formatSwitcher
+        readOnly
+      />,
+    );
     fireEvent.click(screen.getByText("YAML"));
     fireEvent.click(await screen.findByRole("button", { name: "Pretty" }));
     expect(onChange).not.toHaveBeenCalled();

--- a/frontend/ui/src/features/offline-eval/components/code.tsx
+++ b/frontend/ui/src/features/offline-eval/components/code.tsx
@@ -191,6 +191,7 @@ export function LineNumberedTextarea({
   value,
   onChange,
   minRows = 1,
+  maxRows,
   placeholder,
   highlightJson = false,
   readOnly = false,
@@ -203,6 +204,10 @@ export function LineNumberedTextarea({
   value: string;
   onChange: (value: string) => void;
   minRows?: number;
+  /** Cap the box at this many lines and scroll internally past it — the full value
+   *  is always shown (no "…expand" clip), it just fits in a bounded, scrollable box.
+   *  Assumes the default 18px line-height. */
+  maxRows?: number;
   placeholder?: string;
   /** When true, JSON content is syntax-highlighted (trace-panel colors). */
   highlightJson?: boolean;
@@ -246,10 +251,19 @@ export function LineNumberedTextarea({
     // drift apart as lines accumulate and the textarea's last line gets clipped.
     <div
       className={cn(
-        "relative overflow-hidden rounded border border-input bg-background font-mono focus-within:ring-1 focus-within:ring-ring",
+        "overflow-hidden rounded border border-input bg-background font-mono focus-within:ring-1 focus-within:ring-ring",
         fontClassName,
+        // With maxRows the box is bounded and scrolls internally; the full value is
+        // still rendered (no clip), so a long input/output stays editable without
+        // an "…expand" step and never balloons the surrounding page.
+        maxRows != null && "overflow-y-auto",
       )}
+      style={maxRows != null ? { maxHeight: maxRows * 18 + 14 } : undefined}
     >
+      {/* `relative` moves here (off the scroll container) so the absolute textarea
+          layer sizes to the FULL content height and scrolls together with the
+          display layer, staying aligned. */}
+      <div className="relative">
       {/* Display layer — line numbers + (highlighted) content, wraps per line.
           Collapsed has no textarea overlay, so it must take pointer events (the
           inline expand control lives here). */}
@@ -323,6 +337,7 @@ export function LineNumberedTextarea({
           style={{ paddingLeft: `calc(${gutterWidth} + 0.5rem)` }}
         />
       )}
+      </div>
     </div>
   );
 }
@@ -491,10 +506,12 @@ export function EditableValueBlock({
   autoDetectKind = false,
   seedJson,
   minRows = 1,
+  maxRows,
   boxed = false,
   readOnly = false,
   collapsible = false,
   collapseResetKey,
+  formatSwitcher = false,
 }: {
   label: string;
   text: string;
@@ -503,6 +520,10 @@ export function EditableValueBlock({
   ariaLabel?: string;
   copyable?: boolean;
   autoDetectKind?: boolean;
+  /** Show the YAML/Text/JSON/Pretty switcher. Off by default so editable fields match
+   *  the production trace panel (no format menu); the value is still seeded/normalised
+   *  via `seedJson`. Opt in only where a format menu is genuinely wanted. */
+  formatSwitcher?: boolean;
   /**
    * Present (and normalise) a seeded JSON value per this field's role rather
    * than following however it was serialised upstream. Supersedes
@@ -510,6 +531,9 @@ export function EditableValueBlock({
    */
   seedJson?: SeedJsonPreference;
   minRows?: number;
+  /** Cap the field at this many lines and scroll internally past it (full value
+   *  always shown, no "…expand"). Pairs with leaving `collapsible` off. */
+  maxRows?: number;
   /** Wrap the block in a bordered card with a muted header strip (like FormCard). */
   boxed?: boolean;
   /** Display only — same look and format switcher, but the text can't be edited. */
@@ -590,32 +614,34 @@ export function EditableValueBlock({
 
   const controls = (
     <div className="flex items-center gap-1">
-      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          >
-            {KIND_LABEL[kind]}
-            <ChevronDown className="h-3 w-3" aria-hidden />
-          </button>
-        </PopoverTrigger>
-        <PopoverContent align="end" className="w-28 p-1">
-          {KINDS.map((k) => (
+      {formatSwitcher && (
+        <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+          <PopoverTrigger asChild>
             <button
-              key={k}
               type="button"
-              onClick={() => changeKind(k)}
-              className={cn(
-                "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
-                k === kind ? "bg-muted/70" : "hover:bg-muted/50",
-              )}
+              className="flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
-              {KIND_LABEL[k]}
+              {KIND_LABEL[kind]}
+              <ChevronDown className="h-3 w-3" aria-hidden />
             </button>
-          ))}
-        </PopoverContent>
-      </Popover>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-28 p-1">
+            {KINDS.map((k) => (
+              <button
+                key={k}
+                type="button"
+                onClick={() => changeKind(k)}
+                className={cn(
+                  "flex w-full items-center rounded px-2 py-1 text-left text-[12px] transition-colors",
+                  k === kind ? "bg-muted/70" : "hover:bg-muted/50",
+                )}
+              >
+                {KIND_LABEL[k]}
+              </button>
+            ))}
+          </PopoverContent>
+        </Popover>
+      )}
       {copyable && (
         // Sized to the read-only I/O section's copy affordance (16px box, 12px
         // icon) so the header strip is the same height as ExpandableSection's.
@@ -669,6 +695,7 @@ export function EditableValueBlock({
         value={readOnly ? display : text}
         onChange={onChange}
         minRows={minRows}
+        maxRows={maxRows}
         highlightJson={kind === "json" || kind === "pretty"}
         readOnly={readOnly}
         collapsed={isCollapsed}

--- a/frontend/ui/src/features/offline-eval/components/dataset-actions-menu.tsx
+++ b/frontend/ui/src/features/offline-eval/components/dataset-actions-menu.tsx
@@ -27,6 +27,9 @@ export function DatasetActionsMenu({
           size="sm"
           className="h-5 w-6 p-0 text-muted-foreground hover:text-foreground"
           onClick={(e) => e.stopPropagation()}
+          // Keyboard users: Enter/Space must open THIS menu, not bubble to the row's
+          // own key handler (which would open the case instead).
+          onKeyDown={(e) => e.stopPropagation()}
           aria-label="Row actions"
         >
           <MoreHorizontal className="h-3.5 w-3.5" />

--- a/frontend/ui/src/features/offline-eval/components/dataset-form.tsx
+++ b/frontend/ui/src/features/offline-eval/components/dataset-form.tsx
@@ -2,70 +2,34 @@
 
 import * as React from "react";
 import { Input } from "@/components/ui/input";
-import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
-import { LineNumberedTextarea } from "./code";
 
 /**
- * The shared dataset form — used by both the "New dataset" centered dialog and
- * the "Edit dataset" side panel, so create and edit stay identical (the way
- * Create Detector and the detector edit panel share fields).
+ * The shared dataset form — used by both the "New dataset" and "Edit dataset"
+ * panels, so create and edit stay identical.
  *
- * Schema toggles default off and are mostly illustrative for now: when enabled
- * they reveal an editable JSON block for the schema's properties/required. We
- * keep the shape visible so the concept is testable before the details are
- * settled.
+ * v1 is deliberately just Name + Description. Per-row input / expected-output
+ * JSON-schema validation is a later addition — it's off by default and nothing
+ * depends on it yet, so it can land without touching existing datasets.
  */
 
 export interface DatasetFormState {
   name: string;
   description: string;
-  metadata: string;
-  inputSchemaEnabled: boolean;
-  inputSchema: string;
-  expectedSchemaEnabled: boolean;
-  expectedSchema: string;
 }
 
-const DEFAULT_INPUT_SCHEMA = `{
-  "type": "object",
-  "properties": {
-    "input": { "type": "string" }
-  },
-  "required": ["input"]
-}`;
-
-const DEFAULT_EXPECTED_SCHEMA = `{
-  "type": "object",
-  "properties": {
-    "expected": { "type": "string" }
-  },
-  "required": ["expected"]
-}`;
-
 export function emptyDatasetForm(overrides: Partial<DatasetFormState> = {}): DatasetFormState {
-  return {
-    name: "",
-    description: "",
-    metadata: "",
-    inputSchemaEnabled: false,
-    inputSchema: DEFAULT_INPUT_SCHEMA,
-    expectedSchemaEnabled: false,
-    expectedSchema: DEFAULT_EXPECTED_SCHEMA,
-    ...overrides,
-  };
+  return { name: "", description: "", ...overrides };
 }
 
 /** Bordered card matching the Create Detector form fields. */
 function Card({
   label,
   optional,
-  action,
   children,
 }: {
   label: string;
   optional?: boolean;
-  action?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
@@ -77,7 +41,6 @@ function Card({
             <span className="ml-1 font-normal text-muted-foreground/70">(optional)</span>
           )}
         </span>
-        {action}
       </div>
       <div className="p-3">{children}</div>
     </div>
@@ -102,7 +65,7 @@ export function DatasetFormFields({
         <Input
           value={state.name}
           onChange={(e) => set("name", e.target.value)}
-          placeholder="e.g. Billing routing"
+          aria-label="Name"
           className="h-7 text-[13px]"
           required
         />
@@ -112,70 +75,10 @@ export function DatasetFormFields({
         <Input
           value={state.description}
           onChange={(e) => set("description", e.target.value)}
-          placeholder="What this collection of test cases is for"
+          aria-label="Description"
           className="h-7 text-[13px]"
         />
       </Card>
-
-      <Card label="Metadata" optional>
-        <LineNumberedTextarea
-          value={state.metadata}
-          onChange={(v) => set("metadata", v)}
-          highlightJson
-          aria-label="Metadata"
-        />
-      </Card>
-
-      <SchemaCard
-        label="Input schema"
-        enabled={state.inputSchemaEnabled}
-        onToggle={(v) => set("inputSchemaEnabled", v)}
-        explanation="Describe the shape each test case's input must take. When on, rows are validated against this schema. Leave off to accept any input."
-        value={state.inputSchema}
-        onValueChange={(v) => set("inputSchema", v)}
-      />
-
-      <SchemaCard
-        label="Expected output schema"
-        enabled={state.expectedSchemaEnabled}
-        onToggle={(v) => set("expectedSchemaEnabled", v)}
-        explanation="Describe the shape of the expected answer. When on, expected values are validated against this schema. Leave off when a scorer judges the output directly."
-        value={state.expectedSchema}
-        onValueChange={(v) => set("expectedSchema", v)}
-      />
     </div>
-  );
-}
-
-function SchemaCard({
-  label,
-  enabled,
-  onToggle,
-  explanation,
-  value,
-  onValueChange,
-}: {
-  label: string;
-  enabled: boolean;
-  onToggle: (v: boolean) => void;
-  explanation: string;
-  value: string;
-  onValueChange: (v: string) => void;
-}) {
-  return (
-    <Card label={label} action={<Switch checked={enabled} onCheckedChange={onToggle} />}>
-      <p className="text-[11px] leading-relaxed text-muted-foreground">{explanation}</p>
-      {enabled && (
-        <div className="mt-2">
-          <LineNumberedTextarea
-            value={value}
-            onChange={onValueChange}
-            minRows={3}
-            highlightJson
-            aria-label={`${label} JSON`}
-          />
-        </div>
-      )}
-    </Card>
   );
 }

--- a/frontend/ui/src/features/offline-eval/types.ts
+++ b/frontend/ui/src/features/offline-eval/types.ts
@@ -164,8 +164,6 @@ export interface TestCase {
    * than comparing it to one exact answer.
    */
   expected: string | null;
-  /** What the span actually produced in production. Read-only, never = expected. */
-  recordedOutput: string | null;
   /** Why this span was captured — read-only context for the reviewer. */
   captureReason: CaptureReason;
   source: CaseSource;

--- a/frontend/ui/src/lib/eval/result-to-dataset.ts
+++ b/frontend/ui/src/lib/eval/result-to-dataset.ts
@@ -7,8 +7,9 @@ import { publishDatasetVersion, newTestCaseId, type TestCaseSeed } from "./versi
  *
  * Invariants enforced here:
  *  - Candidate output is NEVER used as expected implicitly. `expected` is set only
- *    from an explicit value or an explicit "use candidate as expected" opt-in; the
- *    candidate always rides along separately as `recordedOutput`.
+ *    from an explicit value or an explicit "use candidate as expected" opt-in. The
+ *    candidate output isn't stored on the case; the source run/result links preserve
+ *    what actually happened (matching the dataset-item model).
  *  - Updating an existing case publishes a new immutable version and preserves the
  *    stable logical `testCaseId`.
  *  - Re-saving a result into its ORIGINATING dataset as a *new* case is refused with
@@ -150,8 +151,6 @@ export async function saveResultToDataset(opts: {
     input: inputProvided ? (opts.input ?? "") : result.input,
     // A brand-new case: expected defaults to null (never the candidate) unless set.
     expected: resolveExpected(null),
-    // The candidate output is recorded separately, never as expected.
-    recordedOutput: result.candidateOutput ?? null,
     metadata: metadataProvided ? opts.metadata : null,
     review: "needs_review",
     captureReason: "manual",

--- a/frontend/ui/src/lib/eval/versions.ts
+++ b/frontend/ui/src/lib/eval/versions.ts
@@ -25,7 +25,6 @@ export type TestCaseSeed = {
   testCaseId: string;
   input: string;
   expected: string | null;
-  recordedOutput: string | null;
   metadata: unknown;
   review: string;
   captureReason: string;
@@ -52,7 +51,6 @@ function toSeed(c: TestCase): TestCaseSeed {
     testCaseId: c.testCaseId,
     input: c.input,
     expected: c.expected,
-    recordedOutput: c.recordedOutput,
     metadata: c.metadata ?? null,
     review: c.review,
     captureReason: c.captureReason,


### PR DESCRIPTION
Part **3 of 3** of the offline-eval UI redesign (tracking: #1844), stacked on the trace-diff-cleanup PR.

## What
- The dataset-row panel's **Experiments** tab now mirrors the Experiments-list columns (Experiment Name, Run Name, Score, Cost / Avg Cost, Duration / Avg Duration) and is **scoped to the dataset version being viewed** — runs that measured a different version of the row are hidden.
- The `test-cases/[id]/runs` route gains each run's `datasetVersionId` plus run-level cost/duration aggregates to power the columns.

Also lands the supporting offline-eval dataset changes it depends on (row editor + delete dialogs, dataset form/components, versioning helpers, schema/contract).

Frontend + a read-only route change; no SDK changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a version-scoped Experiments tab for dataset rows and updates dataset detail to show only runs that measured the viewed version. Also ships a test-case editor and delete flow that publish new dataset versions, simplifies dataset forms, and removes `recorded_output` from the schema and APIs.

- **New Features**
  - Experiments tab shows Experiment, Run, Score, Cost/Avg Cost, and Duration/Avg Duration, filtered to the dataset version in view.
  - Test-case runs API returns `datasetVersionId`, `caseCount`, and run-level cost/duration aggregates to power those columns.
  - New Test Case editor modal and Delete dialog; both publish a new dataset version so older snapshots stay intact.

- **Refactors**
  - Remove `recorded_output` from DB, API contract, and types; candidate output isn’t stored on the case (provenance comes from the source run/result).
  - Runs list API includes dataset-version `createTime` and `versionNumber` for UI sorting.
  - Simplify the dataset form to Name and Description; streamline dataset detail and “Add to datasets” flows.

<sup>Written for commit 34132be74241b2cd1a8063763944f873dfe8dc58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

