### PR TITLE
fix(ui): distinguish fallback field glyph

### DIFF
--- a/frontend/ui/src/components/icons/domain-icons.ts
+++ b/frontend/ui/src/components/icons/domain-icons.ts
@@ -7,6 +7,7 @@ import {
   Box,
   CircleAlert,
   CircleCheck,
+  CircleDashed,
   CircleDollarSign,
   CircleStop,
   Clock,
@@ -65,9 +66,8 @@ export const DOMAIN_ICONS = {
   // Free-form key/value data the user attached to a trace, not a traceroot field.
   metadata: Braces,
   dashboard: LayoutDashboard,
-  // Neutral "unknown field" fallback for filter/widget dropdowns. Kept
-  // decoupled from `model` even though both currently render as Box — if the
-  // model glyph ever changes, unmapped fields shouldn't silently change with
-  // it.
-  fallback: Box,
+  // Neutral "unknown field" fallback for filter/widget dropdowns. The dashed
+  // circle is not assigned to a domain concept, so unmapped fields cannot read
+  // as models or another known field type.
+  fallback: CircleDashed,
 } as const satisfies Record<string, LucideIcon>;

--- a/frontend/ui/src/features/dashboards/components/field-icons.test.ts
+++ b/frontend/ui/src/features/dashboards/components/field-icons.test.ts
@@ -3,6 +3,7 @@ import {
   CircleAlert,
   Box,
   CircleCheck,
+  CircleDashed,
   CircleDollarSign,
   CircleStop,
   Clock,
@@ -49,7 +50,7 @@ describe("fieldIcon", () => {
     expect(fieldIcon("status")).toBe(CircleCheck);
   });
 
-  it("falls back to the generic box like the trace list does", () => {
-    expect(fieldIcon("some_future_field")).toBe(Box);
+  it("falls back to the neutral glyph like the trace list does", () => {
+    expect(fieldIcon("some_future_field")).toBe(CircleDashed);
   });
 });

--- a/frontend/ui/src/features/dashboards/components/field-icons.ts
+++ b/frontend/ui/src/features/dashboards/components/field-icons.ts
@@ -4,10 +4,9 @@ import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 
 // The trace-list filter icons, extended with the widget registry's field
 // names the trace list spells differently (errors -> error_count), the token
-// variants, a distinct count symbol (the shared map's Box doubles as the
-// model icon, so count falling back to it read as "model"), and the user /
-// session symbols the trace-page tabs use. DOMAIN_ICONS.fallback (Box) stays
-// the generic fallback for unmapped fields.
+// variants, a distinct count symbol, and the user / session symbols the
+// trace-page tabs use. DOMAIN_ICONS.fallback stays the neutral fallback for
+// unmapped fields.
 const WIDGET_FIELD_ICONS: Record<string, LucideIcon> = {
   ...FIELD_ICONS,
   error_count: DOMAIN_ICONS.error,

--- a/frontend/ui/src/features/filters/filter-controls.test.tsx
+++ b/frontend/ui/src/features/filters/filter-controls.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { Hash } from "lucide-react";
+import { Box, Hash } from "lucide-react";
 import {
   FieldDropdown,
   FilterControlSizeProvider,
@@ -113,6 +113,7 @@ describe("ValueDropdown", () => {
 describe("FieldDropdown", () => {
   const options = [
     { key: "trace_id", label: "Trace ID", icon: Hash },
+    { key: "model_name", label: "Model", icon: Box },
     { key: "mystery", label: "Mystery" }, // no icon → generic fallback
   ];
 
@@ -127,6 +128,21 @@ describe("FieldDropdown", () => {
 
     rerender(<FieldDropdown options={options} valueKey="trace_id" onPick={onPick} />);
     expect(screen.getByRole("button", { name: /Trace ID/ })).toBeTruthy();
+  });
+
+  it("renders an iconless field with a glyph distinct from the model glyph", () => {
+    render(<FieldDropdown options={options} valueKey="mystery" onPick={vi.fn()} />);
+
+    const triggerIcon = screen.getByRole("button", { name: /Mystery/ }).querySelector("svg");
+    expect(triggerIcon?.getAttribute("class")).toContain("lucide-circle-dashed");
+
+    fireEvent.click(screen.getByRole("button", { name: /Mystery/ }));
+    const modelIcon = screen.getByRole("option", { name: /Model/ }).querySelector("svg");
+    const fallbackIcon = screen.getByRole("option", { name: /Mystery/ }).querySelector("svg");
+
+    expect(modelIcon?.getAttribute("class")).toContain("lucide-box");
+    expect(fallbackIcon?.getAttribute("class")).toContain("lucide-circle-dashed");
+    expect(fallbackIcon?.getAttribute("class")).not.toBe(modelIcon?.getAttribute("class"));
   });
 });
 


### PR DESCRIPTION
Fixes #1628

## Summary

Use Lucide's neutral dashed-circle glyph for unmapped filter and dashboard-widget fields, keeping them visually distinct from model fields.

## Type of Change

- [x] fix - A bug fix

## Details

- Preserves the explicit count glyph.
- Adds rendered dropdown coverage for the iconless fallback versus the model glyph.
- Adds dashboard resolver coverage for unknown fields.

## Screenshots / Recordings (if applicable)

Not captured locally; this glyph-only UI change was verified with focused component tests.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

## Validation

- `pnpm --filter traceroot-ui test -- src/features/filters/filter-controls.test.tsx src/features/dashboards/components/field-icons.test.ts` (17 passed)
- `pnpm --filter traceroot-ui format:check`
- `pnpm --filter traceroot-ui lint` (passes with 55 pre-existing warnings outside this change)
- Full UI suite attempted but blocked by missing generated Prisma client and unrelated mock setup failures in the fresh environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use Lucide’s `CircleDashed` as the neutral fallback icon for unmapped fields in filters and dashboard widgets, replacing the model-like `Box` so unknown fields are clearly distinct. Adds tests to verify the new fallback and that dropdowns render different glyphs for model vs. unknown fields.

<sup>Written for commit 2184d3bcc689453b9eeefa2d59672d576652cc80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

