### PR TITLE
feat(agent): drive detector and finding reads from the shared registry

### DIFF
--- a/backend/rest/main.py
+++ b/backend/rest/main.py
@@ -25,6 +25,7 @@ from starlette.responses import Response
 from rest.openapi_public import PUBLIC_PREFIX
 from rest.rate_limit import limiter, rate_limit_exceeded_handler
 from rest.routers.dashboards import router as dashboards_router
+from rest.routers.detectors import router as detectors_router
 from rest.routers.internal import router as internal_router
 from rest.routers.live import router as live_router
 from rest.routers.public.detectors_read import router as public_detectors_read_router
@@ -102,6 +103,7 @@ app.include_router(traces_router, prefix="/api/v1")
 app.include_router(users_router, prefix="/api/v1")
 app.include_router(sessions_router, prefix="/api/v1")
 app.include_router(dashboards_router, prefix="/api/v1")
+app.include_router(detectors_router, prefix="/api/v1")
 
 # Live trace streaming (SSE, user auth)
 app.include_router(live_router, prefix="/api/v1")

--- a/backend/rest/routers/detector_read_common.py
+++ b/backend/rest/routers/detector_read_common.py
@@ -1,0 +1,137 @@
+"""Shared handler bodies for the detector read surfaces.
+
+The public (API-key) and internal (user/service) detector read routers expose
+the same reads over the same service and response schemas; only the auth
+source differs. Each router resolves auth and declares its params, then
+delegates here, so retention and error-mapping semantics cannot drift between
+the two surfaces.
+"""
+
+import logging
+from collections.abc import Callable
+from datetime import datetime
+
+from fastapi import HTTPException, status
+
+from rest.retention import clamp_retention_window, enforce_retention_by_time
+from rest.schemas.common import PaginationMeta
+from rest.schemas.public import (
+    FindingDetail,
+    PublicDetectorListResponse,
+    PublicFindingListResponse,
+)
+from rest.services.detector_reader import DetectorReaderService
+
+logger = logging.getLogger(__name__)
+
+
+def list_detectors_page(
+    service: DetectorReaderService,
+    project_id: str,
+    limit: int,
+    start_after: datetime | None,
+    end_before: datetime | None,
+) -> PublicDetectorListResponse:
+    """List a project's detectors, mapping reader errors to a clean 500.
+
+    The detector catalog is configuration, not telemetry, so no retention
+    clamp applies.
+
+    Args:
+        service (DetectorReaderService): Reader resolved by the calling router.
+        project_id (str): Project the calling router's auth resolved.
+        limit (int): Max items in the returned page.
+        start_after (datetime | None): Inclusive lower bound on creation time.
+        end_before (datetime | None): Exclusive upper bound on creation time.
+
+    Returns:
+        PublicDetectorListResponse: The page plus pagination meta.
+    """
+    try:
+        items, total = service.list_detectors(
+            project_id=project_id,
+            limit=limit,
+            start_after=start_after,
+            end_before=end_before,
+        )
+    except Exception as e:
+        logger.exception(f"Error listing detectors: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list detectors",
+        ) from e
+
+    return PublicDetectorListResponse(
+        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
+    )
+
+
+def list_findings_page(
+    service: DetectorReaderService,
+    billing_plan: str,
+    project_id: str,
+    limit: int,
+    start_after: datetime | None,
+    end_before: datetime | None,
+    detector: str | None,
+    trace_id: str | None,
+) -> PublicFindingListResponse:
+    """List a project's findings with the plan's retention clamp applied.
+
+    Args:
+        service (DetectorReaderService): Reader resolved by the calling router.
+        billing_plan (str): Plan whose retention window clamps ``start_after``.
+        project_id (str): Project the calling router's auth resolved.
+        limit (int): Max items in the returned page.
+        start_after (datetime | None): Inclusive lower bound on ``timestamp``.
+        end_before (datetime | None): Exclusive upper bound on ``timestamp``.
+        detector (str | None): Optional detector id/name/template filter.
+        trace_id (str | None): Optional single-trace filter.
+
+    Returns:
+        PublicFindingListResponse: The page plus pagination meta.
+    """
+    start_after, end_before = clamp_retention_window(billing_plan, start_after, end_before)
+    try:
+        items, total = service.list_findings(
+            project_id=project_id,
+            limit=limit,
+            start_after=start_after,
+            end_before=end_before,
+            detector=detector,
+            trace_id=trace_id,
+        )
+    except Exception as e:
+        logger.exception(f"Error listing detector findings: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list findings",
+        ) from e
+
+    return PublicFindingListResponse(
+        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
+    )
+
+
+def require_finding(fetch: Callable[[], FindingDetail | None], billing_plan: str) -> FindingDetail:
+    """Run a reader fetch, mapping None -> 404 and reader errors -> a clean 500.
+
+    Args:
+        fetch (Callable[[], FindingDetail | None]): Zero-arg reader call.
+        billing_plan (str): Plan used for the retention-by-time check.
+
+    Returns:
+        FindingDetail: The finding, when present and inside the retention window.
+    """
+    try:
+        finding = fetch()
+    except Exception as e:
+        logger.exception(f"Error reading detector finding: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to read finding",
+        ) from e
+    if finding is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Finding not found")
+    enforce_retention_by_time(billing_plan, finding.timestamp)
+    return finding

--- a/backend/rest/routers/detector_read_common.py
+++ b/backend/rest/routers/detector_read_common.py
@@ -4,9 +4,11 @@ The public (API-key) and internal (user/service) detector read routers expose
 the same reads over the same service and response schemas; only the auth
 source differs. Each router resolves auth and declares its params, then
 delegates here, so retention and error-mapping semantics cannot drift between
-the two surfaces.
+the two surfaces. The reader's ClickHouse/Postgres clients are synchronous, so
+every service call runs via ``asyncio.to_thread`` to keep it off the event loop.
 """
 
+import asyncio
 import logging
 from collections.abc import Callable
 from datetime import datetime
@@ -25,7 +27,7 @@ from rest.services.detector_reader import DetectorReaderService
 logger = logging.getLogger(__name__)
 
 
-def list_detectors_page(
+async def list_detectors_page(
     service: DetectorReaderService,
     project_id: str,
     limit: int,
@@ -48,7 +50,8 @@ def list_detectors_page(
         PublicDetectorListResponse: The page plus pagination meta.
     """
     try:
