### PR TITLE
feat(eval): converge dataset identity — content-address versions + UI name guards

### DIFF
--- a/frontend/packages/core/prisma/migrations/20260811020000_dataset_name_unique_ui/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260811020000_dataset_name_unique_ui/migration.sql
@@ -1,0 +1,11 @@
+-- Race-safe backstop for the UI dataset name-uniqueness guards. The application-level
+-- pre-checks in the create/rename routes are check-then-write and can be raced past by
+-- two concurrent requests; this partial unique index is the authoritative enforcement.
+--
+-- Scoped to UI-authored datasets (client_dataset_id IS NULL) and case-insensitive to match
+-- the guards. SDK-authored datasets (client_dataset_id set) are intentionally EXCLUDED —
+-- they converge on (project_id, client_dataset_id) and may legitimately share a display
+-- name under different stable ids.
+CREATE UNIQUE INDEX "uq_dataset_project_lower_name_ui"
+  ON "datasets" (project_id, lower(name))
+  WHERE client_dataset_id IS NULL;

--- a/frontend/packages/core/prisma/migrations/20260811020000_dataset_name_unique_ui/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260811020000_dataset_name_unique_ui/migration.sql
@@ -6,6 +6,29 @@
 -- the guards. SDK-authored datasets (client_dataset_id set) are intentionally EXCLUDED —
 -- they converge on (project_id, client_dataset_id) and may legitimately share a display
 -- name under different stable ids.
+-- Name uniqueness was NOT enforced before this migration, so a project may already hold two
+-- UI datasets with the same (case-insensitive) name. The bare index build below would then
+-- abort the deploy with an opaque duplicate-key error. Fail loudly first, with an actionable
+-- message and the offending (project, name) pairs, so an operator deduplicates before retrying.
+DO $$
+DECLARE
+  dup record;
+  msg text := '';
+BEGIN
+  FOR dup IN
+    SELECT project_id, lower(name) AS lname, count(*) AS n
+    FROM datasets
+    WHERE client_dataset_id IS NULL
+    GROUP BY project_id, lower(name)
+    HAVING count(*) > 1
+  LOOP
+    msg := msg || format('  project %s → "%s" (%s copies)%s', dup.project_id, dup.lname, dup.n, chr(10));
+  END LOOP;
+  IF msg <> '' THEN
+    RAISE EXCEPTION 'Cannot add uq_dataset_project_lower_name_ui — duplicate UI dataset names exist; deduplicate then re-run:%s%s', chr(10), msg;
+  END IF;
+END $$;
+
 CREATE UNIQUE INDEX "uq_dataset_project_lower_name_ui"
   ON "datasets" (project_id, lower(name))
   WHERE client_dataset_id IS NULL;

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -357,7 +357,9 @@ export type CompleteRunResponse = z.infer<typeof CompleteRunResponseSchema>;
 
 export const CreateDatasetRequestSchema = z
   .object({
-    name: z.string().min(1).max(200),
+    // Trim before validating so a name's stored/compared form is normalized — otherwise
+    // "Regression" vs "Regression " read as distinct and defeat the uniqueness guard.
+    name: z.string().trim().min(1).max(200),
     description: z.string().max(2000).nullable().optional(),
   })
   .strict();
@@ -365,7 +367,7 @@ export type CreateDatasetRequest = z.infer<typeof CreateDatasetRequestSchema>;
 
 export const UpdateDatasetRequestSchema = z
   .object({
-    name: z.string().min(1).max(200).optional(),
+    name: z.string().trim().min(1).max(200).optional(),
     description: z.string().max(2000).nullable().optional(),
   })
   .strict();

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts
@@ -201,6 +201,7 @@ describe("PATCH", () => {
       .find((a) => "name" in a.where)!;
     expect(clashCall.where).toEqual({
       projectId: "p1",
+      clientDatasetId: null,
       id: { not: "ds1" },
       name: { equals: "support", mode: "insensitive" },
     });

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts
@@ -206,6 +206,18 @@ describe("PATCH", () => {
     });
   });
 
