### PR TITLE
feat(auth): dual-credential public API auth dependency

### DIFF
--- a/backend/rest/routers/public/deps.py
+++ b/backend/rest/routers/public/deps.py
@@ -10,10 +10,10 @@ Postgres/Prisma control-plane data.
 import hashlib
 import logging
 from dataclasses import dataclass
-from typing import Annotated
+from typing import Annotated, Literal
 
 import httpx
-from fastapi import Depends, Header, HTTPException, Request, status
+from fastapi import Depends, Header, HTTPException, Query, Request, status
 
 from rest.rate_limit import clear_request_rate_limit_exempt, set_rate_limit_identity
 from shared.config import settings
@@ -29,6 +29,11 @@ class AuthResult:
     (``project_name``/``workspace_name``/``key_name``/``key_hint``) power the
     ``whoami`` endpoint; they are optional because ``validate-api-key`` may not
     return them, and ingestion does not need them.
+
+    ``kind`` discriminates the credential that produced this result: an API key
+    (``"api_key"``, the default so every existing construction stays valid) or a
+    user session token (``"user"``). ``user_id``/``role`` are populated only on
+    the user path; they are ``None`` for API-key results.
     """
 
     project_id: str
@@ -39,6 +44,9 @@ class AuthResult:
     workspace_name: str | None = None
     key_name: str | None = None
     key_hint: str | None = None
+    kind: Literal["api_key", "user"] = "api_key"
+    user_id: str | None = None
+    role: str | None = None
 
 
 async def authenticate_api_key(
@@ -152,6 +160,7 @@ async def authenticate_api_key(
         )
 
     return AuthResult(
+        kind="api_key",
         project_id=project_id,
         workspace_id=workspace_id,
         billing_plan=billing_plan,
@@ -191,3 +200,219 @@ async def authenticate_and_stamp_identity(request: Request, auth: Auth) -> AuthR
 
 
 StampedAuth = Annotated[AuthResult, Depends(authenticate_and_stamp_identity)]
+
+
+async def authenticate_user_token(token: str, project_id: str) -> AuthResult:
+    """Authenticate a user session token against the internal validate-user-token route.
+
+    Mirrors :func:`authenticate_api_key`'s httpx structure and fail-closed 503
+    mapping. The token is a better-auth session token (the CLI's credential), not
+    an API key; it is POSTed to the internal route for introspection and is never
+    logged. A non-empty ``project_id`` is required — the caller guarantees it.
+
+    Args:
+        token (str): The raw user session token to validate. Never logged.
+        project_id (str): The project the caller is scoping the request to; sent
+            to the internal route so it can check membership and access.
+
+    Returns:
+        AuthResult: A ``kind="user"`` result carrying the resolved project,
+            workspace, plan, role, and user id. ``ingestion_blocked`` is always
+            ``True`` for user credentials (see below).
+
+    Raises:
+        HTTPException: 401 for an invalid/expired token, 403 when the token is
+            valid but has no access to ``project_id``, and 503 (fail closed) for
+            any introspection ambiguity — network error, unexpected status, or a
+            malformed/incomplete 200 body.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(
+                f"{settings.traceroot_ui_url}/api/internal/validate-user-token",
+                json={"token": token, "projectId": project_id},
+                headers={"X-Internal-Secret": settings.internal_api_secret},
+            )
+    except httpx.RequestError as e:
+        logger.error(f"Failed to validate user token: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service unavailable",
+        ) from e
+
+    if response.status_code == 401:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication failed",
+        )
+
+    # A valid token that simply lacks access to this project — instructive, not a 503.
+    if response.status_code == 403:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"No access to project '{project_id}'",
+        )
+
+    if response.status_code != 200:
+        logger.error(f"Unexpected response from auth service: {response.status_code}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        )
+
+    # A 200 with a malformed body (non-JSON, or a non-object) is an auth-service
+    # error, not a client error — surface a controlled 503, never an uncaught 500.
+    try:
+        data = response.json()
+    except ValueError as e:
+        logger.error(f"Malformed JSON from auth service: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        ) from e
+
+    if not isinstance(data, dict):
+        logger.error("Auth service returned a non-object JSON body")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        )
+
+    if not data.get("valid"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=data.get("error", "Invalid token"),
+        )
+
+    # A valid:true (200) response missing required project fields is malformed → 503.
+    try:
+        resolved_project_id = data["projectId"]
+        workspace_id = data["workspaceId"]
+        billing_plan = data["billingPlan"]
+        role = data["role"]
+        user_id = data["userId"]
+    except KeyError as e:
+        logger.error(f"Auth service response missing required field: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        ) from e
+
+    # An empty workspaceId would key every such tenant into one shared rate-limit
+    # bucket. Reject it too (parity with the API-key path).
+    if not workspace_id:
+        logger.error("Auth service response has an empty workspaceId")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        )
+
+    return AuthResult(
+        kind="user",
+        project_id=resolved_project_id,
+        workspace_id=workspace_id,
+        billing_plan=billing_plan,
+        # ingestion is API-key-only: a user session token must never be usable to
+        # ingest. Block it defensively even though no route wires user auth to
+        # ingest, so the invariant holds regardless of future route wiring.
+        ingestion_blocked=True,
+        role=role,
+        user_id=user_id,
+    )
+
+
+async def authenticate_public_caller(
+    authorization: Annotated[str | None, Header()] = None,
+    project_id: Annotated[str | None, Query()] = None,
+) -> AuthResult:
+    """Authenticate a public caller by either an API key or a user session token.
+
+    The unified public-API auth dependency. It parses the bearer token exactly
+    like :func:`authenticate_api_key`, then discriminates on the ``tr-`` prefix:
+    API keys are ``tr-<uuid>``; user session tokens never start with ``tr-``.
+
+    Security invariant: a ``tr-``-prefixed value can never reach
+    :func:`authenticate_user_token` — it always routes to the API-key validator.
+    Conversely a non-``tr-`` value never reaches the key validator.
+
+    Args:
+        authorization (str | None): The ``Authorization: Bearer <token>`` header.
+        project_id (str | None): Optional ``project_id`` query parameter. For an
+            API key it is an optional cross-check; for a user token it is required
+            (a user credential is only meaningful scoped to a project).
+
+    Returns:
+        AuthResult: The API-key result (``kind="api_key"``) or the user result
+            (``kind="user"``).
+
+    Raises:
+        HTTPException: 401 for a missing/malformed header (or failed auth), 400
+            when ``project_id`` is missing for a user token or contradicts the
+            API key's project, 403/503 per the delegated validators.
+    """
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header",
+        )
+
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Authorization header format. Expected: Bearer <token>",
+        )
+
+    token = parts[1]
+
+    if token.startswith("tr-"):
+        # Key path: reuse the existing validator verbatim (do not duplicate it).
+        result = await authenticate_api_key(authorization)
+        # An API key already fixes its project; a provided project_id may only
+        # confirm it, never override it.
+        if project_id and project_id != result.project_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="project_id does not match the API key's project",
+            )
+        return result
+
+    # User path: a user credential is only meaningful scoped to a project.
+    if not project_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "project_id query parameter is required for user credentials; "
+                "call list_projects to find one."
+            ),
+        )
+    return await authenticate_user_token(token, project_id)
+
+
+DualAuth = Annotated[AuthResult, Depends(authenticate_public_caller)]
+
+
+async def authenticate_and_stamp_public_caller(request: Request, auth: DualAuth) -> AuthResult:
+    """Authenticate a public caller, then stamp workspace/plan for rate limiting.
+
+    The dual-credential analog of :func:`authenticate_and_stamp_identity`: both
+    credential kinds carry ``workspace_id`` and ``billing_plan`` for
+    project-scoped requests, so the stamping is identical. It runs during
+    dependency resolution — before slowapi evaluates the limit — so ``key_func``
+    sees the identity on ``request.state``.
+
+    Args:
+        request (Request): Incoming request; its ``state`` is stamped with the
+            resolved rate-limit identity.
+        auth (DualAuth): Dual-credential auth dependency resolving the workspace
+            and plan.
+
+    Returns:
+        AuthResult: The authenticated result, passed through to the route handler.
+    """
+    clear_request_rate_limit_exempt()
+    set_rate_limit_identity(request, auth.workspace_id, auth.billing_plan)
+    return auth
+
+
+DualStampedAuth = Annotated[AuthResult, Depends(authenticate_and_stamp_public_caller)]

