### PR TITLE
feat(ui): device verification and consent page

### DIFF
--- a/frontend/ui/src/app/device/__tests__/device-client.test.tsx
+++ b/frontend/ui/src/app/device/__tests__/device-client.test.tsx
@@ -1,0 +1,293 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// The mocked `device` call must carry its `.approve`/`.deny` sub-mocks from
+// the moment it's created — vi.mock's factory below runs at import time
+// (before any later top-level statement in this file), so reassigning
+// `mocks.device` afterwards would be invisible to it.
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  useSession: vi.fn(),
+  device: Object.assign(vi.fn(), { approve: vi.fn(), deny: vi.fn() }),
+}));
+
+let searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => mocks.useSession(),
+    device: mocks.device,
+  },
+}));
+
+import { DeviceClient } from "../device-client";
+
+function setParams(params: Record<string, string>) {
+  searchParams = new URLSearchParams(params);
+}
+
+function signedIn(email = "kai@example.com") {
+  mocks.useSession.mockReturnValue({
+    data: { user: { email, name: "Kai" } },
+    isPending: false,
+  });
+}
+
+function signedOut() {
+  mocks.useSession.mockReturnValue({ data: null, isPending: false });
+}
+
+afterEach(() => {
+  cleanup();
+  mocks.push.mockReset();
+  mocks.useSession.mockReset();
+  mocks.device.mockReset();
+  mocks.device.approve.mockReset();
+  mocks.device.deny.mockReset();
+  searchParams = new URLSearchParams();
+});
+
+describe("DeviceClient", () => {
+  it("pre-fills the code entry input from ?user_code", () => {
+    setParams({ user_code: "abcd1234" });
+    signedOut();
+
+    render(<DeviceClient />);
+
+    const input = screen.getByLabelText("Device code") as HTMLInputElement;
+    expect(input.value).toBe("ABCD-1234");
+  });
+
+  it("shows an empty entry field when no code is present", () => {
+    signedOut();
+
+    render(<DeviceClient />);
+
+    const input = screen.getByLabelText("Device code") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
+  it("redirects to sign-in with the code preserved in callbackUrl when signed out", async () => {
+    setParams({ user_code: "abcd1234" });
+    signedOut();
+
+    render(<DeviceClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => expect(mocks.push).toHaveBeenCalled());
+    const target = mocks.push.mock.calls[0][0] as string;
+    expect(target).toBe(
+      `/auth/sign-in?callbackUrl=${encodeURIComponent("/device?user_code=ABCD1234")}`,
+    );
+  });
+
+  it("renders the client display name and the signed-in email on consent", async () => {
+    setParams({ user_code: "abcd1234", client_id: "traceroot-cli" });
+    signedIn("kai@example.com");
+    mocks.device.mockResolvedValue({
+      data: { user_code: "ABCD1234", status: "pending" },
+      error: null,
+    });
+
+    render(<DeviceClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => expect(screen.getByText("TraceRoot CLI")).toBeDefined());
+    expect(screen.getByText("as kai@example.com")).toBeDefined();
+    expect(screen.getByText("ABCD-1234")).toBeDefined();
+  });
+
+  it("falls back to a generic name for an unrecognized client id", async () => {
+    setParams({ user_code: "abcd1234", client_id: "some-other-app" });
+    signedIn();
+    mocks.device.mockResolvedValue({
+      data: { user_code: "ABCD1234", status: "pending" },
+      error: null,
+    });
+
+    render(<DeviceClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => expect(screen.getByText("A command-line application")).toBeDefined());
+  });
+
+  it("approves with the hyphen-stripped code and shows the success state", async () => {
+    setParams({ user_code: "abcd1234" });
+    signedIn();
+    mocks.device.mockResolvedValue({
+      data: { user_code: "ABCD1234", status: "pending" },
+      error: null,
+    });
+    mocks.device.approve.mockResolvedValue({ data: { success: true }, error: null });
+
+    render(<DeviceClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => screen.getByRole("button", { name: "Approve" }));
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => expect(screen.getByText("Approved")).toBeDefined());
+    expect(mocks.device.approve).toHaveBeenCalledWith({ userCode: "ABCD1234" });
+  });
+
+  it("denies and shows the denied state", async () => {
+    setParams({ user_code: "abcd1234" });
+    signedIn();
+    mocks.device.mockResolvedValue({
+      data: { user_code: "ABCD1234", status: "pending" },
+      error: null,
+    });
+    mocks.device.deny.mockResolvedValue({ data: { success: true }, error: null });
+
+    render(<DeviceClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => screen.getByRole("button", { name: "Deny" }));
+    fireEvent.click(screen.getByRole("button", { name: "Deny" }));
+
+    await waitFor(() => expect(screen.getByText("Denied")).toBeDefined());
+    expect(mocks.device.deny).toHaveBeenCalledWith({ userCode: "ABCD1234" });
+  });
+
+  it("surfaces an error instead of success when approval is rejected (not the claiming session)", async () => {
+    setParams({ user_code: "abcd1234" });
+    signedIn();
+    mocks.device.mockResolvedValue({
+      data: { user_code: "ABCD1234", status: "pending" },
+      error: null,
+    });
+    mocks.device.approve.mockResolvedValue({
+      data: null,
+      error: {
+        error: "access_denied",
+        error_description: "You are not authorized to approve this device authorization",
+      },
+    });
+
+    render(<DeviceClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => screen.getByRole("button", { name: "Approve" }));
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "This code isn't associated with your account, so it can't be approved or denied from here.",
+        ),
+      ).toBeDefined(),
+    );
+    expect(screen.queryByText("Approved")).toBeNull();
+  });
+
+  it("shows a mapped message for an expired code", async () => {
+    setParams({ user_code: "abcd1234" });
+    signedIn();
+    mocks.device.mockResolvedValue({
+      data: null,
+      error: { error: "expired_token", error_description: "User code has expired" },
+    });
+
+    render(<DeviceClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "This code has expired. Go back to your terminal and run the login command again.",
+        ),
+      ).toBeDefined(),
+    );
+  });
+
+  it("shows a mapped message for an invalid code", async () => {
+    setParams({ user_code: "abcd1234" });
+    signedIn();
+    mocks.device.mockResolvedValue({
+      data: null,
+      error: { error: "invalid_request", error_description: "Invalid user code" },
+    });
+
+    render(<DeviceClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "That code doesn't match a pending request. Double-check it and try again.",
+        ),
+      ).toBeDefined(),
+    );
+  });
+
+  it("shows an already-used message when the code has already been claimed", async () => {
+    setParams({ user_code: "abcd1234" });
+    signedIn();
+    mocks.device.mockResolvedValue({
+      data: { user_code: "ABCD1234", status: "approved" },
+      error: null,
+    });
+
+    render(<DeviceClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => expect(screen.getByText("This code has already been used.")).toBeDefined());
+  });
+
+  it("shows an entry error instead of submitting when the code field is empty", () => {
+    signedOut();
+
+    render(<DeviceClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(screen.getByText("Enter the code shown in your terminal.")).toBeDefined();
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error instead of the denied state when denial is rejected", async () => {
+    setParams({ user_code: "abcd1234" });
+    signedIn();
+    mocks.device.mockResolvedValue({
+      data: { user_code: "ABCD1234", status: "pending" },
+      error: null,
+    });
+    mocks.device.deny.mockResolvedValue({
+      data: null,
+      error: { error: "expired_token", error_description: "User code has expired" },
+    });
+
+    render(<DeviceClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => screen.getByRole("button", { name: "Deny" }));
+    fireEvent.click(screen.getByRole("button", { name: "Deny" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "This code has expired. Go back to your terminal and run the login command again.",
+        ),
+      ).toBeDefined(),
+    );
+    expect(screen.queryByText("Denied")).toBeNull();
+  });
+
+  it("returns to the entry form from an error state via Try again", async () => {
+    setParams({ user_code: "abcd1234" });
+    signedIn();
+    mocks.device.mockResolvedValue({
+      data: null,
+      error: { error: "expired_token", error_description: "User code has expired" },
+    });
+
+    render(<DeviceClient />);
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() => screen.getByRole("button", { name: "Try again" }));
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    const input = screen.getByLabelText("Device code") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+});

