### PR TITLE
feat(api): account-scope workspace and project discovery

### DIFF
--- a/backend/rest/main.py
+++ b/backend/rest/main.py
@@ -27,6 +27,7 @@ from rest.rate_limit import limiter, rate_limit_exceeded_handler
 from rest.routers.dashboards import router as dashboards_router
 from rest.routers.internal import router as internal_router
 from rest.routers.live import router as live_router
+from rest.routers.public.account_read import router as public_account_read_router
 from rest.routers.public.detectors_read import router as public_detectors_read_router
 from rest.routers.public.eval import router as public_eval_router
 from rest.routers.public.sessions_read import router as public_sessions_read_router
@@ -118,6 +119,9 @@ app.include_router(public_detectors_read_router, prefix="/api/v1")
 # Public offline-eval API (dataset authoring + run reporting). Thin authenticated
 # proxy to the Next.js control-plane routes so the SDK stays single-host.
 app.include_router(public_eval_router, prefix="/api/v1")
+
+# Account-scope discovery API for user credentials (the CLI login flow)
+app.include_router(public_account_read_router, prefix="/api/v1")
 
 # Internal API for worker/service communication (protected by secret)
 app.include_router(internal_router, prefix="/api/v1")

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -600,6 +600,35 @@
         "title": "PaginationMeta",
         "type": "object"
       },
+      "ProjectListItem": {
+        "description": "A project the user can access, tagged with its owning workspace.",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "workspace_id": {
+            "title": "Workspace Id",
+            "type": "string"
+          },
+          "workspace_name": {
+            "title": "Workspace Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "workspace_id",
+          "workspace_name"
+        ],
+        "title": "ProjectListItem",
+        "type": "object"
+      },
       "PublicDetectorListResponse": {
         "description": "Paginated list of the project's detectors for the public API.",
         "properties": {
@@ -640,6 +669,23 @@
           "meta"
         ],
         "title": "PublicFindingListResponse",
+        "type": "object"
+      },
+      "PublicProjectListResponse": {
+        "description": "Account-scope discovery: the projects the user can access.\n\nReturned by ``list_projects`` \u2014 a user-credential-only op. Projects are\nflattened across the user's workspaces; an optional ``workspace_id`` query\nnarrows the result to one workspace.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ProjectListItem"
+            },
+            "title": "Data",
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "PublicProjectListResponse",
         "type": "object"
       },
       "PublicTraceDetailResponse": {
@@ -966,6 +1012,23 @@
           "meta"
         ],
         "title": "PublicTraceListResponse",
+        "type": "object"
+      },
+      "PublicWorkspaceListResponse": {
+        "description": "Account-scope discovery: the workspaces the user can access.\n\nReturned by ``list_workspaces`` \u2014 a user-credential-only op that needs no\n``project_id``. Not paginated: a user's workspace membership is small and\nbounded.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceListItem"
+            },
+            "title": "Data",
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "PublicWorkspaceListResponse",
         "type": "object"
       },
       "RCAResult": {
@@ -2306,6 +2369,30 @@
         ],
         "title": "WhoamiResponse",
         "type": "object"
+      },
+      "WorkspaceListItem": {
+        "description": "A workspace the authenticated user belongs to, with their role in it.",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "role"
+        ],
+        "title": "WorkspaceListItem",
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -3286,6 +3373,98 @@
         ],
         "x-tool": {
           "enabled": false
+        }
+      }
+    },
+    "/api/v1/public/projects": {
+      "get": {
+        "description": "List the projects the authenticated user can access, across workspaces.\n\nA user-credential-only discovery op (no ``project_id``). Projects are\nflattened across the user's workspaces and tagged with their owning\nworkspace; the answer is what you pass as ``project_id`` to a project-scoped\nrequest.\n\nArgs:\n    request (Request): Incoming request (rate-limit plumbing).\n    response (Response): Outgoing response (rate-limit plumbing).\n    auth (AccountStampedAuth): Account-scope user auth; also stamps the\n        per-user rate-limit identity.\n    authorization (str | None): The bearer header, re-read to forward the\n        already-authenticated token to the internal listing call.\n    workspace_id (str | None): Optional filter; when given, only projects in\n        that workspace are returned.\n\nReturns:\n    PublicProjectListResponse: The accessible projects (id, name,\n        workspace_id, workspace_name).",
+        "operationId": "list_projects",
+        "parameters": [
+          {
+            "description": "Restrict the result to projects in this workspace.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Restrict the result to projects in this workspace.",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicProjectListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List Projects",
+        "tags": [
+          "Account (Public)"
+        ],
+        "x-tool": {
+          "description": "List the projects the logged-in user can access, across workspaces (id, name, workspace). User-credential-only account discovery: use it to resolve the project_id a project-scoped request needs. Optionally filter by workspace_id.",
+          "enabled": true,
+          "name": "list_projects"
         }
       }
     },
@@ -4829,6 +5008,78 @@
           "description": "Identify the project and workspace the current credential belongs to.",
           "enabled": true,
           "name": "whoami"
+        }
+      }
+    },
+    "/api/v1/public/workspaces": {
+      "get": {
+        "description": "List the workspaces the authenticated user belongs to.\n\nA user-credential-only discovery op (no ``project_id``). Use it, then\n``list_projects``, to resolve the project a subsequent request scopes to.\n\nArgs:\n    request (Request): Incoming request (rate-limit plumbing).\n    response (Response): Outgoing response (rate-limit plumbing).\n    auth (AccountStampedAuth): Account-scope user auth; also stamps the\n        per-user rate-limit identity.\n    authorization (str | None): The bearer header, re-read to forward the\n        already-authenticated token to the internal listing call.\n\nReturns:\n    PublicWorkspaceListResponse: The user's workspaces (id, name, role).",
+        "operationId": "list_workspaces",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicWorkspaceListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List Workspaces",
+        "tags": [
+          "Account (Public)"
+        ],
+        "x-tool": {
+          "description": "List the workspaces the logged-in user belongs to (id, name, role). User-credential-only account discovery: it needs no project_id and is not available to project-scoped API keys.",
+          "enabled": true,
+          "name": "list_workspaces"
         }
       }
     }

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -325,6 +325,25 @@ _TOOL_CURATION: dict[str, dict[str, Any]] = {
     "register_run": {"enabled": False},
     "upsert_result": {"enabled": False},
     "complete_run": {"enabled": False},
+    "list_workspaces": {
+        "name": "list_workspaces",
+        "description": (
+            "List the workspaces the logged-in user belongs to (id, name, role). "
+            "User-credential-only account discovery: it needs no project_id and "
+            "is not available to project-scoped API keys."
+        ),
+        "enabled": True,
+    },
+    "list_projects": {
+        "name": "list_projects",
+        "description": (
+            "List the projects the logged-in user can access, across workspaces "
+            "(id, name, workspace). User-credential-only account discovery: use it "
+            "to resolve the project_id a project-scoped request needs. Optionally "
+            "filter by workspace_id."
+        ),
+        "enabled": True,
+    },
 }
 
 

