### PR TITLE
feat(agent): metadata key discovery for keyed trace filtering

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -388,6 +388,23 @@
         "title": "IngestResponse",
         "type": "object"
       },
+      "MetadataKeysResponse": {
+        "description": "Metadata keys observed in a window, by frequency \u2014 the discovery answer.\n\nFeeds the metadata filter's key combobox and the public metadata-keys\nroute (the agent's key-discovery tool). The trace list's column picker\nis not a consumer \u2014 it offers fixed fields only, and metadata reaches the list as a\nsingle blob cell rather than a column per key. Rows reuse ``FilterValueCount``\n(``value``/``count``) because a key with an occurrence count is the same shape as a\ncategorical value with one, and both are rendered by the same suggestion list.",
+        "properties": {
+          "keys": {
+            "items": {
+              "$ref": "#/components/schemas/FilterValueCount"
+            },
+            "title": "Keys",
+            "type": "array"
+          }
+        },
+        "required": [
+          "keys"
+        ],
+        "title": "MetadataKeysResponse",
+        "type": "object"
+      },
       "PaginationMeta": {
         "description": "Pagination metadata for list responses.",
         "properties": {
@@ -2658,6 +2675,7 @@
                       },
                       {
                         "additionalProperties": false,
+                        "description": "Matches traces where the metadata key/value pair is attached at the trace level or on any span within the trace. Use list_trace_metadata_keys to discover which keys exist.",
                         "properties": {
                           "field": {
                             "const": "metadata",
@@ -3087,6 +3105,133 @@
           "description": "Discover the current values of a categorical trace filter field (e.g. model_name, environment) for the project \u2014 use before filtering the trace list by that field.",
           "enabled": true,
           "name": "list_trace_filter_values"
+        }
+      }
+    },
+    "/api/v1/public/traces/metadata-keys": {
+      "get": {
+        "description": "Metadata keys seen on the window's traces and spans, by descending frequency.\n\nThe key-discovery companion to the typed ``filters`` parameter's keyed\n``metadata`` field: the key catalog is dynamic per project, so callers\n(agents, generated CLIs) list it here instead of guessing key names. Both\nscopes are covered \u2014 a key set on the trace and a key set on a span are\ndisjoint key spaces, and a metadata filter matches either. The list only\nsuggests: an unlisted key stays filterable by naming it.\n\nArgs:\n    auth (StampedAuth): Resolved API-key context; scopes the read to its\n        project and stamps the rate-limit identity.\n    start_after (datetime | None): Lower bound on trace and span start time\n        (active window). An omitted bound is defaulted to a fixed lookback,\n        never scanned all-time.\n    end_before (datetime | None): Upper bound on trace and span start time\n        (active window), symmetric with ``start_after``.\n\nReturns:\n    MetadataKeysResponse: Keys with occurrence counts, by descending frequency.\n\nRaises:\n    HTTPException: 500 on a reader failure.",
+        "operationId": "list_trace_metadata_keys",
+        "parameters": [
+          {
+            "description": "Only consider traces and spans starting at or after this timestamp",
+            "in": "query",
+            "name": "start_after",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only consider traces and spans starting at or after this timestamp",
+              "title": "Start After"
+            }
+          },
+          {
+            "description": "Only consider traces and spans starting before this timestamp",
+            "in": "query",
+            "name": "end_before",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only consider traces and spans starting before this timestamp",
+              "title": "End Before"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataKeysResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to list metadata keys"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List Trace Metadata Keys",
+        "tags": [
+          "Traces (Public)"
+        ],
+        "x-tool": {
+          "description": "Discover which metadata keys exist on the project's traces and spans (by frequency) \u2014 use before filtering the trace list with a keyed metadata predicate, instead of guessing key names.",
+          "enabled": true,
+          "name": "list_trace_metadata_keys"
         }
       }
     },

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -11,7 +11,7 @@ import copy
 import json
 from typing import Any
 
-from rest.services.filters.columns import FILTER_COLUMNS, FilterType
+from rest.services.filters.columns import FILTER_COLUMNS, FilterLevel, FilterType
 from rest.services.filters.translate import (
     MAX_FILTERS,
     MAX_KEY_LENGTH,
@@ -105,6 +105,13 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
             "500", _error_response("Failed to list filter values")
         )
 
+    # Metadata-key discovery error contract (matches the route code).
+    metadata_keys_op = schema["paths"].get("/api/v1/public/traces/metadata-keys", {}).get("get")
+    if metadata_keys_op is not None:
+        metadata_keys_op["responses"].setdefault(
+            "500", _error_response("Failed to list metadata keys")
+        )
+
     # Detector catalog list error contract (matches the route code).
     detectors_list_op = schema["paths"].get("/api/v1/public/detectors", {}).get("get")
     if detectors_list_op is not None:
@@ -190,14 +197,22 @@ def _filter_predicate_variants() -> list[dict[str, Any]]:
                 "description": f"Which {col.name} key the value is compared against",
             }
             required = ["field", "key", "op", "value"]
-        variants.append(
-            {
-                "type": "object",
-                "properties": properties,
-                "required": required,
-                "additionalProperties": False,
-            }
-        )
+        variant: dict[str, Any] = {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+            "additionalProperties": False,
+        }
+        if col.level == FilterLevel.KEYED_MAP:
+            # A keyed-map predicate matches at either scope; without this a
+            # consumer reasonably assumes trace-level metadata only and routes
+            # around the filter for span-attached keys.
+            variant["description"] = (
+                f"Matches traces where the {col.name} key/value pair is attached "
+                "at the trace level or on any span within the trace. Use "
+                "list_trace_metadata_keys to discover which keys exist."
+            )
+        variants.append(variant)
     return variants
 
 
@@ -262,6 +277,15 @@ _TOOL_CURATION: dict[str, dict[str, Any]] = {
             "Discover the current values of a categorical trace filter field "
             "(e.g. model_name, environment) for the project — use before "
             "filtering the trace list by that field."
+        ),
+        "enabled": True,
+    },
+    "list_trace_metadata_keys": {
+        "name": "list_trace_metadata_keys",
+        "description": (
+            "Discover which metadata keys exist on the project's traces and "
+            "spans (by frequency) — use before filtering the trace list with "
+            "a keyed metadata predicate, instead of guessing key names."
         ),
         "enabled": True,
     },

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -6,6 +6,7 @@ never supplies a project id. Kept separate from the ingestion route so read and
 write concerns stay decoupled; both reuse the shared API-key auth dependency.
 """
 
+import asyncio
 import logging
 from datetime import datetime
 
@@ -36,9 +37,10 @@ from rest.schemas.public import (
     PublicTraceExportResponse,
     PublicTraceListResponse,
 )
-from rest.schemas.traces import FilterValuesResponse
+from rest.schemas.traces import FilterValuesResponse, MetadataKeysResponse
 from rest.services.filters import columns as filter_columns
 from rest.services.filters.translate import parse_filters_param
+from rest.services.trace_discovery import get_trace_discovery_service
 from rest.services.trace_reader import get_trace_reader_service
 from rest.url_utils import build_trace_url
 from shared.config import settings
@@ -187,6 +189,71 @@ async def list_trace_filter_values(
             detail="Failed to list filter values",
         ) from e
     return {"field": field, "values": values}
+
+
+# Also declared above the /{trace_id} route, for the same segment-capture reason.
+@router.get(
+    "/metadata-keys",
+    response_model=MetadataKeysResponse,
+    operation_id="list_trace_metadata_keys",
+)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def list_trace_metadata_keys(
+    request: Request,
+    response: Response,
+    auth: StampedAuth,
+    start_after: datetime | None = Query(
+        None,
+        description="Only consider traces and spans starting at or after this timestamp",
+    ),
+    end_before: datetime | None = Query(
+        None, description="Only consider traces and spans starting before this timestamp"
+    ),
+):
+    """Metadata keys seen on the window's traces and spans, by descending frequency.
+
+    The key-discovery companion to the typed ``filters`` parameter's keyed
+    ``metadata`` field: the key catalog is dynamic per project, so callers
+    (agents, generated CLIs) list it here instead of guessing key names. Both
+    scopes are covered — a key set on the trace and a key set on a span are
+    disjoint key spaces, and a metadata filter matches either. The list only
+    suggests: an unlisted key stays filterable by naming it.
+
+    Args:
+        auth (StampedAuth): Resolved API-key context; scopes the read to its
+            project and stamps the rate-limit identity.
+        start_after (datetime | None): Lower bound on trace and span start time
+            (active window). An omitted bound is defaulted to a fixed lookback,
+            never scanned all-time.
+        end_before (datetime | None): Upper bound on trace and span start time
+            (active window), symmetric with ``start_after``.
+
+    Returns:
+        MetadataKeysResponse: Keys with occurrence counts, by descending frequency.
+
+    Raises:
+        HTTPException: 500 on a reader failure.
+    """
+    start_after, end_before = clamp_retention_window(auth.billing_plan, start_after, end_before)
+    try:
+        service = get_trace_discovery_service()
+        # Off the event loop, mirroring the internal twin: the key scan arrayJoins
+        # over mapKeys on both tables' base rows — the heaviest discovery read.
+        keys = await asyncio.to_thread(
+            service.get_distinct_metadata_keys,
+            project_id=auth.project_id,
+            start_after=start_after,
+            end_before=end_before,
+        )
+    except Exception as e:
+        logger.exception(f"Error listing metadata keys: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list metadata keys",
+        ) from e
+    return {"keys": keys}
 
 
 @router.get("/{trace_id}", response_model=PublicTraceDetailResponse, operation_id="get_trace")

--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -175,7 +175,8 @@ class FilterValuesResponse(BaseModel):
 class MetadataKeysResponse(BaseModel):
     """Metadata keys observed in a window, by frequency — the discovery answer.
 