--- a/frontend/ui/src/app/device/__tests__/page.test.tsx
+++ b/frontend/ui/src/app/device/__tests__/page.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("../device-client", () => ({
+  DeviceClient: () => <div data-testid="device-client" />,
+}));
+
+import DevicePage from "../page";
+
+describe("DevicePage", () => {
+  it("renders the device client", () => {
+    render(<DevicePage />);
+    expect(screen.getByTestId("device-client")).toBeDefined();
+  });
+});

--- a/frontend/ui/src/app/device/device-client.tsx
+++ b/frontend/ui/src/app/device/device-client.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import { authClient } from "@/lib/auth-client";
+import { safeCallbackUrl } from "@/lib/safe-callback-url";
+import { formatUserCode } from "@/lib/device-user-code";
+import { DEVICE_CLIENT_IDS, DEVICE_CLIENT_NAMES } from "@/lib/auth-clients";
+import { mapDeviceErrorMessage } from "./device-error-messages";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Logo } from "@/components/Logo";
+
+const FALLBACK_CLIENT_NAME = "A command-line application";
+
+// Only the plugin's own record of a device code is authoritative on who's
+// asking. The `client_id` query param arrives on an unauthenticated GET
+// request and isn't checked against that record, so it's just as
+// attacker-suppliable as any other query string — reflecting it verbatim
+// would let a crafted link put arbitrary text on the consent screen. Only
+// resolve a display name for ids in the known allowlist; anything else falls
+// back to a generic label instead of parroting unverified text back to the
+// user.
+function resolveClientDisplayName(clientId: string | null): string {
+  if (!clientId || !DEVICE_CLIENT_IDS.has(clientId)) {
+    return FALLBACK_CLIENT_NAME;
+  }
+  return DEVICE_CLIENT_NAMES[clientId] ?? clientId;
+}
+
+// The plugin strips hyphens server-side before every lookup, so this is
+// purely for a forgiving input (users may paste the "XXXX-XXXX" display
+// form, or a mix of cases).
+function normalizeCodeInput(raw: string): string {
+  return raw.replace(/-/g, "").trim().toUpperCase();
+}
+
+type Phase =
+  | { kind: "entry" }
+  | { kind: "verifying" }
+  | { kind: "consent" }
+  | { kind: "approved" }
+  | { kind: "denied" }
+  | { kind: "error"; message: string };
+
+function DeviceContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { data: sessionData, isPending: sessionPending } = authClient.useSession();
+
+  const initialCode = normalizeCodeInput(searchParams.get("user_code") ?? "");
+  const clientId = searchParams.get("client_id");
+
+  const [codeInput, setCodeInput] = useState(initialCode ? formatUserCode(initialCode) : "");
+  const [entryError, setEntryError] = useState<string | null>(null);
+  const [activeCode, setActiveCode] = useState<string | null>(null);
+  const [phase, setPhase] = useState<Phase>({ kind: "entry" });
+  const [actionPending, setActionPending] = useState(false);
+
+  // Resolve the pending request once we have both a code and a signed-in
+  // session. Runs once per (activeCode, session) pair — activeCode only
+  // changes when the user (re)submits the entry form, and session identity
+  // is keyed off the user id rather than the whole object so a re-render
+  // with an equivalent-but-new session object doesn't re-trigger the fetch.
+  useEffect(() => {
+    if (!activeCode || sessionPending) {
+      return;
+    }
+
+    if (!sessionData?.user) {
+      // Round-trip the code through sign-in so it survives the redirect,
+      // including the Google OAuth hop. The target is built from user
+      // input (the entry field), so run it through the same same-origin
+      // guard used elsewhere before handing it to the router.
+      const target = safeCallbackUrl(`/device?user_code=${activeCode}`, "/device");
+      router.push(`/auth/sign-in?callbackUrl=${encodeURIComponent(target)}`);
+      return;
+    }
+
+    let cancelled = false;
+    setPhase({ kind: "verifying" });
+
+    (async () => {
+      const { data, error } = await authClient.device({ query: { user_code: activeCode } });
+      if (cancelled) {
+        return;
+      }
+      if (error) {
+        setPhase({ kind: "error", message: mapDeviceErrorMessage(error) });
+        return;
+      }
+      if (data && data.status !== "pending") {
+        setPhase({
+          kind: "error",
+          message: mapDeviceErrorMessage({
+            error: "invalid_request",
+            error_description: "Device code already processed",
+          }),
+        });
+        return;
+      }
+      setPhase({ kind: "consent" });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeCode, sessionPending, sessionData?.user?.id]);
+
+  function handleSubmitCode() {
+    const cleaned = normalizeCodeInput(codeInput);
+    if (!cleaned) {
+      setEntryError("Enter the code shown in your terminal.");
+      return;
+    }
+    setEntryError(null);
+    setActiveCode(cleaned);
+  }
+
+  async function handleApprove() {
+    if (!activeCode) {
+      return;
+    }
+    setActionPending(true);
+    const { error } = await authClient.device.approve({ userCode: activeCode });
+    setActionPending(false);
+    if (error) {
+      setPhase({ kind: "error", message: mapDeviceErrorMessage(error) });
+      return;
+    }
+    setPhase({ kind: "approved" });
+  }
+
+  async function handleDeny() {
+    if (!activeCode) {
+      return;
+    }
+    setActionPending(true);
+    const { error } = await authClient.device.deny({ userCode: activeCode });
+    setActionPending(false);
+    if (error) {
+      setPhase({ kind: "error", message: mapDeviceErrorMessage(error) });
+      return;
+    }
+    setPhase({ kind: "denied" });
+  }
+
+  function handleStartOver() {
+    setActiveCode(null);
+    setEntryError(null);
+    setCodeInput("");
+    setPhase({ kind: "entry" });
+  }
+
+  return (
+    <div className="flex h-full min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mb-2 flex justify-center">
+            <Logo size="lg" />
+          </div>
+          <CardTitle className="text-lg font-semibold">Device sign-in</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {phase.kind === "entry" && (
+            <CodeEntry
+              value={codeInput}
+              onChange={setCodeInput}
+              onSubmit={handleSubmitCode}
+              error={entryError}
+            />
+          )}
+
+          {phase.kind === "verifying" && (
+            <div className="flex flex-col items-center gap-2 py-6 text-[13px] text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              <p>Checking your code...</p>
+            </div>
+          )}
+
+          {phase.kind === "consent" && activeCode && (
+            <Consent
+              clientName={resolveClientDisplayName(clientId)}
+              email={sessionData?.user?.email ?? null}
+              code={activeCode}
+              pending={actionPending}
+              onApprove={handleApprove}
+              onDeny={handleDeny}
+            />
+          )}
+
+          {phase.kind === "approved" && <Approved />}
+
+          {phase.kind === "denied" && <Denied />}
+
+          {phase.kind === "error" && (
+            <ErrorState message={phase.message} onStartOver={handleStartOver} />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+type CodeEntryProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  error: string | null;
+};
+
+function CodeEntry({ value, onChange, onSubmit, error }: CodeEntryProps) {
+  return (
+    <div className="space-y-4">
+      <p className="text-center text-[13px] text-muted-foreground">
+        Enter the code shown in your terminal to sign in on this device.
+      </p>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSubmit();
+        }}
+        className="space-y-3"
+      >
+        <div>
+          <label htmlFor="device-code" className="mb-1 block text-[13px] font-medium">
+            Device code
+          </label>
+          <Input
+            id="device-code"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder="XXXX-XXXX"
+            className="h-9 text-center text-[15px] tracking-widest"
+            autoFocus
+          />
+          {error && <p className="mt-1 text-[11px] text-red-500">{error}</p>}
+        </div>
+        <Button type="submit" size="sm" className="h-8 w-full text-[13px]">
+          Continue
+        </Button>
+      </form>
+    </div>
+  );
+}
+
+type ConsentProps = {
+  clientName: string;
+  email: string | null;
+  code: string;
+  pending: boolean;
+  onApprove: () => void;
+  onDeny: () => void;
+};
+
+function Consent({ clientName, email, code, pending, onApprove, onDeny }: ConsentProps) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1 text-center">
+        <p className="text-[13px]">
+          <span className="font-medium">{clientName}</span> wants to sign in
+        </p>
+        {email && <p className="text-[12px] text-muted-foreground">as {email}</p>}
+      </div>
+
+      <div className="border bg-muted/50 px-3 py-2 text-center">
+        <p className="text-[11px] uppercase text-muted-foreground">Confirm this code</p>
+        <p className="text-[18px] font-semibold tracking-widest">{formatUserCode(code)}</p>
+      </div>
+
+      <p className="text-[12px] text-muted-foreground">
+        This grants {clientName} read access to your workspaces. You can revoke it any time from
+        Active Sessions in your account settings.
+      </p>
+
+      <p className="border border-amber-200 bg-amber-50 p-2 text-[11px] text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
+        Only approve a code you generated yourself just now. If you didn&apos;t start a traceroot
+        login, deny this.
+      </p>
+
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 flex-1 text-[13px]"
+          onClick={onDeny}
+          disabled={pending}
+        >
+          Deny
+        </Button>
+        <Button size="sm" className="h-8 flex-1 text-[13px]" onClick={onApprove} disabled={pending}>
+          {pending ? "Working..." : "Approve"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Approved() {
+  return (
+    <div className="py-4 text-center">
+      <p className="text-[14px] font-medium">Approved</p>
+      <p className="mt-1 text-[13px] text-muted-foreground">You can return to your terminal.</p>
+    </div>
+  );
+}
+
+function Denied() {
+  return (
+    <div className="py-4 text-center">
+      <p className="text-[14px] font-medium">Denied</p>
+      <p className="mt-1 text-[13px] text-muted-foreground">
+        This sign-in request was denied. You can close this page.
+      </p>
+    </div>
+  );
+}
+
+type ErrorStateProps = {
+  message: string;
+  onStartOver: () => void;
+};
+
+function ErrorState({ message, onStartOver }: ErrorStateProps) {
+  return (
+    <div className="space-y-3 py-2 text-center">
+      <p className="text-[13px] text-red-600 dark:text-red-400">{message}</p>
+      <Button variant="outline" size="sm" className="h-8 text-[13px]" onClick={onStartOver}>
+        Try again
+      </Button>
+    </div>
+  );
+}
+
+export function DeviceClient() {
+  return (
+    <Suspense>
+      <DeviceContent />
+    </Suspense>
+  );
+}

--- a/frontend/ui/src/app/device/device-error-messages.test.ts
+++ b/frontend/ui/src/app/device/device-error-messages.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { mapDeviceErrorMessage } from "./device-error-messages";
+
+describe("mapDeviceErrorMessage", () => {
+  it("maps expired_token", () => {
+    expect(
+      mapDeviceErrorMessage({ error: "expired_token", error_description: "User code has expired" }),
+    ).toBe("This code has expired. Go back to your terminal and run the login command again.");
+  });
+
+  it("maps access_denied", () => {
+    expect(
+      mapDeviceErrorMessage({
+        error: "access_denied",
+        error_description: "You are not authorized",
+      }),
+    ).toBe(
+      "This code isn't associated with your account, so it can't be approved or denied from here.",
+    );
+  });
+
+  it("maps unauthorized", () => {
+    expect(
+      mapDeviceErrorMessage({
+        error: "unauthorized",
+        error_description: "Authentication required",
+      }),
+    ).toBe("You need to sign in again before continuing.");
+  });
+
+  it("maps an already-processed invalid_request by description", () => {
+    expect(
+      mapDeviceErrorMessage({
+        error: "invalid_request",
+        error_description: "Device code already processed",
+      }),
+    ).toBe("This code has already been used.");
+  });
+
+  it("maps a not-yet-claimed invalid_request by description", () => {
+    expect(
+      mapDeviceErrorMessage({
+        error: "invalid_request",
+        error_description: "Device code has not been claimed by a verifying session",
+      }),
+    ).toBe("This code hasn't been verified yet. Go back and re-enter it.");
+  });
+
+  it("maps an unknown-code invalid_request by description", () => {
+    expect(
+      mapDeviceErrorMessage({ error: "invalid_request", error_description: "Invalid user code" }),
+    ).toBe("That code doesn't match a pending request. Double-check it and try again.");
+  });
+
+  it("falls back to the raw description for an unrecognized error", () => {
+    expect(
+      mapDeviceErrorMessage({ error: "some_new_error", error_description: "Something odd" }),
+    ).toBe("Something odd");
+  });
+
+  it("falls back to a generic message when there is no description", () => {
+    expect(mapDeviceErrorMessage({ error: "some_new_error" })).toBe(
+      "Something went wrong. Please try again.",
+    );
+    expect(mapDeviceErrorMessage(null)).toBe("Something went wrong. Please try again.");
+    expect(mapDeviceErrorMessage(undefined)).toBe("Something went wrong. Please try again.");
+  });
+});

--- a/frontend/ui/src/app/device/device-error-messages.ts
+++ b/frontend/ui/src/app/device/device-error-messages.ts
@@ -1,0 +1,45 @@
+// The device-authorization plugin reuses the single "invalid_request" error
+// code for several distinct situations (unknown code, already-approved code,
+// not-yet-claimed code), so the short `error` code alone can't tell them
+// apart — the human-readable `error_description` text is what disambiguates.
+// Matching on that text (rather than a brittle status/response-shape check)
+// keeps this working even though the description strings live in the
+// installed better-auth package, not in this repo.
+export type DeviceErrorLike = {
+  error?: string;
+  error_description?: string;
+};
+
+/**
+ * Map a device-authorization plugin error response to a plain-language
+ * message for the /device consent page.
+ *
+ * @param err - The `{ error, error_description }` body returned by the
+ *   plugin's device endpoints (verify/approve/deny) on failure.
+ * @returns A user-facing sentence describing what went wrong.
+ */
+export function mapDeviceErrorMessage(err: DeviceErrorLike | null | undefined): string {
+  const code = err?.error;
+  const description = err?.error_description;
+
+  if (code === "expired_token") {
+    return "This code has expired. Go back to your terminal and run the login command again.";
+  }
+  if (code === "access_denied") {
+    return "This code isn't associated with your account, so it can't be approved or denied from here.";
+  }
+  if (code === "unauthorized") {
+    return "You need to sign in again before continuing.";
+  }
+  if (description?.includes("already processed")) {
+    return "This code has already been used.";
+  }
+  if (description?.includes("not been claimed")) {
+    return "This code hasn't been verified yet. Go back and re-enter it.";
+  }
+  if (description?.includes("Invalid user code")) {
+    return "That code doesn't match a pending request. Double-check it and try again.";
+  }
+
+  return description || "Something went wrong. Please try again.";
+}

--- a/frontend/ui/src/app/device/page.tsx
+++ b/frontend/ui/src/app/device/page.tsx
@@ -1,0 +1,7 @@
+import { DeviceClient } from "./device-client";
+
+export const dynamic = "force-dynamic";
+
+export default function DevicePage() {
+  return <DeviceClient />;
+}


### PR DESCRIPTION
**Stacked PR 2 of 11** — part of the CLI-login epic (#1863). Base: `feat/device-authorization`.

Adds the /device verification + consent page where a user approves a device code in an authenticated browser session.

Rebased onto latest `main`; drift checks (public OpenAPI + tool registry) are clean at this cut point. Review only the commits added on top of the base branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `/device` verification and consent page for CLI login so users can approve or deny a device code in an authenticated browser session. Previously there was no UI; now the page supports code entry/prefill, a sign-in redirect that preserves the code, consent with client and identity, and clear success/error states.

- Verifies a submitted code via `authClient.device({ query: { user_code } })`, then shows consent with an allowlisted client name from `DEVICE_CLIENT_IDS`/`DEVICE_CLIENT_NAMES` (unknown ids fall back to “A command-line application”).
- Prefills from `?user_code`, normalizes input, and formats display (`XXXX-XXXX`). If signed out, redirects to `/auth/sign-in?callbackUrl=...` using `safeCallbackUrl` to keep the return URL same-origin.
- Approves/denies with `authClient.device.approve/deny({ userCode })`, showing “Approved”/“Denied” or a mapped error via `mapDeviceErrorMessage` (expired, already used, invalid, or wrong session). “Try again” resets to entry.
- Route is dynamic (`export const dynamic = "force-dynamic"`). Tests cover entry, redirect, consent, approve/deny, and error mappings.

<sup>Written for commit 4de691b0e275e09d863249ae03986ed91e3c618f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

