### PR TITLE
feat(detectors): whitelist trigger fields and operators at the write path

### DIFF
--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -393,7 +393,10 @@ model DetectorTrigger {
   id         String   @id @default(cuid()) @db.VarChar
   detectorId String   @unique @map("detector_id") @db.VarChar
   conditions Json     @db.JsonB
-  // [{field: "root_span_finished", op: "=", value: true}, {field: "total_tokens", op: ">", value: 1000}]
+  // [{field: "environment", op: "=", value: "prod"}, {field: "total_tokens", op: ">", value: 1000},
+  //  {field: "metadata", key: "tenant", op: "contains", value: "acme"}]
+  // Fields/ops are whitelisted by features/detectors/trigger-fields.ts (UI + API routes)
+  // and evaluated by backend/worker/detector_tasks.py.
 
   detector Detector @relation(fields: [detectorId], references: [id], onDelete: Cascade)
 

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({ NextRequest: class {} }));
+
+const detectorFindFirstMock = vi.fn();
+const detectorUpdateMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    detector: {
+      findFirst: (...args: unknown[]) => detectorFindFirstMock(...args),
+      update: (...args: unknown[]) => detectorUpdateMock(...args),
+    },
+  },
+}));
+
+const requireAuthMock = vi.fn();
+const requireProjectAccessMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireProjectAccess: (...args: unknown[]) => requireProjectAccessMock(...args),
+  errorResponse: (msg: string, status: number) => ({ status, json: async () => ({ error: msg }) }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { PATCH } from "./route";
+
+function makeRequest(body: unknown) {
+  return { json: async () => body } as unknown as Parameters<typeof PATCH>[0];
+}
+
+function makeParams() {
+  return { params: Promise.resolve({ projectId: "proj-1", detectorId: "det-1" }) };
+}
+
+beforeEach(() => {
+  detectorFindFirstMock.mockReset();
+  detectorUpdateMock.mockReset();
+  requireAuthMock.mockReset();
+  requireProjectAccessMock.mockReset();
+  requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+  requireProjectAccessMock.mockResolvedValue({});
+  detectorFindFirstMock.mockResolvedValue({ id: "det-1", projectId: "proj-1" });
+  detectorUpdateMock.mockResolvedValue({ id: "det-1" });
+});
+
+describe("PATCH .../detectors/[detectorId] — trigger conditions", () => {
+  it("upserts a condition on an offered field", async () => {
+    const conditions = [{ field: "metadata", op: "contains", value: "acme", key: "tenant" }];
+    const res = await PATCH(makeRequest({ triggerConditions: conditions }), makeParams());
+
+    expect(res.status).toBe(200);
+    expect(detectorUpdateMock.mock.calls[0][0].data.trigger.upsert.update.conditions).toEqual(
+      conditions,
+    );
+  });
+
+  it("refuses to save a half-filled condition carried over from an older detector", async () => {
+    // A row saved before the registry validation existed can hold an empty
+    // value; saving it back would store a condition that matches nothing.
+    const res = await PATCH(
+      makeRequest({ triggerConditions: [{ field: "environment", op: "=", value: "" }] }),
+      makeParams(),
+    );
+
+    expect(res.status).toBe(400);
+    expect(detectorUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses an operator the field does not offer", async () => {
+    const res = await PATCH(
+      makeRequest({ triggerConditions: [{ field: "cost", op: "contains", value: "1" }] }),
+      makeParams(),
+    );
+
+    expect(res.status).toBe(400);
+    expect(detectorUpdateMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@traceroot/core";
+import { validateTriggerConditions } from "@/features/detectors/trigger-fields";
 import {
   requireAuth,
   requireProjectAccess,
@@ -89,8 +90,12 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
       return errorResponse("sampleRate must be an integer between 0 and 100", 400);
     }
   }
-  if (triggerConditions !== undefined && !Array.isArray(triggerConditions)) {
-    return errorResponse("triggerConditions must be an array", 400);
+  if (triggerConditions !== undefined) {
+    // Registry validation, not just an array check: an unknown field or
+    // operator would be stored fine but never match at evaluation time,
+    // silently disabling the detector.
+    const conditionsError = validateTriggerConditions(triggerConditions);
+    if (conditionsError) return errorResponse(conditionsError, 400);
   }
   if (outputSchema !== undefined && !Array.isArray(outputSchema)) {
     return errorResponse("outputSchema must be an array", 400);

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.test.ts
@@ -73,3 +73,25 @@ describe("POST .../detectors — sampleRate default", () => {
     expect(detectorCreateMock).not.toHaveBeenCalled();
   });
 });
+
+describe("POST .../detectors — trigger conditions", () => {
+  it("stores a condition on an offered field", async () => {
+    const conditions = [{ field: "duration_ms", op: ">", value: 4500 }];
+    const res = await POST(makeRequest(validBody({ triggerConditions: conditions })), makeParams());
+
+    expect(res.status).toBe(201);
+    expect(detectorCreateMock.mock.calls[0][0].data.trigger.create.conditions).toEqual(conditions);
+  });
+
+  it("rejects a condition the worker could not evaluate instead of storing it", async () => {
+    // Stored, this detector would look configured and enabled while never
+    // matching a trace, so the refusal has to happen at the write path.
+    const res = await POST(
+      makeRequest(validBody({ triggerConditions: [{ field: "trace_id", op: "=", value: "abc" }] })),
+      makeParams(),
+    );
+
+    expect(res.status).toBe(400);
+    expect(detectorCreateMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@traceroot/core";
 import { DEFAULT_DETECTOR_SAMPLE_RATE } from "@/features/detectors/templates";
+import { validateTriggerConditions } from "@/features/detectors/trigger-fields";
 import {
   requireAuth,
   requireProjectAccess,
@@ -116,11 +117,12 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     resolvedSampleRate = sampleRate;
   }
 
-  // Validate triggerConditions and outputSchema are arrays when provided —
-  // a non-array object would otherwise silently produce an empty list and
-  // cause the detector to fire on every trace.
-  if (triggerConditions !== undefined && !Array.isArray(triggerConditions)) {
-    return errorResponse("triggerConditions must be an array", 400);
+  // Validate triggerConditions against the trigger-field registry — an
+  // unknown field or operator would be stored fine but never match at
+  // evaluation time, silently disabling the detector.
+  if (triggerConditions !== undefined) {
+    const conditionsError = validateTriggerConditions(triggerConditions);
+    if (conditionsError) return errorResponse(conditionsError, 400);
   }
   if (outputSchema !== undefined && !Array.isArray(outputSchema)) {
     return errorResponse("outputSchema must be an array", 400);

--- a/frontend/ui/src/features/detectors/hooks/use-detectors.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-detectors.ts
@@ -16,7 +16,9 @@ export interface Detector {
   detectionSource: "system" | "byok" | null;
   createTime: string;
   updateTime: string;
-  trigger?: { conditions: Array<{ field: string; op: string; value: unknown }> } | null;
+  trigger?: {
+    conditions: Array<{ field: string; op: string; value: unknown; key?: string }>;
+  } | null;
 }
 
 interface PaginationMeta {
@@ -44,7 +46,7 @@ export interface CreateDetectorInput {
   sampleRate?: number;
   enabled?: boolean;
   enableRca?: boolean;
-  triggerConditions?: Array<{ field: string; op: string; value: unknown }>;
+  triggerConditions?: Array<{ field: string; op: string; value: unknown; key?: string }>;
   detectionModel?: string;
   detectionProvider?: string;
   detectionSource?: "system" | "byok";
@@ -95,7 +97,7 @@ export interface UpdateDetectorInput {
   sampleRate?: number;
   enabled?: boolean;
   enableRca?: boolean;
-  triggerConditions?: Array<{ field: string; op: string; value: unknown }>;
+  triggerConditions?: Array<{ field: string; op: string; value: unknown; key?: string }>;
   detectionModel?: string;
   detectionProvider?: string;
   detectionSource?: "system" | "byok";

--- a/frontend/ui/src/features/detectors/trigger-fields.test.ts
+++ b/frontend/ui/src/features/detectors/trigger-fields.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { MAX_FILTERS } from "@/features/filters/predicate";
+import {
+  TRIGGER_FIELD_DEFS,
+  defaultTriggerCondition,
+  normalizeTriggerConditions,
+  validateTriggerConditions,
+} from "./trigger-fields";
+
+/**
+ * The registry is the write path's whitelist: a condition the worker cannot
+ * evaluate has to be refused here, at save time, rather than stored and then
+ * silently never matched at evaluation time.
+ */
+
+/** One valid condition per offered field, in registry order. */
+const VALID_CONDITIONS = [
+  { field: "model_name", op: "=", value: "gpt-4" },
+  { field: "environment", op: "!=", value: "prod" },
+  { field: "cost", op: ">", value: 0.25 },
+  { field: "total_tokens", op: ">=", value: 1200 },
+  { field: "duration_ms", op: "<", value: 4500 },
+  { field: "errors", op: "=", value: 0 },
+  { field: "metadata", op: "contains", value: "acme", key: "tenant" },
+];
+
+describe("validateTriggerConditions — what the write path accepts", () => {
+  it("accepts one condition on every offered field", () => {
+    expect(VALID_CONDITIONS.map((c) => c.field)).toEqual(TRIGGER_FIELD_DEFS.map((d) => d.field));
+    expect(validateTriggerConditions(VALID_CONDITIONS)).toBeNull();
+  });
+
+  it("accepts none through the filter cap, and refuses past it", () => {
+    // No conditions is valid: the detector then runs on every completed trace.
+    expect(validateTriggerConditions([])).toBeNull();
+    const overCap = Array.from({ length: MAX_FILTERS + 1 }, () => VALID_CONDITIONS[0]);
+    expect(validateTriggerConditions(overCap.slice(0, MAX_FILTERS))).toBeNull();
+    expect(validateTriggerConditions(overCap)).not.toBeNull();
+  });
+});
+
+describe("validateTriggerConditions — fields and operators the evaluator cannot run", () => {
+  it("refuses a field that is not offered, including the deliberately excluded trace id", () => {
+    expect(
+      validateTriggerConditions([{ field: "status", op: "=", value: "ERROR" }]),
+    ).not.toBeNull();
+    expect(
+      validateTriggerConditions([{ field: "trace_id", op: "=", value: "abc" }]),
+    ).not.toBeNull();
+    expect(TRIGGER_FIELD_DEFS.some((d) => d.field === "trace_id")).toBe(false);
+  });
+
+  it("refuses an operator the field does not offer", () => {
+    // Ordering on a membership field, and inequality on a numeric aggregate:
+    // both are operators the trace list does not offer for that field either.
+    expect(validateTriggerConditions([{ field: "environment", op: ">", value: "prod" }])).toContain(
+      "Environment",
+    );
+    expect(validateTriggerConditions([{ field: "cost", op: "!=", value: 1 }])).toContain("Cost");
+  });
+});
+
+describe("validateTriggerConditions — value shapes", () => {
+  it("refuses the empty value a half-filled row carries, so Save stays blocked", () => {
+    // The trigger editor stores "" for an untouched value, and a legacy row can
+    // hold one already; either would evaluate against nothing.
+    expect(validateTriggerConditions([defaultTriggerCondition("model_name")])).not.toBeNull();
+    expect(validateTriggerConditions([defaultTriggerCondition("cost")])).not.toBeNull();
+    expect(validateTriggerConditions([{ field: "cost", op: ">", value: "0.25" }])).not.toBeNull();
+  });
+
+  it("refuses a fractional or negative value on a whole-number field", () => {
+    expect(validateTriggerConditions([{ field: "errors", op: ">", value: 1.5 }])).not.toBeNull();
+    expect(
+      validateTriggerConditions([{ field: "total_tokens", op: ">", value: -1 }]),
+    ).not.toBeNull();
+    expect(validateTriggerConditions([{ field: "cost", op: ">", value: 0.5 }])).toBeNull();
+  });
+
+  it("requires a metadata key, and refuses one on every other field", () => {
+    const metadata = { field: "metadata", op: "=", value: "acme" };
+    expect(validateTriggerConditions([metadata])).not.toBeNull();
+    expect(validateTriggerConditions([{ ...metadata, key: "" }])).not.toBeNull();
+    expect(validateTriggerConditions([{ ...metadata, key: "tenant" }])).toBeNull();
+    expect(
+      validateTriggerConditions([{ field: "environment", op: "=", value: "prod", key: "tenant" }]),
+    ).not.toBeNull();
+  });
+
+  it("refuses a payload that is not an array of objects", () => {
+    expect(validateTriggerConditions({ field: "cost", op: ">", value: 1 })).not.toBeNull();
+    expect(validateTriggerConditions([null])).not.toBeNull();
+    expect(validateTriggerConditions(["environment=prod"])).not.toBeNull();
+  });
+});
+
+describe("normalizeTriggerConditions — the editor's rows as the write path stores them", () => {
+  it("strips the whitespace around a metadata key", () => {
+    expect(
+      normalizeTriggerConditions([{ field: "metadata", op: "=", value: "acme", key: " tenant " }]),
+    ).toEqual([{ field: "metadata", op: "=", value: "acme", key: "tenant" }]);
+  });
+
+  it("leaves a whitespace-only metadata key blocking the save", () => {
+    // A key of one space matched nothing forever, because validation saw a
+    // non-empty string and let it through.
+    const blank = normalizeTriggerConditions([
+      { field: "metadata", op: "=", value: "acme", key: " " },
+    ]);
+    expect(blank[0].key).toBe("");
+    expect(validateTriggerConditions(blank)).not.toBeNull();
+  });
+
+  it("turns a typed numeric value into the number the write path requires", () => {
+    const typed = [
+      { field: "cost", op: ">", value: "0.25" },
+      { field: "total_tokens", op: ">=", value: "1200" },
+    ];
+    expect(normalizeTriggerConditions(typed)).toEqual([
+      { field: "cost", op: ">", value: 0.25 },
+      { field: "total_tokens", op: ">=", value: 1200 },
+    ]);
+    expect(validateTriggerConditions(normalizeTriggerConditions(typed))).toBeNull();
+  });
+
+  it("keeps a long digit string exact rather than rounding it through the input", () => {
+    const long = normalizeTriggerConditions([{ field: "cost", op: ">", value: "22222222222" }]);
+    expect(long[0].value).toBe(22222222222);
+  });
+
+  it("leaves a text field's digits as the string it stores", () => {
+    expect(
+      normalizeTriggerConditions([{ field: "metadata", op: "=", value: "42", key: "tenant" }]),
+    ).toEqual([{ field: "metadata", op: "=", value: "42", key: "tenant" }]);
+  });
+
+  it("leaves an untouched numeric row empty so the save stays blocked", () => {
+    const untouched = normalizeTriggerConditions([defaultTriggerCondition("cost")]);
+    expect(untouched[0].value).toBe("");
+    expect(validateTriggerConditions(untouched)).not.toBeNull();
+  });
+});
+
+describe("validateTriggerConditions — agreeing with what the write path receives", () => {
+  it("passes a numeric value that is only valid once normalized", () => {
+    const typed = [{ field: "cost", op: ">", value: "0.25" }];
+    expect(validateTriggerConditions(typed)).not.toBeNull();
+    expect(validateTriggerConditions(normalizeTriggerConditions(typed))).toBeNull();
+  });
+
+  it("refuses a non-numeric entry that normalization cannot rescue", () => {
+    const typed = [{ field: "cost", op: ">", value: "abc" }];
+    expect(normalizeTriggerConditions(typed)[0].value).toBeNaN();
+    expect(validateTriggerConditions(normalizeTriggerConditions(typed))).not.toBeNull();
+  });
+
+  it("refuses a metadata key that is only whitespace, normalized or not", () => {
+    const typed = [{ field: "metadata", op: "=", value: "acme", key: " " }];
+    expect(validateTriggerConditions(typed)).not.toBeNull();
+    expect(validateTriggerConditions(normalizeTriggerConditions(typed))).not.toBeNull();
+  });
+});

--- a/frontend/ui/src/features/detectors/trigger-fields.ts
+++ b/frontend/ui/src/features/detectors/trigger-fields.ts
@@ -1,0 +1,149 @@
+/**
+ * Detector trigger-condition field registry — the single source of truth for which
+ * fields a detector filter may name, which operators each takes, and what a valid
+ * condition looks like. The trigger editor renders from it and the detector API
+ * routes validate against it, so a field cannot appear in the UI without the write
+ * path accepting it.
+ *
+ * Fields and grain mirror the trace-list filter registry
+ * (backend/rest/services/filters/columns.py); the evaluator in
+ * backend/worker/detector_tasks.py fetches each field at that same grain. Operators
+ * are the detector's stored vocabulary (symbolic: "=", ">", ...) — the same one the
+ * dashboard widget filters use — rather than the trace list's wire names (eq/gt/...),
+ * because that is what existing DetectorTrigger rows already hold.
+ *
+ * Trace ID is deliberately absent: detectors evaluate live traces as they complete,
+ * so pinning one to a single known trace id is not a meaningful trigger.
+ */
+
+import { MAX_FILTERS, MAX_KEY_LENGTH, MAX_VALUE_LENGTH } from "@/features/filters/predicate";
+
+export interface TriggerCondition {
+  field: string;
+  op: string;
+  value: unknown;
+  /** Map key for keyed fields (metadata). Absent for every other field. */
+  key?: string;
+}
+
+export interface TriggerFieldDef {
+  field: string;
+  label: string;
+  ops: readonly string[];
+  /** enum: observed-values dropdown; number: numeric input; text: free text. */
+  valueKind: "enum" | "number" | "text";
+  integer?: boolean;
+  requiresKey?: boolean;
+}
+
+const STRING_OPS = ["=", "!="] as const;
+const NUMERIC_OPS = [">", ">=", "<", "<=", "="] as const;
+const METADATA_OPS = ["=", "contains"] as const;
+
+export const TRIGGER_FIELD_DEFS: readonly TriggerFieldDef[] = [
+  { field: "model_name", label: "Model", ops: STRING_OPS, valueKind: "enum" },
+  { field: "environment", label: "Environment", ops: STRING_OPS, valueKind: "enum" },
+  { field: "cost", label: "Cost", ops: NUMERIC_OPS, valueKind: "number" },
+  { field: "total_tokens", label: "Tokens", ops: NUMERIC_OPS, valueKind: "number", integer: true },
+  { field: "duration_ms", label: "Latency", ops: NUMERIC_OPS, valueKind: "number", integer: true },
+  { field: "errors", label: "Errors", ops: NUMERIC_OPS, valueKind: "number", integer: true },
+  {
+    field: "metadata",
+    label: "Metadata",
+    ops: METADATA_OPS,
+    valueKind: "text",
+    requiresKey: true,
+  },
+];
+
+const DEFS_BY_FIELD: Record<string, TriggerFieldDef> = Object.fromEntries(
+  TRIGGER_FIELD_DEFS.map((d) => [d.field, d]),
+);
+
+export function triggerFieldDef(field: string): TriggerFieldDef | undefined {
+  return DEFS_BY_FIELD[field];
+}
+
+export function defaultTriggerCondition(field: string): TriggerCondition {
+  const def = DEFS_BY_FIELD[field] ?? TRIGGER_FIELD_DEFS[0];
+  return {
+    field: def.field,
+    op: def.ops[0],
+    value: "",
+    ...(def.requiresKey ? { key: "" } : {}),
+  };
+}
+
+/**
+ * Editor rows as the write path stores them. The editor holds what was typed;
+ * this is the one place it becomes a payload, mirroring the trace-list builder,
+ * which also trims the metadata key only when it builds a predicate.
+ */
+export function normalizeTriggerConditions(conditions: TriggerCondition[]): TriggerCondition[] {
+  return conditions.map((c) => {
+    const def = DEFS_BY_FIELD[c.field];
+    const value =
+      def?.valueKind === "number" && typeof c.value === "string" && c.value.trim() !== ""
+        ? Number(c.value)
+        : c.value;
+    return typeof c.key === "string" ? { ...c, value, key: c.key.trim() } : { ...c, value };
+  });
+}
+
+const NUMERIC_OP_SYMBOL: Record<string, string> = { ">=": "≥", "<=": "≤" };
+const STRING_OP_LABEL: Record<string, string> = { "=": "is", "!=": "is not" };
+
+/** Display label for an operator, matching the shared filter builders' vocabulary. */
+export function triggerOpLabel(def: TriggerFieldDef | undefined, op: string): string {
+  if (def?.valueKind === "number") return NUMERIC_OP_SYMBOL[op] ?? op;
+  return STRING_OP_LABEL[op] ?? op;
+}
+
+function conditionError(item: unknown, index: number): string | null {
+  const at = `condition ${index + 1}`;
+  if (item === null || typeof item !== "object" || Array.isArray(item)) {
+    return `${at} must be an object`;
+  }
+  const { field, op, value, key } = item as Record<string, unknown>;
+  const def = typeof field === "string" ? DEFS_BY_FIELD[field] : undefined;
+  if (!def) return `${at} has an unknown field`;
+  if (typeof op !== "string" || !def.ops.includes(op)) {
+    return `${at} has an invalid operator for ${def.label}`;
+  }
+  if (def.requiresKey) {
+    const trimmedKey = typeof key === "string" ? key.trim() : "";
+    if (trimmedKey.length === 0) return `${at} requires a metadata key`;
+    if (trimmedKey.length > MAX_KEY_LENGTH) return `${at} key is too long`;
+  } else if (key !== undefined) {
+    return `${at} does not take a key`;
+  }
+  if (def.valueKind === "number") {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+      return `${at} requires a non-negative number`;
+    }
+    if (def.integer && !Number.isInteger(value)) return `${at} requires a whole number`;
+  } else {
+    if (typeof value !== "string" || value.length === 0) {
+      return `${at} requires a non-empty value`;
+    }
+    if (value.length > MAX_VALUE_LENGTH) return `${at} value is too long`;
+  }
+  return null;
+}
+
+/**
+ * Validate a trigger-conditions payload at the boundary. Returns the first
+ * problem as a human-readable message, or null when the payload is valid.
+ * An empty array is valid — it means the detector runs on all completed traces.
+ */
+export function validateTriggerConditions(conditions: unknown): string | null {
+  if (!Array.isArray(conditions)) return "triggerConditions must be an array";
+  if (conditions.length > MAX_FILTERS) {
+    return `triggerConditions carries more than the maximum of ${MAX_FILTERS} conditions`;
+  }
+  for (let i = 0; i < conditions.length; i++) {
+    const error = conditionError(conditions[i], i);
+    if (error) return error;
+  }
+  return null;
+}

--- a/frontend/ui/src/features/detectors/utils/index.ts
+++ b/frontend/ui/src/features/detectors/utils/index.ts
@@ -13,7 +13,7 @@ export interface DetectorFormValues {
   detectionModel: string;
   detectionProvider: string;
   detectionSource: "system" | "byok";
-  conditions: Array<{ field: string; op: string; value: unknown }>;
+  conditions: Array<{ field: string; op: string; value: unknown; key?: string }>;
 }
 
 export function detectorToFormValues(d: Detector): DetectorFormValues {

--- a/tests/rest/test_detector_trigger_field_parity.py
+++ b/tests/rest/test_detector_trigger_field_parity.py
@@ -1,0 +1,203 @@
+"""Drift tests between the detector trigger-field registry and the evaluator.
+
+A detector's Filter section offers seven fields. The list of them lives in
+TypeScript (``trigger-fields.ts`` — the trigger editor renders from it and both
+detector routes validate against it), while the code that answers a condition
+lives in Python (``worker.detector_tasks``). Neither side can import the other,
+and a field offered on one side but not fetched by the other fails silently:
+the evaluator reads ``trace_summary.get(field)``, and a missing field answers
+True only for ``!=`` and False for everything else — a detector that is
+configured, enabled, and never fires.
+
+Grain is asserted against the trace-list filter registry
+(``rest.services.filters.columns``) rather than restated here, because a
+detector filter has to answer the same question the trace list's filter
+answers; divergence between the two would be its own bug.
+
+Every parse below asserts what it found. A regex that silently matches nothing
+would make its assertion vacuous, which reads as coverage while protecting
+nothing.
+"""
+
+import re
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from rest.services.filters.columns import FILTER_COLUMNS, FILTER_COLUMNS_BY_NAME, FilterLevel
+from worker.detector_tasks import _get_trace_summaries
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+TRIGGER_FIELDS_TS = (
+    _REPO_ROOT / "frontend" / "ui" / "src" / "features" / "detectors" / "trigger-fields.ts"
+)
+
+requires_frontend = pytest.mark.skipif(
+    not TRIGGER_FIELDS_TS.exists(),
+    reason="frontend sources not present in this checkout",
+)
+
+_FIELD_ENTRY_RE = re.compile(r"field:\s*\"(\w+)\"\s*,\s*label:\s*\"([^\"]+)\"")
+
+
+def _parse_offered_fields() -> list[tuple[str, str]]:
+    """The (field, label) pairs the UI offers, in render order.
+
+    Raises ValueError when the declaration is gone, which is the loud failure a
+    renamed or moved registry deserves: a soft "no match" would leave every
+    assertion downstream comparing two empty collections.
+    """
+    source = TRIGGER_FIELDS_TS.read_text()
+    start = source.index("export const TRIGGER_FIELD_DEFS")
+    end = source.index("\n];", start)
+    return [(m[1], m[2]) for m in _FIELD_ENTRY_RE.finditer(source[start:end])]
+
+
+class _FakeResult:
+    def __init__(self, rows: list[tuple]) -> None:
+        self.result_rows = rows
+
+
+class _RecordingClickHouse:
+    """Answers the two queries ``_get_trace_summaries`` issues and keeps the SQL."""
+
+    def __init__(self, span_rows: list[tuple], trace_rows: list[tuple]) -> None:
+        self._span_rows = span_rows
+        self._trace_rows = trace_rows
+        self.queries: list[str] = []
+
+    def query(self, sql: str, parameters: dict | None = None) -> _FakeResult:
+        self.queries.append(sql)
+        return _FakeResult(self._trace_rows if "FROM traces" in sql else self._span_rows)
+
+
+# One row per query, every column a distinguishable value, so a summary built
+# from the wrong column index is visible rather than plausible.
+_SPAN_ROW = (
+    "trace-1",
+    ["prod", "staging"],
+    ["gpt-4"],
+    Decimal("0.25"),
+    1200,
+    4500,
+    2,
+    [{"tier": "gold"}],
+    datetime(2026, 8, 1, 12, 0),
+)
+_TRACE_ROW = ("trace-1", {"tenant": "acme"})
+
+
+def _fetch(monkeypatch) -> tuple[dict, _RecordingClickHouse]:
+    import db.clickhouse.client as ch_mod
+
+    fake = _RecordingClickHouse([_SPAN_ROW], [_TRACE_ROW])
+    monkeypatch.setattr(ch_mod, "get_clickhouse_client", lambda: fake)
+    return _get_trace_summaries("proj-1", ["trace-1"]), fake
+
+
+def _spans_query(fake: _RecordingClickHouse) -> str:
+    spans_queries = [q for q in fake.queries if "FROM spans" in q]
+    assert len(spans_queries) == 1, "the span-scope fetch is no longer a single query"
+    return spans_queries[0]
+
+
+# --- Which fields exist on both sides ---
+
+
+@requires_frontend
+def test_every_offered_field_is_fetched_by_the_evaluator(monkeypatch):
+    """The defect this feature was built to avoid: a field the UI offers but the
+    fetch never selects is not a degraded filter, it is a detector that never
+    fires (or, on ``!=``, one that fires on everything)."""
+    summary = _fetch(monkeypatch)[0]["trace-1"]
+    missing = [field for field, _ in _parse_offered_fields() if field not in summary]
+    assert missing == [], (
+        f"trigger-fields.ts offers {missing}, which _get_trace_summaries does not fetch; "
+        "conditions on those fields would silently never match"
+    )
+
+
+@requires_frontend
+def test_the_offered_field_registry_was_actually_parsed():
+    """A regex that silently matched nothing would make the parity check above
+    vacuous, so the shape of the parse is asserted rather than assumed."""
+    offered = _parse_offered_fields()
+    assert len(offered) == 7
+    assert offered[0] == ("model_name", "Model")
+
+
+@requires_frontend
+def test_the_offered_fields_are_the_trace_list_fields_without_trace_id():
+    """Detectors filter at the trace list's vocabulary minus Trace ID: a single
+    known trace id is not a meaningful trigger for a detector that watches live
+    traces. Order is compared too, because it is the field dropdown's order on
+    both surfaces."""
+    trace_list = [(c.name, c.label) for c in FILTER_COLUMNS if c.name != "trace_id"]
+    assert _parse_offered_fields() == trace_list
+    assert "trace_id" not in [field for field, _ in _parse_offered_fields()]
+    # Guards the exclusion above against becoming vacuous if the trace list
+    # itself ever drops the field.
+    assert "trace_id" in FILTER_COLUMNS_BY_NAME
+
+
+# --- What each field is worth ---
+
+
+def test_the_fetch_maps_each_column_onto_the_field_the_evaluator_reads(monkeypatch):
+    """Pins the whole summary, not just its keys: a column added or reordered in
+    the SELECT shifts every field after it onto the wrong value, which reads as
+    a working detector filtering on someone else's number."""
+    summaries = _fetch(monkeypatch)[0]
+    assert summaries == {
+        "trace-1": {
+            "environment": ["prod", "staging"],
+            "model_name": ["gpt-4"],
+            "cost": Decimal("0.25"),
+            "total_tokens": 1200,
+            "duration_ms": 4500,
+            "errors": 2,
+            # Trace scope and span scope merged into one key space.
+            "metadata": {"tenant": ["acme"], "tier": ["gold"]},
+        }
+    }
+
+
+def test_numeric_fields_are_fetched_at_the_trace_lists_aggregate_grain(monkeypatch):
+    """Latency is the trace's wall clock (max end minus min start), not a sum of
+    span durations, and errors is an ERROR-span count — both derived, neither a
+    stored column. Read from the trace-list registry so the two cannot drift."""
+    spans_sql = _spans_query(_fetch(monkeypatch)[1])
+    aggregates = {
+        c.name: c.aggregate_expr
+        for c in FILTER_COLUMNS
+        if c.level is FilterLevel.SPAN_AGGREGATE and c.aggregate_expr
+    }
+    assert set(aggregates) == {"cost", "total_tokens", "duration_ms", "errors"}
+    for name, expr in aggregates.items():
+        assert expr in spans_sql, (
+            f"the detector fetch computes '{name}' differently from the trace list, "
+            f"which expects {expr}"
+        )
+
+
+def test_model_and_environment_are_fetched_as_span_membership_sets(monkeypatch):
+    """Membership, not the root span's value: the trace list answers "some span
+    carries this", so a detector on a mixed trace must answer the same."""
+    spans_sql = _spans_query(_fetch(monkeypatch)[1])
+    membership = [c.name for c in FILTER_COLUMNS if c.level is FilterLevel.SPAN_MEMBERSHIP]
+    assert membership == ["model_name", "environment"]
+    for name in membership:
+        assert f"groupUniqArray({name})" in spans_sql
+
+
+def test_metadata_is_fetched_from_both_trace_and_span_scope(monkeypatch):
+    """The SDK may attach metadata at either scope and the two key spaces are
+    disjoint, so reading only spans would drop every trace-level key — the same
+    OR the trace list's keyed-map filter lowers to."""
+    fake = _fetch(monkeypatch)[1]
+    assert "groupArray(metadata_map)" in _spans_query(fake)
+    trace_scope = [q for q in fake.queries if "FROM traces" in q]
+    assert len(trace_scope) == 1 and "metadata_map" in trace_scope[0]


### PR DESCRIPTION
Part **2 of 3** of the detector trigger-field stack, stacked on #1887.

Nothing stopped a trigger condition naming a field or operator the worker cannot evaluate. It **stored fine and then never matched**, producing the same silently-dead detector part 1 fixes from the other side.

One registry (`trigger-fields.ts`) declares the seven filterable fields, their operators and value shapes, and both detector routes validate against it, so a condition that saves is a condition the evaluator can run:

- Adds the optional metadata key slot to the condition types.
- Trims the metadata key before storing — a key of one space passed validation and then matched nothing forever.
- Holds a typed number as typed and coerces once on the way out; coercing per keystroke turned twenty-two digits into `1e+21`.
- A parity test reads the TypeScript registry from Python and fails on any difference from the evaluator, since neither side can import the other. Grain is asserted against the trace-list filter registry rather than restated, so a detector filter cannot start answering a different question from the list the user built it in.

Two notes for review. `normalizeTriggerConditions` ships here with its unit tests and gains its three callers in part 3, so it is unused for the length of one PR. And **this should land in the same cycle as #1886**: merged alone, the old editor is still in place, and while everything it can build is accepted by the new registry, it can still add a blank environment row that the write path now rejects with a 400 it has no way to explain.

---

Stack: **#1887** (evaluator) → **#1885** (registry) → **#1886** (editor)