-        items, total = service.list_detectors(
+        items, total = await asyncio.to_thread(
+            service.list_detectors,
             project_id=project_id,
             limit=limit,
             start_after=start_after,
@@ -66,7 +69,7 @@ def list_detectors_page(
     )
 
 
-def list_findings_page(
+async def list_findings_page(
     service: DetectorReaderService,
     billing_plan: str,
     project_id: str,
@@ -93,7 +96,8 @@ def list_findings_page(
     """
     start_after, end_before = clamp_retention_window(billing_plan, start_after, end_before)
     try:
-        items, total = service.list_findings(
+        items, total = await asyncio.to_thread(
+            service.list_findings,
             project_id=project_id,
             limit=limit,
             start_after=start_after,
@@ -113,7 +117,9 @@ def list_findings_page(
     )
 
 
-def require_finding(fetch: Callable[[], FindingDetail | None], billing_plan: str) -> FindingDetail:
+async def require_finding(
+    fetch: Callable[[], FindingDetail | None], billing_plan: str
+) -> FindingDetail:
     """Run a reader fetch, mapping None -> 404 and reader errors -> a clean 500.
 
     Args:
@@ -124,7 +130,7 @@ def require_finding(fetch: Callable[[], FindingDetail | None], billing_plan: str
         FindingDetail: The finding, when present and inside the retention window.
     """
     try:
-        finding = fetch()
+        finding = await asyncio.to_thread(fetch)
     except Exception as e:
         logger.exception(f"Error reading detector finding: {e}")
         raise HTTPException(

--- a/backend/rest/routers/detectors.py
+++ b/backend/rest/routers/detectors.py
@@ -55,7 +55,7 @@ async def list_detectors(
     ),
 ):
     """List the project's detectors (newest first)."""
-    return list_detectors_page(service, project_id, limit, start_after, end_before)
+    return await list_detectors_page(service, project_id, limit, start_after, end_before)
 
 
 @router.get("/findings", response_model=PublicFindingListResponse)
@@ -79,7 +79,7 @@ async def list_findings(
     trace_id: str | None = Query(None, description="Filter to a single trace"),
 ):
     """List recent detector findings for the project (newest first)."""
-    return list_findings_page(
+    return await list_findings_page(
         service,
         _access.billing_plan,
         project_id,
@@ -104,7 +104,7 @@ async def get_finding(
     service: DetectorReaderService = Depends(get_detector_reader_service),
 ):
     """Get a single finding by id, with per-detector results and RCA."""
-    return require_finding(
+    return await require_finding(
         lambda: service.get_finding(project_id, finding_id), _access.billing_plan
     )
 
@@ -122,6 +122,6 @@ async def get_finding_by_trace(
     service: DetectorReaderService = Depends(get_detector_reader_service),
 ):
     """Get the finding for a single trace (findings are 1-per-trace)."""
-    return require_finding(
+    return await require_finding(
         lambda: service.get_finding_by_trace(project_id, trace_id), _access.billing_plan
     )

--- a/backend/rest/routers/detectors.py
+++ b/backend/rest/routers/detectors.py
@@ -1,0 +1,176 @@
+"""Detector read endpoints (user-authenticated, not public API).
+
+Thin internal mirrors of the public detector reads so the in-app agent's
+registry-bound tools can dispatch here with service auth. Payload shapes are
+shared with the public surface (rest.schemas.public) by design — one registry
+definition serves both. Params must stay a superset of the public twins
+(enforced by tests/rest/test_public_internal_parity.py).
+"""
+
+import logging
+from collections.abc import Callable
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+
+from rest.rate_limit import (
+    BUCKET_READ,
+    is_request_rate_limit_exempt,
+    key_read,
+    limiter,
+    resolve_limit,
+)
+from rest.retention import clamp_retention_window, enforce_retention_by_time
+from rest.routers.deps import RateLimitedProjectAccess
+from rest.schemas.common import PaginationMeta
+from rest.schemas.public import (
+    FindingDetail,
+    PublicDetectorListResponse,
+    PublicFindingListResponse,
+)
+from rest.services.detector_reader import DetectorReaderService, get_detector_reader_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/projects/{project_id}/detectors", tags=["Detectors"])
+
+
+@router.get("", response_model=PublicDetectorListResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def list_detectors(
+    request: Request,
+    response: Response,
+    project_id: str,
+    _access: RateLimitedProjectAccess,
+    service: DetectorReaderService = Depends(get_detector_reader_service),
+    limit: int = Query(50, ge=1, le=200, description="Items per page"),
+    start_after: datetime | None = Query(
+        None, description="Only detectors created at or after this time (inclusive, ISO 8601)"
+    ),
+    end_before: datetime | None = Query(
+        None, description="Only detectors created before this time (exclusive, ISO 8601)"
+    ),
+):
+    """List the project's detectors (newest first)."""
+    try:
+        items, total = service.list_detectors(
+            project_id=project_id,
+            limit=limit,
+            start_after=start_after,
+            end_before=end_before,
+        )
+    except Exception as e:
+        logger.exception(f"Error listing detectors: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list detectors",
+        ) from e
+
+    return PublicDetectorListResponse(
+        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
+    )
+
+
+@router.get("/findings", response_model=PublicFindingListResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def list_findings(
+    request: Request,
+    response: Response,
+    project_id: str,
+    _access: RateLimitedProjectAccess,
+    service: DetectorReaderService = Depends(get_detector_reader_service),
+    limit: int = Query(50, ge=1, le=200, description="Items per page"),
+    start_after: datetime | None = Query(
+        None, description="Only findings at or after this time (inclusive, ISO 8601)"
+    ),
+    end_before: datetime | None = Query(
+        None, description="Only findings before this time (exclusive, ISO 8601)"
+    ),
+    detector: str | None = Query(None, description="Filter by detector id, name, or template"),
+    trace_id: str | None = Query(None, description="Filter to a single trace"),
+):
+    """List recent detector findings for the project (newest first)."""
+    start_after, end_before = clamp_retention_window(_access.billing_plan, start_after, end_before)
+    try:
+        items, total = service.list_findings(
+            project_id=project_id,
+            limit=limit,
+            start_after=start_after,
+            end_before=end_before,
+            detector=detector,
+            trace_id=trace_id,
+        )
+    except Exception as e:
+        logger.exception(f"Error listing detector findings: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list findings",
+        ) from e
+
+    return PublicFindingListResponse(
+        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
+    )
+
+
+@router.get("/findings/{finding_id}", response_model=FindingDetail)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def get_finding(
+    request: Request,
+    response: Response,
+    project_id: str,
+    finding_id: str,
+    _access: RateLimitedProjectAccess,
+    service: DetectorReaderService = Depends(get_detector_reader_service),
+):
+    """Get a single finding by id, with per-detector results and RCA."""
+    return _require_finding(
+        lambda: service.get_finding(project_id, finding_id), _access.billing_plan
+    )
+
+
+@router.get("/traces/{trace_id}/finding", response_model=FindingDetail)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def get_finding_by_trace(
+    request: Request,
+    response: Response,
+    project_id: str,
+    trace_id: str,
+    _access: RateLimitedProjectAccess,
+    service: DetectorReaderService = Depends(get_detector_reader_service),
+):
+    """Get the finding for a single trace (findings are 1-per-trace)."""
+    return _require_finding(
+        lambda: service.get_finding_by_trace(project_id, trace_id), _access.billing_plan
+    )
+
+
+def _require_finding(fetch: Callable[[], FindingDetail | None], billing_plan: str) -> FindingDetail:
+    """Run a reader fetch, mapping None -> 404 and reader errors -> a clean 500.
+
+    Args:
+        fetch (Callable[[], FindingDetail | None]): Zero-arg reader call.
+        billing_plan (str): Plan used for the retention-by-time check.
+
+    Returns:
+        FindingDetail: The finding, when present and inside the retention window.
+    """
+    try:
+        finding = fetch()
+    except Exception as e:
+        logger.exception(f"Error reading detector finding: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to read finding",
+        ) from e
+    if finding is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Finding not found")
+    enforce_retention_by_time(billing_plan, finding.timestamp)
+    return finding

--- a/backend/rest/routers/detectors.py
+++ b/backend/rest/routers/detectors.py
@@ -4,14 +4,14 @@ Thin internal mirrors of the public detector reads so the in-app agent's
 registry-bound tools can dispatch here with service auth. Payload shapes are
 shared with the public surface (rest.schemas.public) by design — one registry
 definition serves both. Params must stay a superset of the public twins
-(enforced by tests/rest/test_public_internal_parity.py).
+(enforced by tests/rest/test_public_internal_parity.py), and the handler
+bodies live in rest.routers.detector_read_common so behavior cannot drift
+between the surfaces.
 """
 
-import logging
-from collections.abc import Callable
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import APIRouter, Depends, Query, Request, Response
 
 from rest.rate_limit import (
     BUCKET_READ,
@@ -20,17 +20,18 @@ from rest.rate_limit import (
     limiter,
     resolve_limit,
 )
-from rest.retention import clamp_retention_window, enforce_retention_by_time
 from rest.routers.deps import RateLimitedProjectAccess
-from rest.schemas.common import PaginationMeta
+from rest.routers.detector_read_common import (
+    list_detectors_page,
+    list_findings_page,
+    require_finding,
+)
 from rest.schemas.public import (
     FindingDetail,
     PublicDetectorListResponse,
     PublicFindingListResponse,
 )
 from rest.services.detector_reader import DetectorReaderService, get_detector_reader_service
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/projects/{project_id}/detectors", tags=["Detectors"])
 
@@ -54,23 +55,7 @@ async def list_detectors(
     ),
 ):
     """List the project's detectors (newest first)."""
-    try:
-        items, total = service.list_detectors(
-            project_id=project_id,
-            limit=limit,
-            start_after=start_after,
-            end_before=end_before,
-        )
-    except Exception as e:
-        logger.exception(f"Error listing detectors: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list detectors",
-        ) from e
-
-    return PublicDetectorListResponse(
-        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
-    )
+    return list_detectors_page(service, project_id, limit, start_after, end_before)
 
 
 @router.get("/findings", response_model=PublicFindingListResponse)
@@ -94,25 +79,15 @@ async def list_findings(
     trace_id: str | None = Query(None, description="Filter to a single trace"),
 ):
     """List recent detector findings for the project (newest first)."""
-    start_after, end_before = clamp_retention_window(_access.billing_plan, start_after, end_before)
-    try:
-        items, total = service.list_findings(
-            project_id=project_id,
-            limit=limit,
-            start_after=start_after,
-            end_before=end_before,
-            detector=detector,
-            trace_id=trace_id,
-        )
-    except Exception as e:
-        logger.exception(f"Error listing detector findings: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list findings",
-        ) from e
-
-    return PublicFindingListResponse(
-        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
+    return list_findings_page(
+        service,
+        _access.billing_plan,
+        project_id,
+        limit,
+        start_after,
+        end_before,
+        detector,
+        trace_id,
     )
 
 
@@ -129,7 +104,7 @@ async def get_finding(
     service: DetectorReaderService = Depends(get_detector_reader_service),
 ):
     """Get a single finding by id, with per-detector results and RCA."""
-    return _require_finding(
+    return require_finding(
         lambda: service.get_finding(project_id, finding_id), _access.billing_plan
     )
 
@@ -147,30 +122,6 @@ async def get_finding_by_trace(
     service: DetectorReaderService = Depends(get_detector_reader_service),
 ):
     """Get the finding for a single trace (findings are 1-per-trace)."""
-    return _require_finding(
+    return require_finding(
         lambda: service.get_finding_by_trace(project_id, trace_id), _access.billing_plan
     )
-
-
-def _require_finding(fetch: Callable[[], FindingDetail | None], billing_plan: str) -> FindingDetail:
-    """Run a reader fetch, mapping None -> 404 and reader errors -> a clean 500.
-
-    Args:
-        fetch (Callable[[], FindingDetail | None]): Zero-arg reader call.
-        billing_plan (str): Plan used for the retention-by-time check.
-
-    Returns:
-        FindingDetail: The finding, when present and inside the retention window.
-    """
-    try:
-        finding = fetch()
-    except Exception as e:
-        logger.exception(f"Error reading detector finding: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to read finding",
-        ) from e
-    if finding is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Finding not found")
-    enforce_retention_by_time(billing_plan, finding.timestamp)
-    return finding

--- a/backend/rest/routers/public/detectors_read.py
+++ b/backend/rest/routers/public/detectors_read.py
@@ -52,7 +52,7 @@ async def list_detectors(
     ),
 ):
     """List the detectors in the API key's project (newest first)."""
-    return list_detectors_page(service, auth.project_id, limit, start_after, end_before)
+    return await list_detectors_page(service, auth.project_id, limit, start_after, end_before)
 
 
 @router.get("/findings", response_model=PublicFindingListResponse, operation_id="list_findings")
@@ -75,7 +75,7 @@ async def list_findings(
     trace_id: str | None = Query(None, description="Filter to a single trace"),
 ):
     """List recent detector findings for the API key's project (newest first)."""
-    return list_findings_page(
+    return await list_findings_page(
         service,
         auth.billing_plan,
         auth.project_id,
@@ -99,7 +99,7 @@ async def get_finding(
     service: DetectorReaderService = Depends(get_detector_reader_service),
 ):
     """Get a single finding by id for the key's project."""
-    return require_finding(
+    return await require_finding(
         lambda: service.get_finding(auth.project_id, finding_id), auth.billing_plan
     )
 
@@ -118,6 +118,6 @@ async def get_finding_by_trace(
     service: DetectorReaderService = Depends(get_detector_reader_service),
 ):
     """Get the finding for a single trace (findings are 1-per-trace)."""
-    return require_finding(
+    return await require_finding(
         lambda: service.get_finding_by_trace(auth.project_id, trace_id), auth.billing_plan
     )

--- a/backend/rest/routers/public/detectors_read.py
+++ b/backend/rest/routers/public/detectors_read.py
@@ -2,14 +2,14 @@
 
 Mirrors the public traces read stack (StampedAuth, READ-bucket rate limiting,
 project-scoped reads). All access is scoped to the project resolved from the API
-key; a finding outside that project simply isn't found (404).
+key; a finding outside that project simply isn't found (404). Handler bodies
+live in rest.routers.detector_read_common, shared with the internal
+project-scoped mirror, so behavior cannot drift between the surfaces.
 """
 
-import logging
-from collections.abc import Callable
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import APIRouter, Depends, Query, Request, Response
 
 from rest.rate_limit import (
     BUCKET_READ,
@@ -18,17 +18,18 @@ from rest.rate_limit import (
     limiter,
     resolve_limit,
 )
-from rest.retention import clamp_retention_window, enforce_retention_by_time
+from rest.routers.detector_read_common import (
+    list_detectors_page,
+    list_findings_page,
+    require_finding,
+)
 from rest.routers.public.deps import StampedAuth
-from rest.schemas.common import PaginationMeta
 from rest.schemas.public import (
     FindingDetail,
     PublicDetectorListResponse,
     PublicFindingListResponse,
 )
 from rest.services.detector_reader import DetectorReaderService, get_detector_reader_service
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/public/detectors", tags=["Detectors (Public)"])
 
@@ -51,23 +52,7 @@ async def list_detectors(
     ),
 ):
     """List the detectors in the API key's project (newest first)."""
-    try:
-        items, total = service.list_detectors(
-            project_id=auth.project_id,
-            limit=limit,
-            start_after=start_after,
-            end_before=end_before,
-        )
-    except Exception as e:
-        logger.exception(f"Error listing detectors: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list detectors",
-        ) from e
-
-    return PublicDetectorListResponse(
-        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
-    )
+    return list_detectors_page(service, auth.project_id, limit, start_after, end_before)
 
 
 @router.get("/findings", response_model=PublicFindingListResponse, operation_id="list_findings")
@@ -90,25 +75,15 @@ async def list_findings(
     trace_id: str | None = Query(None, description="Filter to a single trace"),
 ):
     """List recent detector findings for the API key's project (newest first)."""
-    start_after, end_before = clamp_retention_window(auth.billing_plan, start_after, end_before)
-    try:
-        items, total = service.list_findings(
-            project_id=auth.project_id,
-            limit=limit,
-            start_after=start_after,
-            end_before=end_before,
-            detector=detector,
-            trace_id=trace_id,
-        )
-    except Exception as e:
-        logger.exception(f"Error listing detector findings: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list findings",
-        ) from e
-
-    return PublicFindingListResponse(
-        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
+    return list_findings_page(
+        service,
+        auth.billing_plan,
+        auth.project_id,
+        limit,
+        start_after,
+        end_before,
+        detector,
+        trace_id,
     )
 
 
@@ -124,7 +99,7 @@ async def get_finding(
     service: DetectorReaderService = Depends(get_detector_reader_service),
 ):
     """Get a single finding by id for the key's project."""
-    return _require_finding(
+    return require_finding(
         lambda: service.get_finding(auth.project_id, finding_id), auth.billing_plan
     )
 
@@ -143,22 +118,6 @@ async def get_finding_by_trace(
     service: DetectorReaderService = Depends(get_detector_reader_service),
 ):
     """Get the finding for a single trace (findings are 1-per-trace)."""
-    return _require_finding(
+    return require_finding(
         lambda: service.get_finding_by_trace(auth.project_id, trace_id), auth.billing_plan
     )
-
-
-def _require_finding(fetch: Callable[[], FindingDetail | None], billing_plan: str) -> FindingDetail:
-    """Run a reader fetch, mapping None -> 404 and reader errors -> a clean 500."""
-    try:
-        finding = fetch()
-    except Exception as e:
-        logger.exception(f"Error reading detector finding: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to read finding",
-        ) from e
-    if finding is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Finding not found")
-    enforce_retention_by_time(billing_plan, finding.timestamp)
-    return finding

--- a/frontend/packages/agent/src/prompts/__tests__/system.test.ts
+++ b/frontend/packages/agent/src/prompts/__tests__/system.test.ts
@@ -23,6 +23,15 @@ describe("getSystemPrompt", () => {
     expect(prompt).toContain("spans.jsonl");
   });
 
+  it("describes the detector read tools", () => {
+    const prompt = getSystemPrompt({ projectId: "proj-123" });
+    expect(prompt).toContain("list_detectors");
+    expect(prompt).toContain("list_findings");
+    expect(prompt).toContain("get_finding");
+    expect(prompt).toContain("get_finding_by_trace");
+    expect(prompt).toContain("root-cause analysis");
+  });
+
   it("points a session context at get_session and download_session", () => {
     const prompt = getSystemPrompt({ projectId: "proj-123", traceSessionId: "sess-9" });
     expect(prompt).toContain("Currently viewing Session ID: sess-9");

--- a/frontend/packages/agent/src/prompts/system.ts
+++ b/frontend/packages/agent/src/prompts/system.ts
@@ -32,6 +32,21 @@ Parameters: search_query (optional string), limit (optional number).
 Use get_session with a session_id to get the full session overview: trace count, user IDs, duration, and per-trace summaries (ID, name, input/output, status).
 Use it when you have a session ID to understand what traces it contains before downloading.
 
+### Detector Catalog: list_detectors
+Use this to list the project's detectors (id, name, template, enabled flag, creation time).
+Parameters: optional limit, start_after, end_before.
+Use it for questions about which detectors exist and whether they are enabled.
+
+### Detector Findings: list_findings
+Use this to browse detector findings — issues detectors identified on traces.
+Parameters: optional detector (id, name, or template), trace_id, limit, start_after, end_before.
+Each row includes the finding_id to pass to get_finding.
+
+### Finding Detail: get_finding and get_finding_by_trace
+Use get_finding with a finding_id, or get_finding_by_trace with a trace_id (findings are 1-per-trace),
+to get the full detail: per-detector results and the root-cause analysis (RCA) text when one exists.
+Flow: list_findings to browse, then get_finding / get_finding_by_trace for results + RCA.
+
 ### Deep Investigation: download_traces
 Use this to download one or more full traces into your workspace in parallel. Creates 3 files per trace.
 Parameters: traceIds (string[]) — one or more trace IDs.
@@ -80,12 +95,13 @@ metadata, git_source_file, git_source_line, git_source_function
 1. Start by understanding what the user is asking about
 2. If you have a session_id context: call get_session to see all traces in the session
 3. Use list_traces to find relevant individual traces (search, filter, browse)
-4. Use download_traces to download specific traces for deep investigation
-5. Use download_session to download all traces in a session at once for cross-trace analysis
-6. Use bash/read/grep to explore downloaded trace data in /workspace/
-7. Look for: errors (level=ERROR), high latency, cost anomalies, pattern changes
-8. **ALWAYS check if the trace has git_repo and git_ref fields.** If it does, follow the GitHub Integration steps below to clone the code and correlate errors with source. Do NOT skip this — source code access is critical for root cause analysis.
-9. Explain findings clearly with specific span IDs and timestamps
+4. If the question is about detector findings or RCA, use list_findings to browse and get_finding / get_finding_by_trace for full results and RCA text
+5. Use download_traces to download specific traces for deep investigation
+6. Use download_session to download all traces in a session at once for cross-trace analysis
+7. Use bash/read/grep to explore downloaded trace data in /workspace/
+8. Look for: errors (level=ERROR), high latency, cost anomalies, pattern changes
+9. **ALWAYS check if the trace has git_repo and git_ref fields.** If it does, follow the GitHub Integration steps below to clone the code and correlate errors with source. Do NOT skip this — source code access is critical for root cause analysis.
+10. Explain findings clearly with specific span IDs and timestamps
 
 ## GitHub Integration
 

--- a/frontend/packages/agent/src/tools/__tests__/registry-tools.test.ts
+++ b/frontend/packages/agent/src/tools/__tests__/registry-tools.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Executor } from "../../executors/interface.js";
-import { formatSessionDetail, formatSessionList, formatTraceList } from "../formatters.js";
+import {
+  formatDetectorList,
+  formatFindingDetail,
+  formatFindingList,
+  formatSessionDetail,
+  formatSessionList,
+  formatTraceList,
+} from "../formatters.js";
 import { createTools } from "../index.js";
 import { createRegistryReadTools } from "../registry-tools.js";
 
@@ -205,5 +212,113 @@ describe("formatters", () => {
     const line = text.split("\n").find((l) => l.startsWith("   Input:"))!;
     expect(line).toBe(`   Input:  ${"x".repeat(199)}`);
     expect(text).not.toContain("\ud83d");
+  });
+
+  it("formatDetectorList renders rows and reports the empty state", () => {
+    expect(formatDetectorList({})).toBe("No detectors found.");
+    expect(
+      formatDetectorList({
+        data: [
+          {
+            detector_id: "det-1",
+            name: "Error spike",
+            template: "error-rate",
+            enabled: true,
+            created_at: "2026-08-01T12:00:00Z",
+          },
+          { detector_id: "det-2", name: "Latency", template: "latency", enabled: false },
+        ],
+        meta: { total: 9 },
+      }),
+    ).toBe(
+      "Found 2 detectors (9 total, showing 2):\n" +
+        "- det-1 | Error spike | template: error-rate | enabled | created 2026-08-01T12:00:00Z\n" +
+        "- det-2 | Latency | template: latency | disabled | created unknown",
+    );
+  });
+
+  it("formatFindingList renders rows with truncated summaries and the empty state", () => {
+    expect(formatFindingList({})).toBe("No detector findings found matching the given filters.");
+    const text = formatFindingList({
+      data: [
+        {
+          finding_id: "f-1",
+          trace_id: "t-1",
+          timestamp: "2026-08-11T09:00:00Z",
+          detectors: ["Error spike", "Latency"],
+          summary: "y".repeat(250),
+        },
+      ],
+      meta: { total: 3 },
+    });
+    expect(text).toContain("Found 1 findings (3 total, showing 1):");
+    expect(text).toContain(
+      "- f-1 | trace t-1 | 2026-08-11T09:00:00Z | detectors: Error spike, Latency",
+    );
+    expect(text).toContain("y".repeat(200));
+    expect(text).not.toContain("y".repeat(201));
+  });
+
+  it("formatFindingDetail renders header, per-detector results, and RCA text", () => {
+    expect(
+      formatFindingDetail({
+        finding_id: "f-1",
+        trace_id: "t-1",
+        timestamp: "2026-08-11T09:00:00Z",
+        detectors: ["Error spike"],
+        summary: "Elevated error rate",
+        results: [
+          {
+            detector_id: "det-1",
+            detector_name: "Error spike",
+            template: "error-rate",
+            summary: "errors spiked",
+            identified: true,
+            data: { count: 3 },
+          },
+        ],
+        rca: { status: "completed", result: "Root cause: bad deploy" },
+      }),
+    ).toBe(
+      "Finding: f-1\n" +
+        "Trace: t-1 | Time: 2026-08-11T09:00:00Z | Detectors: Error spike\n" +
+        "Summary: Elevated error rate\n" +
+        "\n" +
+        "Per-detector results:\n" +
+        "#1 Error spike (template: error-rate)\n" +
+        "   errors spiked\n" +
+        '   Data: {"count":3}\n' +
+        "\n" +
+        "RCA (completed):\n" +
+        "Root cause: bad deploy",
+    );
+  });
+
+  it("formatFindingDetail states missing results and RCA explicitly", () => {
+    const text = formatFindingDetail({
+      finding_id: "f-2",
+      trace_id: "t-2",
+      timestamp: "2026-08-11T09:00:00Z",
+      detectors: [],
+      summary: "",
+    });
+    expect(text).toContain("Detectors: unknown");
+    expect(text).toContain("Summary: (no summary)");
+    expect(text).toContain("Per-detector results: (none)");
+    expect(text).toContain("RCA: none recorded for this finding.");
+  });
+
+  it("formatFindingDetail marks a pending RCA with empty text", () => {
+    const text = formatFindingDetail({
+      finding_id: "f-3",
+      trace_id: "t-3",
+      timestamp: "2026-08-11T09:00:00Z",
+      detectors: ["Error spike"],
+      summary: "s",
+      results: [],
+      rca: { status: "pending", result: null },
+    });
+    expect(text).toContain("RCA (pending):");
+    expect(text).toContain("(no RCA text yet)");
   });
 });

--- a/frontend/packages/agent/src/tools/__tests__/registry-tools.test.ts
+++ b/frontend/packages/agent/src/tools/__tests__/registry-tools.test.ts
@@ -158,8 +158,8 @@ describe("createRegistryReadTools", () => {
     expect(String(url)).toBe("http://fastapi.test/api/v1/projects/p1/detectors/traces/t1/finding");
   });
 
-  it("get_finding formats the finding detail with RCA", async () => {
-    stubFetch({
+  it("get_finding hits the internal finding route and formats the detail with RCA", async () => {
+    const impl = stubFetch({
       finding_id: "f1",
       trace_id: "t1",
       timestamp: "2026-08-11T09:00:00Z",
@@ -170,30 +170,25 @@ describe("createRegistryReadTools", () => {
     });
     const tool = createRegistryReadTools("p1", "u1").find((t) => t.name === "get_finding")!;
     const result = await tool.execute("id", { label: "x", finding_id: "f1" });
+    const [url] = impl.mock.calls[0]!;
+    expect(String(url)).toBe("http://fastapi.test/api/v1/projects/p1/detectors/findings/f1");
     expect(result.content[0]!.text).toContain("Finding: f1");
     expect(result.content[0]!.text).toContain("RCA (completed):");
     expect(result.content[0]!.text).toContain("Root cause: bad deploy");
   });
 
-  it("list_detectors formats the detector catalog", async () => {
-    stubFetch({
-      data: [
-        {
-          detector_id: "det-1",
-          name: "Error spike",
-          template: "error-rate",
-          enabled: true,
-          created_at: "2026-08-01T12:00:00Z",
-        },
-      ],
+  it("list_detectors hits the internal detectors route and runs the catalog formatter", async () => {
+    const impl = stubFetch({
+      data: [{ detector_id: "det-1", name: "Error spike", template: "error-rate", enabled: true }],
       meta: { total: 1 },
     });
     const tool = createRegistryReadTools("p1", "u1").find((t) => t.name === "list_detectors")!;
     const result = await tool.execute("id", { label: "x" });
-    expect(result.content[0]!.text).toBe(
-      "Found 1 detectors (1 total, showing 1):\n" +
-        "- det-1 | Error spike | template: error-rate | enabled | created 2026-08-01T12:00:00Z",
-    );
+    const [url] = impl.mock.calls[0]!;
+    expect(String(url)).toBe("http://fastapi.test/api/v1/projects/p1/detectors");
+    // Exact rendering is owned by the formatter tests; this proves dispatch + formatter wiring.
+    expect(result.content[0]!.text).toContain("Found 1 detectors");
+    expect(result.content[0]!.text).toContain("det-1");
   });
 
   it("returns HTTP failures as tool text instead of throwing", async () => {
@@ -402,5 +397,20 @@ describe("formatters", () => {
     });
     expect(text).toContain("RCA (pending):");
     expect(text).toContain("(no RCA text yet)");
+  });
+
+  it("formatFindingDetail does not say 'yet' for a failed RCA with empty text", () => {
+    const text = formatFindingDetail({
+      finding_id: "f-4",
+      trace_id: "t-4",
+      timestamp: "2026-08-11T09:00:00Z",
+      detectors: ["Error spike"],
+      summary: "s",
+      results: [],
+      rca: { status: "failed", result: null },
+    });
+    expect(text).toContain("RCA (failed):");
+    expect(text).toContain("(no RCA text)");
+    expect(text).not.toContain("(no RCA text yet)");
   });
 });

--- a/frontend/packages/agent/src/tools/__tests__/registry-tools.test.ts
+++ b/frontend/packages/agent/src/tools/__tests__/registry-tools.test.ts
@@ -24,9 +24,17 @@ describe("createRegistryReadTools", () => {
     return impl;
   }
 
-  it("exposes exactly the three internally-bound read tools", () => {
+  it("exposes exactly the seven internally-bound read tools", () => {
     const names = createRegistryReadTools("p1", "u1").map((t) => t.name);
-    expect(names).toEqual(["list_traces", "list_sessions", "get_session"]);
+    expect(names).toEqual([
+      "list_traces",
+      "list_sessions",
+      "get_session",
+      "list_detectors",
+      "list_findings",
+      "get_finding",
+      "get_finding_by_trace",
+    ]);
   });
 
   it("hides the fixed project_id from every tool's model-facing schema", () => {
@@ -118,6 +126,76 @@ describe("createRegistryReadTools", () => {
     );
   });
 
+  it("list_findings hits the internal detectors route with query filters", async () => {
+    const impl = stubFetch({ data: [], meta: {} });
+    const tool = createRegistryReadTools("p1", "u1").find((t) => t.name === "list_findings")!;
+    await tool.execute("id", { label: "x", detector: "error-rate", trace_id: "t1" });
+    const [url, init] = impl.mock.calls[0]!;
+    expect(String(url)).toBe(
+      "http://fastapi.test/api/v1/projects/p1/detectors/findings?detector=error-rate&trace_id=t1",
+    );
+    expect((init as RequestInit).headers).toMatchObject({
+      "X-Internal-Secret": "s3cret",
+      "x-user-id": "u1",
+    });
+  });
+
+  it("get_finding_by_trace hits the internal trace-finding route", async () => {
+    const impl = stubFetch({
+      finding_id: "f1",
+      trace_id: "t1",
+      timestamp: "2026-08-11T09:00:00Z",
+      detectors: [],
+      summary: "s",
+      results: [],
+      rca: null,
+    });
+    const tool = createRegistryReadTools("p1", "u1").find(
+      (t) => t.name === "get_finding_by_trace",
+    )!;
+    await tool.execute("id", { label: "x", trace_id: "t1" });
+    const [url] = impl.mock.calls[0]!;
+    expect(String(url)).toBe("http://fastapi.test/api/v1/projects/p1/detectors/traces/t1/finding");
+  });
+
+  it("get_finding formats the finding detail with RCA", async () => {
+    stubFetch({
+      finding_id: "f1",
+      trace_id: "t1",
+      timestamp: "2026-08-11T09:00:00Z",
+      detectors: ["Error spike"],
+      summary: "Elevated error rate",
+      results: [],
+      rca: { status: "completed", result: "Root cause: bad deploy" },
+    });
+    const tool = createRegistryReadTools("p1", "u1").find((t) => t.name === "get_finding")!;
+    const result = await tool.execute("id", { label: "x", finding_id: "f1" });
+    expect(result.content[0]!.text).toContain("Finding: f1");
+    expect(result.content[0]!.text).toContain("RCA (completed):");
+    expect(result.content[0]!.text).toContain("Root cause: bad deploy");
+  });
+
+  it("list_detectors formats the detector catalog", async () => {
+    stubFetch({
+      data: [
+        {
+          detector_id: "det-1",
+          name: "Error spike",
+          template: "error-rate",
+          enabled: true,
+          created_at: "2026-08-01T12:00:00Z",
+        },
+      ],
+      meta: { total: 1 },
+    });
+    const tool = createRegistryReadTools("p1", "u1").find((t) => t.name === "list_detectors")!;
+    const result = await tool.execute("id", { label: "x" });
+    expect(result.content[0]!.text).toBe(
+      "Found 1 detectors (1 total, showing 1):\n" +
+        "- det-1 | Error spike | template: error-rate | enabled | created 2026-08-01T12:00:00Z",
+    );
+  });
+
   it("returns HTTP failures as tool text instead of throwing", async () => {
     vi.stubGlobal(
       "fetch",
@@ -142,6 +220,10 @@ describe("createTools", () => {
       "list_traces",
       "list_sessions",
       "get_session",
+      "list_detectors",
+      "list_findings",
+      "get_finding",
+      "get_finding_by_trace",
       "download_traces",
       "download_session",
       "check_github_access",

--- a/frontend/packages/agent/src/tools/formatters.ts
+++ b/frontend/packages/agent/src/tools/formatters.ts
@@ -154,9 +154,11 @@ export function formatFindingDetail(data: unknown): string {
       ? ["", "Per-detector results:", resultBlocks.join("\n")]
       : ["", "Per-detector results: (none)"];
 
-  // A pending/failed RCA is stated explicitly so the model doesn't invent one.
+  // A pending/failed RCA is stated explicitly so the model doesn't invent one;
+  // "yet" only fits a pending RCA, not a failed one.
+  const rcaPlaceholder = f.rca?.status === "pending" ? "(no RCA text yet)" : "(no RCA text)";
   const rcaSection = f.rca
-    ? ["", `RCA (${f.rca.status}):`, f.rca.result || "(no RCA text yet)"]
+    ? ["", `RCA (${f.rca.status}):`, f.rca.result || rcaPlaceholder]
     : ["", "RCA: none recorded for this finding."];
 
   return [...header, ...resultsSection, ...rcaSection].join("\n");

--- a/frontend/packages/agent/src/tools/formatters.ts
+++ b/frontend/packages/agent/src/tools/formatters.ts
@@ -85,3 +85,79 @@ export function formatSessionList(data: unknown): string {
 
   return `Found ${sessions.length} sessions:\n${lines.join("\n")}`;
 }
+
+/** Render a detector list response as per-detector summary lines. */
+export function formatDetectorList(data: unknown): string {
+  const body = (data ?? {}) as { data?: unknown; meta?: unknown };
+  const detectors = (body.data || []) as any[];
+  const meta = (body.meta || {}) as { total?: number };
+
+  if (!Array.isArray(detectors) || detectors.length === 0) {
+    return "No detectors found.";
+  }
+
+  const lines = detectors.map((d: any) => {
+    const state = d.enabled ? "enabled" : "disabled";
+    return `- ${d.detector_id} | ${d.name || "(unnamed)"} | template: ${d.template || "none"} | ${state} | created ${d.created_at || "unknown"}`;
+  });
+
+  const totalInfo = meta.total ? ` (${meta.total} total, showing ${detectors.length})` : "";
+
+  return `Found ${detectors.length} detectors${totalInfo}:\n${lines.join("\n")}`;
+}
+
+/** Render a finding list response as per-finding summary lines. */
+export function formatFindingList(data: unknown): string {
+  const body = (data ?? {}) as { data?: unknown; meta?: unknown };
+  const findings = (body.data || []) as any[];
+  const meta = (body.meta || {}) as { total?: number };
+
+  if (!Array.isArray(findings) || findings.length === 0) {
+    return "No detector findings found matching the given filters.";
+  }
+
+  const lines = findings.map((f: any) => {
+    const detectors = (f.detectors || []).join(", ") || "unknown";
+    return [
+      `- ${f.finding_id} | trace ${f.trace_id} | ${f.timestamp} | detectors: ${detectors}`,
+      `  ${truncate(f.summary || "(no summary)", 200)}`,
+    ].join("\n");
+  });
+
+  const totalInfo = meta.total ? ` (${meta.total} total, showing ${findings.length})` : "";
+
+  return `Found ${findings.length} findings${totalInfo}:\n${lines.join("\n")}`;
+}
+
+/** Render a finding detail: header, per-detector results, then the RCA text. */
+export function formatFindingDetail(data: unknown): string {
+  const f = (data ?? {}) as any;
+  const detectors = (f.detectors || []).join(", ") || "unknown";
+
+  const header = [
+    `Finding: ${f.finding_id}`,
+    `Trace: ${f.trace_id} | Time: ${f.timestamp} | Detectors: ${detectors}`,
+    `Summary: ${f.summary || "(no summary)"}`,
+  ];
+
+  const results: any[] = f.results || [];
+  const resultBlocks = results.map((r: any, i: number) => {
+    const detail = r.data != null ? truncate(JSON.stringify(r.data), 400) : "(none)";
+    return [
+      `#${i + 1} ${r.detector_name || r.detector_id} (template: ${r.template || "none"})`,
+      `   ${r.summary || "(no summary)"}`,
+      `   Data: ${detail}`,
+    ].join("\n");
+  });
+  const resultsSection =
+    resultBlocks.length > 0
+      ? ["", "Per-detector results:", resultBlocks.join("\n")]
+      : ["", "Per-detector results: (none)"];
+
+  // A pending/failed RCA is stated explicitly so the model doesn't invent one.
+  const rcaSection = f.rca
+    ? ["", `RCA (${f.rca.status}):`, f.rca.result || "(no RCA text yet)"]
+    : ["", "RCA: none recorded for this finding."];
+
+  return [...header, ...resultsSection, ...rcaSection].join("\n");
+}

--- a/frontend/packages/agent/src/tools/registry-tools.ts
+++ b/frontend/packages/agent/src/tools/registry-tools.ts
@@ -6,7 +6,14 @@ import {
   internalAuth,
   toPiAgentTool,
 } from "@traceroot-ai/tools";
-import { formatSessionDetail, formatSessionList, formatTraceList } from "./formatters.js";
+import {
+  formatDetectorList,
+  formatFindingDetail,
+  formatFindingList,
+  formatSessionDetail,
+  formatSessionList,
+  formatTraceList,
+} from "./formatters.js";
 
 function requireEntry(name: string) {
   const entry = REGISTRY.find((e) => e.name === name);
@@ -37,5 +44,9 @@ export function createRegistryReadTools(projectId: string, userId: string): Agen
     bind("list_traces", formatTraceList),
     bind("list_sessions", formatSessionList),
     bind("get_session", formatSessionDetail),
+    bind("list_detectors", formatDetectorList),
+    bind("list_findings", formatFindingList),
+    bind("get_finding", formatFindingDetail),
+    bind("get_finding_by_trace", formatFindingDetail),
   ];
 }

--- a/frontend/packages/tools/src/__tests__/pi.test.ts
+++ b/frontend/packages/tools/src/__tests__/pi.test.ts
@@ -130,6 +130,10 @@ describe("INTERNAL_BINDINGS", () => {
       list_traces: "/api/v1/projects/{project_id}/traces",
       list_sessions: "/api/v1/projects/{project_id}/sessions",
       get_session: "/api/v1/projects/{project_id}/sessions/{session_id}",
+      list_detectors: "/api/v1/projects/{project_id}/detectors",
+      list_findings: "/api/v1/projects/{project_id}/detectors/findings",
+      get_finding: "/api/v1/projects/{project_id}/detectors/findings/{finding_id}",
+      get_finding_by_trace: "/api/v1/projects/{project_id}/detectors/traces/{trace_id}/finding",
     });
   });
 });

--- a/frontend/packages/tools/src/internal.ts
+++ b/frontend/packages/tools/src/internal.ts
@@ -9,4 +9,8 @@ export const INTERNAL_BINDINGS: Readonly<Record<string, string>> = {
   list_traces: "/api/v1/projects/{project_id}/traces",
   list_sessions: "/api/v1/projects/{project_id}/sessions",
   get_session: "/api/v1/projects/{project_id}/sessions/{session_id}",
+  list_detectors: "/api/v1/projects/{project_id}/detectors",
+  list_findings: "/api/v1/projects/{project_id}/detectors/findings",
+  get_finding: "/api/v1/projects/{project_id}/detectors/findings/{finding_id}",
+  get_finding_by_trace: "/api/v1/projects/{project_id}/detectors/traces/{trace_id}/finding",
 };

--- a/tests/rest/test_detectors_router.py
+++ b/tests/rest/test_detectors_router.py
@@ -1,0 +1,220 @@
+"""Unit tests for the internal project-scoped detector read endpoints."""
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rest.main import app
+from rest.routers.deps import ProjectAccessInfo, get_project_access
+from rest.schemas.public import (
+    DetectorItem,
+    DetectorResultItem,
+    FindingDetail,
+    RCAResult,
+)
+from rest.services.detector_reader import get_detector_reader_service
+
+
+def _now_naive():
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+class FakeReader:
+    def __init__(self):
+        self.detectors_args: dict | None = None
+        self.detectors_return: tuple = ([], 0)
+        self.raise_on_detectors = False
+        self.list_args: dict | None = None
+        self.list_return: tuple = ([], 0)
+        self.raise_on_list = False
+        self.finding: FindingDetail | None = None
+        self.by_trace: FindingDetail | None = None
+        self.last_get: tuple | None = None
+        self.last_by_trace: tuple | None = None
+
+    def list_detectors(self, **kwargs):
+        self.detectors_args = kwargs
+        if self.raise_on_detectors:
+            raise RuntimeError("boom")
+        return self.detectors_return
+
+    def list_findings(self, **kwargs):
+        self.list_args = kwargs
+        if self.raise_on_list:
+            raise RuntimeError("boom")
+        return self.list_return
+
+    def get_finding(self, project_id, finding_id):
+        self.last_get = (project_id, finding_id)
+        return self.finding
+
+    def get_finding_by_trace(self, project_id, trace_id):
+        self.last_by_trace = (project_id, trace_id)
+        return self.by_trace
+
+
+def _detector(i: int = 1) -> DetectorItem:
+    return DetectorItem(
+        detector_id=f"det-{i}",
+        name=f"Detector {i}",
+        template="error-rate",
+        enabled=True,
+        created_at=datetime(2026, 8, 1, 12, 0, 0),
+    )
+
+
+def _finding(timestamp: datetime | None = None) -> FindingDetail:
+    return FindingDetail(
+        finding_id="f-1",
+        project_id="proj-A",
+        trace_id="t-1",
+        summary="Elevated error rate",
+        timestamp=timestamp or _now_naive(),
+        detectors=["Detector 1"],
+        results=[
+            DetectorResultItem(
+                detector_id="det-1",
+                detector_name="Detector 1",
+                template="error-rate",
+                summary="errors spiked",
+                identified=True,
+                data={"count": 3},
+            )
+        ],
+        rca=RCAResult(status="completed", result="Root cause: bad deploy"),
+    )
+
+
+@pytest.fixture()
+def reader():
+    return FakeReader()
+
+
+def _make_client(reader: FakeReader, billing_plan: str) -> TestClient:
+    """Build a TestClient with auth + reader overrides for one billing plan.
+
+    Args:
+        reader (FakeReader): Fake detector reader returned by the service dep.
+        billing_plan (str): Plan stamped on the mocked project access.
+
+    Returns:
+        TestClient: Client against the app with overrides installed.
+    """
+
+    async def mock_get_access(project_id: str, x_user_id=None):
+        return ProjectAccessInfo(
+            project_id=project_id,
+            user_id="test-user",
+            role="ADMIN",
+            workspace_id="ws-test",
+            billing_plan=billing_plan,
+        )
+
+    app.dependency_overrides[get_project_access] = mock_get_access
+    app.dependency_overrides[get_detector_reader_service] = lambda: reader
+    return TestClient(app)
+
+
+@pytest.fixture()
+def client(reader):
+    yield _make_client(reader, "enterprise")
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def free_plan_client(reader):
+    yield _make_client(reader, "free")
+    app.dependency_overrides.clear()
+
+
+class TestListDetectors:
+    def test_200_returns_page_and_scopes_to_project(self, client, reader):
+        reader.detectors_return = ([_detector()], 1)
+        resp = client.get("/api/v1/projects/proj-A/detectors")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"][0]["detector_id"] == "det-1"
+        assert body["meta"]["total"] == 1
+        assert reader.detectors_args["project_id"] == "proj-A"
+
+    def test_window_params_pass_through(self, client, reader):
+        resp = client.get(
+            "/api/v1/projects/proj-A/detectors",
+            params={
+                "limit": 5,
+                "start_after": "2026-08-01T00:00:00Z",
+                "end_before": "2026-08-10T00:00:00Z",
+            },
+        )
+        assert resp.status_code == 200
+        assert reader.detectors_args["limit"] == 5
+        assert reader.detectors_args["start_after"] is not None
+        assert reader.detectors_args["end_before"] is not None
+
+    def test_reader_error_maps_to_500(self, client, reader):
+        reader.raise_on_detectors = True
+        resp = client.get("/api/v1/projects/proj-A/detectors")
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Failed to list detectors"
+
+
+class TestListFindings:
+    def test_200_with_filters_passed_through(self, client, reader):
+        reader.list_return = ([], 0)
+        resp = client.get(
+            "/api/v1/projects/proj-A/detectors/findings",
+            params={"detector": "error-rate", "trace_id": "t-9", "limit": 10},
+        )
+        assert resp.status_code == 200
+        assert reader.list_args["project_id"] == "proj-A"
+        assert reader.list_args["detector"] == "error-rate"
+        assert reader.list_args["trace_id"] == "t-9"
+        assert reader.list_args["limit"] == 10
+
+    def test_free_plan_clamps_start_after_to_retention_cutoff(self, free_plan_client, reader):
+        resp = free_plan_client.get("/api/v1/projects/proj-A/detectors/findings")
+        assert resp.status_code == 200
+        assert reader.list_args["start_after"] is not None
+
+    def test_reader_error_maps_to_500(self, client, reader):
+        reader.raise_on_list = True
+        resp = client.get("/api/v1/projects/proj-A/detectors/findings")
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Failed to list findings"
+
+
+class TestGetFinding:
+    def test_200_includes_results_and_rca(self, client, reader):
+        reader.finding = _finding()
+        resp = client.get("/api/v1/projects/proj-A/detectors/findings/f-1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["finding_id"] == "f-1"
+        assert body["results"][0]["detector_name"] == "Detector 1"
+        assert body["rca"]["result"] == "Root cause: bad deploy"
+        assert reader.last_get == ("proj-A", "f-1")
+
+    def test_missing_finding_is_404(self, client, reader):
+        reader.finding = None
+        resp = client.get("/api/v1/projects/proj-A/detectors/findings/nope")
+        assert resp.status_code == 404
+
+    def test_free_plan_out_of_retention_is_403(self, free_plan_client, reader):
+        reader.finding = _finding(timestamp=datetime(2020, 1, 1))
+        resp = free_plan_client.get("/api/v1/projects/proj-A/detectors/findings/f-1")
+        assert resp.status_code == 403
+
+
+class TestGetFindingByTrace:
+    def test_200_scopes_to_project_and_trace(self, client, reader):
+        reader.by_trace = _finding()
+        resp = client.get("/api/v1/projects/proj-A/detectors/traces/t-1/finding")
+        assert resp.status_code == 200
+        assert resp.json()["trace_id"] == "t-1"
+        assert reader.last_by_trace == ("proj-A", "t-1")
+
+    def test_missing_finding_is_404(self, client, reader):
+        reader.by_trace = None
+        resp = client.get("/api/v1/projects/proj-A/detectors/traces/t-x/finding")
+        assert resp.status_code == 404

--- a/tests/rest/test_detectors_router.py
+++ b/tests/rest/test_detectors_router.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from rest.main import app
+from rest.retention import get_retention_cutoff
 from rest.routers.deps import ProjectAccessInfo, get_project_access
 from rest.schemas.public import (
     DetectorItem,
@@ -175,7 +176,10 @@ class TestListFindings:
     def test_free_plan_clamps_start_after_to_retention_cutoff(self, free_plan_client, reader):
         resp = free_plan_client.get("/api/v1/projects/proj-A/detectors/findings")
         assert resp.status_code == 200
-        assert reader.list_args["start_after"] is not None
+        clamped = reader.list_args["start_after"]
+        expected_cutoff = get_retention_cutoff("free")
+        assert expected_cutoff is not None
+        assert abs((clamped - expected_cutoff).total_seconds()) < 60
 
     def test_reader_error_maps_to_500(self, client, reader):
         reader.raise_on_list = True

--- a/tests/rest/test_detectors_router.py
+++ b/tests/rest/test_detectors_router.py
@@ -29,6 +29,7 @@ class FakeReader:
         self.list_args: dict | None = None
         self.list_return: tuple = ([], 0)
         self.raise_on_list = False
+        self.raise_on_get_finding_by_trace = False
         self.finding: FindingDetail | None = None
         self.by_trace: FindingDetail | None = None
         self.last_get: tuple | None = None
@@ -52,6 +53,8 @@ class FakeReader:
 
     def get_finding_by_trace(self, project_id, trace_id):
         self.last_by_trace = (project_id, trace_id)
+        if self.raise_on_get_finding_by_trace:
+            raise RuntimeError("boom")
         return self.by_trace
 
 
@@ -222,3 +225,9 @@ class TestGetFindingByTrace:
         reader.by_trace = None
         resp = client.get("/api/v1/projects/proj-A/detectors/traces/t-x/finding")
         assert resp.status_code == 404
+
+    def test_reader_error_maps_to_500(self, client, reader):
+        reader.raise_on_get_finding_by_trace = True
+        resp = client.get("/api/v1/projects/proj-A/detectors/traces/t-1/finding")
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Failed to read finding"

--- a/tests/rest/test_public_detectors_read.py
+++ b/tests/rest/test_public_detectors_read.py
@@ -39,6 +39,7 @@ class FakeReader:
         self.list_args: dict | None = None
         self.list_return: tuple = ([], 0)
         self.raise_on_list = False
+        self.raise_on_get_finding_by_trace = False
         self.detectors_args: dict | None = None
         self.detectors_return: tuple = ([], 0)
         self.raise_on_detectors = False
@@ -65,6 +66,8 @@ class FakeReader:
 
     def get_finding_by_trace(self, project_id, trace_id):
         self.last_by_trace = (project_id, trace_id)
+        if self.raise_on_get_finding_by_trace:
+            raise RuntimeError("boom")
         return self.by_trace
 
 
@@ -256,6 +259,14 @@ def test_detail_by_trace_returns_finding(client, reader):
 def test_detail_by_trace_404_when_none(client, reader):
     reader.by_trace = None
     assert client.get("/api/v1/public/detectors/traces/none/finding").status_code == 404
+
+
+def test_detail_by_trace_reader_failure_returns_sanitized_500(client, reader):
+    reader.raise_on_get_finding_by_trace = True
+    resp = client.get("/api/v1/public/detectors/traces/t1/finding")
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Failed to read finding"
+    assert "boom" not in resp.text
 
 
 def test_auth_required_without_key(reader):

--- a/tests/rest/test_public_internal_parity.py
+++ b/tests/rest/test_public_internal_parity.py
@@ -13,6 +13,14 @@ BINDINGS = {
     "/api/v1/public/traces": "/api/v1/projects/{project_id}/traces",
     "/api/v1/public/sessions": "/api/v1/projects/{project_id}/sessions",
     "/api/v1/public/sessions/{session_id}": "/api/v1/projects/{project_id}/sessions/{session_id}",
+    "/api/v1/public/detectors": "/api/v1/projects/{project_id}/detectors",
+    "/api/v1/public/detectors/findings": "/api/v1/projects/{project_id}/detectors/findings",
+    "/api/v1/public/detectors/findings/{finding_id}": (
+        "/api/v1/projects/{project_id}/detectors/findings/{finding_id}"
+    ),
+    "/api/v1/public/detectors/traces/{trace_id}/finding": (
+        "/api/v1/projects/{project_id}/detectors/traces/{trace_id}/finding"
+    ),
 }
 
 


### PR DESCRIPTION
## What

Gives the in-app agent read access to detectors, findings, and RCA output through four tools that already existed in the shared registry: `list_detectors`, `list_findings`, `get_finding`, `get_finding_by_trace`. The agent can now answer "what detectors do I have", browse findings by detector/trace/time window, and pull a finding's per-detector results plus its root-cause analysis.

## How

- **Backend:** new internal project-scoped router (`backend/rest/routers/detectors.py`) mirroring the public detector reads, with the handler bodies extracted to `backend/rest/routers/detector_read_common.py` and shared by both surfaces so retention and error-mapping semantics cannot drift. Same auth/rate-limit/retention idioms as the sessions/traces internal routers.
- **Tools package:** four `INTERNAL_BINDINGS` entries plus the mirrored rows in `tests/rest/test_public_internal_parity.py` — one registry definition serves the agent (internal surface) and API-key clients (public surface), with the params-subset invariant CI-enforced.
- **Agent:** surface-local formatters (`formatDetectorList`, `formatFindingList`, `formatFindingDetail` — pending/missing RCA stated explicitly so the model can't invent one), tool bindings, and system-prompt guidance for the browse → detail flow.

## Verification

- Backend suite green (includes free-plan retention clamp pinned to the actual cutoff, 404/500 contracts on both surfaces); agent and tools package suites green; tsc clean.
- Diff coverage vs main: backend and frontend both 100% on changed lines.
- Live-verified end-to-end against a locally seeded project: catalog, findings list with server-side time filtering, finding detail with completed RCA, and the no-finding negative case.

Closes #1875. Part of epic #1877; the `get_detector` PR stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives the in‑app agent read access to detectors, findings, and RCA by adding internal project‑scoped routes and binding them to shared‑registry tools. Previously the agent could only use public routes; now an internal mirror shares handler bodies with the public surface for identical retention, error mapping, and schemas, and runs blocking reads off the event loop.

- Backend: adds `/api/v1/projects/{project_id}/detectors` with `list_detectors`, `list_findings`, `get_finding`, and `get_finding_by_trace`; centralizes handler bodies in `rest.routers.detector_read_common` used by both public and internal routers; keeps READ‑bucket rate limiting; clamps free‑plan finding lists to retention and enforces retention‑by‑time on detail; maps None→404 and reader errors→sanitized 500; runs synchronous reads via `asyncio.to_thread`. Public API shapes and params are unchanged; it now delegates to the shared bodies.
- Agent/tools: binds the four detector read tools to the internal routes in `@traceroot-ai/tools`; adds formatters for detector list, finding list, and finding detail with explicit RCA status; updates the system prompt to describe the browse → detail flow; `createRegistryReadTools` now exposes seven read tools total.
- Tests: adds internal router tests (filters passthrough, retention clamp, 404, by‑trace 500); extends public/internal parity to cover detector routes; pins the by‑trace 500 contract on both surfaces; updates agent and tools tests to assert internal URLs and formatter output.

<sup>Written for commit 9f223873ff4c3d5f8d950d1fe018089e6780222b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Review follow-ups (disposition)

- **by-trace reader-error→500 symmetry gap** — fixed **in this PR**: `test(api): pin the by-trace finding read 500 contract on both surfaces` (raise flag + tests on the internal and public surfaces).
- **Prompt template catalog hand-duplication** — sync assertion implemented in the stacked PR (#1913, `template-catalog-sync.test.ts`): reads the UI's `DETECTOR_TEMPLATES` source and asserts the prompt lists exactly its ids (this is where the prompt catalog lives).
- **`as any` in formatters / consuming generated response types** — deferred deliberately: the registry generator currently emits input schemas only, so this is a codegen extension, tracked on epic #1877's follow-up list.
- **Pagination past the first N results** — filed as #1919 (keyset-cursor direction recommended; applies across all public list reads, so it's a cross-cutting change rather than a patch to this PR).
