### PR TITLE
fix(ui): fetch the GitHub star count through a cached server route

### DIFF
--- a/frontend/ui/src/app/api/github-stars/route.ts
+++ b/frontend/ui/src/app/api/github-stars/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+// Server-side, cached proxy for the GitHub star count. The widget used to call
+// api.github.com directly from every browser, which hits GitHub's unauthenticated
+// 60-requests/hour-per-IP limit (everyone behind one office/VPN IP shares it) and
+// returns 403 → the widget showed "—". Proxying here means the server makes at most
+// one upstream call per hour (Next caches the response) for ALL viewers, and can
+// attach a token to lift the limit entirely.
+const REPO = "traceroot-ai/traceroot";
+const TTL_SECONDS = 3600; // 1 hour
+
+export const revalidate = 3600;
+
+export async function GET() {
+  try {
+    const headers: Record<string, string> = { Accept: "application/vnd.github+json" };
+    if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+
+    const res = await fetch(`https://api.github.com/repos/${REPO}`, {
+      headers,
+      next: { revalidate: TTL_SECONDS },
+    });
+    if (!res.ok) return NextResponse.json({ stars: null });
+
+    const data = (await res.json()) as { stargazers_count?: number };
+    const stars = typeof data.stargazers_count === "number" ? data.stargazers_count : null;
+    return NextResponse.json({ stars });
+  } catch {
+    // Never surface an error to the widget — a missing count just renders as "—".
+    return NextResponse.json({ stars: null });
+  }
+}

--- a/frontend/ui/src/components/layout/GitHubStarWidget.test.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.test.tsx
@@ -79,8 +79,10 @@ describe("GitHubStarWidget", () => {
       "github-star-count-cache",
       JSON.stringify({ count: 1, timestamp: Date.now() - 2 * 60 * 60 * 1000 }),
     );
+    // The widget goes through our own cached server route (not api.github.com
+    // directly), which returns `{ stars }`.
     const fetchMock = vi.fn().mockResolvedValue({
-      json: () => Promise.resolve({ stargazers_count: 1500 }),
+      json: () => Promise.resolve({ stars: 1500 }),
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -90,7 +92,7 @@ describe("GitHubStarWidget", () => {
       await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledWith("https://api.github.com/repos/traceroot-ai/traceroot");
+    expect(fetchMock).toHaveBeenCalledWith("/api/github-stars");
     expect(container.textContent).toContain("1.5k");
   });
 });

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -7,7 +7,6 @@ import { clientEnv } from "@/env.client";
 const DISMISSED_KEY = "github-star-widget-dismissed";
 const STAR_CACHE_KEY = "github-star-count-cache";
 const STAR_CACHE_TTL = 60 * 60 * 1000; // 1 hour
-const REPO = "traceroot-ai/traceroot";
 
 function formatStarCount(n: number): string {
   return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
@@ -34,14 +33,18 @@ export function GitHubStarWidget() {
         // malformed cache entry — fall through to fetch
       }
     }
-    fetch(`https://api.github.com/repos/${REPO}`)
+    // Go through our own cached server route, not api.github.com directly: the
+    // unauthenticated GitHub API is capped at 60 req/hour per IP, so calling it from
+    // every browser fails with 403 and the count renders as "—". The proxy makes at
+    // most one upstream call per hour for all viewers.
+    fetch("/api/github-stars")
       .then((r) => r.json())
-      .then((data: { stargazers_count?: number }) => {
-        if (typeof data.stargazers_count === "number") {
-          setStarCount(data.stargazers_count);
+      .then((data: { stars?: number | null }) => {
+        if (typeof data.stars === "number") {
+          setStarCount(data.stars);
           localStorage.setItem(
             STAR_CACHE_KEY,
-            JSON.stringify({ count: data.stargazers_count, timestamp: Date.now() }),
+            JSON.stringify({ count: data.stars, timestamp: Date.now() }),
           );
         }
       })


### PR DESCRIPTION
Independent of the eval stack.

The star-count widget hit `api.github.com` directly from the browser, which is **unauthenticated and rate-limited per client IP** — visitors over the limit got a 403 and the count rendered as `—`.

This routes the request through a small cached server route (`/api/github-stars`) that fetches once server-side, and the widget reads `{ stars }` from it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route GitHub star count through a cached server endpoint to avoid unauthenticated rate limits and prevent the widget from showing "—" on 403s. The widget now reads `{ stars }` from `/api/github-stars`, ensuring consistent counts for all users.

- **Bug Fixes**
  - Added cached server route `/api/github-stars` (1h TTL) that proxies GitHub and uses `GITHUB_TOKEN` if present.
  - Updated `GitHubStarWidget` to fetch from the server route and use `{ stars }`, with local storage caching.
  - Adjusted tests to expect `/api/github-stars` and the `{ stars }` response shape.

<sup>Written for commit d5fc08b50ba32c5442f303fe4d898f9bfd5c92cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

