### PR TITLE
fix(ui): validate sign-in callback redirects as same-origin

### DIFF
--- a/frontend/ui/src/app/auth/sign-in/sign-in-client.tsx
+++ b/frontend/ui/src/app/auth/sign-in/sign-in-client.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
+import { safeCallbackUrl } from "@/lib/safe-callback-url";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
@@ -27,7 +28,8 @@ type SignInContentProps = {
 function SignInContent({ googleAuthConfigured }: SignInContentProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const callbackUrl = searchParams.get("callbackUrl") || "/";
+  // Attacker-suppliable query param; only same-origin destinations may pass.
+  const callbackUrl = safeCallbackUrl(searchParams.get("callbackUrl"));
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);

--- a/frontend/ui/src/lib/__tests__/safe-callback-url.test.ts
+++ b/frontend/ui/src/lib/__tests__/safe-callback-url.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { safeCallbackUrl } from "../safe-callback-url";
+
+describe("safeCallbackUrl", () => {
+  it("falls back on missing or empty input", () => {
+    expect(safeCallbackUrl(null)).toBe("/");
+    expect(safeCallbackUrl(undefined)).toBe("/");
+    expect(safeCallbackUrl("")).toBe("/");
+  });
+
+  it("accepts same-origin paths, preserving query and hash", () => {
+    expect(safeCallbackUrl("/projects/p1/traces")).toBe("/projects/p1/traces");
+    expect(safeCallbackUrl("/device?user_code=ABCD-1234")).toBe("/device?user_code=ABCD-1234");
+    expect(safeCallbackUrl("/invites/abc#section")).toBe("/invites/abc#section");
+  });
+
+  it("normalizes a bare relative path onto the root", () => {
+    expect(safeCallbackUrl("settings")).toBe("/settings");
+  });
+
+  it("rejects absolute URLs to foreign origins", () => {
+    expect(safeCallbackUrl("https://evil.example/phish")).toBe("/");
+    expect(safeCallbackUrl("http://evil.example")).toBe("/");
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(safeCallbackUrl("//evil.example/phish")).toBe("/");
+  });
+
+  it("rejects dot-segment paths that normalize to a protocol-relative authority", () => {
+    // The parse is same-origin, but `/..` collapses to leave a leading `//`,
+    // which re-parses cross-origin at the redirect site.
+    expect(safeCallbackUrl("/..//evil.example/phish")).toBe("/");
+    expect(safeCallbackUrl("/../..//evil.example")).toBe("/");
+    expect(safeCallbackUrl("/foo/..//evil.example")).toBe("/");
+    expect(safeCallbackUrl("/.//evil.example")).toBe("/");
+    expect(safeCallbackUrl("/%2e%2e//evil.example")).toBe("/");
+  });
+
+  it("never returns a protocol-relative or non-absolute path", () => {
+    for (const raw of ["/..//evil.example", "//evil.example", "/\\evil.example", "javascript:x"]) {
+      const out = safeCallbackUrl(raw);
+      expect(out.startsWith("/")).toBe(true);
+      expect(out.startsWith("//")).toBe(false);
+    }
+  });
+
+  it("rejects the backslash authority trick", () => {
+    // Browsers treat a backslash after the leading slash as a slash, turning
+    // the value into a protocol-relative URL with a foreign authority.
+    expect(safeCallbackUrl("/\\evil.example")).toBe("/");
+    expect(safeCallbackUrl("\\/evil.example")).toBe("/");
+    expect(safeCallbackUrl("\\\\evil.example")).toBe("/");
+  });
+
+  it("rejects non-http schemes", () => {
+    expect(safeCallbackUrl("javascript:alert(1)")).toBe("/");
+    expect(safeCallbackUrl("data:text/html,<script>alert(1)</script>")).toBe("/");
+    expect(safeCallbackUrl("vbscript:msgbox(1)")).toBe("/");
+  });
+
+  it("uses the provided fallback for rejected values", () => {
+    expect(safeCallbackUrl("https://evil.example", "/home")).toBe("/home");
+    expect(safeCallbackUrl(null, "/home")).toBe("/home");
+  });
+});

--- a/frontend/ui/src/lib/safe-callback-url.ts
+++ b/frontend/ui/src/lib/safe-callback-url.ts
@@ -1,0 +1,44 @@
+// The sign-in page redirects to `callbackUrl` after login. The value is
+// attacker-suppliable (it arrives in the query string of a link that renders
+// our real sign-in page), so an unvalidated redirect is an open redirect:
+// a phishing link can bounce a freshly-authenticated user to a foreign site.
+// Only same-origin destinations may pass; everything else falls back.
+
+const BASE = "http://same-origin.invalid";
+
+/**
+ * Validate a post-login redirect target as same-origin.
+ *
+ * Parses with the WHATWG URL parser against a sentinel base, so the known
+ * smuggling shapes are rejected by spec-compliant parsing rather than by
+ * pattern-matching: absolute URLs keep their own origin, protocol-relative
+ * `//host` and backslash variants (`/\host` — browsers treat the backslash
+ * as a slash) resolve to a foreign authority, and non-HTTP schemes
+ * (`javascript:`, `data:`) have no matching origin at all.
+ *
+ * Returns the normalized path (+ query + hash) for same-origin values, the
+ * fallback for everything else.
+ */
+export function safeCallbackUrl(raw: string | null | undefined, fallback = "/"): string {
+  if (!raw) {
+    return fallback;
+  }
+  let url: URL;
+  try {
+    url = new URL(raw, BASE);
+  } catch {
+    return fallback;
+  }
+  if (url.origin !== BASE) {
+    return fallback;
+  }
+  const target = url.pathname + url.search + url.hash;
+  // Same-origin parse is not enough: dot-segment normalization can collapse a
+  // leading `/..` and leave a protocol-relative path (`/..//host` -> `//host`),
+  // which re-parses cross-origin at the redirect site. A legitimate target is
+  // always a single-slash absolute path, so require exactly that.
+  if (!target.startsWith("/") || target.startsWith("//")) {
+    return fallback;
+  }
+  return target;
+}


### PR DESCRIPTION
Task A0 of the CLI-login epic (#1863): close a pre-existing open redirect on the sign-in page, as its own small PR before the device-authorization work builds on this path.

## The bug

`/auth/sign-in?callbackUrl=…` renders our real sign-in page, then after login redirects the browser to `callbackUrl` **unvalidated** (`router.push(callbackUrl)` and the Google flow's `callbackURL`). An absolute foreign URL there navigates the freshly-authenticated user off-site — a phishing bounce that starts on our own domain. The `callbackUrl` mechanism is legitimate (it returns you to where you were headed); the missing piece was validating the destination.

## The fix

A pure `safeCallbackUrl` helper (`frontend/ui/src/lib/safe-callback-url.ts`) validates via WHATWG URL parsing against a sentinel base: same-origin values return the normalized path (+query+hash), everything else falls back. Rejected shapes: foreign absolute URLs, protocol-relative `//host`, backslash authority tricks (`/\host`), non-http schemes (`javascript:`/`data:`), unparseable input, and — caught in review — **dot-segment paths that normalize to a protocol-relative authority** (`/..//host` collapses to `//host`, which re-parses cross-origin at the redirect site): the result is required to be a single-slash absolute path, not `//`. Applied at the sign-in page's one consumption point; sibling consumers (sign-up, invites) use hardcoded paths and are untouched.

## Why A0 / first

Both the epic's `/device` consent page (which preserves a user code across the sign-in round trip, including the Google redirect) and the CLI onboarding wizard depend on this exact path — so the fix lands independently, ahead of either, and both consume one implementation.

## Verification

Full UI suite 1260/1260 (11-case validator suite incl. the dot-segment bypass and an "output never starts with //" invariant); tsc unchanged (6 pre-existing errors, none in the changed files). The fix was hardened by an adversarial security review that found and closed the dot-segment bypass before this PR opened.

Closes #1864

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate sign-in callback redirects as same-origin to close an open redirect. Before: `/auth/sign-in` pushed the unvalidated `callbackUrl`, allowing absolute foreign URLs. Now: only same-origin paths pass; others fall back to "/".

- Introduces `safeCallbackUrl` (WHATWG URL parse with a sentinel base) that returns a normalized path+query+hash and rejects foreign absolute URLs, protocol-relative `//`, backslash authority forms, non-HTTP schemes, unparseable input, and dot-segments that normalize to `//`.
- Applies the helper in the sign-in client; missing or rejected values redirect to "/", and bare relative paths normalize to "/path".
- Adds focused unit tests for accepted and rejected shapes; other auth flows using hardcoded paths are unchanged.

<sup>Written for commit da7d4ccfd9562460b3a5fe979bcb7ab4ce9dd9a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