--- a/backend/rest/routers/public/deps.py
+++ b/backend/rest/routers/public/deps.py
@@ -365,7 +365,20 @@ async def authenticate_public_caller(
 
     token = parts[1]
 
-    if token.startswith("tr-"):
+    # An empty/whitespace-only token is a malformed credential, not an upstream
+    # outage — reject it here as 401 rather than letting it reach a validator and
+    # surface as a misleading 503.
+    if not token.strip():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Authorization header. Expected: Bearer <token>",
+        )
+
+    # Discriminate case-insensitively and ignoring surrounding whitespace so any
+    # key-shaped value (e.g. "TR-…", or a stray-space " tr-…") routes to the key
+    # validator — where the raw key is hashed before it leaves this process — and
+    # never to the user endpoint, which would POST the raw key unhashed.
+    if token.strip().lower().startswith("tr-"):
         # Key path: reuse the existing validator verbatim (do not duplicate it).
         result = await authenticate_api_key(authorization)
         # An API key already fixes its project; a provided project_id may only

--- a/frontend/ui/src/app/api/internal/validate-user-token/route.test.ts
+++ b/frontend/ui/src/app/api/internal/validate-user-token/route.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextRequest: class {},
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+const projectFindUniqueMock = vi.fn();
+const memberFindUniqueMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    project: {
+      findUnique: (...args: unknown[]) => projectFindUniqueMock(...args),
+    },
+    workspaceMember: {
+      findUnique: (...args: unknown[]) => memberFindUniqueMock(...args),
+    },
+  },
+  PlanType: { FREE: "free" },
+}));
+
+const verifyInternalSecretMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  verifyInternalSecret: (...args: unknown[]) => verifyInternalSecretMock(...args),
+}));
+
+const getSessionMock = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: (...args: unknown[]) => getSessionMock(...args) } },
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: unknown) {
+  return { json: async () => body } as unknown as Parameters<typeof POST>[0];
+}
+
+beforeEach(() => {
+  projectFindUniqueMock.mockReset();
+  memberFindUniqueMock.mockReset();
+  verifyInternalSecretMock.mockReset();
+  verifyInternalSecretMock.mockReturnValue(true);
+  getSessionMock.mockReset();
+});
+
+describe("POST /api/internal/validate-user-token", () => {
+  it("rejects an unauthorized caller before touching auth or the database", async () => {
+    verifyInternalSecretMock.mockReturnValue(false);
+
+    const res = await POST(makeRequest({ token: "tok" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toEqual({ valid: false, error: "Unauthorized" });
+    expect(getSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    const badRequest = {
+      json: async () => {
+        throw new SyntaxError("bad json");
+      },
+    } as unknown as Parameters<typeof POST>[0];
+
+    const res = await POST(badRequest);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.valid).toBe(false);
+  });
+
+  it("returns 400 when token is missing", async () => {
+    const res = await POST(makeRequest({}));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.valid).toBe(false);
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 401 when getSession resolves no session", async () => {
+    getSessionMock.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ token: "tok" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toEqual({ valid: false, error: "invalid or expired token" });
+  });
+
+  it("treats a getSession throw as an invalid token, not a 500", async () => {
+    getSessionMock.mockRejectedValue(new Error("boom"));
+
+    const res = await POST(makeRequest({ token: "tok" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toEqual({ valid: false, error: "invalid or expired token" });
+  });
+
+  it("account-scope: no projectId returns valid + userId + email", async () => {
+    getSessionMock.mockResolvedValue({
+      user: { id: "user-1", email: "user@example.com" },
+    });
+
+    const res = await POST(makeRequest({ token: "tok" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ valid: true, userId: "user-1", email: "user@example.com" });
+    expect(projectFindUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("project-scope: member returns valid + role/workspaceId/billingPlan/projectId", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
+    projectFindUniqueMock.mockResolvedValue({
+      id: "proj-123",
+      workspaceId: "ws-456",
+      workspace: { billingPlan: "pro" },
+    });
+    memberFindUniqueMock.mockResolvedValue({ role: "admin" });
+
+    const res = await POST(makeRequest({ token: "tok", projectId: "proj-123" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      valid: true,
+      userId: "user-1",
+      role: "admin",
+      workspaceId: "ws-456",
+      billingPlan: "pro",
+      projectId: "proj-123",
+    });
+  });
+
+  it("project-scope: falls back to the FREE plan when the workspace has no billingPlan", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
+    projectFindUniqueMock.mockResolvedValue({
+      id: "proj-123",
+      workspaceId: "ws-456",
+      workspace: { billingPlan: null },
+    });
+    memberFindUniqueMock.mockResolvedValue({ role: "viewer" });
+
+    const res = await POST(makeRequest({ token: "tok", projectId: "proj-123" }));
+    const body = await res.json();
+
+    expect(body.billingPlan).toBe("free");
+  });
+
+  it("project-scope: project not found returns valid:true, hasAccess:false at 403", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
+    projectFindUniqueMock.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ token: "tok", projectId: "missing" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body).toEqual({ valid: true, hasAccess: false });
+    expect(memberFindUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("project-scope: not a member returns valid:true, hasAccess:false at 403", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
+    projectFindUniqueMock.mockResolvedValue({
+      id: "proj-123",
+      workspaceId: "ws-456",
+      workspace: { billingPlan: "pro" },
+    });
+    memberFindUniqueMock.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ token: "tok", projectId: "proj-123" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body).toEqual({ valid: true, hasAccess: false });
+  });
+});

--- a/frontend/ui/src/app/api/internal/validate-user-token/route.ts
+++ b/frontend/ui/src/app/api/internal/validate-user-token/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma, PlanType } from "@traceroot/core";
+import { verifyInternalSecret } from "@/lib/auth-helpers";
+import { auth } from "@/lib/auth";
+
+const validateUserTokenSchema = z.object({
+  token: z.string().min(1, "Token is required"),
+  projectId: z.string().optional(),
+});
+
+// POST /api/internal/validate-user-token
+// Internal endpoint for Python backend to validate a user's session token (the CLI's credential)
+export async function POST(request: NextRequest) {
+  // Verify internal secret
+  if (!verifyInternalSecret(request)) {
+    return NextResponse.json({ valid: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ valid: false, error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const result = validateUserTokenSchema.safeParse(body);
+  if (!result.success) {
+    return NextResponse.json(
+      { valid: false, error: result.error.issues[0].message },
+      { status: 400 },
+    );
+  }
+
+  const { token, projectId } = result.data;
+
+  // Resolve the session via the bearer plugin, which accepts the session token as an
+  // Authorization header in place of the cookie. Never log the token or these headers.
+  let session: Awaited<ReturnType<typeof auth.api.getSession>>;
+  try {
+    session = await auth.api.getSession({
+      headers: new Headers({ Authorization: `Bearer ${token}` }),
+    });
+  } catch {
+    session = null;
+  }
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ valid: false, error: "invalid or expired token" }, { status: 401 });
+  }
+
+  const { user } = session;
+
+  // Account-scope: no project requested, so a live session is sufficient (e.g. list_workspaces).
+  if (!projectId) {
+    return NextResponse.json({ valid: true, userId: user.id, email: user.email });
+  }
+
+  // Project-scoped: `valid` stays true (the token is a real live session) even when the
+  // session has no access to this project — that distinction is carried by `hasAccess`.
+  const project = await prisma.project.findUnique({
+    where: { id: projectId, deleteTime: null },
+    select: {
+      id: true,
+      workspaceId: true,
+      workspace: { select: { billingPlan: true } },
+    },
+  });
+
+  if (!project) {
+    return NextResponse.json({ valid: true, hasAccess: false }, { status: 403 });
+  }
+
+  const membership = await prisma.workspaceMember.findUnique({
+    where: {
+      workspaceId_userId: {
+        workspaceId: project.workspaceId,
+        userId: user.id,
+      },
+    },
+    select: { role: true },
+  });
+
+  if (!membership) {
+    return NextResponse.json({ valid: true, hasAccess: false }, { status: 403 });
+  }
+
+  return NextResponse.json({
+    valid: true,
+    userId: user.id,
+    role: membership.role,
+    workspaceId: project.workspaceId,
+    billingPlan: project.workspace?.billingPlan || PlanType.FREE,
+    projectId: project.id,
+  });
+}

--- a/tests/rest/test_auth_deps.py
+++ b/tests/rest/test_auth_deps.py
@@ -13,9 +13,46 @@ from fastapi import HTTPException
 from httpx import Response
 
 from rest.routers.deps import get_project_access
+from rest.routers.public.deps import (
+    authenticate_public_caller,
+    authenticate_user_token,
+)
 from rest.routers.public.traces import AuthResult, authenticate_api_key
 
 BASE_URL = "http://localhost:3000"
+
+
+def _mock_valid_key(project_id: str = "proj-123"):
+    """Mock validate-api-key returning a valid member key for ``project_id``."""
+    return respx.post(f"{BASE_URL}/api/internal/validate-api-key").mock(
+        return_value=Response(
+            200,
+            json={
+                "valid": True,
+                "projectId": project_id,
+                "workspaceId": "ws-456",
+                "billingPlan": "pro",
+                "ingestionBlocked": False,
+            },
+        )
+    )
+
+
+def _mock_valid_user_token(project_id: str = "proj-123"):
+    """Mock validate-user-token returning the project-member 200 shape."""
+    return respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+        return_value=Response(
+            200,
+            json={
+                "valid": True,
+                "userId": "user-789",
+                "role": "ADMIN",
+                "workspaceId": "ws-456",
+                "billingPlan": "pro",
+                "projectId": project_id,
+            },
+        )
+    )
 
 
 # ── authenticate_api_key ────────────────────────────────────────────────
@@ -302,3 +339,214 @@ class TestGetProjectAccess:
             await get_project_access("proj-123", "user-456")
         assert exc_info.value.status_code == 503
         assert exc_info.value.detail == "Authentication service error"
+
+
+# ── authenticate_user_token ─────────────────────────────────────────────
+
+
+class TestAuthenticateUserToken:
+    @respx.mock
+    async def test_valid_member_token(self):
+        _mock_valid_user_token()
+        result = await authenticate_user_token("sess-token-abc", "proj-123")
+        assert result.kind == "user"
+        assert result.project_id == "proj-123"
+        assert result.workspace_id == "ws-456"
+        assert result.billing_plan == "pro"
+        assert result.role == "ADMIN"
+        assert result.user_id == "user-789"
+        # A user session token must never be usable to ingest.
+        assert result.ingestion_blocked is True
+
+    @respx.mock
+    async def test_401_returns_401(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(401, json={"valid": False, "error": "invalid or expired token"})
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_user_token("bad-token", "proj-123")
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    async def test_403_no_access_returns_403(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(403, json={"valid": True, "hasAccess": False})
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_user_token("sess-token", "proj-999")
+        assert exc_info.value.status_code == 403
+        assert "proj-999" in exc_info.value.detail
+
+    @respx.mock
+    async def test_service_down_returns_503(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_user_token("sess-token", "proj-123")
+        assert exc_info.value.status_code == 503
+
+    @respx.mock
+    async def test_unexpected_status_returns_503(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(return_value=Response(500))
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_user_token("sess-token", "proj-123")
+        assert exc_info.value.status_code == 503
+
+    @respx.mock
+    async def test_malformed_json_returns_503(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, content=b"<html>not json</html>")
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_user_token("sess-token", "proj-123")
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service error"
+
+    @respx.mock
+    async def test_200_missing_required_fields_returns_503(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, json={"valid": True, "userId": "user-789"})
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_user_token("sess-token", "proj-123")
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service error"
+
+    @respx.mock
+    async def test_200_valid_false_returns_401(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, json={"valid": False, "error": "nope"})
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_user_token("sess-token", "proj-123")
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    async def test_200_empty_workspace_id_returns_503(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(
+                200,
+                json={
+                    "valid": True,
+                    "userId": "user-789",
+                    "role": "ADMIN",
+                    "workspaceId": "",
+                    "billingPlan": "pro",
+                    "projectId": "proj-123",
+                },
+            )
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_user_token("sess-token", "proj-123")
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service error"
+
+    @respx.mock
+    async def test_token_not_logged_on_malformed_response(self, caplog):
+        """The raw session token must never appear in logs, even on the error path."""
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, content=b"oops")
+        )
+        with caplog.at_level(logging.DEBUG), pytest.raises(HTTPException):
+            await authenticate_user_token("supersecretsessiontoken", "proj-123")
+        assert "supersecretsessiontoken" not in caplog.text
+
+
+# ── authenticate_public_caller (unified dependency) ──────────────────────
+
+
+class TestAuthenticatePublicCaller:
+    @respx.mock
+    async def test_tr_token_routes_to_key_validator(self):
+        """A tr- token hits validate-api-key and never validate-user-token."""
+        _mock_valid_key()
+        user_route = respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, json={"valid": True})
+        )
+        result = await authenticate_public_caller("Bearer tr-abc123", project_id=None)
+        assert result.kind == "api_key"
+        assert result.project_id == "proj-123"
+        assert user_route.call_count == 0
+
+    @respx.mock
+    async def test_non_tr_token_with_project_routes_to_user_validator(self):
+        _mock_valid_user_token()
+        result = await authenticate_public_caller("Bearer sess-token-abc", project_id="proj-123")
+        assert result.kind == "user"
+        assert result.role == "ADMIN"
+        assert result.workspace_id == "ws-456"
+        assert result.billing_plan == "pro"
+        assert result.user_id == "user-789"
+        assert result.ingestion_blocked is True
+
+    async def test_non_tr_token_without_project_returns_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_public_caller("Bearer sess-token-abc", project_id=None)
+        assert exc_info.value.status_code == 400
+        assert "list_projects" in exc_info.value.detail
+
+    @respx.mock
+    async def test_key_with_matching_project_ok(self):
+        _mock_valid_key("proj-123")
+        result = await authenticate_public_caller("Bearer tr-abc123", project_id="proj-123")
+        assert result.kind == "api_key"
+        assert result.project_id == "proj-123"
+
+    @respx.mock
+    async def test_key_with_mismatched_project_returns_400(self):
+        _mock_valid_key("proj-123")
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_public_caller("Bearer tr-abc123", project_id="proj-999")
+        assert exc_info.value.status_code == 400
+        assert "does not match" in exc_info.value.detail
+
+    @respx.mock
+    async def test_user_token_403_hasaccess_false(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(403, json={"valid": True, "hasAccess": False})
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_public_caller("Bearer sess-token", project_id="proj-123")
+        assert exc_info.value.status_code == 403
+
+    @respx.mock
+    async def test_user_token_401(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(401, json={"valid": False, "error": "invalid"})
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_public_caller("Bearer sess-token", project_id="proj-123")
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    async def test_user_path_network_error_returns_503(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_public_caller("Bearer sess-token", project_id="proj-123")
+        assert exc_info.value.status_code == 503
+
+    @respx.mock
+    async def test_tr_token_never_reaches_user_validator_even_with_project(self):
+        """Discrimination safety: a tr- value routes to the key validator even
+        when a project_id is passed — it must never hit validate-user-token.
+        """
+        _mock_valid_key("proj-123")
+        user_route = respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, json={"valid": True})
+        )
+        result = await authenticate_public_caller("Bearer tr-abc123", project_id="proj-123")
+        assert result.kind == "api_key"
+        assert user_route.call_count == 0
+
+    async def test_missing_header_returns_401(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_public_caller(None)
+        assert exc_info.value.status_code == 401
+
+    async def test_bad_format_returns_401(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_public_caller("BadFormat token123")
+        assert exc_info.value.status_code == 401

--- a/tests/rest/test_auth_deps.py
+++ b/tests/rest/test_auth_deps.py
@@ -9,15 +9,21 @@ import logging
 import httpx
 import pytest
 import respx
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from httpx import Response
 
+from rest.rate_limit import (
+    is_request_rate_limit_exempt,
+    mark_request_rate_limit_exempt,
+)
 from rest.routers.deps import get_project_access
 from rest.routers.public.deps import (
+    authenticate_and_stamp_public_caller,
     authenticate_public_caller,
     authenticate_user_token,
 )
 from rest.routers.public.traces import AuthResult, authenticate_api_key
+from shared.config import normalize_plan
 
 BASE_URL = "http://localhost:3000"
 
@@ -414,6 +420,17 @@ class TestAuthenticateUserToken:
         assert exc_info.value.detail == "Authentication service error"
 
     @respx.mock
+    async def test_200_non_dict_body_returns_503(self):
+        """A 200 whose JSON body is a non-object (array/string) is malformed → 503."""
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, json=["not", "an", "object"])
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_user_token("sess-token", "proj-123")
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service error"
+
+    @respx.mock
     async def test_200_valid_false_returns_401(self):
         respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
             return_value=Response(200, json={"valid": False, "error": "nope"})
@@ -550,3 +567,81 @@ class TestAuthenticatePublicCaller:
         with pytest.raises(HTTPException) as exc_info:
             await authenticate_public_caller("BadFormat token123")
         assert exc_info.value.status_code == 401
+
+    async def test_empty_token_returns_401(self):
+        """`Bearer ` with an empty token is a malformed credential → 401, not a 503."""
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_public_caller("Bearer ")
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    async def test_uppercase_prefix_routes_to_key_validator(self):
+        """A `TR-` (uppercase) value is key-shaped: route to the key validator,
+        where it is hashed, and never POST it unhashed to validate-user-token.
+        """
+        _mock_valid_key()
+        user_route = respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, json={"valid": True})
+        )
+        result = await authenticate_public_caller("Bearer TR-abc123", project_id="proj-123")
+        assert result.kind == "api_key"
+        assert user_route.call_count == 0
+
+    @respx.mock
+    async def test_leading_space_prefix_routes_to_key_validator(self):
+        """A stray-space `Bearer  tr-…` (token " tr-…") is still key-shaped and
+        must route to the key validator, never to validate-user-token.
+        """
+        _mock_valid_key()
+        user_route = respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, json={"valid": True})
+        )
+        result = await authenticate_public_caller("Bearer  tr-abc123", project_id="proj-123")
+        assert result.kind == "api_key"
+        assert user_route.call_count == 0
+
+
+# ── authenticate_and_stamp_public_caller (stamping wrapper) ──────────────
+
+
+class TestAuthenticateAndStampPublicCaller:
+    @staticmethod
+    def _bare_request() -> Request:
+        return Request({"type": "http", "headers": [], "state": {}})
+
+    async def test_key_result_clears_exempt_and_stamps_identity(self):
+        """A KEY AuthResult clears the exempt flag and stamps workspace+plan."""
+        # Poison the exempt flag first so we prove the wrapper clears it.
+        mark_request_rate_limit_exempt()
+        request = self._bare_request()
+        auth = AuthResult(
+            kind="api_key",
+            project_id="proj-123",
+            workspace_id="ws-456",
+            billing_plan="pro",
+            ingestion_blocked=False,
+        )
+        result = await authenticate_and_stamp_public_caller(request, auth)
+        assert result is auth
+        assert is_request_rate_limit_exempt() is False
+        assert request.state.rl_workspace_id == "ws-456"
+        assert request.state.rl_billing_plan == normalize_plan("pro")
+
+    async def test_user_result_clears_exempt_and_stamps_identity(self):
+        """A USER AuthResult (project-scoped) stamps the same identity fields."""
+        mark_request_rate_limit_exempt()
+        request = self._bare_request()
+        auth = AuthResult(
+            kind="user",
+            project_id="proj-123",
+            workspace_id="ws-456",
+            billing_plan="pro",
+            ingestion_blocked=True,
+            role="ADMIN",
+            user_id="user-789",
+        )
+        result = await authenticate_and_stamp_public_caller(request, auth)
+        assert result is auth
+        assert is_request_rate_limit_exempt() is False
+        assert request.state.rl_workspace_id == "ws-456"
+        assert request.state.rl_billing_plan == normalize_plan("pro")


### PR DESCRIPTION
**Stacked PR 4 of 11** — part of the CLI-login epic (#1863). Base: `feat/active-sessions`.

Adds the internal user-token introspection route and the dual-credential public auth dependency that accepts either an API key or a user session token, discriminating on the tr- prefix.

Rebased onto latest `main`; drift checks (public OpenAPI + tool registry) are clean at this cut point. Review only the commits added on top of the base branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an internal user-session introspection endpoint and a dual-credential public auth dependency that accepts either a project API key or a user session token. Previously public routes authenticated only API keys; now user tokens work for project-scoped calls, while ingestion stays key-only and rate-limit stamping remains intact.

- New internal POST /api/internal/validate-user-token: checks internal secret, validates a better-auth session token via the bearer plugin, and for project scope returns role, workspaceId, billingPlan, and projectId. Distinguishes invalid token (401) from no project access (403); unexpected/malformed responses fail closed (503).
- Backend: adds authenticate_user_token and a unified authenticate_public_caller that routes by a case-insensitive tr- prefix (keys → key validator; others → user validator). Extends AuthResult with kind/user_id/role; user credentials always set ingestion_blocked=True. Empty tokens return 401; API keys with mismatched project_id return 400. Adds a stamping wrapper that clears exemptions and stamps workspace/plan for rate limiting.
- Tests: cover user-token introspection happy/edge paths, public-caller routing safety (never POST raw keys), and stamping behavior.

**Rollout**
- No public routes are switched to the dual dependency in this PR.
- When adopting the dual auth on a route, require clients using user tokens to include a project_id query parameter; API key callers remain unchanged.

<sup>Written for commit 7bafd5f77ebd9029bff26b6db5c09a84fc2dd612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

