### PR TITLE
feat(detectors): build the filter editor on the shared filter controls

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   mutateAsync: vi.fn().mockResolvedValue({ id: "det-1" }),
   selectorProps: null as Record<string, unknown> | null,
+  editedConditions: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -29,8 +30,14 @@ vi.mock("@/features/ai-assistant/components/model-selector", () => ({
     return null;
   },
 }));
+// Stands in for the filter editor: the button hands the page the rows a user
+// would have built, which is all the page sees of it.
 vi.mock("@/features/detectors/components/trigger-editor", () => ({
-  TriggerEditor: () => null,
+  TriggerEditor: ({ onChange }: { onChange?: (c: Array<Record<string, unknown>>) => void }) => (
+    <button type="button" onClick={() => onChange?.(mocks.editedConditions)}>
+      edit filter
+    </button>
+  ),
 }));
 vi.mock("@/features/detectors/components/agent-model-link", () => ({
   AgentModelLink: () => null,
@@ -46,7 +53,12 @@ afterEach(() => {
   mocks.mutateAsync.mockClear();
   mocks.push.mockClear();
   mocks.selectorProps = null;
+  mocks.editedConditions = [];
 });
+
+const createButton = () =>
+  screen.getByRole("button", { name: "Create Detector" }) as HTMLButtonElement;
+const editFilter = () => fireEvent.click(screen.getByRole("button", { name: "edit filter" }));
 
 describe("NewDetectorPage", () => {
   it("submits the selected template's defaults", async () => {
@@ -92,5 +104,42 @@ describe("NewDetectorPage", () => {
   it("renders the screening-model picker with a system-default model id (no auto-pick)", () => {
     render(<NewDetectorPage />);
     expect(mocks.selectorProps?.defaultModelId).toBe(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
+  });
+});
+
+describe("NewDetectorPage — an incomplete filter row", () => {
+  it("says on screen why Create is blocked", () => {
+    render(<NewDetectorPage />);
+    mocks.editedConditions = [{ field: "metadata", op: "=", value: "acme", key: " " }];
+    editFilter();
+
+    expect(screen.getByText("condition 1 requires a metadata key")).toBeDefined();
+    expect(createButton().disabled).toBe(true);
+  });
+});
+
+describe("NewDetectorPage — the conditions it submits", () => {
+  it("submits the metadata key without the whitespace around it", async () => {
+    render(<NewDetectorPage />);
+    mocks.editedConditions = [{ field: "metadata", op: "=", value: "acme", key: " tenant " }];
+    editFilter();
+    fireEvent.click(createButton());
+
+    await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mocks.mutateAsync.mock.calls[0][0]).toMatchObject({
+      triggerConditions: [{ field: "metadata", op: "=", value: "acme", key: "tenant" }],
+    });
+  });
+
+  it("submits a typed numeric value as a number", async () => {
+    render(<NewDetectorPage />);
+    mocks.editedConditions = [{ field: "duration_ms", op: ">", value: "4500" }];
+    editFilter();
+    fireEvent.click(createButton());
+
+    await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mocks.mutateAsync.mock.calls[0][0]).toMatchObject({
+      triggerConditions: [{ field: "duration_ms", op: ">", value: 4500 }],
+    });
   });
 });

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -18,6 +18,10 @@ import { useCreateDetector } from "@/features/detectors/hooks/use-detectors";
 import type { CreateDetectorInput } from "@/features/detectors/hooks/use-detectors";
 import { TriggerEditor } from "@/features/detectors/components/trigger-editor";
 import type { TriggerCondition } from "@/features/detectors/components/trigger-editor";
+import {
+  normalizeTriggerConditions,
+  validateTriggerConditions,
+} from "@/features/detectors/trigger-fields";
 import { AgentModelLink } from "@/features/detectors/components/agent-model-link";
 import { RcaToggle } from "@/features/detectors/components/rca-toggle";
 import { useProject } from "@/features/projects/hooks";
@@ -72,7 +76,7 @@ export default function NewDetectorPage() {
       sampleRate,
       enabled: sampleRate > 0,
       enableRca,
-      triggerConditions,
+      triggerConditions: normalizeTriggerConditions(triggerConditions),
       detectionModel: modelSelection.model || undefined,
       detectionProvider: modelSelection.provider || undefined,
       detectionSource: modelSelection.source === "byok" ? "byok" : "system",
@@ -82,6 +86,11 @@ export default function NewDetectorPage() {
   };
 
   const selectedTemplateDef = DETECTOR_TEMPLATES.find((t) => t.id === selectedTemplate);
+
+  // Block Create while a filter row is incomplete (missing value or metadata
+  // key) — the write path rejects such payloads with a message the fetch
+  // layer would flatten into a generic failure.
+  const conditionsError = validateTriggerConditions(normalizeTriggerConditions(triggerConditions));
 
   return (
     <div className="relative flex h-full text-[13px]">
@@ -201,6 +210,7 @@ export default function NewDetectorPage() {
             <div className="border border-border">
               <TriggerEditor
                 conditions={triggerConditions}
+                projectId={projectId}
                 onChange={setTriggerConditions}
                 asCard
               />
@@ -227,7 +237,10 @@ export default function NewDetectorPage() {
             </div>
 
             {/* Footer */}
-            <div className="flex justify-end gap-2 pt-1">
+            <div className="flex items-center justify-end gap-2 pt-1">
+              {conditionsError && (
+                <span className="text-[12px] text-destructive">{conditionsError}</span>
+              )}
               <Button
                 type="button"
                 variant="outline"
@@ -241,7 +254,12 @@ export default function NewDetectorPage() {
                 type="submit"
                 size="sm"
                 className="h-7 text-[12px]"
-                disabled={createMutation.isPending || !name.trim() || !prompt.trim()}
+                disabled={
+                  createMutation.isPending ||
+                  !name.trim() ||
+                  !prompt.trim() ||
+                  conditionsError !== null
+                }
               >
                 {createMutation.isPending ? "Creating..." : "Create Detector"}
               </Button>

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   detector: undefined as Detector | undefined,
   mutate: vi.fn(),
   selectorProps: null as Record<string, unknown> | null,
+  editedConditions: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock("../hooks/use-detectors", () => ({
@@ -17,8 +18,14 @@ vi.mock("../hooks/use-detectors", () => ({
 vi.mock("@/features/projects/hooks", () => ({
   useProject: () => ({ data: undefined }),
 }));
+// Stands in for the filter editor: the button hands the panel the rows a user
+// would have built, which is all the panel sees of it.
 vi.mock("./trigger-editor", () => ({
-  TriggerEditor: () => null,
+  TriggerEditor: ({ onChange }: { onChange?: (c: Array<Record<string, unknown>>) => void }) => (
+    <button type="button" onClick={() => onChange?.(mocks.editedConditions)}>
+      edit filter
+    </button>
+  ),
 }));
 vi.mock("./agent-model-link", () => ({
   AgentModelLink: () => null,
@@ -80,13 +87,22 @@ function renderPanel(detectorId = "det-1") {
 
 const rcaToggle = () => screen.getByTestId("rca-toggle") as HTMLInputElement;
 const promptBox = () => document.querySelector("textarea") as HTMLTextAreaElement;
-const saveButton = () => screen.getByRole("button", { name: "Save" });
+const saveButton = () => screen.getByRole("button", { name: "Save" }) as HTMLButtonElement;
+const nameBox = () => screen.getByDisplayValue(baseDetector.name) as HTMLInputElement;
+const editFilter = () => fireEvent.click(screen.getByRole("button", { name: "edit filter" }));
+
+/** A detector saved before the trigger registry existed, holding a row it rejects. */
+const legacyDetector: Detector = {
+  ...baseDetector,
+  trigger: { conditions: [{ field: "cost", op: ">", value: "" }] },
+};
 
 afterEach(() => {
   cleanup();
   mocks.detector = undefined;
   mocks.mutate.mockReset();
   mocks.selectorProps = null;
+  mocks.editedConditions = [];
 });
 
 describe("DetectorPanel", () => {
@@ -148,6 +164,54 @@ describe("DetectorPanel", () => {
     mocks.detector = baseDetector;
     renderPanel("det-2");
     expect(promptBox().value).toBe("");
-    expect((saveButton() as HTMLButtonElement).disabled).toBe(true);
+    expect(saveButton().disabled).toBe(true);
+  });
+});
+
+describe("DetectorPanel — a stored filter row the registry now rejects", () => {
+  it("still saves a rename, because the rename does not rewrite the row", () => {
+    mocks.detector = legacyDetector;
+    renderPanel();
+    fireEvent.change(nameBox(), { target: { value: "Renamed" } });
+
+    expect(saveButton().disabled).toBe(false);
+    fireEvent.click(saveButton());
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({ name: "Renamed" });
+  });
+
+  it("blocks the save once that row is edited, and says why on screen", () => {
+    mocks.detector = legacyDetector;
+    renderPanel();
+    mocks.editedConditions = [{ field: "cost", op: ">=", value: "" }];
+    editFilter();
+
+    expect(screen.getByText("condition 1 requires a non-negative number")).toBeDefined();
+    expect(saveButton().disabled).toBe(true);
+  });
+});
+
+describe("DetectorPanel — the conditions it sends", () => {
+  it("sends the metadata key without the whitespace around it", () => {
+    mocks.detector = baseDetector;
+    renderPanel();
+    mocks.editedConditions = [{ field: "metadata", op: "=", value: "acme", key: " tenant " }];
+    editFilter();
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({
+      triggerConditions: [{ field: "metadata", op: "=", value: "acme", key: "tenant" }],
+    });
+  });
+
+  it("sends a typed numeric value as a number", () => {
+    mocks.detector = baseDetector;
+    renderPanel();
+    mocks.editedConditions = [{ field: "duration_ms", op: ">", value: "4500" }];
+    editFilter();
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({
+      triggerConditions: [{ field: "duration_ms", op: ">", value: 4500 }],
+    });
   });
 });

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -9,6 +9,7 @@ import { DEFAULT_DETECTOR_SAMPLE_RATE } from "../templates";
 import { useProject } from "@/features/projects/hooks";
 import { TriggerEditor } from "./trigger-editor";
 import type { TriggerCondition } from "./trigger-editor";
+import { normalizeTriggerConditions, validateTriggerConditions } from "../trigger-fields";
 import { AgentModelLink } from "./agent-model-link";
 import { RcaToggle } from "./rca-toggle";
 import {
@@ -77,7 +78,7 @@ export function DetectorPanel({
     detectionModel: editModelSelection.model,
     detectionProvider: editModelSelection.provider,
     detectionSource: editModelSelection.source === "byok" ? "byok" : "system",
-    conditions: editConditions as DetectorFormValues["conditions"],
+    conditions: normalizeTriggerConditions(editConditions) as DetectorFormValues["conditions"],
   });
 
   const applyForm = (values: DetectorFormValues) => {
@@ -140,6 +141,18 @@ export function DetectorPanel({
   }, [detectorId]);
 
   const updateMutation = useUpdateDetector(projectId, detectorId);
+
+  // Block Save while a filter row is incomplete (missing value or metadata
+  // key) — the write path rejects such payloads, and the fetch layer would
+  // surface only a generic failure. Scoped to a save that actually writes the
+  // conditions: a detector stored before this registry existed can hold a row
+  // the registry now rejects, and that must not lock its name or prompt.
+  const loadedValues = loadedRef.current?.values;
+  const savesConditions =
+    !!loadedValues && buildDetectorPatch(loadedValues, readForm()).triggerConditions !== undefined;
+  const conditionsError = savesConditions
+    ? validateTriggerConditions(normalizeTriggerConditions(editConditions))
+    : null;
 
   const handleSave = () => {
     // Guard against saving while the new detector's data is still loading.
@@ -282,7 +295,12 @@ export function DetectorPanel({
 
         {/* Filter */}
         <div className="border border-border">
-          <TriggerEditor conditions={editConditions} onChange={setEditConditions} asCard />
+          <TriggerEditor
+            conditions={editConditions}
+            projectId={projectId}
+            onChange={setEditConditions}
+            asCard
+          />
         </div>
 
         {/* Sampling */}
@@ -306,14 +324,22 @@ export function DetectorPanel({
         </div>
 
         {/* Save / Cancel */}
-        <div className="flex justify-end gap-2 pt-1">
+        <div className="flex items-center justify-end gap-2 pt-1">
+          {conditionsError && (
+            <span className="text-[12px] text-destructive">{conditionsError}</span>
+          )}
           <Button variant="outline" size="sm" onClick={onClose} className="h-7 text-[12px]">
             Cancel
           </Button>
           <Button
             size="sm"
             onClick={handleSave}
-            disabled={updateMutation.isPending || !detector || detector.id !== detectorId}
+            disabled={
+              updateMutation.isPending ||
+              !detector ||
+              detector.id !== detectorId ||
+              conditionsError !== null
+            }
             className="h-7 text-[12px]"
           >
             {updateMutation.isPending ? "Saving..." : "Save"}

--- a/frontend/ui/src/features/detectors/components/trigger-editor.test.tsx
+++ b/frontend/ui/src/features/detectors/components/trigger-editor.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { MAX_FILTERS } from "@/features/filters/predicate";
+import type { TriggerCondition } from "../trigger-fields";
+
+const mockUseFilterValues = vi.hoisted(() =>
+  vi.fn((): { values: { value: string; count?: number }[]; isLoading: boolean } => ({
+    values: [],
+    isLoading: false,
+  })),
+);
+vi.mock("@/features/filters/hooks", () => ({
+  useFilterValues: mockUseFilterValues,
+  useMetadataKeys: () => ({ keys: [], isLoading: false }),
+}));
+
+import { TriggerEditor } from "./trigger-editor";
+
+/** Server-observed values for the row's field, as the suggestions endpoint answers. */
+function observeValues(values: { value: string; count?: number }[]) {
+  mockUseFilterValues.mockReturnValue({ values, isLoading: false });
+}
+
+function renderEditor(
+  conditions: TriggerCondition[],
+  props: { onChange?: (c: TriggerCondition[]) => void; onSave?: (c: TriggerCondition[]) => void },
+) {
+  render(<TriggerEditor conditions={conditions} projectId="proj-1" {...props} />);
+}
+
+const valueInput = () => screen.getByLabelText("value") as HTMLInputElement;
+const lastCall = (spy: ReturnType<typeof vi.fn>) => spy.mock.calls[spy.mock.calls.length - 1][0];
+
+afterEach(() => {
+  cleanup();
+  mockUseFilterValues.mockReturnValue({ values: [], isLoading: false });
+});
+
+describe("TriggerEditor — the value control for a field with no observed values", () => {
+  it("stays a text input across keystrokes so a whole word can be typed", () => {
+    const onChange = vi.fn();
+    renderEditor([{ field: "environment", op: "=", value: "" }], { onChange });
+
+    fireEvent.change(valueInput(), { target: { value: "s" } });
+    expect(valueInput().tagName).toBe("INPUT");
+    fireEvent.change(valueInput(), { target: { value: "staging" } });
+
+    expect(valueInput().value).toBe("staging");
+    expect(lastCall(onChange)).toEqual([{ field: "environment", op: "=", value: "staging" }]);
+  });
+});
+
+describe("TriggerEditor — the value control for a field with observed values", () => {
+  it("is a dropdown from the start and stays one after a value is picked", () => {
+    observeValues([{ value: "prod", count: 3 }]);
+    const onChange = vi.fn();
+    renderEditor([{ field: "environment", op: "=", value: "" }], { onChange });
+
+    expect(screen.queryByLabelText("value")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Enter value" }));
+    fireEvent.click(screen.getByRole("option", { name: /prod/ }));
+
+    expect(lastCall(onChange)).toEqual([{ field: "environment", op: "=", value: "prod" }]);
+    expect(screen.queryByLabelText("value")).toBeNull();
+  });
+});
+
+describe("TriggerEditor — picking a field on a row that already has one", () => {
+  it("keeps the operator and value when the field picked is the one already there", () => {
+    const onChange = vi.fn();
+    renderEditor([{ field: "cost", op: ">=", value: "250" }], { onChange });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cost" }));
+    fireEvent.click(screen.getByRole("option", { name: "Cost" }));
+
+    expect(lastCall(onChange)).toEqual([{ field: "cost", op: ">=", value: "250" }]);
+    expect(valueInput().value).toBe("250");
+  });
+
+  it("resets the operator and value when a different field is picked", () => {
+    const onChange = vi.fn();
+    renderEditor([{ field: "cost", op: ">=", value: "250" }], { onChange });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cost" }));
+    fireEvent.click(screen.getByRole("option", { name: "Tokens" }));
+
+    expect(lastCall(onChange)).toEqual([{ field: "total_tokens", op: ">", value: "" }]);
+  });
+});
+
+describe("TriggerEditor — a number typed into a filter row", () => {
+  it("keeps a long digit string exactly as typed and saves it as a number", () => {
+    const onSave = vi.fn();
+    renderEditor([{ field: "cost", op: ">", value: "" }], { onSave });
+
+    fireEvent.change(valueInput(), { target: { value: "1111111111111111111111" } });
+    expect(valueInput().value).toBe("1111111111111111111111");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSave).toHaveBeenCalledWith([{ field: "cost", op: ">", value: 1.1111111111111111e21 }]);
+  });
+
+  it("saves a fractional value as a number, not the typed string", () => {
+    const onSave = vi.fn();
+    renderEditor([{ field: "cost", op: ">", value: "" }], { onSave });
+
+    fireEvent.change(valueInput(), { target: { value: "0.25" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).toHaveBeenCalledWith([{ field: "cost", op: ">", value: 0.25 }]);
+  });
+});
+
+describe("TriggerEditor — saving a metadata row", () => {
+  it("saves the metadata key without the whitespace around it", () => {
+    const onSave = vi.fn();
+    renderEditor([{ field: "metadata", op: "=", value: "acme", key: "tenant" }], { onSave });
+
+    fireEvent.change(screen.getByLabelText("metadata key"), { target: { value: " tenant " } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).toHaveBeenCalledWith([
+      { field: "metadata", op: "=", value: "acme", key: "tenant" },
+    ]);
+  });
+});
+
+describe("TriggerEditor — why its own Save is blocked", () => {
+  it("shows the reason as readable text beside the disabled button", () => {
+    renderEditor([{ field: "cost", op: ">", value: "5" }], { onSave: vi.fn() });
+    fireEvent.change(valueInput(), { target: { value: "" } });
+
+    expect(screen.getByText("condition 1 requires a non-negative number")).toBeDefined();
+    expect((screen.getByRole("button", { name: "Save" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+describe("TriggerEditor — the filter cap the write path enforces", () => {
+  const atCap = (): TriggerCondition[] =>
+    Array.from({ length: MAX_FILTERS }, () => ({ field: "cost", op: ">", value: "1" }));
+
+  it("adds no further row once the cap is reached", () => {
+    const onChange = vi.fn();
+    render(
+      <TriggerEditor conditions={atCap()} projectId="proj-1" onChange={onChange} />, // header variant
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add condition" }));
+
+    expect(screen.getAllByLabelText("value")).toHaveLength(MAX_FILTERS);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("disables Add condition at the cap", () => {
+    render(<TriggerEditor conditions={atCap()} projectId="proj-1" onChange={vi.fn()} asCard />);
+    const add = screen.getByRole("button", { name: "Add condition" }) as HTMLButtonElement;
+    expect(add.disabled).toBe(true);
+  });
+
+  it("offers Add condition below the cap", () => {
+    render(
+      <TriggerEditor
+        conditions={atCap().slice(0, MAX_FILTERS - 1)}
+        projectId="proj-1"
+        onChange={vi.fn()}
+        asCard
+      />,
+    );
+    const add = screen.getByRole("button", { name: "Add condition" }) as HTMLButtonElement;
+    expect(add.disabled).toBe(false);
+    fireEvent.click(add);
+    expect(screen.getAllByLabelText("value")).toHaveLength(MAX_FILTERS);
+  });
+});

--- a/frontend/ui/src/features/detectors/components/trigger-editor.tsx
+++ b/frontend/ui/src/features/detectors/components/trigger-editor.tsx
@@ -1,49 +1,38 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { X, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Input } from "@/components/ui/input";
+  Dropdown,
+  DropdownItem,
+  FIELD_ICONS,
+  FIELD_UNIT,
+  FieldDropdown,
+  FilterControlSizeProvider,
+  MetadataKeyCombobox,
+  NumberField,
+  TextField,
+  ValueDropdown,
+} from "@/features/filters/filter-controls";
+import { useFilterValues } from "@/features/filters/hooks";
+import { MAX_FILTERS } from "@/features/filters/predicate";
+import {
+  TRIGGER_FIELD_DEFS,
+  defaultTriggerCondition,
+  normalizeTriggerConditions,
+  triggerFieldDef,
+  triggerOpLabel,
+  validateTriggerConditions,
+  type TriggerCondition,
+} from "../trigger-fields";
 
-export interface TriggerCondition {
-  field: string;
-  op: string;
-  value: unknown;
-}
-
-interface FieldDef {
-  field: string;
-  label: string;
-  ops: string[];
-  valueType: "text" | "select";
-  options?: { label: string; value: string }[];
-}
-
-const FIELD_DEFS: FieldDef[] = [
-  {
-    field: "environment",
-    label: "Environment",
-    ops: ["=", "!="],
-    valueType: "text",
-  },
-];
-
-const defaultValueForField = (field: string): unknown => {
-  const def = FIELD_DEFS.find((d) => d.field === field);
-  if (!def) return "";
-  if (def.valueType === "select") return def.options?.[0]?.value ?? "";
-  return "";
-};
+export type { TriggerCondition } from "../trigger-fields";
 
 interface TriggerEditorProps {
   conditions: TriggerCondition[];
+  /** Project the detector belongs to — scopes value/key suggestions. */
+  projectId: string;
   /** Controlled mode: called on every change, no Save button shown */
   onChange?: (conditions: TriggerCondition[]) => void;
   /** Uncontrolled/save mode: shows a Save button when dirty */
@@ -55,8 +44,135 @@ interface TriggerEditorProps {
   asCard?: boolean;
 }
 
+function ConditionRow({
+  condition,
+  projectId,
+  readOnly,
+  onPatch,
+  onRemove,
+}: {
+  condition: TriggerCondition;
+  projectId: string;
+  readOnly?: boolean;
+  onPatch: (patch: Partial<TriggerCondition>) => void;
+  onRemove: () => void;
+}) {
+  const def = triggerFieldDef(condition.field);
+  const enumerable = def?.valueKind === "enum";
+
+  // Detectors watch live traces, so suggestions are not window-bounded: the
+  // hooks fall back to the project's retention window.
+  const { values, isLoading } = useFilterValues(
+    projectId,
+    condition.field,
+    undefined,
+    undefined,
+    enumerable && !readOnly,
+  );
+
+  // Keep a previously-saved value selectable even when it no longer occurs in
+  // the observed values (it gets no count, marking it as stale).
+  const options = useMemo(() => {
+    const current = String(condition.value ?? "");
+    const hasCurrent = values.some((v) => v.value === current);
+    return current && !hasCurrent ? [{ value: current }, ...values] : values;
+  }, [values, condition.value]);
+
+  const showValueDropdown = enumerable && (values.length > 0 || isLoading);
+  const isNumeric = def?.valueKind === "number";
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <FieldDropdown
+        options={TRIGGER_FIELD_DEFS.map((d) => ({
+          key: d.field,
+          label: d.label,
+          icon: FIELD_ICONS[d.field],
+        }))}
+        valueKey={condition.field || null}
+        onPick={(field) => onPatch(defaultTriggerCondition(field))}
+      />
+
+      {def?.requiresKey && (
+        <MetadataKeyCombobox
+          projectId={projectId}
+          value={condition.key ?? ""}
+          onValue={(v) => onPatch({ key: v })}
+          // The trigger row applies as it is edited, so Enter has nothing to submit.
+          onEnter={() => {}}
+        />
+      )}
+
+      <Dropdown
+        disabled={!def}
+        trigger={
+          <span className="whitespace-nowrap">
+            {def && condition.op ? triggerOpLabel(def, condition.op) : "is"}
+          </span>
+        }
+        triggerClassName="min-w-[3.5rem] shrink-0"
+        contentClassName="w-28"
+      >
+        {(close) =>
+          (def?.ops ?? []).map((op) => (
+            <DropdownItem
+              key={op}
+              active={op === condition.op}
+              onClick={() => {
+                onPatch({ op });
+                close();
+              }}
+            >
+              {triggerOpLabel(def, op)}
+            </DropdownItem>
+          ))
+        }
+      </Dropdown>
+
+      {showValueDropdown ? (
+        <ValueDropdown
+          value={String(condition.value ?? "")}
+          options={options}
+          onValue={(v) => onPatch({ value: v })}
+          placeholder={isLoading ? "Loading…" : undefined}
+        />
+      ) : isNumeric ? (
+        <NumberField
+          ariaLabel="value"
+          placeholder="Enter value"
+          value={String(condition.value ?? "")}
+          // Held as typed and coerced once on the way out: Number() here would
+          // round-trip a long entry back into the field as "1e+21".
+          onChange={(v) => onPatch({ value: v })}
+          unit={FIELD_UNIT[condition.field]}
+          integer={def?.integer}
+        />
+      ) : (
+        <TextField
+          ariaLabel="value"
+          placeholder="Enter value"
+          value={String(condition.value ?? "")}
+          onChange={(v) => onPatch({ value: v })}
+        />
+      )}
+
+      {!readOnly && (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+          aria-label="Remove condition"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}
+
 export function TriggerEditor({
   conditions: initialConditions,
+  projectId,
   onChange,
   onSave,
   isSaving,
@@ -80,12 +196,13 @@ export function TriggerEditor({
     }
   };
 
+  // The write path caps the array at MAX_FILTERS, so refuse the row here rather
+  // than building a payload the save would reject.
+  const atFilterCap = conditions.length >= MAX_FILTERS;
+
   const addCondition = () => {
-    const first = FIELD_DEFS[0];
-    update([
-      ...conditions,
-      { field: first.field, op: first.ops[0], value: defaultValueForField(first.field) },
-    ]);
+    if (atFilterCap) return;
+    update([...conditions, defaultTriggerCondition(TRIGGER_FIELD_DEFS[0].field)]);
   };
 
   const removeCondition = (i: number) => {
@@ -96,91 +213,33 @@ export function TriggerEditor({
     update(
       conditions.map((c, idx) => {
         if (idx !== i) return c;
-        const merged = { ...c, ...patch };
-        if (patch.field && patch.field !== c.field) {
-          const def = FIELD_DEFS.find((d) => d.field === patch.field);
-          merged.op = def?.ops[0] ?? "=";
-          merged.value = defaultValueForField(patch.field);
-        }
-        return merged;
+        // A field pick arrives as a full fresh condition (op/value/key reset);
+        // re-picking the field already on the row leaves it as it is rather
+        // than wiping what has been typed. Any other patch merges.
+        if (patch.field) return patch.field === c.field ? c : { ...(patch as TriggerCondition) };
+        return { ...c, ...patch };
       }),
     );
   };
 
+  const normalized = normalizeTriggerConditions(conditions);
+  const validationError = validateTriggerConditions(normalized);
+
   const conditionRows = (
-    <div className={`space-y-1.5 ${readOnly ? "pointer-events-none opacity-60" : ""}`}>
-      {conditions.map((cond, i) => {
-        const fieldDef = FIELD_DEFS.find((d) => d.field === cond.field) ?? FIELD_DEFS[0];
-        return (
-          <div key={i} className="flex items-center gap-1.5">
-            {/* Field */}
-            <Select value={cond.field} onValueChange={(val) => updateCondition(i, { field: val })}>
-              <SelectTrigger className="h-7 w-[120px] shrink-0 text-[12px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {FIELD_DEFS.map((d) => (
-                  <SelectItem key={d.field} value={d.field} className="text-[12px]">
-                    {d.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-
-            {/* Op */}
-            <Select value={cond.op} onValueChange={(val) => updateCondition(i, { op: val })}>
-              <SelectTrigger className="h-7 w-14 shrink-0 text-[12px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {fieldDef.ops.map((op) => (
-                  <SelectItem key={op} value={op} className="text-[12px]">
-                    {op}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-
-            {/* Value */}
-            {fieldDef.valueType === "select" ? (
-              <Select
-                value={cond.value as string}
-                onValueChange={(val) => updateCondition(i, { value: val })}
-              >
-                <SelectTrigger className="h-7 flex-1 text-[12px]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {fieldDef.options?.map((opt) => (
-                    <SelectItem key={opt.value} value={opt.value} className="text-[12px]">
-                      {opt.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            ) : (
-              <Input
-                value={cond.value as string}
-                onChange={(e) => updateCondition(i, { value: e.target.value })}
-                placeholder="Enter value..."
-                className="h-7 flex-1 text-[12px]"
-              />
-            )}
-
-            {/* Remove — hidden in readOnly */}
-            {!readOnly && (
-              <button
-                type="button"
-                onClick={() => removeCondition(i)}
-                className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <X className="h-3.5 w-3.5" />
-              </button>
-            )}
-          </div>
-        );
-      })}
-    </div>
+    <FilterControlSizeProvider size="sm">
+      <div className={`space-y-1.5 ${readOnly ? "pointer-events-none opacity-60" : ""}`}>
+        {conditions.map((cond, i) => (
+          <ConditionRow
+            key={i}
+            condition={cond}
+            projectId={projectId}
+            readOnly={readOnly}
+            onPatch={(patch) => updateCondition(i, patch)}
+            onRemove={() => removeCondition(i)}
+          />
+        ))}
+      </div>
+    </FilterControlSizeProvider>
   );
 
   if (asCard) {
@@ -193,7 +252,8 @@ export function TriggerEditor({
             <button
               type="button"
               onClick={addCondition}
-              className="flex items-center gap-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground"
+              disabled={atFilterCap}
+              className="flex items-center gap-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50 disabled:hover:text-muted-foreground"
             >
               <Plus className="h-3 w-3" />
               Add condition
@@ -243,12 +303,15 @@ export function TriggerEditor({
 
       {/* Save button — only in uncontrolled/save mode when dirty and not readOnly */}
       {!readOnly && !onChange && dirty && onSave && (
-        <div className="mt-3 flex justify-end">
+        <div className="mt-3 flex items-center justify-end gap-2">
+          {validationError && (
+            <span className="text-[12px] text-destructive">{validationError}</span>
+          )}
           <Button
             size="sm"
             className="h-7 text-[12px]"
-            onClick={() => onSave(conditions)}
-            disabled={isSaving}
+            onClick={() => onSave(normalized)}
+            disabled={isSaving || validationError !== null}
           >
             {isSaving ? "Saving..." : "Save"}
           </Button>

--- a/frontend/ui/src/features/detectors/components/trigger-editor.tsx
+++ b/frontend/ui/src/features/detectors/components/trigger-editor.tsx
@@ -38,8 +38,6 @@ interface TriggerEditorProps {
   /** Uncontrolled/save mode: shows a Save button when dirty */
   onSave?: (conditions: TriggerCondition[]) => void;
   isSaving?: boolean;
-  /** Read-only: show conditions but hide add/remove/save controls */
-  readOnly?: boolean;
   /** Card mode: renders as a bordered card section (header + body) for embedding inside a card container */
   asCard?: boolean;
 }
@@ -47,13 +45,11 @@ interface TriggerEditorProps {
 function ConditionRow({
   condition,
   projectId,
-  readOnly,
   onPatch,
   onRemove,
 }: {
   condition: TriggerCondition;
   projectId: string;
-  readOnly?: boolean;
   onPatch: (patch: Partial<TriggerCondition>) => void;
   onRemove: () => void;
 }) {
@@ -67,7 +63,7 @@ function ConditionRow({
     condition.field,
     undefined,
     undefined,
-    enumerable && !readOnly,
+    enumerable,
   );
 
   // Keep a previously-saved value selectable even when it no longer occurs in
@@ -156,16 +152,14 @@ function ConditionRow({
         />
       )}
 
-      {!readOnly && (
-        <button
-          type="button"
-          onClick={onRemove}
-          className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-          aria-label="Remove condition"
-        >
-          <X className="h-3.5 w-3.5" />
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={onRemove}
+        className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+        aria-label="Remove condition"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
     </div>
   );
 }
@@ -176,7 +170,6 @@ export function TriggerEditor({
   onChange,
   onSave,
   isSaving,
-  readOnly,
   asCard,
 }: TriggerEditorProps) {
   const [conditions, setConditions] = useState<TriggerCondition[]>(initialConditions);
@@ -227,13 +220,12 @@ export function TriggerEditor({
 
   const conditionRows = (
     <FilterControlSizeProvider size="sm">
-      <div className={`space-y-1.5 ${readOnly ? "pointer-events-none opacity-60" : ""}`}>
+      <div className="space-y-1.5">
         {conditions.map((cond, i) => (
           <ConditionRow
             key={i}
             condition={cond}
             projectId={projectId}
-            readOnly={readOnly}
             onPatch={(patch) => updateCondition(i, patch)}
             onRemove={() => removeCondition(i)}
           />
@@ -248,17 +240,15 @@ export function TriggerEditor({
         {/* Card header */}
         <div className="flex items-center justify-between border-b border-border bg-muted/50 px-3 py-1.5">
           <span className="text-[12px] font-medium text-muted-foreground">Filter</span>
-          {!readOnly && (
-            <button
-              type="button"
-              onClick={addCondition}
-              disabled={atFilterCap}
-              className="flex items-center gap-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50 disabled:hover:text-muted-foreground"
-            >
-              <Plus className="h-3 w-3" />
-              Add condition
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={addCondition}
+            disabled={atFilterCap}
+            className="flex items-center gap-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50 disabled:hover:text-muted-foreground"
+          >
+            <Plus className="h-3 w-3" />
+            Add condition
+          </button>
         </div>
         {/* Card body */}
         <div className="p-3">
@@ -280,16 +270,14 @@ export function TriggerEditor({
       {/* Header row */}
       <div className="mb-2 flex items-center justify-between">
         <p className="text-[12px] font-medium text-muted-foreground">Filter</p>
-        {!readOnly && (
-          <button
-            type="button"
-            onClick={addCondition}
-            className="flex items-center gap-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <Plus className="h-3 w-3" />
-            Add condition
-          </button>
-        )}
+        <button
+          type="button"
+          onClick={addCondition}
+          className="flex items-center gap-1 text-[12px] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Plus className="h-3 w-3" />
+          Add condition
+        </button>
       </div>
 
       {conditions.length === 0 ? (
@@ -301,8 +289,8 @@ export function TriggerEditor({
         </>
       )}
 
-      {/* Save button — only in uncontrolled/save mode when dirty and not readOnly */}
-      {!readOnly && !onChange && dirty && onSave && (
+      {/* Save button — only in uncontrolled/save mode when dirty */}
+      {!onChange && dirty && onSave && (
         <div className="mt-3 flex items-center justify-end gap-2">
           {validationError && (
             <span className="text-[12px] text-destructive">{validationError}</span>

--- a/frontend/ui/src/features/detectors/utils/index.test.ts
+++ b/frontend/ui/src/features/detectors/utils/index.test.ts
@@ -89,6 +89,17 @@ describe("buildDetectorPatch", () => {
     });
   });
 
+  it("omits triggerConditions for a name-only edit that rebuilt the conditions array", () => {
+    // The editor hands back a fresh array every render, so a save that only
+    // renamed the detector must still leave its filter rows out of the patch.
+    const patch = buildDetectorPatch(baseForm, {
+      ...baseForm,
+      name: "Renamed",
+      conditions: baseForm.conditions.map((c) => ({ ...c })),
+    });
+    expect(patch).toEqual({ name: "Renamed" });
+  });
+
   it("sends changed trigger conditions as triggerConditions", () => {
     const conditions = [{ field: "status", op: "eq", value: "error" }];
     const patch = buildDetectorPatch(baseForm, { ...baseForm, conditions });


### PR DESCRIPTION
Part **3 of 3** of the detector trigger-field stack, stacked on #1885. Should land in the same cycle as it.

The trigger editor had its own hand-rolled field, operator and value controls, so a detector filter looked and behaved unlike the same filter anywhere else in the product. Trigger rows now render the shared controls the trace list and widget builder use:

- Observed-value dropdowns for model and environment, numeric inputs with units for cost/tokens/latency/errors, and the metadata key combobox with suggested keys plus a free-text value.
- Save and Create are blocked with an on-screen reason while a row is incomplete, since the write path rejects such payloads. The reason previously hung off a `title` attribute on a disabled button, **which cannot fire**.
- A detector stored with a row the registry now rejects still takes a rename; the block returns as soon as that row is edited.
- Re-picking the field a row already has leaves the row alone; picking a different one still resets the operator and value.
- Adding past the filter cap built a payload the save would reject, so the guard refuses the row regardless of which variant of the editor is on screen.

The key combobox gets its own no-op Enter handler rather than making `onEnter` optional in shared `filter-controls` — the trigger row applies as it is edited, so there is nothing for Enter to submit, and this keeps the PR touching no shared file.

Two pre-existing defects surfaced while building this. Both live in shared `filter-controls`, both are visible in the dashboards widget builder on main today, and neither is introduced here — they are inherited by correctly reusing the shared controls. Fixing either means changing a shared component this PR deliberately does not touch, so both are left as-is and named here instead:

- `<input type="number">` reports `""` for a half-typed `1.`, so a numeric filter value is dropped mid-decimal.
- Removable filter rows are keyed by array index while the shared controls hold their own popover state, so removing a row while a dropdown is open strands the open state on whichever row slides up into that position.

Happy to file these against the shared filter surface if that is the preferred home for them.

---

Stack: **#1887** (evaluator) → **#1885** (registry) → **#1886** (editor)