-    Feeds one surface: the metadata filter's key combobox. The trace list's column picker
+    Feeds the metadata filter's key combobox and the public metadata-keys
+    route (the agent's key-discovery tool). The trace list's column picker
     is not a consumer — it offers fixed fields only, and metadata reaches the list as a
     single blob cell rather than a column per key. Rows reuse ``FilterValueCount``
     (``value``/``count``) because a key with an occurrence count is the same shape as a

--- a/backend/rest/services/trace_discovery.py
+++ b/backend/rest/services/trace_discovery.py
@@ -324,7 +324,8 @@ class TraceDiscoveryService:
     ) -> list[dict]:
         """Distinct metadata keys on traces and spans in the active window, by frequency.
 
-        The discovery answer behind the metadata filter's key combobox, its one consumer.
+        The discovery answer behind the metadata filter's key combobox and the
+        public metadata-keys route (and, through it, the agent's key-discovery tool).
         It covers BOTH key spaces, which are disjoint by construction — a trace-level key
         arrives on the ``traceroot.trace.`` attribute prefix and can never reach a span —
         so scanning one table would leave the other's keys unsuggestable, and either half's

--- a/frontend/packages/agent/src/prompts/__tests__/system.test.ts
+++ b/frontend/packages/agent/src/prompts/__tests__/system.test.ts
@@ -13,6 +13,14 @@ describe("getSystemPrompt", () => {
     expect(prompt).toContain("search and filter traces");
     expect(prompt).toContain("list_sessions");
     expect(prompt).toContain("get_session");
+    expect(prompt).toContain("list_trace_metadata_keys");
+  });
+
+  it("steers attribute questions to keyed metadata filters at either scope", () => {
+    const prompt = getSystemPrompt({ projectId: "proj-123" });
+    expect(prompt).toContain('{field: "metadata", key: <key>, op: "eq", value: <value>}');
+    expect(prompt).toContain("prefer a typed metadata filter over free-text search");
+    expect(prompt).toContain("either scope");
   });
 
   it("describes download_trace tool", () => {

--- a/frontend/packages/agent/src/prompts/system.ts
+++ b/frontend/packages/agent/src/prompts/system.ts
@@ -23,8 +23,14 @@ You help users analyze telemetry data (traces and spans) from their AI agent sys
 
 ### Discovery: list_traces
 Use this to search and filter traces. Returns a summary table (trace IDs, names, timestamps, error counts, spans, duration).
-Parameters: optional filters like limit, user_id, name, search_query, start_after, end_before.
+Parameters: optional filters like limit, user_id, name, search_query, start_after, end_before, and a typed filters array (model, environment, cost, tokens, latency, error count, keyed metadata).
+When a question names an attribute or tag (a tenant, tier, region, stage, feature flag, ...), prefer a typed metadata filter over free-text search: call list_trace_metadata_keys to see which keys exist, then filter with {field: "metadata", key: <key>, op: "eq", value: <value>}.
+Metadata filters match at either scope — a key attached to the trace or to any span within it.
 Use this first to find relevant traces before diving deeper.
+
+### Metadata Key Discovery: list_trace_metadata_keys
+Lists the metadata keys present on this project's traces and spans, by frequency.
+Use it before a metadata filter instead of guessing key names.
 
 ### Session Discovery: list_sessions and get_session
 Use list_sessions to list sessions.

--- a/frontend/packages/agent/src/tools/__tests__/registry-tools.test.ts
+++ b/frontend/packages/agent/src/tools/__tests__/registry-tools.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Executor } from "../../executors/interface.js";
-import { formatSessionDetail, formatSessionList, formatTraceList } from "../formatters.js";
+import {
+  formatMetadataKeys,
+  formatSessionDetail,
+  formatSessionList,
+  formatTraceList,
+} from "../formatters.js";
 import { createTools } from "../index.js";
 import { createRegistryReadTools } from "../registry-tools.js";
 
@@ -17,9 +22,14 @@ describe("createRegistryReadTools", () => {
     return impl;
   }
 
-  it("exposes exactly the three internally-bound read tools", () => {
+  it("exposes exactly the internally-bound read tools", () => {
     const names = createRegistryReadTools("p1", "u1").map((t) => t.name);
-    expect(names).toEqual(["list_traces", "list_sessions", "get_session"]);
+    expect(names).toEqual([
+      "list_traces",
+      "list_sessions",
+      "get_session",
+      "list_trace_metadata_keys",
+    ]);
   });
 
   it("hides the fixed project_id from every tool's model-facing schema", () => {
@@ -135,6 +145,7 @@ describe("createTools", () => {
       "list_traces",
       "list_sessions",
       "get_session",
+      "list_trace_metadata_keys",
       "download_traces",
       "download_session",
       "check_github_access",
@@ -147,6 +158,21 @@ describe("createTools", () => {
 });
 
 describe("formatters", () => {
+  it("formatMetadataKeys reports the empty state and lists keys by frequency", () => {
+    expect(formatMetadataKeys({})).toBe(
+      "No metadata keys found on this project's traces or spans.",
+    );
+    const text = formatMetadataKeys({
+      keys: [
+        { value: "customer_tier", count: 15 },
+        { value: "pipeline_stage", count: 30 },
+      ],
+    });
+    expect(text).toContain("- customer_tier (15 occurrences)");
+    expect(text).toContain("- pipeline_stage (30 occurrences)");
+    expect(text).toContain('as the "key" of a metadata filter');
+  });
+
   it("formatTraceList reports the empty state and tolerates missing fields", () => {
     expect(formatTraceList({})).toBe("No traces found matching the given filters.");
     expect(formatTraceList({ data: [], meta: {} })).toBe(

--- a/frontend/packages/agent/src/tools/formatters.ts
+++ b/frontend/packages/agent/src/tools/formatters.ts
@@ -69,6 +69,19 @@ export function formatSessionDetail(data: unknown): string {
   ].join("\n");
 }
 
+/** Render a metadata-keys response as one key-per-line with occurrence counts. */
+export function formatMetadataKeys(data: unknown): string {
+  const body = (data ?? {}) as { keys?: unknown };
+  const keys = (body.keys || []) as any[];
+
+  if (!Array.isArray(keys) || keys.length === 0) {
+    return "No metadata keys found on this project's traces or spans.";
+  }
+
+  const lines = keys.map((k: any) => `- ${k.value} (${k.count} occurrences)`);
+  return `Metadata keys on this project's traces and spans (by frequency):\n${lines.join("\n")}\nUse one as the "key" of a metadata filter on list_traces.`;
+}
+
 /** Render a session list response as the per-session summary lines. */
 export function formatSessionList(data: unknown): string {
   const body = (data ?? {}) as { data?: unknown };

--- a/frontend/packages/agent/src/tools/registry-tools.ts
+++ b/frontend/packages/agent/src/tools/registry-tools.ts
@@ -6,7 +6,12 @@ import {
   internalAuth,
   toPiAgentTool,
 } from "@traceroot-ai/tools";
-import { formatSessionDetail, formatSessionList, formatTraceList } from "./formatters.js";
+import {
+  formatMetadataKeys,
+  formatSessionDetail,
+  formatSessionList,
+  formatTraceList,
+} from "./formatters.js";
 
 function requireEntry(name: string) {
   const entry = REGISTRY.find((e) => e.name === name);
@@ -37,5 +42,6 @@ export function createRegistryReadTools(projectId: string, userId: string): Agen
     bind("list_traces", formatTraceList),
     bind("list_sessions", formatSessionList),
     bind("get_session", formatSessionDetail),
+    bind("list_trace_metadata_keys", formatMetadataKeys),
   ];
 }

--- a/frontend/packages/tools/src/__tests__/pi.test.ts
+++ b/frontend/packages/tools/src/__tests__/pi.test.ts
@@ -130,6 +130,7 @@ describe("INTERNAL_BINDINGS", () => {
       list_traces: "/api/v1/projects/{project_id}/traces",
       list_sessions: "/api/v1/projects/{project_id}/sessions",
       get_session: "/api/v1/projects/{project_id}/sessions/{session_id}",
+      list_trace_metadata_keys: "/api/v1/projects/{project_id}/traces/metadata-keys",
     });
   });
 });

--- a/frontend/packages/tools/src/__tests__/registry-drift.test.ts
+++ b/frontend/packages/tools/src/__tests__/registry-drift.test.ts
@@ -14,7 +14,7 @@ describe("committed registry", () => {
     expect(REGISTRY).toEqual(generateRegistry(doc));
   });
 
-  it("pins the curated 11-tool surface", () => {
+  it("pins the curated 12-tool surface", () => {
     expect(REGISTRY.map((entry) => entry.name)).toEqual([
       "export_trace",
       "get_finding",
@@ -25,6 +25,7 @@ describe("committed registry", () => {
       "list_findings",
       "list_sessions",
       "list_trace_filter_values",
+      "list_trace_metadata_keys",
       "list_traces",
       "whoami",
     ]);

--- a/frontend/packages/tools/src/internal.ts
+++ b/frontend/packages/tools/src/internal.ts
@@ -9,4 +9,5 @@ export const INTERNAL_BINDINGS: Readonly<Record<string, string>> = {
   list_traces: "/api/v1/projects/{project_id}/traces",
   list_sessions: "/api/v1/projects/{project_id}/sessions",
   get_session: "/api/v1/projects/{project_id}/sessions/{session_id}",
+  list_trace_metadata_keys: "/api/v1/projects/{project_id}/traces/metadata-keys",
 };

--- a/frontend/packages/tools/src/registry.generated.ts
+++ b/frontend/packages/tools/src/registry.generated.ts
@@ -237,6 +237,30 @@ export const REGISTRY: readonly RegistryEntry[] = [
     },
   },
   {
+    name: "list_trace_metadata_keys",
+    description:
+      "Discover which metadata keys exist on the project's traces and spans (by frequency) — use before filtering the trace list with a keyed metadata predicate, instead of guessing key names.",
+    method: "get",
+    path: "/api/v1/public/traces/metadata-keys",
+    inputSchema: {
+      type: "object",
+      properties: {
+        start_after: {
+          format: "date-time",
+          type: "string",
+          description: "Only consider traces and spans starting at or after this timestamp",
+        },
+        end_before: {
+          format: "date-time",
+          type: "string",
+          description: "Only consider traces and spans starting before this timestamp",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+  },
+  {
     name: "list_traces",
     description:
       "List recent traces for the project (newest first). Filter by time range, trace name, user id, or a free-text search across trace/session/user ids and names. Use this for discovery before fetching a specific trace. Structured filters (model, environment, cost, tokens, latency, error count, keyed metadata) are available via the typed filters parameter.",
@@ -418,6 +442,8 @@ export const REGISTRY: readonly RegistryEntry[] = [
               },
               {
                 additionalProperties: false,
+                description:
+                  "Matches traces where the metadata key/value pair is attached at the trace level or on any span within the trace. Use list_trace_metadata_keys to discover which keys exist.",
                 properties: {
                   field: {
                     const: "metadata",

--- a/tests/rest/test_public_internal_parity.py
+++ b/tests/rest/test_public_internal_parity.py
@@ -13,6 +13,7 @@ BINDINGS = {
     "/api/v1/public/traces": "/api/v1/projects/{project_id}/traces",
     "/api/v1/public/sessions": "/api/v1/projects/{project_id}/sessions",
     "/api/v1/public/sessions/{session_id}": "/api/v1/projects/{project_id}/sessions/{session_id}",
+    "/api/v1/public/traces/metadata-keys": "/api/v1/projects/{project_id}/traces/metadata-keys",
 }
 
 

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -156,6 +156,12 @@ def test_read_endpoints_document_error_responses():
         assert responses["404"]["description"] == "Trace not found"
 
 
+def test_metadata_keys_route_documents_error_responses():
+    responses = _schema()["paths"]["/api/v1/public/traces/metadata-keys"]["get"]["responses"]
+    assert set(responses) >= {"200", "401", "500"}
+    assert responses["500"]["description"] == "Failed to list metadata keys"
+
+
 def test_detectors_list_route_documents_error_responses():
     paths = _schema()["paths"]
     assert "get" in paths["/api/v1/public/detectors"]
@@ -182,6 +188,7 @@ EXPECTED_OPERATION_IDS = {
     "/api/v1/public/sessions/{session_id}": {"get": "get_session"},
     "/api/v1/public/traces": {"get": "list_traces", "post": "ingest_traces"},
     "/api/v1/public/traces/filter-values/{field}": {"get": "list_trace_filter_values"},
+    "/api/v1/public/traces/metadata-keys": {"get": "list_trace_metadata_keys"},
     "/api/v1/public/traces/{trace_id}": {"get": "get_trace"},
     "/api/v1/public/traces/{trace_id}/export": {"get": "export_trace"},
     "/api/v1/public/whoami": {"get": "whoami"},
@@ -237,6 +244,7 @@ def test_x_tool_enabled_set_and_shape():
         "whoami",
         "list_traces",
         "list_trace_filter_values",
+        "list_trace_metadata_keys",
         "get_trace",
         "export_trace",
         "list_sessions",
@@ -287,6 +295,11 @@ def test_filters_param_is_json_content_with_registry_variants():
             assert key_schema["type"] == "string"
             assert key_schema["minLength"] == 1
             assert key_schema["maxLength"] == MAX_KEY_LENGTH
+            # The either-scope semantics travel in the contract: without this a
+            # consumer assumes trace-level metadata only and skips the filter
+            # for span-attached keys.
+            assert "any span" in v["description"]
+            assert "list_trace_metadata_keys" in v["description"]
         else:
             assert v["required"] == ["field", "op", "value"]
             assert "key" not in v["properties"]

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -86,16 +86,24 @@ def mock_reader():
 
 
 @pytest.fixture()
-def client(mock_reader):
-    """TestClient with mocked API-key auth and trace reader."""
+def mock_discovery():
+    return MagicMock()
+
+
+@pytest.fixture()
+def client(mock_reader, mock_discovery):
+    """TestClient with mocked API-key auth, trace reader, and trace discovery."""
     app.dependency_overrides[authenticate_api_key] = lambda: make_auth()
 
     import rest.routers.public.traces_read as mod
 
     original = mod.get_trace_reader_service
+    original_discovery = mod.get_trace_discovery_service
     mod.get_trace_reader_service = lambda: mock_reader
+    mod.get_trace_discovery_service = lambda: mock_discovery
     yield TestClient(app)
     mod.get_trace_reader_service = original
+    mod.get_trace_discovery_service = original_discovery
 
 
 AUTH_HEADER = {"Authorization": "Bearer tr_sometoken"}
@@ -303,6 +311,36 @@ class TestPublicListTraceFilterValues:
         resp = client.get("/api/v1/public/traces/filter-values/model_name", headers=AUTH_HEADER)
         assert resp.status_code == 500
         assert resp.json()["detail"] == "Failed to list filter values"
+
+
+class TestPublicListTraceMetadataKeys:
+    def test_returns_keys_scoped_to_project(self, client, mock_discovery):
+        mock_discovery.get_distinct_metadata_keys.return_value = [
+            {"value": "customer_tier", "count": 15},
+            {"value": "pipeline_stage", "count": 30},
+        ]
+        resp = client.get("/api/v1/public/traces/metadata-keys", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        assert resp.json()["keys"] == [
+            {"value": "customer_tier", "count": 15},
+            {"value": "pipeline_stage", "count": 30},
+        ]
+        call = mock_discovery.get_distinct_metadata_keys.call_args
+        assert call.kwargs["project_id"] == "proj-A"
+
+    def test_literal_segment_not_captured_as_trace_id(self, client, mock_reader, mock_discovery):
+        # Guards the route-declaration order: /metadata-keys must win over
+        # /{trace_id}. If ordering regresses, this 404s via get_trace.
+        mock_discovery.get_distinct_metadata_keys.return_value = []
+        resp = client.get("/api/v1/public/traces/metadata-keys", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        mock_reader.get_trace.assert_not_called()
+
+    def test_500_on_reader_failure(self, client, mock_discovery):
+        mock_discovery.get_distinct_metadata_keys.side_effect = RuntimeError("boom")
+        resp = client.get("/api/v1/public/traces/metadata-keys", headers=AUTH_HEADER)
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Failed to list metadata keys"
 
 
 class TestPublicGetTrace:


### PR DESCRIPTION
Gives the agent (and any registry consumer) first-class discovery for keyed metadata filtering, closing the three gaps observed in live testing: the model guessed metadata key names, assumed metadata filters only match trace-scope keys, and tried free-text search before the typed filter.

## What's in here

**`feat(api)`: public metadata-key discovery**
- New `GET /api/v1/public/traces/metadata-keys` (`operation_id: list_trace_metadata_keys`), mirroring the internal discovery twin: same `trace_discovery` service call off the event loop, retention-clamped window, declared above `/{trace_id}` (with a route-order guard test). Curated into the registry with an agent-facing description.
- The generated `filters` schema's keyed metadata variant now documents **either-scope matching** ("trace level or any span within the trace") and points at the discovery tool — so the contract itself carries the semantics, for the CLI and MCP consumers too.
- 500 documented in the public contract like every sibling read op; parity row added (public params ⊆ internal twin).

**`feat(agent)`: the tool + guidance**
- `INTERNAL_BINDINGS` gains `list_trace_metadata_keys` → the internal project-scoped route; the agent binds it with a keys formatter (frequency-ordered, points at the filter's `key` slot).
- System prompt: attribute/tag questions prefer a typed metadata filter over free-text search; discover keys first; either-scope noted.
- Regenerated `registry.generated.ts` (drift-pinned, now 12 curated tools).

## Deliberately not folded into `filter-values`

`list_trace_filter_values` answers the **value** slot; this op answers the **key** slot. Overloading one op to return either would make the contract polymorphic for generated consumers, and would occupy the call shape per-key value discovery will want later (`filter-values/metadata?key=…`).

## Tests

Backend 712 passed (route behavior incl. project scoping, route-order, 500; schema/curation/operation-id pins; parity). Tools 27 (bindings map, 12-tool pin, drift). Agent 44 (tool list, formatter, prompt assertions).

Closes #1861

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds public metadata-key discovery for trace filtering and updates the contract to clarify either-scope matching; the agent now discovers keys and prefers typed metadata filters over search. Previously the model guessed key names, assumed trace-only keys, and used free-text search first.

**Review notes**
- API: adds `GET /api/v1/public/traces/metadata-keys` (`operation_id: list_trace_metadata_keys`) that returns keys by frequency within a retention-clamped window; documents `500`; declared above `/{trace_id}` to avoid segment capture.
- Contract: the `filters` schema’s keyed `metadata` variant now states either-scope matching (trace-level or any span) and references key discovery; no breaking changes.
- Agent: binds `list_trace_metadata_keys` via internal project route in `INTERNAL_BINDINGS`, exposes it in `frontend` registry (`registry.generated.ts` now includes 12 curated tools), adds a keys formatter, and updates the system prompt to prefer typed metadata filters over free-text search.
- Tests and parity: adds OpenAPI error-contract tests, route-order guard, internal/public parity row, and tool/prompt assertions. Closes #1861.

<sup>Written for commit 849296fdeb5181cb54e36c5bd911cf75e9655e2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

