### PR TITLE
feat(auth): device authorization flow with better-auth 1.6.27

### DIFF
--- a/frontend/packages/core/prisma/migrations/20260812000000_add_device_codes/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260812000000_add_device_codes/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "device_codes" (
+    "id" VARCHAR NOT NULL,
+    "device_code" VARCHAR NOT NULL,
+    "user_code" VARCHAR NOT NULL,
+    "user_id" VARCHAR,
+    "expires_at" TIMESTAMP(6) NOT NULL,
+    "status" VARCHAR NOT NULL,
+    "last_polled_at" TIMESTAMP(6),
+    "polling_interval" INTEGER,
+    "client_id" VARCHAR,
+    "scope" VARCHAR,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "device_codes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ix_device_code_device_code" ON "device_codes"("device_code");
+
+-- CreateIndex
+CREATE INDEX "ix_device_code_user_code" ON "device_codes"("user_code");

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -250,6 +250,28 @@ model Verification {
   @@map("verifications")
 }
 
+// Device Codes - better-auth device-authorization plugin (CLI login).
+// deviceCode and userCode are looked up on every poll/approval, so both get
+// indexes beyond the upstream plugin's unindexed defaults.
+model DeviceCode {
+  id              String    @id @default(cuid()) @db.VarChar
+  deviceCode      String    @map("device_code") @db.VarChar
+  userCode        String    @map("user_code") @db.VarChar
+  userId          String?   @map("user_id") @db.VarChar
+  expiresAt       DateTime  @map("expires_at") @db.Timestamp(6)
+  status          String    @db.VarChar
+  lastPolledAt    DateTime? @map("last_polled_at") @db.Timestamp(6)
+  pollingInterval Int?      @map("polling_interval")
+  clientId        String?   @map("client_id") @db.VarChar
+  scope           String?   @db.VarChar
+  createdAt       DateTime  @default(now()) @db.Timestamp(6)
+  updatedAt       DateTime  @updatedAt @db.Timestamp(6)
+
+  @@index([deviceCode], map: "ix_device_code_device_code")
+  @@index([userCode], map: "ix_device_code_user_code")
+  @@map("device_codes")
+}
+
 // Workspace-level GitHub App installations.
 // One row per (workspace, GitHub installation). Multiple rows per workspace
 // supports the multi-org case (e.g. workspace has projects under github.com/acme

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -234,8 +234,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       better-auth:
-        specifier: ^1.6.11
-        version: 1.6.11(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(mongodb@7.1.0(socks@2.8.7))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(prisma@5.22.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+        specifier: ^1.6.27
+        version: 1.6.27(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(mongodb@7.1.0(socks@2.8.7))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(prisma@5.22.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -913,16 +913,16 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@better-auth/core@1.6.11':
-    resolution: {integrity: sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ==}
+  '@better-auth/core@1.6.27':
+    resolution: {integrity: sha512-A6/mQW4AT2kSHCRZDh9+k8jPUqnCUUCymzBgIroK0l60wLioMtJdcmZiTwrAn6KVUw+4XWw64MgaRn7LOie3wg==}
     peerDependencies:
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
       '@cloudflare/workers-types': '>=4'
       '@opentelemetry/api': ^1.9.0
-      better-call: 1.3.5
+      better-call: 1.4.0
       jose: ^6.1.0
-      kysely: ^0.28.5
+      kysely: ^0.28.5 || ^0.29.0
       nanostores: ^1.0.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
@@ -930,47 +930,47 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@better-auth/drizzle-adapter@1.6.11':
-    resolution: {integrity: sha512-4jpkETIGZOHCf7BK4jnu22fdN6jjomH0/HhEzkaWy3+Eppi5PYlHTF/460jrTmA3Xc+Vqwp9t282ymHiEPypGw==}
+  '@better-auth/drizzle-adapter@1.6.27':
+    resolution: {integrity: sha512-BDJ02ra/fji/ah3aIpxjjNOu/JQVex0UisxS4S0vGZZyiAs+DL24mn3/iovyD5dWB3u3NaGg1n8zpTOntiIXcg==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': ^1.6.27
+      '@better-auth/utils': 0.4.2
       drizzle-orm: ^0.45.2
     peerDependenciesMeta:
       drizzle-orm:
         optional: true
 
-  '@better-auth/kysely-adapter@1.6.11':
-    resolution: {integrity: sha512-/g8M9RfIjdcZDnbstSUvQiINkvdNlCeZr248zwqx2/PVksQI1MhQofbzUn3RnQnbPKp0EPwpX/dR3oudRFenUg==}
+  '@better-auth/kysely-adapter@1.6.27':
+    resolution: {integrity: sha512-aavv7W4+b3QVObYo166baplWvwocCk8ORDxRqQ9ytzVl/waiUpSXAOtDHdXZHFsoVHFVPtEzyEq0Tqr3Qvvfig==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
-      kysely: ^0.28.17
+      '@better-auth/core': ^1.6.27
+      '@better-auth/utils': 0.4.2
+      kysely: ^0.28.17 || ^0.29.0
     peerDependenciesMeta:
       kysely:
         optional: true
 
-  '@better-auth/memory-adapter@1.6.11':
-    resolution: {integrity: sha512-hpdfw0BBf8MuzLkIdmbcUZICbY9r/bhLO2RxSnkzT5+/O+0I0u2I8+m0YUP7vNllP/ZCKASHOYgXPLO75Z0f9Q==}
+  '@better-auth/memory-adapter@1.6.27':
+    resolution: {integrity: sha512-p4NB37MdaVFkxkpLEAKjORgTPhaOAPu1M2zgQXiTJJ3F6Uq3Y1YcCgoz+VxJu0TQfxibCsJD/dZlJMVgf+CF7A==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': ^1.6.27
+      '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.11':
-    resolution: {integrity: sha512-3Tor8rSv8vSEIMEaV2PFpPEuVhqc1gNoZ6eGvoh3LwExXXuj8madew6ob+H1pH7Aphn3Ar5PQ08AguT8TbwFAA==}
+  '@better-auth/mongo-adapter@1.6.27':
+    resolution: {integrity: sha512-IOYbJMIjEC//f+JpFlmIQjh6x1R/rGAfdzlojFk6HeAJqbsELuMcI+27dIoesbfHLF/icTrSpZtK986XhJrCfA==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': ^1.6.27
+      '@better-auth/utils': 0.4.2
       mongodb: ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
       mongodb:
         optional: true
 
-  '@better-auth/prisma-adapter@1.6.11':
-    resolution: {integrity: sha512-Pw+7q7zTp+VSci1V+CYMvuxIbAeVMZLe4lRo46LJoAKMHfjFl5T/ycsyFvWs/DkWC7n9gZZzRDEbHp0I5FiKKw==}
+  '@better-auth/prisma-adapter@1.6.27':
+    resolution: {integrity: sha512-v7DXVyaFbkrfLoiFDtcVF7BkEZgFa/DgEGE7XjrAXmMACa5pjDvb7lm8W5X+/qgIbQP04eThhgFQ6EWOsjr8OQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': ^1.6.27
+      '@better-auth/utils': 0.4.2
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
@@ -979,18 +979,21 @@ packages:
       prisma:
         optional: true
 
-  '@better-auth/telemetry@1.6.11':
-    resolution: {integrity: sha512-hsjDHc8MZbm6/AHeNdtywrWedXevnBjmdvnHTcZub+rTVjOv+Td0roI8USKuC6uUibmrl//2rJfVCsGbopihNA==}
+  '@better-auth/telemetry@1.6.27':
+    resolution: {integrity: sha512-aYrSiVWQfua8w5YX8X1cM6ca48EdS0t5k+CvYXIsruaNIpR1DXMe1DOD0M5FWAVABnlCf9joyHXbFRSIZSNY/A==}
     peerDependencies:
-      '@better-auth/core': ^1.6.11
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
+      '@better-auth/core': ^1.6.27
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
 
-  '@better-auth/utils@0.4.0':
-    resolution: {integrity: sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==}
+  '@better-auth/utils@0.4.2':
+    resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
 
-  '@better-fetch/fetch@1.1.21':
-    resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
+  '@better-auth/utils@0.5.0':
+    resolution: {integrity: sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA==}
+
+  '@better-fetch/fetch@1.3.1':
+    resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -3621,8 +3624,8 @@ packages:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
-  better-auth@1.6.11:
-    resolution: {integrity: sha512-Wwt6+q07dwIhsp6XiM7L1qSXVUWBEtNl+eZvwM778CguFqDZFBN9Pt6LtFaHl55t8Z+Zc//5kxcbgDY8/79vFQ==}
+  better-auth@1.6.27:
+    resolution: {integrity: sha512-x3jyxpAiBSsMO/DaXMFSVwM8bTqnYZlCKsZxBV43zL3ZtsGa/CzeUuNKxPT2Lsz7ahTBY90Ku1tibN6nRpVEbw==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -3683,8 +3686,8 @@ packages:
       vue:
         optional: true
 
-  better-call@1.3.5:
-    resolution: {integrity: sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==}
+  better-call@1.4.0:
+    resolution: {integrity: sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -5660,8 +5663,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rou3@0.7.12:
-    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+  rou3@0.9.2:
+    resolution: {integrity: sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -5690,8 +5693,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  set-cookie-parser@3.1.0:
-    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -7568,13 +7571,13 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)':
+  '@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)':
     dependencies:
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
       '@opentelemetry/semantic-conventions': 1.41.1
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.5(zod@4.4.3)
+      better-call: 1.4.0(zod@4.4.3)
       jose: 6.2.3
       kysely: 0.28.17
       nanostores: 1.3.0
@@ -7582,49 +7585,53 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
 
-  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/drizzle-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
 
-  '@better-auth/kysely-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
+  '@better-auth/kysely-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/memory-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(mongodb@7.1.0(socks@2.8.7))':
+  '@better-auth/mongo-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0(socks@2.8.7))':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
     optionalDependencies:
       mongodb: 7.1.0(socks@2.8.7)
 
-  '@better-auth/prisma-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@prisma/client@5.22.0(prisma@5.22.0))(prisma@5.22.0)':
+  '@better-auth/prisma-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@5.22.0(prisma@5.22.0))(prisma@5.22.0)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/utils': 0.4.0
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
     optionalDependencies:
       '@prisma/client': 5.22.0(prisma@5.22.0)
       prisma: 5.22.0
 
-  '@better-auth/telemetry@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
+  '@better-auth/telemetry@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
 
-  '@better-auth/utils@0.4.0':
+  '@better-auth/utils@0.4.2':
     dependencies:
       '@noble/hashes': 2.2.0
 
-  '@better-fetch/fetch@1.1.21': {}
+  '@better-auth/utils@0.5.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@better-fetch/fetch@1.3.1': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -10488,20 +10495,20 @@ snapshots:
 
   bcryptjs@3.0.3: {}
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(mongodb@7.1.0(socks@2.8.7))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(prisma@5.22.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)):
+  better-auth@1.6.27(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(mongodb@7.1.0(socks@2.8.7))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(prisma@5.22.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(mongodb@7.1.0(socks@2.8.7))
-      '@better-auth/prisma-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@prisma/client@5.22.0(prisma@5.22.0))(prisma@5.22.0)
-      '@better-auth/telemetry': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0(socks@2.8.7))
+      '@better-auth/prisma-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@prisma/client@5.22.0(prisma@5.22.0))(prisma@5.22.0)
+      '@better-auth/telemetry': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      better-call: 1.3.5(zod@4.4.3)
+      better-call: 1.4.0(zod@4.4.3)
       defu: 6.1.7
       jose: 6.2.3
       kysely: 0.28.17
@@ -10519,12 +10526,12 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-call@1.3.5(zod@4.4.3):
+  better-call@1.4.0(zod@4.4.3):
     dependencies:
-      '@better-auth/utils': 0.4.0
-      '@better-fetch/fetch': 1.1.21
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.0
+      '@better-auth/utils': 0.5.0
+      '@better-fetch/fetch': 1.3.1
+      rou3: 0.9.2
+      set-cookie-parser: 3.1.2
     optionalDependencies:
       zod: 4.4.3
 
@@ -12740,7 +12747,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
-  rou3@0.7.12: {}
+  rou3@0.9.2: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -12760,7 +12767,7 @@ snapshots:
 
   semver@7.8.1: {}
 
-  set-cookie-parser@3.1.0: {}
+  set-cookie-parser@3.1.2: {}
 
   sharp@0.34.5:
     dependencies:

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -27,7 +27,7 @@
     "@traceroot/github": "workspace:*",
     "@traceroot/slack": "workspace:*",
     "bcryptjs": "^3.0.3",
-    "better-auth": "^1.6.11",
+    "better-auth": "^1.6.27",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/frontend/ui/src/app/auth/sign-in/sign-in-client.tsx
+++ b/frontend/ui/src/app/auth/sign-in/sign-in-client.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
+import { safeCallbackUrl } from "@/lib/safe-callback-url";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
@@ -27,7 +28,8 @@ type SignInContentProps = {
 function SignInContent({ googleAuthConfigured }: SignInContentProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const callbackUrl = searchParams.get("callbackUrl") || "/";
+  // Attacker-suppliable query param; only same-origin destinations may pass.
+  const callbackUrl = safeCallbackUrl(searchParams.get("callbackUrl"));
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);

--- a/frontend/ui/src/lib/__tests__/device-user-code.test.ts
+++ b/frontend/ui/src/lib/__tests__/device-user-code.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { formatUserCode, generateUserCode } from "../device-user-code";
+
+const UNAMBIGUOUS_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const AMBIGUOUS_CHARS = ["0", "O", "1", "I"];
+const SAMPLES = 200;
+
+describe("generateUserCode", () => {
+  it("returns an 8-character code with no hyphen", () => {
+    for (let i = 0; i < SAMPLES; i++) {
+      const code = generateUserCode();
+      expect(code).toHaveLength(8);
+      expect(code).not.toContain("-");
+    }
+  });
+
+  it("only uses characters from the unambiguous alphabet", () => {
+    for (let i = 0; i < SAMPLES; i++) {
+      const code = generateUserCode();
+      for (const char of code) {
+        expect(UNAMBIGUOUS_ALPHABET).toContain(char);
+        expect(AMBIGUOUS_CHARS).not.toContain(char);
+      }
+    }
+  });
+});
+
+describe("formatUserCode", () => {
+  it("inserts exactly one hyphen, producing a 4-1-4 shape", () => {
+    const raw = generateUserCode();
+    const formatted = formatUserCode(raw);
+    expect(formatted).toHaveLength(9);
+    expect(formatted.split("-")).toHaveLength(2);
+    expect(formatted).toBe(`${raw.slice(0, 4)}-${raw.slice(4)}`);
+    expect(formatted).toMatch(/^[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+  });
+
+  it("round-trips: stripping the hyphen recovers the raw code", () => {
+    for (let i = 0; i < SAMPLES; i++) {
+      const raw = generateUserCode();
+      const formatted = formatUserCode(raw);
+      expect(formatted.replace(/-/g, "")).toBe(raw);
+    }
+  });
+});

--- a/frontend/ui/src/lib/__tests__/safe-callback-url.test.ts
+++ b/frontend/ui/src/lib/__tests__/safe-callback-url.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { safeCallbackUrl } from "../safe-callback-url";
+
+describe("safeCallbackUrl", () => {
+  it("falls back on missing or empty input", () => {
+    expect(safeCallbackUrl(null)).toBe("/");
+    expect(safeCallbackUrl(undefined)).toBe("/");
+    expect(safeCallbackUrl("")).toBe("/");
+  });
+
+  it("accepts same-origin paths, preserving query and hash", () => {
+    expect(safeCallbackUrl("/projects/p1/traces")).toBe("/projects/p1/traces");
+    expect(safeCallbackUrl("/device?user_code=ABCD-1234")).toBe("/device?user_code=ABCD-1234");
+    expect(safeCallbackUrl("/invites/abc#section")).toBe("/invites/abc#section");
+  });
+
+  it("normalizes a bare relative path onto the root", () => {
+    expect(safeCallbackUrl("settings")).toBe("/settings");
+  });
+
+  it("rejects absolute URLs to foreign origins", () => {
+    expect(safeCallbackUrl("https://evil.example/phish")).toBe("/");
+    expect(safeCallbackUrl("http://evil.example")).toBe("/");
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(safeCallbackUrl("//evil.example/phish")).toBe("/");
+  });
+
+  it("rejects dot-segment paths that normalize to a protocol-relative authority", () => {
+    // The parse is same-origin, but `/..` collapses to leave a leading `//`,
+    // which re-parses cross-origin at the redirect site.
+    expect(safeCallbackUrl("/..//evil.example/phish")).toBe("/");
+    expect(safeCallbackUrl("/../..//evil.example")).toBe("/");
+    expect(safeCallbackUrl("/foo/..//evil.example")).toBe("/");
+    expect(safeCallbackUrl("/.//evil.example")).toBe("/");
+    expect(safeCallbackUrl("/%2e%2e//evil.example")).toBe("/");
+  });
+
+  it("never returns a protocol-relative or non-absolute path", () => {
+    for (const raw of ["/..//evil.example", "//evil.example", "/\\evil.example", "javascript:x"]) {
+      const out = safeCallbackUrl(raw);
+      expect(out.startsWith("/")).toBe(true);
+      expect(out.startsWith("//")).toBe(false);
+    }
+  });
+
+  it("rejects the backslash authority trick", () => {
+    // Browsers treat a backslash after the leading slash as a slash, turning
+    // the value into a protocol-relative URL with a foreign authority.
+    expect(safeCallbackUrl("/\\evil.example")).toBe("/");
+    expect(safeCallbackUrl("\\/evil.example")).toBe("/");
+    expect(safeCallbackUrl("\\\\evil.example")).toBe("/");
+  });
+
+  it("rejects non-http schemes", () => {
+    expect(safeCallbackUrl("javascript:alert(1)")).toBe("/");
+    expect(safeCallbackUrl("data:text/html,<script>alert(1)</script>")).toBe("/");
+    expect(safeCallbackUrl("vbscript:msgbox(1)")).toBe("/");
+  });
+
+  it("uses the provided fallback for rejected values", () => {
+    expect(safeCallbackUrl("https://evil.example", "/home")).toBe("/home");
+    expect(safeCallbackUrl(null, "/home")).toBe("/home");
+  });
+});

--- a/frontend/ui/src/lib/auth-client.ts
+++ b/frontend/ui/src/lib/auth-client.ts
@@ -1,11 +1,11 @@
 "use client";
 
 import { createAuthClient } from "better-auth/react";
-import { adminClient } from "better-auth/client/plugins";
+import { adminClient, deviceAuthorizationClient } from "better-auth/client/plugins";
 
 export const authClient = createAuthClient({
   baseURL: process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000",
-  plugins: [adminClient()],
+  plugins: [adminClient(), deviceAuthorizationClient()],
 });
 
 export const { useSession, signIn, signOut, signUp } = authClient;

--- a/frontend/ui/src/lib/auth-clients.ts
+++ b/frontend/ui/src/lib/auth-clients.ts
@@ -1,0 +1,9 @@
+// client_id is display metadata for the consent screen, NOT a security boundary:
+// the device flow's security comes from the user approving a code in an authenticated
+// session, not from the client id. The allowlist just limits which ids may start a flow.
+export const DEVICE_CLIENT_IDS = new Set<string>(["traceroot-cli"]);
+
+// Human-readable names for the consent page, keyed by client id.
+export const DEVICE_CLIENT_NAMES: Record<string, string> = {
+  "traceroot-cli": "TraceRoot CLI",
+};

--- a/frontend/ui/src/lib/auth.ts
+++ b/frontend/ui/src/lib/auth.ts
@@ -1,8 +1,21 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
-import { admin } from "better-auth/plugins";
+import { admin, bearer, deviceAuthorization } from "better-auth/plugins";
 import { prisma } from "@traceroot/core";
 import { env } from "@/env";
+import { DEVICE_CLIENT_IDS } from "@/lib/auth-clients";
+
+// Unambiguous alphabet (no 0/O/1/I) so a user reading the code aloud, or typing
+// it from a screen at a glance, can't confuse similar-looking characters.
+const USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+// 8-character code split into two hyphenated groups (XXXX-XXXX) — easier to
+// read and re-type than a single unbroken run of 8 characters.
+function hyphenated8(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(8));
+  const chars = Array.from(bytes, (byte) => USER_CODE_ALPHABET[byte % USER_CODE_ALPHABET.length]);
+  return `${chars.slice(0, 4).join("")}-${chars.slice(4).join("")}`;
+}
 
 export const auth = betterAuth({
   database: prismaAdapter(prisma, {
@@ -38,6 +51,18 @@ export const auth = betterAuth({
   plugins: [
     admin({
       impersonationSessionDuration: 60 * 60 * 24, // 1 day
+    }),
+    // Lets a session token double as an `Authorization: Bearer <token>` header,
+    // which the CLI uses after completing the device flow. requireSignature must
+    // stay false (the default): device-flow tokens are unsigned, and turning on
+    // signature verification would reject every one of them.
+    bearer(),
+    deviceAuthorization({
+      expiresIn: "30m", // a sign-up round trip (not just sign-in) needs to fit in the window
+      interval: "5s",
+      generateUserCode: hyphenated8,
+      validateClient: (clientId) => DEVICE_CLIENT_IDS.has(clientId),
+      verificationUri: "/device",
     }),
   ],
 });

--- a/frontend/ui/src/lib/auth.ts
+++ b/frontend/ui/src/lib/auth.ts
@@ -4,18 +4,7 @@ import { admin, bearer, deviceAuthorization } from "better-auth/plugins";
 import { prisma } from "@traceroot/core";
 import { env } from "@/env";
 import { DEVICE_CLIENT_IDS } from "@/lib/auth-clients";
-
-// Unambiguous alphabet (no 0/O/1/I) so a user reading the code aloud, or typing
-// it from a screen at a glance, can't confuse similar-looking characters.
-const USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-
-// 8-character code split into two hyphenated groups (XXXX-XXXX) — easier to
-// read and re-type than a single unbroken run of 8 characters.
-function hyphenated8(): string {
-  const bytes = crypto.getRandomValues(new Uint8Array(8));
-  const chars = Array.from(bytes, (byte) => USER_CODE_ALPHABET[byte % USER_CODE_ALPHABET.length]);
-  return `${chars.slice(0, 4).join("")}-${chars.slice(4).join("")}`;
-}
+import { generateUserCode } from "@/lib/device-user-code";
 
 export const auth = betterAuth({
   database: prismaAdapter(prisma, {
@@ -60,7 +49,7 @@ export const auth = betterAuth({
     deviceAuthorization({
       expiresIn: "30m", // a sign-up round trip (not just sign-in) needs to fit in the window
       interval: "5s",
-      generateUserCode: hyphenated8,
+      generateUserCode,
       validateClient: (clientId) => DEVICE_CLIENT_IDS.has(clientId),
       verificationUri: "/device",
     }),

--- a/frontend/ui/src/lib/device-user-code.ts
+++ b/frontend/ui/src/lib/device-user-code.ts
@@ -1,0 +1,21 @@
+// Unambiguous alphabet (no 0/O/1/I) so a user reading the code aloud, or typing
+// it from a screen at a glance, can't confuse similar-looking characters.
+const USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+// Raw 8-character user code, no separators. This is what gets stored and what
+// the plugin's lookup routes compare against — better-auth's device-verify,
+// device-approve, and device-deny endpoints all strip hyphens from the
+// incoming code before querying (`user_code.replace(/-/g, "")`), so the
+// stored value must be hyphen-free or every lookup mismatches and fails with
+// INVALID_USER_CODE. Hyphens are added only at display time, via
+// formatUserCode below.
+export function generateUserCode(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(8));
+  return Array.from(bytes, (byte) => USER_CODE_ALPHABET[byte % USER_CODE_ALPHABET.length]).join("");
+}
+
+// Formats a raw 8-character code as "XXXX-XXXX" for display (the /device
+// page, CLI output). Not used for storage or lookup — see generateUserCode.
+export function formatUserCode(raw: string): string {
+  return `${raw.slice(0, 4)}-${raw.slice(4)}`;
+}

--- a/frontend/ui/src/lib/safe-callback-url.ts
+++ b/frontend/ui/src/lib/safe-callback-url.ts
@@ -1,0 +1,44 @@
+// The sign-in page redirects to `callbackUrl` after login. The value is
+// attacker-suppliable (it arrives in the query string of a link that renders
+// our real sign-in page), so an unvalidated redirect is an open redirect:
+// a phishing link can bounce a freshly-authenticated user to a foreign site.
+// Only same-origin destinations may pass; everything else falls back.
+
+const BASE = "http://same-origin.invalid";
+
+/**
+ * Validate a post-login redirect target as same-origin.
+ *
+ * Parses with the WHATWG URL parser against a sentinel base, so the known
+ * smuggling shapes are rejected by spec-compliant parsing rather than by
+ * pattern-matching: absolute URLs keep their own origin, protocol-relative
+ * `//host` and backslash variants (`/\host` — browsers treat the backslash
+ * as a slash) resolve to a foreign authority, and non-HTTP schemes
+ * (`javascript:`, `data:`) have no matching origin at all.
+ *
+ * Returns the normalized path (+ query + hash) for same-origin values, the
+ * fallback for everything else.
+ */
+export function safeCallbackUrl(raw: string | null | undefined, fallback = "/"): string {
+  if (!raw) {
+    return fallback;
+  }
+  let url: URL;
+  try {
+    url = new URL(raw, BASE);
+  } catch {
+    return fallback;
+  }
+  if (url.origin !== BASE) {
+    return fallback;
+  }
+  const target = url.pathname + url.search + url.hash;
+  // Same-origin parse is not enough: dot-segment normalization can collapse a
+  // leading `/..` and leave a protocol-relative path (`/..//host` -> `//host`),
+  // which re-parses cross-origin at the redirect site. A legitimate target is
+  // always a single-slash absolute path, so require exactly that.
+  if (!target.startsWith("/") || target.startsWith("//")) {
+    return fallback;
+  }
+  return target;
+}


### PR DESCRIPTION
**Stacked PR 1 of 11** — part of the CLI-login epic (#1863). Base: `main`.

Upgrades better-auth to 1.6.27 and adds the RFC 8628 device-authorization plugin with its code-table migration, plus same-origin validation of the sign-in callback. Foundation for CLI/device login.

Rebased onto latest `main`; drift checks (public OpenAPI + tool registry) are clean at this cut point. Review only the commits added on top of the base branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RFC 8628 device authorization for CLI login by upgrading `better-auth` to `1.6.27` and enabling device/bearer plugins, and fixes an open redirect by enforcing same‑origin sign‑in redirects. Previously, the sign‑in page accepted any `callbackUrl` and could redirect off‑site; now it only allows same‑origin paths and falls back to “/” when unsafe.

- Database: adds `device_codes` table with indexes on `device_code` and `user_code`. Required action: run the new Prisma migration for the core service before deploying.
- Server auth: enables `deviceAuthorization({ verificationUri: "/device", expiresIn: "30m", interval: "5s", validateClient: allowlist })` and `bearer()`; allowlists client id `traceroot-cli`. Keeps default signature verification to accept device‑flow tokens.
- Client auth: wires `deviceAuthorizationClient()` into the React auth client.
- Device codes: stores 8‑char user codes without hyphens and formats them as “XXXX‑XXXX” only for display, fixing lookup mismatches against plugin routes.
- Sign‑in safety: validates `callbackUrl` via `safeCallbackUrl` (same‑origin only; rejects absolute/protocol‑relative/non‑HTTP values; normalizes bare paths).
- Tests: adds unit tests for user‑code generation/formatting and callback‑URL validation.

<sup>Written for commit e5c077112a141b65ed16722a84c0e9a443756a62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

