### PR TITLE
feat: add Grok 4.6 to BYOK model catalog

### DIFF
--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -193,6 +193,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "deepseek-chat", label: "deepseek-chat" },
   ],
   xai: [
+    { id: "grok-4.6", label: "grok-4.6" },
     { id: "grok-4.5", label: "grok-4.5" },
     { id: "grok-4.20", label: "grok-4.20" },
     { id: "grok-4", label: "grok-4" },


### PR DESCRIPTION
Closes #1873

## Summary

xAI released Grok 4.6 as its newest flagship model. TraceRoot's curated xAI BYOK catalog did not list it, causing users to see it as unsupported in Model Providers.

## What Changed

- Added { id: 'grok-4.6', label: 'grok-4.6' } at index 0 of ADAPTER_MODELS.xai.
- Keeps newest-first ordering and makes Grok 4.6 the default first xAI model.
- No apiProtocol override; xAI continues using openai-completions.
- No changes to SYSTEM_MODELS, PROVIDER_PRIORITY, pricing, or backend routing.
- grok-4.6-fast remains out of scope.

## Screenshots / Recordings

The xAI provider dialog displays grok-4.6 first and selects it by default without an unsupported warning.

## Validation

- pnpm --filter @traceroot/core test -- src/__tests__/llm-providers.test.ts (11 tests passed)
- git diff --check passed
- One changed file: frontend/packages/core/src/llm-providers.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `grok-4.6` to the xAI BYOK model catalog and makes it the default xAI model. Previously `grok-4.6` was missing, so users saw it as unsupported in Model Providers.

**Review notes**
- Inserted `{ id: "grok-4.6", label: "grok-4.6" }` at index 0 of `ADAPTER_MODELS.xai`; ordering remains newest-first and selects `grok-4.6` by default.
- Protocol and backend are unchanged: xAI continues using `openai-completions`; no changes to `SYSTEM_MODELS`, `PROVIDER_PRIORITY`, pricing, or routing.
- Out of scope: `grok-4.6-fast`.

<sup>Written for commit 576b28cc1be278c959c1781e11cd0b0226ff536a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

