### PR TITLE
chore(ui): drop stale sourcing note from provider-icon comments

### DIFF
--- a/frontend/ui/src/components/icons/provider-icons.tsx
+++ b/frontend/ui/src/components/icons/provider-icons.tsx
@@ -20,7 +20,7 @@ export const OpenAIIcon: FC<IconProps> = ({ className }) => (
   </svg>
 );
 
-// Anthropic "A" mark (from lmnr reference)
+// Anthropic "A" mark
 export const AnthropicIcon: FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 24 24"
@@ -34,7 +34,7 @@ export const AnthropicIcon: FC<IconProps> = ({ className }) => (
   </svg>
 );
 
-// Azure (multi-gradient, from lmnr reference)
+// Azure (multi-gradient)
 export const AzureIcon: FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 24 24"
@@ -99,7 +99,7 @@ export const AzureIcon: FC<IconProps> = ({ className }) => (
   </svg>
 );
 
-// Google Gemini (gradient gem, from lmnr reference)
+// Google Gemini (gradient gem)
 export const GoogleIcon: FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 24 24"
@@ -122,7 +122,7 @@ export const GoogleIcon: FC<IconProps> = ({ className }) => (
   </svg>
 );
 
-// AWS Bedrock (gradient, from lmnr reference)
+// AWS Bedrock (gradient)
 export const AWSIcon: FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 24 24"


### PR DESCRIPTION
Removes a stale `(from lmnr reference)` sourcing note from four provider-icon comments (Anthropic / Azure / Gemini / Bedrock). Comment-only; the icons themselves are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes stale “(from lmnr reference)” notes from provider icon comments (Anthropic, Azure, Google Gemini, AWS Bedrock) to avoid confusing sourcing references. No runtime or UI changes; SVGs and component exports are unchanged.

<sup>Written for commit 040d0daa55abdbda8a187d6b497bccb1ec333408. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

