### PR TITLE
Fix/dashboard filter value control

### DIFF
--- a/frontend/ui/src/features/dashboards/components/FilterRow.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/FilterRow.test.tsx
@@ -76,10 +76,14 @@ describe("FilterRow value input", () => {
     expect(vi.mocked(useWidgetFieldValues).mock.lastCall?.[4]).toBe(false);
   });
 
-  it("falls back to free text when no stored values exist", () => {
+  it("keeps the value dropdown for string equality when no stored values exist", () => {
     vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
     render(<FilterRow {...baseProps} filter={{ field: "model_name", op: "=", value: "" }} />);
-    expect(screen.getByRole("textbox")).toBeTruthy();
+    // an empty field must not offer a free input that a first keystroke would
+    // then swap out from under the user
+    expect(screen.queryByRole("textbox")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Enter value" }));
+    expect(screen.getByText("No options")).toBeTruthy();
   });
 
   it("keeps the number input for numeric fields", () => {

--- a/frontend/ui/src/features/dashboards/components/FilterRow.tsx
+++ b/frontend/ui/src/features/dashboards/components/FilterRow.tsx
@@ -68,8 +68,6 @@ export function FilterRow({
     return current && !hasCurrent ? [{ value: current }, ...values] : values;
   }, [values, filter.value]);
 
-  const showValueDropdown = enumerable && (options.length > 0 || isLoading);
-
   return (
     // The widget builder's config column runs at 12px, so the shared controls
     // render at their compact size here.
@@ -118,7 +116,7 @@ export function FilterRow({
         {/* value — same controls as the trace-list builder's ValueControl */}
         {!fieldMeta ? (
           <ParkedValueField />
-        ) : showValueDropdown ? (
+        ) : enumerable ? (
           <ValueDropdown
             value={String(filter.value)}
             options={options}


### PR DESCRIPTION
Fixes #1881 

## Summary
In the dashboard widget builder, typing into an `Environment` filter replaced the value control after the first character, leaving one letter entered and a dropdown reading "No options". The value control now stays the dropdown, matching the trace-list filter.

## Type of Change

- [x] fix - A bug fix

## Details
`FilterRow.tsx` chose between `ValueDropdown` and `TextField` from `options`, which prepends the row's own current value so a saved-but-no-longer-observed value stays selectable:

```ts
const showValueDropdown = enumerable && (options.length > 0 || isLoading);
```

On a field with no stored values in the active window, the user's first keystroke into the fallback `TextField` made `options.length === 1`, so a predicate meant to mean "the server returned suggestions" was satisfied by the user's own input and the control swapped mid-word.

The fix drops `showValueDropdown` and renders on `enumerable` directly, so a string field with `=` is always the dropdown. This is what `CategoricalValue` in the trace-list builder already does, so the two filter surfaces now behave the same.

The `options` memo is unchanged — prepending the current value is still correct for a saved widget whose value has aged out of the window.

## Screenshots / Recordings
<img width="868" height="524" alt="Screenshot 2026-08-12 at 5 47 58 PM" src="https://github.com/user-attachments/assets/389e461f-5dd8-48cb-b3d2-c8e6c9c9a3a3" />

End to end test hosted via localhost docker build

<img width="803" height="360" alt="Screenshot 2026-08-12 at 5 51 33 PM" src="https://github.com/user-attachments/assets/c5d19b01-f637-4c29-a215-92d3dd46bfc2" />

<img width="839" height="347" alt="Screenshot 2026-08-12 at 6 10 17 PM" src="https://github.com/user-attachments/assets/8915bcf3-2538-4b6f-939d-e5ba6796c372" />
TraceRoot Console -> Tracing UI: "Environment" filter is proven end-to-end working. Fix proposes maching expected behavior here.


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the widget filter’s value input from swapping to a dropdown after the first keystroke. Enumerable string fields with “=” now always render the dropdown, matching the trace-list builder and avoiding stranded one-character inputs.

- Replaces the `showValueDropdown` predicate with a direct `enumerable` check in `FilterRow.tsx`, so string “=” fields consistently use `ValueDropdown`.
- Keeps prepending the current value to `options`, so saved, out-of-window values remain selectable.
- Leaves numeric and other non-enumerable fields unchanged; empty string “=” fields show a dropdown with “No options” until suggestions load.
- Updates the test to assert no textbox appears for empty string “=” fields and that opening the control shows “No options”.

<sup>Written for commit fa03f1b58473ddc324ac9ccd1102a96d10d16e3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