+  it("409s when a concurrent write wins the rename race (P2002 from the unique index)", async () => {
+    // Both pre-checks clear (name-clash lookup → null), but the update loses to the DB index.
+    prismaMock.dataset.findFirst.mockImplementation(
+      async ({ where }: { where: Record<string, unknown> }) =>
+        "name" in where ? null : { id: "ds1" },
+    );
+    prismaMock.dataset.update.mockRejectedValue({ code: "P2002" });
+    const res = await PATCH(jsonReq({ name: "renamed" }), params);
+    expect(res.status).toBe(409);
+    expect((await body(res)).error).toContain("already exists");
+  });
+
   it("clears the description when it is explicitly null", async () => {
     prismaMock.dataset.findFirst.mockResolvedValue({ id: "ds1" });
     prismaMock.dataset.update.mockResolvedValue({ id: "ds1" });

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts
@@ -169,7 +169,12 @@ describe("GET", () => {
 
 describe("PATCH", () => {
   it("updates only the fields present in the body", async () => {
-    prismaMock.dataset.findFirst.mockResolvedValue({ id: "ds1" });
+    // Two findFirst calls when a name is sent: the existence check (by id) finds the
+    // dataset; the name-collision check (by name) finds nothing → the rename proceeds.
+    prismaMock.dataset.findFirst.mockImplementation(
+      async ({ where }: { where: Record<string, unknown> }) =>
+        "name" in where ? null : { id: "ds1" },
+    );
     prismaMock.dataset.update.mockResolvedValue({ id: "ds1", name: "renamed" });
 
     const res = await PATCH(jsonReq({ name: "renamed" }), params);
@@ -178,6 +183,26 @@ describe("PATCH", () => {
     expect(prismaMock.dataset.update).toHaveBeenCalledWith({
       where: { id: "ds1" },
       data: { name: "renamed" }, // description untouched, not nulled
+    });
+  });
+
+  it("409s a rename onto a name another dataset in the project already uses", async () => {
+    prismaMock.dataset.findFirst.mockImplementation(
+      async ({ where }: { where: Record<string, unknown> }) =>
+        "name" in where ? { name: "Support" } : { id: "ds1" }, // clash on a different-cased name
+    );
+    const res = await PATCH(jsonReq({ name: "support" }), params);
+    expect(res.status).toBe(409);
+    expect((await body(res)).error).toContain("already exists");
+    expect(prismaMock.dataset.update).not.toHaveBeenCalled();
+    // The collision lookup excludes this dataset itself and is case-insensitive.
+    const clashCall = prismaMock.dataset.findFirst.mock.calls
+      .map((c) => c[0] as { where: Record<string, unknown> })
+      .find((a) => "name" in a.where)!;
+    expect(clashCall.where).toEqual({
+      projectId: "p1",
+      id: { not: "ds1" },
+      name: { equals: "support", mode: "insensitive" },
     });
   });
 

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
@@ -108,14 +108,26 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     }
   }
 
-  const dataset = await prisma.dataset.update({
-    where: { id: datasetId },
-    data: {
-      ...(parsed.data.name !== undefined ? { name: parsed.data.name } : {}),
-      ...(parsed.data.description !== undefined ? { description: parsed.data.description } : {}),
-    },
-  });
-  return successResponse({ dataset });
+  try {
+    const dataset = await prisma.dataset.update({
+      where: { id: datasetId },
+      data: {
+        ...(parsed.data.name !== undefined ? { name: parsed.data.name } : {}),
+        ...(parsed.data.description !== undefined ? { description: parsed.data.description } : {}),
+      },
+    });
+    return successResponse({ dataset });
+  } catch (e) {
+    // A rename racing a concurrent create/rename to the same name loses to the partial
+    // unique index (uq_dataset_project_lower_name_ui); surface the same 409 as the pre-check.
+    if (parsed.data.name !== undefined && isPrismaKnownError(e, "P2002")) {
+      return errorResponse(
+        `A dataset named "${parsed.data.name}" already exists in this project. Pick a different name.`,
+        409,
+      );
+    }
+    throw e;
+  }
 }
 
 // DELETE — remove the dataset and cascade its versions/test cases.

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
@@ -95,6 +95,7 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     const clash = await prisma.dataset.findFirst({
       where: {
         projectId,
+        clientDatasetId: null, // UI-scoped, matching the partial unique index
         id: { not: datasetId },
         name: { equals: parsed.data.name, mode: "insensitive" as const },
       },

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
@@ -88,6 +88,26 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   });
   if (!existing) return errorResponse("Dataset not found", 404);
 
+  // A dataset's name is its human identity: renaming onto a name another dataset in the
+  // project already uses would deduplicate them, so deny it (case-insensitive). Excludes
+  // this dataset itself, so keeping (or re-casing) its own name is allowed.
+  if (parsed.data.name !== undefined) {
+    const clash = await prisma.dataset.findFirst({
+      where: {
+        projectId,
+        id: { not: datasetId },
+        name: { equals: parsed.data.name, mode: "insensitive" as const },
+      },
+      select: { name: true },
+    });
+    if (clash) {
+      return errorResponse(
+        `A dataset named "${clash.name}" already exists in this project. Pick a different name.`,
+        409,
+      );
+    }
+  }
+
   const dataset = await prisma.dataset.update({
     where: { id: datasetId },
     data: {

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/route.test.ts
@@ -187,6 +187,14 @@ describe("POST", () => {
     expect(prismaMock.dataset.create.mock.calls[0][0].data.description).toBeNull();
   });
 
+  it("trims surrounding whitespace from the name before the guard and store", async () => {
+    prismaMock.dataset.create.mockResolvedValue({ id: "ds_new", name: "support" });
+    await POST(jsonReq({ name: "  support  " }), params);
+    // Both the uniqueness pre-check and the stored value see the normalized name.
+    expect(prismaMock.dataset.findFirst.mock.calls[0][0].where.name.equals).toBe("support");
+    expect(prismaMock.dataset.create.mock.calls[0][0].data.name).toBe("support");
+  });
+
   it("409s a name that already exists in the project (case-insensitive), without creating", async () => {
     prismaMock.dataset.findFirst.mockResolvedValue({ name: "Support" }); // existing, different case
     const res = await POST(jsonReq({ name: "support" }), params);

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/route.test.ts
@@ -200,6 +200,15 @@ describe("POST", () => {
     });
   });
 
+  it("409s when a concurrent create wins the race (P2002 from the partial unique index)", async () => {
+    // The pre-check clears (findFirst → null), but the create loses to the DB index —
+    // the race-safe backstop must surface the same 409, not an unhandled 500.
+    prismaMock.dataset.create.mockRejectedValue({ code: "P2002" });
+    const res = await POST(jsonReq({ name: "support" }), params);
+    expect(res.status).toBe(409);
+    expect((await body(res)).error).toContain("already exists");
+  });
+
   it("400s an unparseable body", async () => {
     const res = await POST(badJsonReq(), params);
     expect(res.status).toBe(400);

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/route.test.ts
@@ -203,7 +203,11 @@ describe("POST", () => {
     expect(prismaMock.dataset.create).not.toHaveBeenCalled();
     // The uniqueness check is scoped to the project and case-insensitive.
     expect(prismaMock.dataset.findFirst).toHaveBeenCalledWith({
-      where: { projectId: "p1", name: { equals: "support", mode: "insensitive" } },
+      where: {
+        projectId: "p1",
+        clientDatasetId: null,
+        name: { equals: "support", mode: "insensitive" },
+      },
       select: { name: true },
     });
   });

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/route.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const prismaMock = vi.hoisted(() => ({
-  dataset: { findMany: vi.fn(), count: vi.fn(), create: vi.fn() },
+  dataset: { findMany: vi.fn(), findFirst: vi.fn(), count: vi.fn(), create: vi.fn() },
   testCase: { groupBy: vi.fn() },
   $transaction: vi.fn(async (arr: Promise<unknown>[]) => Promise.all(arr)),
 }));
@@ -65,6 +65,7 @@ beforeEach(() => {
   auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
   prismaMock.$transaction.mockImplementation(async (arr: Promise<unknown>[]) => Promise.all(arr));
   prismaMock.dataset.findMany.mockResolvedValue([]);
+  prismaMock.dataset.findFirst.mockResolvedValue(null); // default: name is free to use
   prismaMock.dataset.count.mockResolvedValue(0);
   prismaMock.testCase.groupBy.mockResolvedValue([]);
 });
@@ -184,6 +185,19 @@ describe("POST", () => {
     prismaMock.dataset.create.mockResolvedValue({ id: "ds_new" });
     await POST(jsonReq({ name: "support" }), params);
     expect(prismaMock.dataset.create.mock.calls[0][0].data.description).toBeNull();
+  });
+
+  it("409s a name that already exists in the project (case-insensitive), without creating", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue({ name: "Support" }); // existing, different case
+    const res = await POST(jsonReq({ name: "support" }), params);
+    expect(res.status).toBe(409);
+    expect((await body(res)).error).toContain("already exists");
+    expect(prismaMock.dataset.create).not.toHaveBeenCalled();
+    // The uniqueness check is scoped to the project and case-insensitive.
+    expect(prismaMock.dataset.findFirst).toHaveBeenCalledWith({
+      where: { projectId: "p1", name: { equals: "support", mode: "insensitive" } },
+      select: { name: true },
+    });
   });
 
   it("400s an unparseable body", async () => {

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/route.ts
@@ -86,6 +86,21 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   const parsed = CreateDatasetRequestSchema.safeParse(body);
   if (!parsed.success) return errorResponse(parsed.error.issues[0].message, 400);
 
+  // A dataset's name is its human identity in the project: creating a second one with the
+  // same name deduplicates against the first from the user's point of view, so deny it here
+  // (case-insensitive) rather than silently making a confusing duplicate. This guards the UI
+  // create flow only — the SDK converges by its stable client id, a separate mechanism.
+  const existing = await prisma.dataset.findFirst({
+    where: { projectId, name: { equals: parsed.data.name, mode: "insensitive" as const } },
+    select: { name: true },
+  });
+  if (existing) {
+    return errorResponse(
+      `A dataset named "${existing.name}" already exists in this project. Pick a different name.`,
+      409,
+    );
+  }
+
   const dataset = await prisma.dataset.create({
     data: {
       projectId,

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/route.ts
@@ -89,10 +89,16 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
 
   // A dataset's name is its human identity in the project: creating a second one with the
   // same name deduplicates against the first from the user's point of view, so deny it here
-  // (case-insensitive) rather than silently making a confusing duplicate. This guards the UI
-  // create flow only — the SDK converges by its stable client id, a separate mechanism.
+  // (case-insensitive) rather than silently making a confusing duplicate. Scoped to UI-authored
+  // datasets (`clientDatasetId: null`) to match the partial unique index that backs it — an SDK
+  // dataset may legitimately share a display name (it converges by its stable client id), so it
+  // must not make this pre-check falsely 409 a valid UI create.
   const existing = await prisma.dataset.findFirst({
-    where: { projectId, name: { equals: parsed.data.name, mode: "insensitive" as const } },
+    where: {
+      projectId,
+      clientDatasetId: null,
+      name: { equals: parsed.data.name, mode: "insensitive" as const },
+    },
     select: { name: true },
   });
   if (existing) {

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/route.ts
@@ -6,6 +6,7 @@ import {
   errorResponse,
   successResponse,
 } from "@/lib/auth-helpers";
+import { isPrismaKnownError } from "@/lib/eval/prisma-errors";
 
 type RouteParams = { params: Promise<{ projectId: string }> };
 
@@ -101,12 +102,25 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     );
   }
 
-  const dataset = await prisma.dataset.create({
-    data: {
-      projectId,
-      name: parsed.data.name,
-      description: parsed.data.description ?? null,
-    },
-  });
-  return successResponse({ dataset }, 201);
+  try {
+    const dataset = await prisma.dataset.create({
+      data: {
+        projectId,
+        name: parsed.data.name,
+        description: parsed.data.description ?? null,
+      },
+    });
+    return successResponse({ dataset }, 201);
+  } catch (e) {
+    // Two concurrent creates can both clear the pre-check above; the partial unique index
+    // (uq_dataset_project_lower_name_ui) is the race-safe backstop, so translate its
+    // violation into the same 409 rather than letting it surface as a 500.
+    if (isPrismaKnownError(e, "P2002")) {
+      return errorResponse(
+        `A dataset named "${parsed.data.name}" already exists in this project. Pick a different name.`,
+        409,
+      );
+    }
+    throw e;
+  }
 }

--- a/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
@@ -165,21 +165,52 @@ describe("A4: publish an immutable version from changes", () => {
     );
   });
 
-  it("rejects a stale base_version_id with 409 and the current version", async () => {
+  it("rejects a stale EXPLICIT base_version_id with 409 and the current version", async () => {
     const first = await publishVersion(
       req({ base_version_id: null, changes: [{ op: "upsert", test_case_id: "tc_1", input: "x" }] }),
       dsParams("ds1"),
     );
     const current = (await readJson(first)).dataset_version_id;
 
+    // A caller that NAMES a base (optimistic concurrency) still conflicts when that base is no
+    // longer current. Only an explicit (string) base is concurrency-checked; a null base is the
+    // SDK's content-addressed upsert (covered below).
     const conflict = await publishVersion(
-      req({ base_version_id: null, changes: [{ op: "upsert", test_case_id: "tc_2", input: "y" }] }),
+      req({
+        base_version_id: "dsv_stale",
+        changes: [{ op: "upsert", test_case_id: "tc_2", input: "y" }],
+      }),
       dsParams("ds1"),
     );
     expect(conflict.status).toBe(409);
     const body = await readJson(conflict);
     expect(body.error).toBe("conflict");
     expect(body.current_version_id).toBe(current);
+  });
+
+  it("content-addressed (base=null): identical content reuses the version, changed content appends", async () => {
+    const first = await publishVersion(
+      req({ base_version_id: null, changes: [{ op: "upsert", test_case_id: "tc_1", input: "x" }] }),
+      dsParams("ds1"),
+    );
+    expect(first.status).toBe(201);
+    const v1 = (await readJson(first)).dataset_version_id;
+
+    // Same content again (e.g. a second run of the same dataset) → the SAME version, no fork.
+    const same = await publishVersion(
+      req({ base_version_id: null, changes: [{ op: "upsert", test_case_id: "tc_1", input: "x" }] }),
+      dsParams("ds1"),
+    );
+    expect(same.status).toBe(200);
+    expect((await readJson(same)).dataset_version_id).toBe(v1);
+
+    // Changed content → a NEW version; versioning is how a changed dataset under one id is handled.
+    const changed = await publishVersion(
+      req({ base_version_id: null, changes: [{ op: "upsert", test_case_id: "tc_1", input: "y" }] }),
+      dsParams("ds1"),
+    );
+    expect(changed.status).toBe(201);
+    expect((await readJson(changed)).dataset_version_id).not.toBe(v1);
   });
 
   it("returns the same version for a retried idempotency_key", async () => {

--- a/frontend/ui/src/lib/eval/versions.ts
+++ b/frontend/ui/src/lib/eval/versions.ts
@@ -69,6 +69,28 @@ export function newTestCaseId(): string {
   return `tc_${randomUUID().replace(/-/g, "").slice(0, 20)}`;
 }
 
+/** Deterministic JSON with recursively sorted object keys — so two structurally equal
+ *  values compare equal regardless of key order (JSONB round-trips don't preserve it). */
+function canonicalJson(v: unknown): string {
+  if (v === null || typeof v !== "object") return JSON.stringify(v) ?? "null";
+  if (Array.isArray(v)) return `[${v.map(canonicalJson).join(",")}]`;
+  const o = v as Record<string, unknown>;
+  return `{${Object.keys(o)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${canonicalJson(o[k])}`)
+    .join(",")}}`;
+}
+
+/** A stable signature of a version's semantic CONTENT — the per-case (id, input, expected,
+ *  metadata), order-independent. Capture provenance (source fields, review, addedBy,
+ *  createTime) is NOT content, so it never forks a version. Identical content shares one. */
+function contentSignature(seeds: TestCaseSeed[]): string {
+  const rows = seeds
+    .map((s) => ({ id: s.testCaseId, input: s.input, expected: s.expected, metadata: s.metadata ?? null }))
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  return canonicalJson(rows);
+}
+
 /**
  * Publish a new version by transforming the current version's cases. `transform`
  * receives the current seeds and returns the full set for the new version, plus
@@ -142,10 +164,12 @@ export async function publishDatasetVersion(opts: {
       }
     }
 
-    // Optimistic concurrency: reject when the caller's base is not the live version.
-    if (opts.baseVersionId !== undefined) {
+    // Optimistic concurrency applies only to an EXPLICIT base — a UI edit naming the version
+    // it was based on. A `null` base is the SDK's "content-addressed upsert" (handled after
+    // the transform below); an omitted base is the session UI editing the live current version.
+    if (typeof opts.baseVersionId === "string") {
       const currentId = dataset.currentVersionId ?? null;
-      if (currentId !== (opts.baseVersionId ?? null)) {
+      if (currentId !== opts.baseVersionId) {
         throw new VersionConflict(currentId);
       }
     }
@@ -157,7 +181,32 @@ export async function publishDatasetVersion(opts: {
         })
       : [];
 
-    const { cases, focusTestCaseId } = opts.transform(current.map(toSeed));
+    const currentSeeds = current.map(toSeed);
+    const { cases, focusTestCaseId } = opts.transform(currentSeeds);
+
+    // Content-addressed upsert (SDK, base === null): a re-publish with byte-identical content
+    // resolves to the SAME version instead of forking one — so repeated runs of a dataset stay
+    // on one version and compare cleanly — while a genuine content change appends a new version
+    // (versioning IS how changed content is handled). Only a null base opts in; an explicit base
+    // already passed its concurrency check, and an omitted base is a live session edit.
+    if (
+      opts.baseVersionId === null &&
+      dataset.currentVersionId &&
+      contentSignature(currentSeeds) === contentSignature(cases)
+    ) {
+      const cur = await tx.datasetVersion.findUnique({
+        where: { id: dataset.currentVersionId },
+        select: { versionNumber: true },
+      });
+      return {
+        datasetId,
+        versionId: dataset.currentVersionId,
+        versionNumber: cur?.versionNumber ?? 0,
+        focusTestCaseId,
+        caseCount: current.length,
+        replayed: true,
+      };
+    }
 
     const last = await tx.datasetVersion.findFirst({
       where: { datasetId },


### PR DESCRIPTION
Fixes: #1849

> **Related context (ships separately):** the SDK-side stable dataset-id / case-id derivation that makes convergence possible lives in the `traceroot-py` / `traceroot-ts` SDKs and releases independently. This PR is the **backend/UI half** — it assumes the SDK sends a stable `client_dataset_id` and identical case content on a re-run.

## Summary

For two runs to be comparable they must be runs of the **same dataset version**. Dataset identity already converges on `(project, client_dataset_id)`, but the missing half is that a repeated publish of the **same content** forks a *new* version instead of reusing the current one — so runs of "the same dataset" never share a version and can't compare. This PR content-addresses version publishing to close that gap, and adds two UI guards so a human can't create two datasets that mean the same thing.

## How it works

```
publishDatasetVersion(base_version_id, cases)
  base == null  (SDK push / live-session edit)
    → hash cases' (id, input, expected, metadata)   [order-independent, metadata-key-canonical]
        == current version's content?
          yes → return the current version (replayed)   → runs of same content compare
          no  → append a new version                     → changed content, new version
  base == "<string>"  (explicit UI edit)
    → optimistic-concurrency check against that base (unchanged)

UI dataset create / rename
  name already used by another dataset in the project (case-insensitive)?
    → 409, refuse  (a dataset's name is its human identity)
```

## What's included

### Content-addressed versions
- **`lib/eval/versions.ts`** — `publishDatasetVersion` treats a `null` `base_version_id` as a **content-addressed upsert**: hash the resulting cases' `(id, input, expected, metadata)` — order-independent, metadata keys canonicalized — and if it equals the current version's content, return that version (replayed) instead of appending. Changed content still appends. Optimistic-concurrency semantics preserved for explicit string bases (UI edits); the two paths are cleanly separated.

### UI name-uniqueness guards
- **`datasets/route.ts` (create)** — rejects a name already used in the project (**409, case-insensitive**). The SDK path still converges by its stable client id (separate, intended mechanism), so re-running the same dataset there is unaffected.
- **`datasets/[datasetId]/route.ts` (rename, PATCH)** — rejects renaming onto a name another dataset in the project already uses (**409, case-insensitive**); excludes the dataset itself, so keeping or re-casing its own name still works.

## Test plan
- [x] Re-publish identical content (null base) → returns the current version id, no new version row
- [x] Re-publish changed content (null base) → appends a new version
- [x] Content hash is order-independent (case reorder ⇒ same version) and metadata-key-canonical
- [x] Explicit string base with a stale base id → optimistic-concurrency rejection (unchanged)
- [x] Create/rename onto an existing project name (any casing) → 409; re-casing / keeping own name → allowed
- [x] SDK path (stable client id) still converges regardless of the UI name guard
- [x] Stack review fixes applied — race-safe UI name-uniqueness (partial unique index + P2002→409, M1) and name trimming (L1)
- [ ] Live e2e (with the SDK branch): two SDK runs of the same unchanged dataset share a version and compare

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Content-addresses dataset versions so re-publishing identical content returns the current version, enabling runs to compare. Adds case-insensitive UI name guards scoped to UI-authored datasets, a race-safe partial unique index, and name trimming to prevent creating or renaming to an existing project name.

- Content-addressed upsert when base_version_id is null: identical content reuses the current version (200), changes append a new version (201). Explicit string bases keep optimistic concurrency (409 on stale); the SDK path remains unchanged.
- UI create/rename now 409 on name collisions within a project (case-insensitive) for UI-authored datasets only; excludes the dataset itself. SDK-authored datasets that converge by stable client_dataset_id are unaffected.
- Enforces UI name uniqueness with a partial unique index on (project_id, lower(name)) where client_dataset_id IS NULL; translate Prisma P2002 into 409. Trim names before validation/storage to block whitespace variants.
- Migration: The index build fails if duplicate UI dataset names already exist; deduplicate per project before applying.

<sup>Written for commit 4fcdbe0ab14bae632851f592d007a6b30dba9101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

