### PR TITLE
refactor(ui): rename Evaluations → Experiments in nav + align trace pages

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -87,11 +87,7 @@ export default function DetectorsPage() {
     search_query: queryOptions.search_query,
   });
 
-  const {
-    data: counts,
-    isLoading: countsLoading,
-    error: countsError,
-  } = useDetectorCounts(projectId, {
+  const { data: counts, isLoading: countsLoading } = useDetectorCounts(projectId, {
     start_after: queryOptions.start_after,
     end_before: queryOptions.end_before,
   });
@@ -126,7 +122,7 @@ export default function DetectorsPage() {
 
   return (
     <div className="relative flex h-full text-[13px]">
-      <ProjectBreadcrumb projectId={projectId} />
+      <ProjectBreadcrumb projectId={projectId} current="Detectors" />
 
       <div className="flex flex-1 flex-col overflow-hidden">
         {/* Page header */}

--- a/frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
@@ -91,9 +91,13 @@ export default function SessionsPage() {
 
   return (
     <div className="relative flex h-full text-[13px]">
-      <ProjectBreadcrumb projectId={projectId} />
+      <ProjectBreadcrumb projectId={projectId} current="Tracing" />
 
       <div className="flex flex-1 flex-col">
+        {/* Page title — consistent with Datasets / Detectors / Evaluations. */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-2">
+          <h1 className="text-[13px] font-medium">Tracing</h1>
+        </div>
         {/* Tab navigation */}
         <div className="border-b border-border bg-background">
           <div className="flex">

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
-import { X, Inbox, AlertTriangle } from "lucide-react";
+import { X, Inbox, AlertTriangle, Plus } from "lucide-react";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { TraceSearchFilterInput } from "@/features/filters/trace-search-filter-input";
@@ -158,10 +158,14 @@ export default function TracesPage() {
 
   return (
     <div className="relative flex h-full text-[13px]">
-      <ProjectBreadcrumb projectId={projectId} />
+      <ProjectBreadcrumb projectId={projectId} current="Tracing" />
 
       {/* Main content */}
       <div className="flex min-w-0 flex-1 flex-col">
+        {/* Page title — consistent with Datasets / Detectors / Evaluations. */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-2">
+          <h1 className="text-[13px] font-medium">Tracing</h1>
+        </div>
         {/* Tab navigation — hidden during onboarding or while checking */}
         {!checking && !showGettingStarted && (
           <div className="border-b border-border bg-background">
@@ -437,13 +441,14 @@ export default function TracesPage() {
             <Button
               variant="outline"
               size="sm"
-              className="h-7 shrink-0 text-[12px]"
+              className="h-7 shrink-0 gap-1.5 text-[12px]"
               onClick={() => {
                 setSaveSpanId(selection.type === "span" ? selection.span.span_id : undefined);
                 setSaveOpen(true);
               }}
             >
-              Save as test case
+              <Plus className="h-3.5 w-3.5" aria-hidden />
+              Add to datasets
             </Button>
           )}
           // Offline eval: while the "Save as test case" drawer is open, clicking a

--- a/frontend/ui/src/app/projects/[projectId]/users/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/users/page.tsx
@@ -91,10 +91,14 @@ export default function UsersPage() {
 
   return (
     <div className="relative flex h-full text-[13px]">
-      <ProjectBreadcrumb projectId={projectId} />
+      <ProjectBreadcrumb projectId={projectId} current="Tracing" />
 
       {/* Main content */}
       <div className="flex flex-1 flex-col">
+        {/* Page title — consistent with Datasets / Detectors / Evaluations. */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-2">
+          <h1 className="text-[13px] font-medium">Tracing</h1>
+        </div>
         {/* Tab navigation */}
         <div className="border-b border-border bg-background">
           <div className="flex">

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -233,12 +233,12 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                     )}
                   >
                     <FlaskConical className="h-3.5 w-3.5 shrink-0" />
-                    {!collapsed && "Evaluations"}
+                    {!collapsed && "Experiments"}
                   </Link>
                 </TooltipTrigger>
                 {collapsed && (
                   <TooltipContent side="right" sideOffset={16}>
-                    Evaluations
+                    Experiments
                   </TooltipContent>
                 )}
               </Tooltip>


### PR DESCRIPTION
Stacked on top of the offline-eval UI redesign (#1847). Finishes the **Evaluations → Experiments** rename so the app reads consistently:

- **Sidebar**: nav entry `Evaluations` → `Experiments`.
- **Trace / session pages**: consistent page title and `Add to datasets` (was `Save as test case`) to match the redesigned surfaces.
- Small breadcrumb `current` labels on the detectors/sessions/traces/users pages.

Frontend only; no behaviour change beyond labels/titles. Stacked after #1847 so the rename lands together with the redesign it names.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the "Evaluations" → "Experiments" rename and aligns tracing pages with the new wording. Frontend-only; labels and titles updated, no behavior changes.

- **Refactors**
  - Sidebar: "Evaluations" → "Experiments".
  - Tracing UI: added a consistent "Tracing" page title and breadcrumb current labels across traces, sessions, and users (detectors labeled "Detectors").
  - Traces action: "Save as test case" → "Add to datasets" with a plus icon.

<sup>Written for commit 46a4859ed9cb2716e01a5ae2a208b48755e5abea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