--- a/backend/rest/routers/public/account_read.py
+++ b/backend/rest/routers/public/account_read.py
@@ -1,0 +1,210 @@
+"""Account-scope discovery API for user credentials (the CLI login flow).
+
+Two user-credential-only reads that answer "which project?" *before* a project
+is known: ``list_workspaces`` and ``list_projects``. Unlike the project-scoped
+public reads, these take no ``project_id`` and reject API keys (403) — they run
+on :data:`AccountStampedAuth`, which authenticates a user session token only.
+
+The account membership graph lives in Postgres/Prisma, so the listing is
+delegated to the Next.js internal ``user-memberships`` route (secret-authed,
+keyed by the caller's token). The raw token is never logged.
+"""
+
+import logging
+from typing import Annotated, Any
+
+import httpx
+from fastapi import APIRouter, Header, HTTPException, Query, Request, Response, status
+
+from rest.rate_limit import (
+    BUCKET_READ,
+    is_request_rate_limit_exempt,
+    key_read,
+    limiter,
+    resolve_limit,
+)
+from rest.routers.public.deps import AccountStampedAuth
+from rest.schemas.public import (
+    ProjectListItem,
+    PublicProjectListResponse,
+    PublicWorkspaceListResponse,
+    WorkspaceListItem,
+)
+from shared.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/public", tags=["Account (Public)"])
+
+
+def _bearer_token(authorization: str | None) -> str:
+    """Extract the bearer token from an ``Authorization`` header.
+
+    The value has already been authenticated by :data:`AccountStampedAuth`; this
+    re-reads it so the route can forward the raw token to the internal listing
+    call. The token is never logged.
+
+    Args:
+        authorization (str | None): The ``Authorization: Bearer <token>`` header.
+
+    Returns:
+        str: The raw bearer token.
+
+    Raises:
+        HTTPException: 401 if the header is missing or malformed (defensive — the
+            dependency has already validated it).
+    """
+    parts = (authorization or "").split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer" or not parts[1].strip():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Authorization header format. Expected: Bearer <token>",
+        )
+    return parts[1]
+
+
+async def _fetch_memberships(token: str) -> list[dict[str, Any]]:
+    """Fetch the caller's workspace/project graph from the internal route.
+
+    Calls the Next.js internal ``user-memberships`` route (secret-authed, keyed
+    by the token). Fails closed with a 503 on any ambiguity — network error,
+    unexpected status, or a malformed body — mirroring the auth siblings. The
+    raw token is never logged.
+
+    Args:
+        token (str): The caller's raw user session token, forwarded to the
+            internal route. Never logged.
+
+    Returns:
+        list[dict[str, Any]]: The ``workspaces`` array, each entry carrying
+            ``id``/``name``/``role`` and a ``projects`` list of ``id``/``name``.
+
+    Raises:
+        HTTPException: 503 (fail closed) on a network error, a non-200 status, a
+            malformed body, or a missing ``workspaces`` array.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(
+                f"{settings.traceroot_ui_url}/api/internal/user-memberships",
+                json={"token": token},
+                headers={"X-Internal-Secret": settings.internal_api_secret},
+            )
+    except httpx.RequestError as e:
+        logger.error(f"Failed to list user memberships: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Account service unavailable",
+        ) from e
+
+    if response.status_code != 200:
+        logger.error(f"Unexpected response from account service: {response.status_code}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Account service error",
+        )
+
+    try:
+        data = response.json()
+    except ValueError as e:
+        logger.error(f"Malformed JSON from account service: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Account service error",
+        ) from e
+
+    if not isinstance(data, dict) or not isinstance(data.get("workspaces"), list):
+        logger.error("Account service returned a malformed memberships body")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Account service error",
+        )
+
+    return data["workspaces"]
+
+
+@router.get(
+    "/workspaces", response_model=PublicWorkspaceListResponse, operation_id="list_workspaces"
+)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def list_workspaces(
+    request: Request,
+    response: Response,
+    auth: AccountStampedAuth,
+    authorization: Annotated[str | None, Header()] = None,
+) -> PublicWorkspaceListResponse:
+    """List the workspaces the authenticated user belongs to.
+
+    A user-credential-only discovery op (no ``project_id``). Use it, then
+    ``list_projects``, to resolve the project a subsequent request scopes to.
+
+    Args:
+        request (Request): Incoming request (rate-limit plumbing).
+        response (Response): Outgoing response (rate-limit plumbing).
+        auth (AccountStampedAuth): Account-scope user auth; also stamps the
+            per-user rate-limit identity.
+        authorization (str | None): The bearer header, re-read to forward the
+            already-authenticated token to the internal listing call.
+
+    Returns:
+        PublicWorkspaceListResponse: The user's workspaces (id, name, role).
+    """
+    token = _bearer_token(authorization)
+    workspaces = await _fetch_memberships(token)
+    return PublicWorkspaceListResponse(
+        data=[WorkspaceListItem(id=ws["id"], name=ws["name"], role=ws["role"]) for ws in workspaces]
+    )
+
+
+@router.get("/projects", response_model=PublicProjectListResponse, operation_id="list_projects")
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def list_projects(
+    request: Request,
+    response: Response,
+    auth: AccountStampedAuth,
+    authorization: Annotated[str | None, Header()] = None,
+    workspace_id: str | None = Query(
+        None, description="Restrict the result to projects in this workspace."
+    ),
+) -> PublicProjectListResponse:
+    """List the projects the authenticated user can access, across workspaces.
+
+    A user-credential-only discovery op (no ``project_id``). Projects are
+    flattened across the user's workspaces and tagged with their owning
+    workspace; the answer is what you pass as ``project_id`` to a project-scoped
+    request.
+
+    Args:
+        request (Request): Incoming request (rate-limit plumbing).
+        response (Response): Outgoing response (rate-limit plumbing).
+        auth (AccountStampedAuth): Account-scope user auth; also stamps the
+            per-user rate-limit identity.
+        authorization (str | None): The bearer header, re-read to forward the
+            already-authenticated token to the internal listing call.
+        workspace_id (str | None): Optional filter; when given, only projects in
+            that workspace are returned.
+
+    Returns:
+        PublicProjectListResponse: The accessible projects (id, name,
+            workspace_id, workspace_name).
+    """
+    token = _bearer_token(authorization)
+    workspaces = await _fetch_memberships(token)
+    items: list[ProjectListItem] = []
+    for ws in workspaces:
+        if workspace_id is not None and ws["id"] != workspace_id:
+            continue
+        for project in ws.get("projects", []):
+            items.append(
+                ProjectListItem(
+                    id=project["id"],
+                    name=project["name"],
+                    workspace_id=ws["id"],
+                    workspace_name=ws["name"],
+                )
+            )
+    return PublicProjectListResponse(data=items)

--- a/backend/rest/routers/public/deps.py
+++ b/backend/rest/routers/public/deps.py
@@ -438,3 +438,172 @@ async def authenticate_and_stamp_public_caller(request: Request, auth: DualAuth)
 
 
 DualStampedAuth = Annotated[AuthResult, Depends(authenticate_and_stamp_public_caller)]
+
+
+async def authenticate_account_caller(
+    authorization: Annotated[str | None, Header()] = None,
+) -> AuthResult:
+    """Authenticate an account-scope caller by a user session token only.
+
+    The discovery surface (``list_workspaces`` / ``list_projects``) answers
+    "which project?" *before* a project is known, so it cannot require a
+    ``project_id`` the way :func:`authenticate_public_caller` does. It is a
+    user-credential-only entry point: an API key (``tr-`` prefix) is
+    project-scoped and cannot enumerate an account, so it is rejected with 403.
+
+    The token is validated against the internal ``validate-user-token`` route
+    WITHOUT a ``projectId`` — the account scope, where a live session alone is
+    sufficient and the route returns ``{valid, userId, email}``. The resulting
+    :class:`AuthResult` carries the user identity only; workspace/project fields
+    are empty because an account has no single one. The raw token is never logged.
+
+    Args:
+        authorization (str | None): The ``Authorization: Bearer <token>`` header.
+
+    Returns:
+        AuthResult: A ``kind="user"`` result with ``user_id`` set and
+            ``project_id``/``workspace_id`` empty. ``ingestion_blocked`` is
+            always ``True`` (a user credential must never ingest).
+
+    Raises:
+        HTTPException: 401 for a missing/malformed header or an invalid/expired
+            token, 403 when an API key is presented (account ops are user-only),
+            and 503 (fail closed) for any introspection ambiguity — network
+            error, unexpected status, or a malformed/incomplete 200 body.
+    """
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header",
+        )
+
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Authorization header format. Expected: Bearer <token>",
+        )
+
+    token = parts[1]
+
+    # An empty/whitespace-only token is a malformed credential, not an outage.
+    if not token.strip():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Authorization header. Expected: Bearer <token>",
+        )
+
+    # Account ops are user-credential-only. A key-shaped value (case-insensitive,
+    # whitespace-tolerant, mirroring the dual-auth discriminator) is a
+    # project-scoped credential and can never enumerate an account → 403.
+    if token.strip().lower().startswith("tr-"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="this operation requires a user login; API keys are project-scoped",
+        )
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(
+                f"{settings.traceroot_ui_url}/api/internal/validate-user-token",
+                json={"token": token},
+                headers={"X-Internal-Secret": settings.internal_api_secret},
+            )
+    except httpx.RequestError as e:
+        logger.error(f"Failed to validate user token: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service unavailable",
+        ) from e
+
+    if response.status_code == 401:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication failed",
+        )
+
+    if response.status_code != 200:
+        logger.error(f"Unexpected response from auth service: {response.status_code}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        )
+
+    # A 200 with a malformed body (non-JSON, or a non-object) is an auth-service
+    # error, not a client error — surface a controlled 503, never an uncaught 500.
+    try:
+        data = response.json()
+    except ValueError as e:
+        logger.error(f"Malformed JSON from auth service: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        ) from e
+
+    if not isinstance(data, dict):
+        logger.error("Auth service returned a non-object JSON body")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        )
+
+    if not data.get("valid"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=data.get("error", "Invalid token"),
+        )
+
+    # A valid:true account response must carry the user identity; its absence is
+    # malformed → 503 (fail closed rather than authenticating an anonymous user).
+    user_id = data.get("userId")
+    if not user_id:
+        logger.error("Auth service response missing userId for account scope")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        )
+
+    return AuthResult(
+        kind="user",
+        # Account scope has no single project/workspace — the user_id is the
+        # identity, and these stay empty by design.
+        project_id="",
+        workspace_id="",
+        # The account-scope introspection returns no plan; account discovery ops
+        # are not plan-gated, so default to the free tier for rate-limit keying.
+        billing_plan="free",
+        # A user session token must never be usable to ingest (parity with the
+        # project-scoped user path).
+        ingestion_blocked=True,
+        user_id=user_id,
+    )
+
+
+AccountAuth = Annotated[AuthResult, Depends(authenticate_account_caller)]
+
+
+async def authenticate_and_stamp_account_caller(request: Request, auth: AccountAuth) -> AuthResult:
+    """Authenticate an account-scope caller, then stamp a per-user rate-limit id.
+
+    Account ops have no workspace, so — unlike the project-scoped stamping
+    wrappers — the bucket is keyed per user: the ``user_id`` is placed in the
+    workspace slot of :func:`set_rate_limit_identity`. This reuses the existing
+    key functions unchanged (a later task formalizes dedicated per-user keys). It
+    runs during dependency resolution, before slowapi evaluates the limit, so
+    ``key_func`` sees the identity on ``request.state``.
+
+    Args:
+        request (Request): Incoming request; its ``state`` is stamped with the
+            resolved (per-user) rate-limit identity.
+        auth (AccountAuth): Account-scope auth dependency resolving the user id.
+
+    Returns:
+        AuthResult: The authenticated result, passed through to the route handler.
+    """
+    clear_request_rate_limit_exempt()
+    # Account-scope ops have no workspace; bucket per user by keying on user_id.
+    set_rate_limit_identity(request, auth.user_id, auth.billing_plan)
+    return auth
+
+
+AccountStampedAuth = Annotated[AuthResult, Depends(authenticate_and_stamp_account_caller)]

--- a/backend/rest/schemas/public.py
+++ b/backend/rest/schemas/public.py
@@ -155,3 +155,42 @@ class PublicDetectorListResponse(BaseModel):
 
     data: list[DetectorItem]
     meta: PaginationMeta
+
+
+class WorkspaceListItem(BaseModel):
+    """A workspace the authenticated user belongs to, with their role in it."""
+
+    id: str
+    name: str
+    role: str
+
+
+class PublicWorkspaceListResponse(BaseModel):
+    """Account-scope discovery: the workspaces the user can access.
+
+    Returned by ``list_workspaces`` — a user-credential-only op that needs no
+    ``project_id``. Not paginated: a user's workspace membership is small and
+    bounded.
+    """
+
+    data: list[WorkspaceListItem]
+
+
+class ProjectListItem(BaseModel):
+    """A project the user can access, tagged with its owning workspace."""
+
+    id: str
+    name: str
+    workspace_id: str
+    workspace_name: str
+
+
+class PublicProjectListResponse(BaseModel):
+    """Account-scope discovery: the projects the user can access.
+
+    Returned by ``list_projects`` — a user-credential-only op. Projects are
+    flattened across the user's workspaces; an optional ``workspace_id`` query
+    narrows the result to one workspace.
+    """
+
+    data: list[ProjectListItem]

--- a/frontend/packages/tools/src/__tests__/registry-drift.test.ts
+++ b/frontend/packages/tools/src/__tests__/registry-drift.test.ts
@@ -14,7 +14,7 @@ describe("committed registry", () => {
     expect(REGISTRY).toEqual(generateRegistry(doc));
   });
 
-  it("pins the curated 11-tool surface", () => {
+  it("pins the curated 13-tool surface", () => {
     expect(REGISTRY.map((entry) => entry.name)).toEqual([
       "export_trace",
       "get_finding",
@@ -23,9 +23,11 @@ describe("committed registry", () => {
       "get_trace",
       "list_detectors",
       "list_findings",
+      "list_projects",
       "list_sessions",
       "list_trace_filter_values",
       "list_traces",
+      "list_workspaces",
       "whoami",
     ]);
   });

--- a/frontend/packages/tools/src/registry.generated.ts
+++ b/frontend/packages/tools/src/registry.generated.ts
@@ -210,6 +210,24 @@ export const REGISTRY: readonly RegistryEntry[] = [
     },
   },
   {
+    name: "list_projects",
+    description:
+      "List the projects the logged-in user can access, across workspaces (id, name, workspace). User-credential-only account discovery: use it to resolve the project_id a project-scoped request needs. Optionally filter by workspace_id.",
+    method: "get",
+    path: "/api/v1/public/projects",
+    inputSchema: {
+      type: "object",
+      properties: {
+        workspace_id: {
+          type: "string",
+          description: "Restrict the result to projects in this workspace.",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+  },
+  {
     name: "list_sessions",
     description:
       "List recent sessions (groups of traces sharing a session id) for the project, with trace counts and durations. Search by session id substring.",
@@ -505,6 +523,19 @@ export const REGISTRY: readonly RegistryEntry[] = [
             "Target project for the request. Required when authenticating with a user session token (a user credential is only meaningful scoped to a project); for an API key it is optional and, if given, must match the key's project.",
         },
       },
+      required: [],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_workspaces",
+    description:
+      "List the workspaces the logged-in user belongs to (id, name, role). User-credential-only account discovery: it needs no project_id and is not available to project-scoped API keys.",
+    method: "get",
+    path: "/api/v1/public/workspaces",
+    inputSchema: {
+      type: "object",
+      properties: {},
       required: [],
       additionalProperties: false,
     },

--- a/frontend/ui/src/app/api/internal/user-memberships/route.test.ts
+++ b/frontend/ui/src/app/api/internal/user-memberships/route.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextRequest: class {},
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+const memberFindManyMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    workspaceMember: {
+      findMany: (...args: unknown[]) => memberFindManyMock(...args),
+    },
+  },
+}));
+
+const verifyInternalSecretMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  verifyInternalSecret: (...args: unknown[]) => verifyInternalSecretMock(...args),
+}));
+
+const getSessionMock = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: (...args: unknown[]) => getSessionMock(...args) } },
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: unknown) {
+  return { json: async () => body } as unknown as Parameters<typeof POST>[0];
+}
+
+beforeEach(() => {
+  memberFindManyMock.mockReset();
+  verifyInternalSecretMock.mockReset();
+  verifyInternalSecretMock.mockReturnValue(true);
+  getSessionMock.mockReset();
+});
+
+describe("POST /api/internal/user-memberships", () => {
+  it("rejects an unauthorized caller before touching auth or the database", async () => {
+    verifyInternalSecretMock.mockReturnValue(false);
+
+    const res = await POST(makeRequest({ token: "tok" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toEqual({ error: "Unauthorized" });
+    expect(getSessionMock).not.toHaveBeenCalled();
+    expect(memberFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    const badRequest = {
+      json: async () => {
+        throw new SyntaxError("bad json");
+      },
+    } as unknown as Parameters<typeof POST>[0];
+
+    const res = await POST(badRequest);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 400 when token is missing", async () => {
+    const res = await POST(makeRequest({}));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 401 when getSession resolves no session", async () => {
+    getSessionMock.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ token: "tok" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toEqual({ error: "invalid or expired token" });
+    expect(memberFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("treats a getSession throw as an invalid token, not a 500", async () => {
+    getSessionMock.mockRejectedValue(new Error("boom"));
+
+    const res = await POST(makeRequest({ token: "tok" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toEqual({ error: "invalid or expired token" });
+  });
+
+  it("returns the workspace/project graph for a live session", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
+    memberFindManyMock.mockResolvedValue([
+      {
+        role: "admin",
+        workspace: {
+          id: "ws-1",
+          name: "Alpha",
+          projects: [
+            { id: "proj-1", name: "P1" },
+            { id: "proj-2", name: "P2" },
+          ],
+        },
+      },
+      {
+        role: "viewer",
+        workspace: { id: "ws-2", name: "Beta", projects: [] },
+      },
+    ]);
+
+    const res = await POST(makeRequest({ token: "tok" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      workspaces: [
+        {
+          id: "ws-1",
+          name: "Alpha",
+          role: "admin",
+          projects: [
+            { id: "proj-1", name: "P1" },
+            { id: "proj-2", name: "P2" },
+          ],
+        },
+        { id: "ws-2", name: "Beta", role: "viewer", projects: [] },
+      ],
+    });
+    // scoped to the session user and ordered by workspace name
+    const args = memberFindManyMock.mock.calls[0][0];
+    expect(args.where).toEqual({ userId: "user-1" });
+    expect(args.orderBy).toEqual({ workspace: { name: "asc" } });
+  });
+
+  it("returns an empty list when the user has no memberships", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+    memberFindManyMock.mockResolvedValue([]);
+
+    const res = await POST(makeRequest({ token: "tok" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ workspaces: [] });
+  });
+});

--- a/frontend/ui/src/app/api/internal/user-memberships/route.ts
+++ b/frontend/ui/src/app/api/internal/user-memberships/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@traceroot/core";
+import { verifyInternalSecret } from "@/lib/auth-helpers";
+import { auth } from "@/lib/auth";
+
+const userMembershipsSchema = z.object({
+  token: z.string().min(1, "Token is required"),
+});
+
+// POST /api/internal/user-memberships
+// Internal endpoint for the Python backend to resolve a user's account-scope
+// workspace/project graph (the CLI login `list_workspaces` / `list_projects`).
+// One query returns everything (no N+1). Never log the token.
+export async function POST(request: NextRequest) {
+  if (!verifyInternalSecret(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const result = userMembershipsSchema.safeParse(body);
+  if (!result.success) {
+    return NextResponse.json({ error: result.error.issues[0].message }, { status: 400 });
+  }
+
+  const { token } = result.data;
+
+  // Resolve the session via the bearer plugin, which accepts the session token as an
+  // Authorization header in place of the cookie. Never log the token or these headers.
+  let session: Awaited<ReturnType<typeof auth.api.getSession>>;
+  try {
+    session = await auth.api.getSession({
+      headers: new Headers({ Authorization: `Bearer ${token}` }),
+    });
+  } catch {
+    session = null;
+  }
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "invalid or expired token" }, { status: 401 });
+  }
+
+  const memberships = await prisma.workspaceMember.findMany({
+    where: { userId: session.user.id },
+    include: {
+      workspace: {
+        include: {
+          projects: {
+            where: { deleteTime: null },
+            select: { id: true, name: true },
+          },
+        },
+      },
+    },
+    orderBy: { workspace: { name: "asc" } },
+  });
+
+  const workspaces = memberships.map((m) => ({
+    id: m.workspace.id,
+    name: m.workspace.name,
+    role: m.role,
+    projects: m.workspace.projects,
+  }));
+
+  return NextResponse.json({ workspaces });
+}

--- a/tests/rest/test_auth_deps.py
+++ b/tests/rest/test_auth_deps.py
@@ -4,6 +4,7 @@ Tests authenticate_api_key (public API auth) and get_project_access (user auth)
 with mocked httpx calls.
 """
 
+import json
 import logging
 
 import httpx
@@ -18,6 +19,8 @@ from rest.rate_limit import (
 )
 from rest.routers.deps import get_project_access
 from rest.routers.public.deps import (
+    authenticate_account_caller,
+    authenticate_and_stamp_account_caller,
     authenticate_and_stamp_public_caller,
     authenticate_public_caller,
     authenticate_user_token,
@@ -645,3 +648,155 @@ class TestAuthenticateAndStampPublicCaller:
         assert is_request_rate_limit_exempt() is False
         assert request.state.rl_workspace_id == "ws-456"
         assert request.state.rl_billing_plan == normalize_plan("pro")
+
+
+# ── authenticate_account_caller (account-scope, user-only) ───────────────
+
+
+def _mock_valid_account_token(user_id: str = "user-789"):
+    """Mock validate-user-token returning the account-scope 200 shape (no project)."""
+    return respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+        return_value=Response(
+            200, json={"valid": True, "userId": user_id, "email": "u@example.com"}
+        )
+    )
+
+
+class TestAuthenticateAccountCaller:
+    @respx.mock
+    async def test_valid_user_token_returns_account_result(self):
+        route = _mock_valid_account_token()
+        result = await authenticate_account_caller("Bearer sess-token-abc")
+        assert result.kind == "user"
+        assert result.user_id == "user-789"
+        # Account scope has no single project/workspace.
+        assert result.project_id == ""
+        assert result.workspace_id == ""
+        assert result.billing_plan == "free"
+        assert result.ingestion_blocked is True
+        # The account introspection is called WITHOUT a projectId.
+        sent = json.loads(route.calls.last.request.content)
+        assert "projectId" not in sent
+
+    @respx.mock
+    async def test_api_key_rejected_with_403(self):
+        """A tr- (API key) value is project-scoped and cannot enumerate an account."""
+        user_route = respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, json={"valid": True, "userId": "u"})
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_account_caller("Bearer tr-abc123")
+        assert exc_info.value.status_code == 403
+        assert "user login" in exc_info.value.detail
+        # It must never reach the token validator.
+        assert user_route.call_count == 0
+
+    @respx.mock
+    async def test_uppercase_key_prefix_rejected_with_403(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_account_caller("Bearer TR-abc123")
+        assert exc_info.value.status_code == 403
+
+    async def test_missing_header_returns_401(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_account_caller(None)
+        assert exc_info.value.status_code == 401
+
+    async def test_bad_format_returns_401(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_account_caller("BadFormat token123")
+        assert exc_info.value.status_code == 401
+
+    async def test_empty_token_returns_401(self):
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_account_caller("Bearer ")
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    async def test_invalid_token_401_returns_401(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(401, json={"valid": False, "error": "invalid or expired token"})
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_account_caller("Bearer bad-token")
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    async def test_valid_false_returns_401(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, json={"valid": False, "error": "nope"})
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_account_caller("Bearer sess-token")
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    async def test_network_error_returns_503(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_account_caller("Bearer sess-token")
+        assert exc_info.value.status_code == 503
+
+    @respx.mock
+    async def test_unexpected_status_returns_503(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(return_value=Response(500))
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_account_caller("Bearer sess-token")
+        assert exc_info.value.status_code == 503
+
+    @respx.mock
+    async def test_malformed_json_returns_503(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, content=b"<html>not json</html>")
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_account_caller("Bearer sess-token")
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service error"
+
+    @respx.mock
+    async def test_200_missing_user_id_returns_503(self):
+        """A valid:true account response without userId is malformed → 503 (fail closed)."""
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, json={"valid": True})
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_account_caller("Bearer sess-token")
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service error"
+
+    @respx.mock
+    async def test_token_not_logged_on_malformed_response(self, caplog):
+        respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+            return_value=Response(200, content=b"oops")
+        )
+        with caplog.at_level(logging.DEBUG), pytest.raises(HTTPException):
+            await authenticate_account_caller("Bearer supersecretsessiontoken")
+        assert "supersecretsessiontoken" not in caplog.text
+
+
+class TestAuthenticateAndStampAccountCaller:
+    @staticmethod
+    def _bare_request() -> Request:
+        return Request({"type": "http", "headers": [], "state": {}})
+
+    async def test_stamps_per_user_identity_and_clears_exempt(self):
+        """Account ops have no workspace: the bucket is keyed per user_id."""
+        mark_request_rate_limit_exempt()
+        request = self._bare_request()
+        auth = AuthResult(
+            kind="user",
+            project_id="",
+            workspace_id="",
+            billing_plan="free",
+            ingestion_blocked=True,
+            user_id="user-789",
+        )
+        result = await authenticate_and_stamp_account_caller(request, auth)
+        assert result is auth
+        assert is_request_rate_limit_exempt() is False
+        # user_id occupies the workspace slot so the bucket is per-user.
+        assert request.state.rl_workspace_id == "user-789"
+        assert request.state.rl_billing_plan == normalize_plan("free")

--- a/tests/rest/test_public_account_read.py
+++ b/tests/rest/test_public_account_read.py
@@ -1,0 +1,164 @@
+"""Integration tests for the account-scope discovery reads.
+
+These exercise the REAL account-scope dependency (``authenticate_account_caller``)
+and the account routes end-to-end, mocking BOTH internal routes with ``respx``:
+``validate-user-token`` (the account-scope auth introspection, no projectId) and
+``user-memberships`` (the workspace/project listing). A user session token is
+required; an API key (``tr-``) is rejected with 403.
+"""
+
+import respx
+from fastapi.testclient import TestClient
+from httpx import Response
+
+from rest.main import app
+
+BASE_URL = "http://localhost:3000"
+
+USER_HEADER = {"Authorization": "Bearer user-session-token"}
+KEY_HEADER = {"Authorization": "Bearer tr-some-key"}
+
+# The account-scope validate-user-token 200 body (no project requested).
+ACCOUNT_OK_BODY = {"valid": True, "userId": "u1", "email": "u@example.com"}
+
+MEMBERSHIPS_BODY = {
+    "workspaces": [
+        {
+            "id": "ws-1",
+            "name": "Alpha",
+            "role": "admin",
+            "projects": [
+                {"id": "proj-1", "name": "P1"},
+                {"id": "proj-2", "name": "P2"},
+            ],
+        },
+        {
+            "id": "ws-2",
+            "name": "Beta",
+            "role": "viewer",
+            "projects": [{"id": "proj-3", "name": "P3"}],
+        },
+    ]
+}
+
+
+def _mock_account_auth():
+    """Mock the account-scope introspection to a valid live session."""
+    return respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+        return_value=Response(200, json=ACCOUNT_OK_BODY)
+    )
+
+
+def _mock_memberships(body=MEMBERSHIPS_BODY, status_code=200):
+    """Mock the internal user-memberships listing route."""
+    return respx.post(f"{BASE_URL}/api/internal/user-memberships").mock(
+        return_value=Response(status_code, json=body)
+    )
+
+
+@respx.mock
+def test_list_workspaces_returns_user_workspaces():
+    _mock_account_auth()
+    _mock_memberships()
+    resp = TestClient(app).get("/api/v1/public/workspaces", headers=USER_HEADER)
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "data": [
+            {"id": "ws-1", "name": "Alpha", "role": "admin"},
+            {"id": "ws-2", "name": "Beta", "role": "viewer"},
+        ]
+    }
+
+
+@respx.mock
+def test_list_projects_flattens_across_workspaces():
+    _mock_account_auth()
+    _mock_memberships()
+    resp = TestClient(app).get("/api/v1/public/projects", headers=USER_HEADER)
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "data": [
+            {"id": "proj-1", "name": "P1", "workspace_id": "ws-1", "workspace_name": "Alpha"},
+            {"id": "proj-2", "name": "P2", "workspace_id": "ws-1", "workspace_name": "Alpha"},
+            {"id": "proj-3", "name": "P3", "workspace_id": "ws-2", "workspace_name": "Beta"},
+        ]
+    }
+
+
+@respx.mock
+def test_list_projects_filters_by_workspace_id():
+    _mock_account_auth()
+    _mock_memberships()
+    resp = TestClient(app).get("/api/v1/public/projects?workspace_id=ws-2", headers=USER_HEADER)
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "data": [
+            {"id": "proj-3", "name": "P3", "workspace_id": "ws-2", "workspace_name": "Beta"},
+        ]
+    }
+
+
+@respx.mock
+def test_list_workspaces_rejects_api_key_with_403():
+    """An API key is project-scoped and cannot enumerate an account."""
+    membership = _mock_memberships()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/v1/public/workspaces", headers=KEY_HEADER)
+    assert resp.status_code == 403
+    # It must never reach the listing call.
+    assert membership.call_count == 0
+
+
+@respx.mock
+def test_list_projects_rejects_api_key_with_403():
+    membership = _mock_memberships()
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/v1/public/projects", headers=KEY_HEADER)
+    assert resp.status_code == 403
+    assert membership.call_count == 0
+
+
+@respx.mock
+def test_list_workspaces_invalid_token_is_401():
+    respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+        return_value=Response(401, json={"valid": False, "error": "invalid or expired token"})
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/v1/public/workspaces", headers=USER_HEADER)
+    assert resp.status_code == 401
+
+
+@respx.mock
+def test_list_projects_invalid_token_is_401():
+    respx.post(f"{BASE_URL}/api/internal/validate-user-token").mock(
+        return_value=Response(401, json={"valid": False, "error": "invalid or expired token"})
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/v1/public/projects", headers=USER_HEADER)
+    assert resp.status_code == 401
+
+
+@respx.mock
+def test_list_workspaces_internal_listing_failure_is_503():
+    """A valid token but a failing listing call fails closed with a 503."""
+    _mock_account_auth()
+    _mock_memberships(body={}, status_code=500)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/v1/public/workspaces", headers=USER_HEADER)
+    assert resp.status_code == 503
+
+
+@respx.mock
+def test_list_projects_internal_listing_failure_is_503():
+    _mock_account_auth()
+    _mock_memberships(body={}, status_code=500)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/v1/public/projects", headers=USER_HEADER)
+    assert resp.status_code == 503
+
+
+def test_list_workspaces_requires_authorization():
+    """No Authorization header → 401 before any internal call."""
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/v1/public/workspaces")
+    assert resp.status_code == 401

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -262,6 +262,8 @@ def test_session_read_routes_document_error_responses():
 _METHODS = {"get", "post", "put", "patch", "delete"}
 
 EXPECTED_OPERATION_IDS = {
+    "/api/v1/public/projects": {"get": "list_projects"},
+    "/api/v1/public/workspaces": {"get": "list_workspaces"},
     "/api/v1/public/detectors": {"get": "list_detectors"},
     "/api/v1/public/detectors/findings": {"get": "list_findings"},
     "/api/v1/public/detectors/findings/{finding_id}": {"get": "get_finding"},
@@ -336,6 +338,8 @@ def test_x_tool_enabled_set_and_shape():
         "list_findings",
         "get_finding",
         "get_finding_by_trace",
+        "list_workspaces",
+        "list_projects",
     }
     for name, tool in enabled.items():
         assert tool["description"], f"{name} needs an agent-facing description"


### PR DESCRIPTION
**Stacked PR 6 of 11** — part of the CLI-login epic (#1863). Base: `feat/dual-credential-reads`.

Adds the account-scope user-credential dependency and the list_workspaces/list_projects discovery endpoints (no project_id; API keys rejected), so a CLI can resolve which project to target; regenerates the schema/registry.

Rebased onto latest `main`; drift checks (public OpenAPI + tool registry) are clean at this cut point. Review only the commits added on top of the base branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds account-scope discovery so the CLI can resolve a target project before a project_id is known. Previously public reads were project-scoped and accepted API keys; now GET /api/v1/public/workspaces and /api/v1/public/projects require user session tokens and return 403 to API keys.

- Introduces a user-only auth dependency that validates the session via /api/internal/validate-user-token without a projectId, rejects `tr-` API keys with 403, and buckets rate limits per user.
- Adds /api/v1/public/workspaces (workspace id/name/role) and /api/v1/public/projects (project id/name with workspace id/name; optional workspace_id filter). Both forward the bearer token to /api/internal/user-memberships and fail closed with 503 on ambiguity.
- Adds the internal Next.js route /api/internal/user-memberships to return the user’s workspace/project graph in one query.
- Regenerates the public OpenAPI and tool registry; curated surface grows from 11 to 13 tools by enabling list_workspaces and list_projects.
- Tests cover auth, public routes, OpenAPI, registry, and the internal listing route.

**Migration**
- Clients must use a user session token for these endpoints; project-scoped API keys are not allowed.
- CLI flow: call list_workspaces → list_projects to obtain a project_id for subsequent project-scoped requests. Existing project-scoped APIs are unchanged.

<sup>Written for commit ccf7af4e60f023de33e72412e4ad7643e1195f30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

