### PR TITLE
feat(ui): device consent UX fixes

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -2410,7 +2410,7 @@
   "paths": {
     "/api/v1/public/detectors": {
       "get": {
-        "description": "List the detectors in the API key's project (newest first).",
+        "description": "List the detectors in the caller's project (newest first).",
         "operationId": "list_detectors",
         "parameters": [
           {
@@ -2569,7 +2569,7 @@
     },
     "/api/v1/public/detectors/findings": {
       "get": {
-        "description": "List recent detector findings for the API key's project (newest first).",
+        "description": "List recent detector findings for the caller's project (newest first).",
         "operationId": "list_findings",
         "parameters": [
           {
@@ -3470,7 +3470,7 @@
     },
     "/api/v1/public/sessions": {
       "get": {
-        "description": "List unique sessions for the API key's project with trace counts.\n\nArgs:\n    auth (DualStampedAuth): Resolved credential context (API key or user\n        session token); scopes the read to its project and stamps the\n        rate-limit identity.\n    limit (int): Items per page (1-200).\n    search_query (str | None): Substring match on session id.\n    start_after (datetime | None): Inclusive lower bound on trace time.\n    end_before (datetime | None): Exclusive upper bound on trace time.\n\nReturns:\n    SessionListResponse: Session summaries, newest first.\n\nRaises:\n    HTTPException: 500 on a reader failure.",
+        "description": "List unique sessions for the caller's project with trace counts.\n\nArgs:\n    auth (DualStampedAuth): Resolved credential context (API key or user\n        session token); scopes the read to its project and stamps the\n        rate-limit identity.\n    limit (int): Items per page (1-200).\n    search_query (str | None): Substring match on session id.\n    start_after (datetime | None): Inclusive lower bound on trace time.\n    end_before (datetime | None): Exclusive upper bound on trace time.\n\nReturns:\n    SessionListResponse: Session summaries, newest first.\n\nRaises:\n    HTTPException: 500 on a reader failure.",
         "operationId": "list_sessions",
         "parameters": [
           {
@@ -3816,7 +3816,7 @@
     },
     "/api/v1/public/traces": {
       "get": {
-        "description": "List recent traces for the API key's project (newest first).\n\nOffline-evaluation traces are excluded by default; pass\n``include_evaluations=true`` to include them.",
+        "description": "List recent traces for the caller's project (newest first).\n\nOffline-evaluation traces are excluded by default; pass\n``include_evaluations=true`` to include them.",
         "operationId": "list_traces",
         "parameters": [
           {
@@ -4613,7 +4613,7 @@
     },
     "/api/v1/public/traces/{trace_id}": {
       "get": {
-        "description": "Get a single trace for the key's project.\n\nDefaults to the lightweight `skeleton` projection (no per-span I/O); pass\n`fields=full` (or `fields=io,metadata`) for per-span input/output/metadata.\n\nArgs:\n    auth (DualStampedAuth): Resolved credential context (API key or user\n        session token); scopes the read to its project and stamps the\n        rate-limit identity.\n    trace_id (str): Trace to fetch.\n    fields (str | None): Comma-separated projection groups (e.g. ``io``,\n        ``metadata``) or an alias (``skeleton``/``full``). ``None`` selects\n        the default `skeleton` projection.\n\nReturns:\n    PublicTraceDetailResponse: The trace with span skeletons, plus per-span\n        I/O when the projection requests it.\n\nRaises:\n    HTTPException: 400 if `fields` is invalid, 404 if the trace is missing\n        or outside the key's project, 500 on a reader failure.",
+        "description": "Get a single trace for the caller's project.\n\nDefaults to the lightweight `skeleton` projection (no per-span I/O); pass\n`fields=full` (or `fields=io,metadata`) for per-span input/output/metadata.\n\nArgs:\n    auth (DualStampedAuth): Resolved credential context (API key or user\n        session token); scopes the read to its project and stamps the\n        rate-limit identity.\n    trace_id (str): Trace to fetch.\n    fields (str | None): Comma-separated projection groups (e.g. ``io``,\n        ``metadata``) or an alias (``skeleton``/``full``). ``None`` selects\n        the default `skeleton` projection.\n\nReturns:\n    PublicTraceDetailResponse: The trace with span skeletons, plus per-span\n        I/O when the projection requests it.\n\nRaises:\n    HTTPException: 400 if `fields` is invalid, 404 if the trace is missing\n        or outside the key's project, 500 on a reader failure.",
         "operationId": "get_trace",
         "parameters": [
           {
@@ -4777,7 +4777,7 @@
     },
     "/api/v1/public/traces/{trace_id}/export": {
       "get": {
-        "description": "Export the V1 bundle (trace + spans + git_context + manifest) for the key's project.\n\nDefaults to the `full` projection \u2014 an export is explicit intent to take the\ncomplete trace, so per-span input/output/metadata are included unless the\ncaller narrows `fields`. `bundle.trace` equals the `traces get` payload at the\nsame projection.\n\nRate limited on its own `export` bucket because it builds and serializes the\nfull bundle.\n\nArgs:\n    auth (DualStampedAuth): Resolved credential context (API key or user\n        session token); scopes the read to its project and stamps the\n        rate-limit identity.\n    trace_id (str): Trace to export.\n    fields (str | None): Comma-separated projection groups or an alias\n        (``skeleton``/``full``). ``None`` selects the default `full`\n        projection.\n\nReturns:\n    PublicTraceExportResponse: The V1 export bundle (manifest, trace, spans,\n        git_context) at the requested projection.\n\nRaises:\n    HTTPException: 400 if `fields` is invalid, 404 if the trace is missing\n        or outside the key's project, 500 on a reader failure.",
+        "description": "Export the V1 bundle (trace + spans + git_context + manifest) for the caller's project.\n\nDefaults to the `full` projection \u2014 an export is explicit intent to take the\ncomplete trace, so per-span input/output/metadata are included unless the\ncaller narrows `fields`. `bundle.trace` equals the `traces get` payload at the\nsame projection.\n\nRate limited on its own `export` bucket because it builds and serializes the\nfull bundle.\n\nArgs:\n    auth (DualStampedAuth): Resolved credential context (API key or user\n        session token); scopes the read to its project and stamps the\n        rate-limit identity.\n    trace_id (str): Trace to export.\n    fields (str | None): Comma-separated projection groups or an alias\n        (``skeleton``/``full``). ``None`` selects the default `full`\n        projection.\n\nReturns:\n    PublicTraceExportResponse: The V1 export bundle (manifest, trace, spans,\n        git_context) at the requested projection.\n\nRaises:\n    HTTPException: 400 if `fields` is invalid, 404 if the trace is missing\n        or outside the key's project, 500 on a reader failure.",
         "operationId": "export_trace",
         "parameters": [
           {

--- a/backend/rest/rate_limit.py
+++ b/backend/rest/rate_limit.py
@@ -5,9 +5,14 @@ Design
 * **Library**  ``slowapi`` (wraps ``limits``) with Redis storage shared across
   REST replicas, plus an in-memory fallback so a Redis outage degrades to
   per-process limiting instead of failing requests.
-* **Key**      the *workspace* (resolved from the API key for ingestion and the
-  public read API, and from the authenticated user for dashboard reads) — never
-  the raw API key, so a customer cannot multiply quota by minting more keys.
+* **Key**      the *workspace* for API-key traffic (ingestion and the public
+  read API) and for dashboard reads — never the raw API key, so a customer
+  cannot multiply quota by minting more keys. A *user-credentialed* read (the
+  CLI's session token) additionally gets a per-member bucket within its
+  workspace (``…:{workspace}:{user}``) so one member's CLI cannot starve a
+  teammate's reads; aggregate workspace read volume therefore scales with active
+  members — intended, since membership is real and not mintable, not a
+  per-workspace ceiling. Account-scope ops (no workspace) key on the user alone.
 * **Tiers**    per ``(bucket, billing-plan)`` limits resolved at request time
   from ``settings.rate_limit`` (see ``RateLimitSettings``).
 * **Self-host** deployments (``ENABLE_BILLING=false``) have no billing tiers, so

--- a/backend/rest/routers/public/detectors_read.py
+++ b/backend/rest/routers/public/detectors_read.py
@@ -1,8 +1,9 @@
-"""Public, API-key-authenticated read API for detector findings.
+"""Public read API for detector findings.
 
 Mirrors the public traces read stack (DualStampedAuth, READ-bucket rate limiting,
-project-scoped reads). All access is scoped to the project resolved from the API
-key; a finding outside that project simply isn't found (404).
+project-scoped reads). Authenticated by either an API key (which fixes its own
+project) or a user session token (which names the project via ``project_id``); a
+finding outside the resolved project simply isn't found (404).
 """
 
 import logging
@@ -50,7 +51,7 @@ async def list_detectors(
         None, description="Only detectors created before this time (exclusive, ISO 8601)"
     ),
 ):
-    """List the detectors in the API key's project (newest first)."""
+    """List the detectors in the caller's project (newest first)."""
     try:
         items, total = service.list_detectors(
             project_id=auth.project_id,
@@ -89,7 +90,7 @@ async def list_findings(
     detector: str | None = Query(None, description="Filter by detector id, name, or template"),
     trace_id: str | None = Query(None, description="Filter to a single trace"),
 ):
-    """List recent detector findings for the API key's project (newest first)."""
+    """List recent detector findings for the caller's project (newest first)."""
     start_after, end_before = clamp_retention_window(auth.billing_plan, start_after, end_before)
     try:
         items, total = service.list_findings(

--- a/backend/rest/routers/public/sessions_read.py
+++ b/backend/rest/routers/public/sessions_read.py
@@ -1,9 +1,11 @@
-"""Public, API-key-authenticated session read endpoints.
+"""Public session read endpoints.
 
 `GET /api/v1/public/sessions` (list) and `GET /api/v1/public/sessions/{session_id}`
-(get). Reads are scoped to the project the API key belongs to — the client never
-supplies a project id. Reuses the shared trace-reader service that also serves
-the user-authenticated session routes, so both surfaces share one implementation.
+(get). Authenticated by either an API key or a user session token
+(``DualStampedAuth``): an API key fixes its own project, while a user credential
+names the project via ``project_id``. Reuses the shared trace-reader service that
+also serves the user-authenticated session routes, so both surfaces share one
+implementation.
 """
 
 import logging
@@ -47,7 +49,7 @@ async def list_sessions(
         description="Only sessions with traces before this time (exclusive, ISO 8601)",
     ),
 ):
-    """List unique sessions for the API key's project with trace counts.
+    """List unique sessions for the caller's project with trace counts.
 
     Args:
         auth (DualStampedAuth): Resolved credential context (API key or user

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -1,9 +1,10 @@
-"""Public, API-key-authenticated trace read endpoints (for the CLI).
+"""Public trace read endpoints (for the CLI).
 
 `GET /api/v1/public/traces` (list) and `GET /api/v1/public/traces/{trace_id}`
-(get). Reads are scoped to the project the API key belongs to — the client
-never supplies a project id. Kept separate from the ingestion route so read and
-write concerns stay decoupled; both reuse the shared API-key auth dependency.
+(get). Authenticated by either an API key or a user session token
+(``DualStampedAuth``): an API key fixes its own project, while a user credential
+names the project via ``project_id``. Kept separate from the ingestion route so
+read and write concerns stay decoupled.
 """
 
 import logging
@@ -83,7 +84,7 @@ async def list_traces(
         ),
     ),
 ):
-    """List recent traces for the API key's project (newest first).
+    """List recent traces for the caller's project (newest first).
 
     Offline-evaluation traces are excluded by default; pass
     ``include_evaluations=true`` to include them.
@@ -211,7 +212,7 @@ async def get_trace(
     trace_id: str,
     fields: str | None = Query(None, description=FIELDS_PARAM_DESC),
 ):
-    """Get a single trace for the key's project.
+    """Get a single trace for the caller's project.
 
     Defaults to the lightweight `skeleton` projection (no per-span I/O); pass
     `fields=full` (or `fields=io,metadata`) for per-span input/output/metadata.
@@ -249,7 +250,7 @@ async def export_trace(
     trace_id: str,
     fields: str | None = Query(None, description=FIELDS_PARAM_DESC),
 ):
-    """Export the V1 bundle (trace + spans + git_context + manifest) for the key's project.
+    """Export the V1 bundle (trace + spans + git_context + manifest) for the caller's project.
 
     Defaults to the `full` projection — an export is explicit intent to take the
     complete trace, so per-span input/output/metadata are included unless the

--- a/frontend/packages/core/prisma/migrations/20260813000000_add_device_code_expires_at_index/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260813000000_add_device_code_expires_at_index/migration.sql
@@ -1,0 +1,3 @@
+-- Index the device-code expiry so expired rows can be pruned cheaply and the
+-- hot verify/poll lookups stay bounded.
+CREATE INDEX "ix_device_code_expires_at" ON "device_codes"("expires_at");

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -269,6 +269,8 @@ model DeviceCode {
 
   @@index([deviceCode], map: "ix_device_code_device_code")
   @@index([userCode], map: "ix_device_code_user_code")
+  // Supports pruning expired rows (cleanup) and bounds the hot verify/poll path.
+  @@index([expiresAt], map: "ix_device_code_expires_at")
   @@map("device_codes")
 }
 

--- a/frontend/ui/src/app/api/internal/user-memberships/route.test.ts
+++ b/frontend/ui/src/app/api/internal/user-memberships/route.test.ts
@@ -24,9 +24,9 @@ vi.mock("@/lib/auth-helpers", () => ({
   verifyInternalSecret: (...args: unknown[]) => verifyInternalSecretMock(...args),
 }));
 
-const getSessionMock = vi.fn();
-vi.mock("@/lib/auth", () => ({
-  auth: { api: { getSession: (...args: unknown[]) => getSessionMock(...args) } },
+const resolveTokenMock = vi.fn();
+vi.mock("@/lib/internal-session", () => ({
+  resolveSessionFromToken: (...args: unknown[]) => resolveTokenMock(...args),
 }));
 
 import { POST } from "./route";
@@ -39,7 +39,7 @@ beforeEach(() => {
   memberFindManyMock.mockReset();
   verifyInternalSecretMock.mockReset();
   verifyInternalSecretMock.mockReturnValue(true);
-  getSessionMock.mockReset();
+  resolveTokenMock.mockReset();
 });
 
 describe("POST /api/internal/user-memberships", () => {
@@ -51,7 +51,7 @@ describe("POST /api/internal/user-memberships", () => {
 
     expect(res.status).toBe(401);
     expect(body).toEqual({ error: "Unauthorized" });
-    expect(getSessionMock).not.toHaveBeenCalled();
+    expect(resolveTokenMock).not.toHaveBeenCalled();
     expect(memberFindManyMock).not.toHaveBeenCalled();
   });
 
@@ -77,8 +77,8 @@ describe("POST /api/internal/user-memberships", () => {
     expect(typeof body.error).toBe("string");
   });
 
-  it("returns 401 when getSession resolves no session", async () => {
-    getSessionMock.mockResolvedValue(null);
+  it("returns 401 when the token resolves to no live session", async () => {
+    resolveTokenMock.mockResolvedValue(null);
 
     const res = await POST(makeRequest({ token: "tok" }));
     const body = await res.json();
@@ -88,18 +88,14 @@ describe("POST /api/internal/user-memberships", () => {
     expect(memberFindManyMock).not.toHaveBeenCalled();
   });
 
-  it("treats a getSession throw as an invalid token, not a 500", async () => {
-    getSessionMock.mockRejectedValue(new Error("boom"));
+  it("propagates a resolver/database error instead of masking it as a bad token", async () => {
+    resolveTokenMock.mockRejectedValue(new Error("db down"));
 
-    const res = await POST(makeRequest({ token: "tok" }));
-    const body = await res.json();
-
-    expect(res.status).toBe(401);
-    expect(body).toEqual({ error: "invalid or expired token" });
+    await expect(POST(makeRequest({ token: "tok" }))).rejects.toThrow("db down");
   });
 
   it("returns the workspace/project graph for a live session", async () => {
-    getSessionMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
+    resolveTokenMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
     memberFindManyMock.mockResolvedValue([
       {
         role: "admin",
@@ -143,7 +139,7 @@ describe("POST /api/internal/user-memberships", () => {
   });
 
   it("returns an empty list when the user has no memberships", async () => {
-    getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+    resolveTokenMock.mockResolvedValue({ user: { id: "user-1" } });
     memberFindManyMock.mockResolvedValue([]);
 
     const res = await POST(makeRequest({ token: "tok" }));

--- a/frontend/ui/src/app/api/internal/validate-user-token/route.test.ts
+++ b/frontend/ui/src/app/api/internal/validate-user-token/route.test.ts
@@ -29,9 +29,9 @@ vi.mock("@/lib/auth-helpers", () => ({
   verifyInternalSecret: (...args: unknown[]) => verifyInternalSecretMock(...args),
 }));
 
-const getSessionMock = vi.fn();
-vi.mock("@/lib/auth", () => ({
-  auth: { api: { getSession: (...args: unknown[]) => getSessionMock(...args) } },
+const resolveTokenMock = vi.fn();
+vi.mock("@/lib/internal-session", () => ({
+  resolveSessionFromToken: (...args: unknown[]) => resolveTokenMock(...args),
 }));
 
 import { POST } from "./route";
@@ -45,7 +45,7 @@ beforeEach(() => {
   memberFindUniqueMock.mockReset();
   verifyInternalSecretMock.mockReset();
   verifyInternalSecretMock.mockReturnValue(true);
-  getSessionMock.mockReset();
+  resolveTokenMock.mockReset();
 });
 
 describe("POST /api/internal/validate-user-token", () => {
@@ -57,7 +57,7 @@ describe("POST /api/internal/validate-user-token", () => {
 
     expect(res.status).toBe(401);
     expect(body).toEqual({ valid: false, error: "Unauthorized" });
-    expect(getSessionMock).not.toHaveBeenCalled();
+    expect(resolveTokenMock).not.toHaveBeenCalled();
   });
 
   it("returns 400 on invalid JSON", async () => {
@@ -83,8 +83,8 @@ describe("POST /api/internal/validate-user-token", () => {
     expect(typeof body.error).toBe("string");
   });
 
-  it("returns 401 when getSession resolves no session", async () => {
-    getSessionMock.mockResolvedValue(null);
+  it("returns 401 when the token resolves to no live session", async () => {
+    resolveTokenMock.mockResolvedValue(null);
 
     const res = await POST(makeRequest({ token: "tok" }));
     const body = await res.json();
@@ -93,18 +93,16 @@ describe("POST /api/internal/validate-user-token", () => {
     expect(body).toEqual({ valid: false, error: "invalid or expired token" });
   });
 
-  it("treats a getSession throw as an invalid token, not a 500", async () => {
-    getSessionMock.mockRejectedValue(new Error("boom"));
+  it("propagates a resolver/database error instead of masking it as a bad token", async () => {
+    // A DB outage must surface as a 500 (which the backend maps to a fail-closed
+    // 503), not a misleading 401 that reads as "your token is invalid".
+    resolveTokenMock.mockRejectedValue(new Error("db down"));
 
-    const res = await POST(makeRequest({ token: "tok" }));
-    const body = await res.json();
-
-    expect(res.status).toBe(401);
-    expect(body).toEqual({ valid: false, error: "invalid or expired token" });
+    await expect(POST(makeRequest({ token: "tok" }))).rejects.toThrow("db down");
   });
 
   it("account-scope: no projectId returns valid + userId + email", async () => {
-    getSessionMock.mockResolvedValue({
+    resolveTokenMock.mockResolvedValue({
       user: { id: "user-1", email: "user@example.com" },
     });
 
@@ -117,7 +115,7 @@ describe("POST /api/internal/validate-user-token", () => {
   });
 
   it("project-scope: member returns valid + role/workspaceId/billingPlan/projectId", async () => {
-    getSessionMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
+    resolveTokenMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
     projectFindUniqueMock.mockResolvedValue({
       id: "proj-123",
       workspaceId: "ws-456",
@@ -140,7 +138,7 @@ describe("POST /api/internal/validate-user-token", () => {
   });
 
   it("project-scope: falls back to the FREE plan when the workspace has no billingPlan", async () => {
-    getSessionMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
+    resolveTokenMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
     projectFindUniqueMock.mockResolvedValue({
       id: "proj-123",
       workspaceId: "ws-456",
@@ -155,7 +153,7 @@ describe("POST /api/internal/validate-user-token", () => {
   });
 
   it("project-scope: project not found returns valid:true, hasAccess:false at 403", async () => {
-    getSessionMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
+    resolveTokenMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
     projectFindUniqueMock.mockResolvedValue(null);
 
     const res = await POST(makeRequest({ token: "tok", projectId: "missing" }));
@@ -167,7 +165,7 @@ describe("POST /api/internal/validate-user-token", () => {
   });
 
   it("project-scope: not a member returns valid:true, hasAccess:false at 403", async () => {
-    getSessionMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
+    resolveTokenMock.mockResolvedValue({ user: { id: "user-1", email: "user@example.com" } });
     projectFindUniqueMock.mockResolvedValue({
       id: "proj-123",
       workspaceId: "ws-456",

--- a/frontend/ui/src/app/auth/sign-in/__tests__/sign-in-client.test.tsx
+++ b/frontend/ui/src/app/auth/sign-in/__tests__/sign-in-client.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+  signInEmail: vi.fn(),
+  signInSocial: vi.fn(),
+}));
+
+let searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push, refresh: mocks.refresh }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    signIn: {
+      email: (...args: unknown[]) => mocks.signInEmail(...args),
+      social: (...args: unknown[]) => mocks.signInSocial(...args),
+    },
+  },
+}));
+
+import { SignInClient } from "../sign-in-client";
+
+function setParams(params: Record<string, string>) {
+  searchParams = new URLSearchParams(params);
+}
+
+afterEach(() => {
+  cleanup();
+  searchParams = new URLSearchParams();
+});
+
+describe("SignInClient", () => {
+  it("carries the callback to the sign-up link so a new user finishes the round-trip", () => {
+    setParams({ callbackUrl: "/device?user_code=ABCD1234" });
+
+    render(<SignInClient googleAuthConfigured={false} />);
+    const link = screen.getByRole("link", { name: "Sign up" });
+    expect(link.getAttribute("href")).toBe(
+      `/auth/sign-up?callbackUrl=${encodeURIComponent("/device?user_code=ABCD1234")}`,
+    );
+  });
+
+  it("uses a bare sign-up link when there is no callback", () => {
+    render(<SignInClient googleAuthConfigured={false} />);
+    const link = screen.getByRole("link", { name: "Sign up" });
+    expect(link.getAttribute("href")).toBe("/auth/sign-up");
+  });
+
+  it("drops a foreign callback rather than forwarding it to sign-up", () => {
+    setParams({ callbackUrl: "https://evil.example.com/steal" });
+
+    render(<SignInClient googleAuthConfigured={false} />);
+    const link = screen.getByRole("link", { name: "Sign up" });
+    // safeCallbackUrl collapses the off-origin value to the "/" fallback, which
+    // is treated as "no real callback" — so the link stays bare.
+    expect(link.getAttribute("href")).toBe("/auth/sign-up");
+  });
+});

--- a/frontend/ui/src/app/auth/sign-in/sign-in-client.tsx
+++ b/frontend/ui/src/app/auth/sign-in/sign-in-client.tsx
@@ -30,6 +30,12 @@ function SignInContent({ googleAuthConfigured }: SignInContentProps) {
   const searchParams = useSearchParams();
   // Attacker-suppliable query param; only same-origin destinations may pass.
   const callbackUrl = safeCallbackUrl(searchParams.get("callbackUrl"));
+  // Preserve the callback when switching to sign-up so a new user finishes the
+  // same round-trip (e.g. a device login returns to /device to approve).
+  const signUpHref =
+    callbackUrl && callbackUrl !== "/"
+      ? `/auth/sign-up?callbackUrl=${encodeURIComponent(callbackUrl)}`
+      : "/auth/sign-up";
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -156,7 +162,7 @@ function SignInContent({ googleAuthConfigured }: SignInContentProps) {
 
           <p className="text-center text-[12px] text-muted-foreground">
             Don&apos;t have an account?{" "}
-            <Link href="/auth/sign-up" className="font-medium text-primary hover:underline">
+            <Link href={signUpHref} className="font-medium text-primary hover:underline">
               Sign up
             </Link>
           </p>

--- a/frontend/ui/src/app/auth/sign-up/__tests__/sign-up-client.test.tsx
+++ b/frontend/ui/src/app/auth/sign-up/__tests__/sign-up-client.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+  signUpEmail: vi.fn(),
+  signInSocial: vi.fn(),
+}));
+
+let searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push, refresh: mocks.refresh }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    signUp: { email: (...args: unknown[]) => mocks.signUpEmail(...args) },
+    signIn: { social: (...args: unknown[]) => mocks.signInSocial(...args) },
+  },
+}));
+
+import { SignUpClient } from "../sign-up-client";
+
+function setParams(params: Record<string, string>) {
+  searchParams = new URLSearchParams(params);
+}
+
+function fillForm() {
+  fireEvent.change(screen.getByPlaceholderText("John Doe"), { target: { value: "Kai" } });
+  fireEvent.change(screen.getByPlaceholderText("you@example.com"), {
+    target: { value: "kai@example.com" },
+  });
+  const passwords = screen.getAllByPlaceholderText("********");
+  fireEvent.change(passwords[0], { target: { value: "password123" } });
+  fireEvent.change(passwords[1], { target: { value: "password123" } });
+}
+
+afterEach(() => {
+  cleanup();
+  mocks.push.mockReset();
+  mocks.refresh.mockReset();
+  mocks.signUpEmail.mockReset();
+  mocks.signInSocial.mockReset();
+  searchParams = new URLSearchParams();
+});
+
+describe("SignUpClient", () => {
+  it("sends a normal signup straight to onboarding", async () => {
+    mocks.signUpEmail.mockResolvedValue({ error: null });
+
+    render(<SignUpClient googleAuthConfigured={false} />);
+    fillForm();
+    fireEvent.click(screen.getByRole("button", { name: "Sign up" }));
+
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith("/onboarding"));
+  });
+
+  it("routes a device-login signup through /device with a next=onboarding hint", async () => {
+    setParams({ callbackUrl: "/device?user_code=ABCD1234" });
+    mocks.signUpEmail.mockResolvedValue({ error: null });
+
+    render(<SignUpClient googleAuthConfigured={false} />);
+    fillForm();
+    fireEvent.click(screen.getByRole("button", { name: "Sign up" }));
+
+    await waitFor(() => expect(mocks.push).toHaveBeenCalled());
+    const dest = mocks.push.mock.calls[0][0] as string;
+    expect(dest.startsWith("/device?")).toBe(true);
+    expect(dest).toContain("user_code=ABCD1234");
+    expect(dest).toContain(`next=${encodeURIComponent("/onboarding")}`);
+  });
+
+  it("passes the same device destination to Google sign-up", async () => {
+    setParams({ callbackUrl: "/device?user_code=ABCD1234" });
+    mocks.signInSocial.mockResolvedValue(undefined);
+
+    render(<SignUpClient googleAuthConfigured={true} />);
+    fireEvent.click(screen.getByRole("button", { name: "Google" }));
+
+    await waitFor(() => expect(mocks.signInSocial).toHaveBeenCalled());
+    const arg = mocks.signInSocial.mock.calls[0][0] as { provider: string; callbackURL: string };
+    expect(arg.provider).toBe("google");
+    expect(arg.callbackURL.startsWith("/device?")).toBe(true);
+    expect(arg.callbackURL).toContain(`next=${encodeURIComponent("/onboarding")}`);
+  });
+
+  it("ignores a non-device callback and onboards a new account directly", async () => {
+    setParams({ callbackUrl: "/projects/p1/traces" });
+    mocks.signUpEmail.mockResolvedValue({ error: null });
+
+    render(<SignUpClient googleAuthConfigured={false} />);
+    fillForm();
+    fireEvent.click(screen.getByRole("button", { name: "Sign up" }));
+
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith("/onboarding"));
+  });
+
+  it("carries the callback to the sign-in link", () => {
+    setParams({ callbackUrl: "/device?user_code=ABCD1234" });
+
+    render(<SignUpClient googleAuthConfigured={false} />);
+    const link = screen.getByRole("link", { name: "Sign in" });
+    expect(link.getAttribute("href")).toBe(
+      `/auth/sign-in?callbackUrl=${encodeURIComponent("/device?user_code=ABCD1234")}`,
+    );
+  });
+
+  it("uses a bare sign-in link when there is no callback", () => {
+    render(<SignUpClient googleAuthConfigured={false} />);
+    const link = screen.getByRole("link", { name: "Sign in" });
+    expect(link.getAttribute("href")).toBe("/auth/sign-in");
+  });
+});

--- a/frontend/ui/src/app/auth/sign-up/sign-up-client.tsx
+++ b/frontend/ui/src/app/auth/sign-up/sign-up-client.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
+import { safeCallbackUrl } from "@/lib/safe-callback-url";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -31,8 +32,30 @@ type SignUpClientProps = {
   googleAuthConfigured: boolean;
 };
 
-export function SignUpClient({ googleAuthConfigured }: SignUpClientProps) {
+// A brand-new account always finishes at onboarding. The one thing that can
+// need to happen first is a pending device authorization — the CLI login flow
+// sends the user through /device before they sign up — so route through it,
+// telling it (via ?next) to continue to onboarding once approved. Anything else
+// goes straight to onboarding; a new user shouldn't be dropped deep in the app.
+function postSignUpDestination(callbackUrl: string): string {
+  if (!callbackUrl.startsWith("/device")) {
+    return "/onboarding";
+  }
+  const params = new URLSearchParams(callbackUrl.split("?")[1] ?? "");
+  params.set("next", "/onboarding");
+  return `/device?${params.toString()}`;
+}
+
+function SignUpContent({ googleAuthConfigured }: SignUpClientProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  // Attacker-suppliable query param; only same-origin destinations may pass.
+  const callbackUrl = safeCallbackUrl(searchParams.get("callbackUrl"));
+  const destination = postSignUpDestination(callbackUrl);
+  const signInHref =
+    callbackUrl !== "/"
+      ? `/auth/sign-in?callbackUrl=${encodeURIComponent(callbackUrl)}`
+      : "/auth/sign-in";
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -61,7 +84,7 @@ export function SignUpClient({ googleAuthConfigured }: SignUpClientProps) {
       if (error) {
         setError(error.message || "Failed to create account");
       } else {
-        router.push("/onboarding");
+        router.push(destination);
         router.refresh();
       }
     } catch {
@@ -75,7 +98,7 @@ export function SignUpClient({ googleAuthConfigured }: SignUpClientProps) {
     setIsGoogleLoading(true);
     await authClient.signIn.social({
       provider: "google",
-      callbackURL: "/onboarding",
+      callbackURL: destination,
     });
   }
 
@@ -191,12 +214,20 @@ export function SignUpClient({ googleAuthConfigured }: SignUpClientProps) {
 
           <p className="text-center text-[12px] text-muted-foreground">
             Already have an account?{" "}
-            <Link href="/auth/sign-in" className="font-medium text-primary hover:underline">
+            <Link href={signInHref} className="font-medium text-primary hover:underline">
               Sign in
             </Link>
           </p>
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+export function SignUpClient({ googleAuthConfigured }: SignUpClientProps) {
+  return (
+    <Suspense>
+      <SignUpContent googleAuthConfigured={googleAuthConfigured} />
+    </Suspense>
   );
 }

--- a/frontend/ui/src/app/device/__tests__/device-client.test.tsx
+++ b/frontend/ui/src/app/device/__tests__/device-client.test.tsx
@@ -9,6 +9,7 @@ import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/re
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   useSession: vi.fn(),
+  signOut: vi.fn(),
   device: Object.assign(vi.fn(), { approve: vi.fn(), deny: vi.fn() }),
 }));
 
@@ -22,6 +23,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/lib/auth-client", () => ({
   authClient: {
     useSession: () => mocks.useSession(),
+    signOut: (...args: unknown[]) => mocks.signOut(...args),
     device: mocks.device,
   },
 }));
@@ -50,44 +52,40 @@ afterEach(() => {
   mocks.device.mockReset();
   mocks.device.approve.mockReset();
   mocks.device.deny.mockReset();
+  mocks.signOut.mockReset();
   searchParams = new URLSearchParams();
 });
 
 describe("DeviceClient", () => {
-  it("pre-fills the code entry input from ?user_code", () => {
+  it("auto-redirects to sign-in with the code in callbackUrl when signed out (no Continue)", async () => {
     setParams({ user_code: "abcd1234" });
     signedOut();
 
     render(<DeviceClient />);
 
-    const input = screen.getByLabelText("Device code") as HTMLInputElement;
-    expect(input.value).toBe("ABCD-1234");
-  });
-
-  it("shows an empty entry field when no code is present", () => {
-    signedOut();
-
-    render(<DeviceClient />);
-
-    const input = screen.getByLabelText("Device code") as HTMLInputElement;
-    expect(input.value).toBe("");
-  });
-
-  it("redirects to sign-in with the code preserved in callbackUrl when signed out", async () => {
-    setParams({ user_code: "abcd1234" });
-    signedOut();
-
-    render(<DeviceClient />);
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
-
+    // A code in the URL advances on its own — no manual Continue to reach login.
     await waitFor(() => expect(mocks.push).toHaveBeenCalled());
     const target = mocks.push.mock.calls[0][0] as string;
     expect(target).toBe(
       `/auth/sign-in?callbackUrl=${encodeURIComponent("/device?user_code=ABCD1234")}`,
     );
+    expect(screen.queryByRole("button", { name: "Continue" })).toBeNull();
   });
 
-  it("renders the client display name and the signed-in email on consent", async () => {
+  it("carries client_id through the signed-out redirect so consent still names the client", async () => {
+    setParams({ user_code: "abcd1234", client_id: "traceroot-cli" });
+    signedOut();
+
+    render(<DeviceClient />);
+
+    await waitFor(() => expect(mocks.push).toHaveBeenCalled());
+    const target = mocks.push.mock.calls[0][0] as string;
+    expect(target).toBe(
+      `/auth/sign-in?callbackUrl=${encodeURIComponent("/device?user_code=ABCD1234&client_id=traceroot-cli")}`,
+    );
+  });
+
+  it("auto-advances to consent when signed in with a code in the URL (no Continue)", async () => {
     setParams({ user_code: "abcd1234", client_id: "traceroot-cli" });
     signedIn("kai@example.com");
     mocks.device.mockResolvedValue({
@@ -96,10 +94,36 @@ describe("DeviceClient", () => {
     });
 
     render(<DeviceClient />);
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     await waitFor(() => expect(screen.getByText("TraceRoot CLI")).toBeDefined());
     expect(screen.getByText("as kai@example.com")).toBeDefined();
+    expect(screen.getByText("ABCD-1234")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Continue" })).toBeNull();
+  });
+
+  it("shows the entry form for a bare visit with no code in the URL", () => {
+    signedOut();
+
+    render(<DeviceClient />);
+
+    const input = screen.getByLabelText("Device code") as HTMLInputElement;
+    expect(input.value).toBe("");
+    expect(screen.getByRole("button", { name: "Continue" })).toBeDefined();
+  });
+
+  it("advances from a manually entered code when the URL has none", async () => {
+    signedIn("kai@example.com");
+    mocks.device.mockResolvedValue({
+      data: { user_code: "ABCD1234", status: "pending" },
+      error: null,
+    });
+
+    render(<DeviceClient />);
+    const input = screen.getByLabelText("Device code");
+    fireEvent.change(input, { target: { value: "abcd1234" } });
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => expect(screen.getByText("as kai@example.com")).toBeDefined());
     expect(screen.getByText("ABCD-1234")).toBeDefined();
   });
 
@@ -112,7 +136,6 @@ describe("DeviceClient", () => {
     });
 
     render(<DeviceClient />);
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     await waitFor(() => expect(screen.getByText("A command-line application")).toBeDefined());
   });
@@ -127,12 +150,28 @@ describe("DeviceClient", () => {
     mocks.device.approve.mockResolvedValue({ data: { success: true }, error: null });
 
     render(<DeviceClient />);
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     await waitFor(() => screen.getByRole("button", { name: "Approve" }));
     fireEvent.click(screen.getByRole("button", { name: "Approve" }));
 
     await waitFor(() => expect(screen.getByText("Approved")).toBeDefined());
     expect(mocks.device.approve).toHaveBeenCalledWith({ userCode: "ABCD1234" });
+  });
+
+  it("hands off to ?next after approve instead of the terminal screen (signup path)", async () => {
+    setParams({ user_code: "abcd1234", next: "/onboarding" });
+    signedIn();
+    mocks.device.mockResolvedValue({
+      data: { user_code: "ABCD1234", status: "pending" },
+      error: null,
+    });
+    mocks.device.approve.mockResolvedValue({ data: { success: true }, error: null });
+
+    render(<DeviceClient />);
+    await waitFor(() => screen.getByRole("button", { name: "Approve" }));
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => expect(mocks.push).toHaveBeenCalledWith("/onboarding"));
+    expect(screen.queryByText("Approved")).toBeNull();
   });
 
   it("denies and shows the denied state", async () => {
@@ -145,7 +184,6 @@ describe("DeviceClient", () => {
     mocks.device.deny.mockResolvedValue({ data: { success: true }, error: null });
 
     render(<DeviceClient />);
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     await waitFor(() => screen.getByRole("button", { name: "Deny" }));
     fireEvent.click(screen.getByRole("button", { name: "Deny" }));
 
@@ -169,18 +207,19 @@ describe("DeviceClient", () => {
     });
 
     render(<DeviceClient />);
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     await waitFor(() => screen.getByRole("button", { name: "Approve" }));
     fireEvent.click(screen.getByRole("button", { name: "Approve" }));
 
     await waitFor(() =>
       expect(
         screen.getByText(
-          "This code isn't associated with your account, so it can't be approved or denied from here.",
+          "This code was already opened by a different account and is locked to it. Go back to your terminal and run the login command again to get a fresh code.",
         ),
       ).toBeDefined(),
     );
     expect(screen.queryByText("Approved")).toBeNull();
+    // Terminal error: no looping "Try again" — the code is dead, they need a new one.
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
   });
 
   it("shows a mapped message for an expired code", async () => {
@@ -192,7 +231,6 @@ describe("DeviceClient", () => {
     });
 
     render(<DeviceClient />);
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     await waitFor(() =>
       expect(
@@ -212,7 +250,6 @@ describe("DeviceClient", () => {
     });
 
     render(<DeviceClient />);
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     await waitFor(() =>
       expect(
@@ -232,7 +269,6 @@ describe("DeviceClient", () => {
     });
 
     render(<DeviceClient />);
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     await waitFor(() => expect(screen.getByText("This code has already been used.")).toBeDefined());
   });
@@ -260,7 +296,6 @@ describe("DeviceClient", () => {
     });
 
     render(<DeviceClient />);
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
     await waitFor(() => screen.getByRole("button", { name: "Deny" }));
     fireEvent.click(screen.getByRole("button", { name: "Deny" }));
 
@@ -274,7 +309,23 @@ describe("DeviceClient", () => {
     expect(screen.queryByText("Denied")).toBeNull();
   });
 
-  it("returns to the entry form from an error state via Try again", async () => {
+  it("offers Try again for a mistyped code and returns to the entry form", async () => {
+    setParams({ user_code: "abcd1234" });
+    signedIn();
+    mocks.device.mockResolvedValue({
+      data: null,
+      error: { error: "invalid_request", error_description: "Invalid user code" },
+    });
+
+    render(<DeviceClient />);
+    await waitFor(() => screen.getByRole("button", { name: "Try again" }));
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    const input = screen.getByLabelText("Device code") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
+  it("shows no Try again for an expired code (terminal — needs a fresh code)", async () => {
     setParams({ user_code: "abcd1234" });
     signedIn();
     mocks.device.mockResolvedValue({
@@ -283,11 +334,30 @@ describe("DeviceClient", () => {
     });
 
     render(<DeviceClient />);
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
-    await waitFor(() => screen.getByRole("button", { name: "Try again" }));
-    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "This code has expired. Go back to your terminal and run the login command again.",
+        ),
+      ).toBeDefined(),
+    );
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+  });
 
-    const input = screen.getByLabelText("Device code") as HTMLInputElement;
-    expect(input.value).toBe("");
+  it("signs out and returns to sign-in from the consent 'Not you?' action", async () => {
+    setParams({ user_code: "abcd1234" });
+    signedIn("wrong@example.com");
+    mocks.device.mockResolvedValue({
+      data: { user_code: "ABCD1234", status: "pending" },
+      error: null,
+    });
+    mocks.signOut.mockResolvedValue(undefined);
+
+    render(<DeviceClient />);
+    await waitFor(() => screen.getByText("as wrong@example.com"));
+    fireEvent.click(screen.getByRole("button", { name: "Not you? Sign out" }));
+
+    await waitFor(() => expect(mocks.signOut).toHaveBeenCalled());
+    expect(mocks.push).toHaveBeenCalledWith("/auth/sign-in");
   });
 });

--- a/frontend/ui/src/app/device/device-client.tsx
+++ b/frontend/ui/src/app/device/device-client.tsx
@@ -191,6 +191,11 @@ function DeviceContent() {
   // one, so drop this session and start clean. Authorizing a different account
   // still needs a fresh code from the CLI — this just gets them out of here.
   async function handleSwitchAccount() {
+    // Clear the code first. Signing out flips the session, which would otherwise
+    // re-fire the verify effect's signed-out branch and push a sign-in URL
+    // carrying this now-dead code — bouncing the user right back to it instead
+    // of the clean sign-in below.
+    setActiveCode(null);
     await authClient.signOut();
     router.push("/auth/sign-in");
   }
@@ -338,7 +343,8 @@ function Consent({
       </div>
 
       <p className="text-[12px] text-muted-foreground">
-        This grants {clientName} read access to your workspaces. You can revoke it any time from{" "}
+        Approving signs {clientName} in to your TraceRoot account. It stays signed in until you
+        revoke it from{" "}
         <Link href="/account/settings/sessions" className="underline hover:text-foreground">
           Active Sessions
         </Link>{" "}

--- a/frontend/ui/src/app/device/device-client.tsx
+++ b/frontend/ui/src/app/device/device-client.tsx
@@ -8,7 +8,7 @@ import { authClient } from "@/lib/auth-client";
 import { safeCallbackUrl } from "@/lib/safe-callback-url";
 import { formatUserCode } from "@/lib/device-user-code";
 import { DEVICE_CLIENT_IDS, DEVICE_CLIENT_NAMES } from "@/lib/auth-clients";
-import { mapDeviceErrorMessage } from "./device-error-messages";
+import { mapDeviceErrorMessage, isRecoverableDeviceError } from "./device-error-messages";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -44,7 +44,18 @@ type Phase =
   | { kind: "consent" }
   | { kind: "approved" }
   | { kind: "denied" }
-  | { kind: "error"; message: string };
+  // `recoverable` gates the "Try again" affordance: only a mistyped/unverified
+  // code can be re-entered here, so a locked/expired/used code shows guidance
+  // (get a fresh code from the CLI) with no looping retry button.
+  | { kind: "error"; message: string; recoverable: boolean };
+
+function errorPhase(err: Parameters<typeof mapDeviceErrorMessage>[0]): Phase {
+  return {
+    kind: "error",
+    message: mapDeviceErrorMessage(err),
+    recoverable: isRecoverableDeviceError(err),
+  };
+}
 
 function DeviceContent() {
   const router = useRouter();
@@ -56,8 +67,13 @@ function DeviceContent() {
 
   const [codeInput, setCodeInput] = useState(initialCode ? formatUserCode(initialCode) : "");
   const [entryError, setEntryError] = useState<string | null>(null);
-  const [activeCode, setActiveCode] = useState<string | null>(null);
-  const [phase, setPhase] = useState<Phase>({ kind: "entry" });
+  // A code in the URL (the CLI opened the "complete" verification URL, or we're
+  // returning from the sign-in round-trip) advances on its own — no manual
+  // Continue. The entry form is only for a bare /device visit with no code.
+  const [activeCode, setActiveCode] = useState<string | null>(initialCode || null);
+  const [phase, setPhase] = useState<Phase>(
+    initialCode ? { kind: "verifying" } : { kind: "entry" },
+  );
   const [actionPending, setActionPending] = useState(false);
 
   // Resolve the pending request once we have both a code and a signed-in
@@ -71,11 +87,18 @@ function DeviceContent() {
     }
 
     if (!sessionData?.user) {
-      // Round-trip the code through sign-in so it survives the redirect,
-      // including the Google OAuth hop. The target is built from user
-      // input (the entry field), so run it through the same same-origin
-      // guard used elsewhere before handing it to the router.
-      const target = safeCallbackUrl(`/device?user_code=${activeCode}`, "/device");
+      // Not signed in yet: go straight to sign-in, carrying the code back in
+      // the callbackUrl so the return lands on consent. better-auth stores the
+      // full callbackUrl (query included) in the OAuth state and redirects to
+      // it verbatim, so the code survives the Google hop. Carry client_id too so
+      // the returning consent screen still names the client. The target is built
+      // from user input (the entry field), so run it through the same
+      // same-origin guard used elsewhere before handing it to the router.
+      const params = new URLSearchParams({ user_code: activeCode });
+      if (clientId) {
+        params.set("client_id", clientId);
+      }
+      const target = safeCallbackUrl(`/device?${params.toString()}`, "/device");
       router.push(`/auth/sign-in?callbackUrl=${encodeURIComponent(target)}`);
       return;
     }
@@ -89,17 +112,16 @@ function DeviceContent() {
         return;
       }
       if (error) {
-        setPhase({ kind: "error", message: mapDeviceErrorMessage(error) });
+        setPhase(errorPhase(error));
         return;
       }
       if (data && data.status !== "pending") {
-        setPhase({
-          kind: "error",
-          message: mapDeviceErrorMessage({
+        setPhase(
+          errorPhase({
             error: "invalid_request",
             error_description: "Device code already processed",
           }),
-        });
+        );
         return;
       }
       setPhase({ kind: "consent" });
@@ -127,11 +149,20 @@ function DeviceContent() {
     }
     setActionPending(true);
     const { error } = await authClient.device.approve({ userCode: activeCode });
-    setActionPending(false);
     if (error) {
-      setPhase({ kind: "error", message: mapDeviceErrorMessage(error) });
+      setActionPending(false);
+      setPhase(errorPhase(error));
       return;
     }
+    // A signup routes the user here to approve before continuing to onboarding
+    // (?next), so hand off there now that the device is authorized. A plain
+    // sign-in carries no ?next — the user just returns to their terminal.
+    const next = searchParams.get("next");
+    if (next) {
+      router.push(safeCallbackUrl(next, "/"));
+      return;
+    }
+    setActionPending(false);
     setPhase({ kind: "approved" });
   }
 
@@ -143,7 +174,7 @@ function DeviceContent() {
     const { error } = await authClient.device.deny({ userCode: activeCode });
     setActionPending(false);
     if (error) {
-      setPhase({ kind: "error", message: mapDeviceErrorMessage(error) });
+      setPhase(errorPhase(error));
       return;
     }
     setPhase({ kind: "denied" });
@@ -154,6 +185,14 @@ function DeviceContent() {
     setEntryError(null);
     setCodeInput("");
     setPhase({ kind: "entry" });
+  }
+
+  // Signed in as the wrong account: the current code is already locked to this
+  // one, so drop this session and start clean. Authorizing a different account
+  // still needs a fresh code from the CLI — this just gets them out of here.
+  async function handleSwitchAccount() {
+    await authClient.signOut();
+    router.push("/auth/sign-in");
   }
 
   return (
@@ -190,6 +229,7 @@ function DeviceContent() {
               pending={actionPending}
               onApprove={handleApprove}
               onDeny={handleDeny}
+              onSwitchAccount={handleSwitchAccount}
             />
           )}
 
@@ -198,7 +238,11 @@ function DeviceContent() {
           {phase.kind === "denied" && <Denied />}
 
           {phase.kind === "error" && (
-            <ErrorState message={phase.message} onStartOver={handleStartOver} />
+            <ErrorState
+              message={phase.message}
+              recoverable={phase.recoverable}
+              onStartOver={handleStartOver}
+            />
           )}
         </CardContent>
       </Card>
@@ -255,16 +299,37 @@ type ConsentProps = {
   pending: boolean;
   onApprove: () => void;
   onDeny: () => void;
+  onSwitchAccount: () => void;
 };
 
-function Consent({ clientName, email, code, pending, onApprove, onDeny }: ConsentProps) {
+function Consent({
+  clientName,
+  email,
+  code,
+  pending,
+  onApprove,
+  onDeny,
+  onSwitchAccount,
+}: ConsentProps) {
   return (
     <div className="space-y-4">
       <div className="space-y-1 text-center">
         <p className="text-[13px]">
           <span className="font-medium">{clientName}</span> wants to sign in
         </p>
-        {email && <p className="text-[12px] text-muted-foreground">as {email}</p>}
+        {email && (
+          <div className="space-y-0.5 text-[12px] text-muted-foreground">
+            <p>as {email}</p>
+            <button
+              type="button"
+              onClick={onSwitchAccount}
+              disabled={pending}
+              className="underline hover:text-foreground disabled:opacity-50"
+            >
+              Not you? Sign out
+            </button>
+          </div>
+        )}
       </div>
 
       <div className="border bg-muted/50 px-3 py-2 text-center">
@@ -325,16 +390,19 @@ function Denied() {
 
 type ErrorStateProps = {
   message: string;
+  recoverable: boolean;
   onStartOver: () => void;
 };
 
-function ErrorState({ message, onStartOver }: ErrorStateProps) {
+function ErrorState({ message, recoverable, onStartOver }: ErrorStateProps) {
   return (
     <div className="space-y-3 py-2 text-center">
       <p className="text-[13px] text-red-600 dark:text-red-400">{message}</p>
-      <Button variant="outline" size="sm" className="h-8 text-[13px]" onClick={onStartOver}>
-        Try again
-      </Button>
+      {recoverable && (
+        <Button variant="outline" size="sm" className="h-8 text-[13px]" onClick={onStartOver}>
+          Try again
+        </Button>
+      )}
     </div>
   );
 }

--- a/frontend/ui/src/app/device/device-error-messages.test.ts
+++ b/frontend/ui/src/app/device/device-error-messages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mapDeviceErrorMessage } from "./device-error-messages";
+import { mapDeviceErrorMessage, isRecoverableDeviceError } from "./device-error-messages";
 
 describe("mapDeviceErrorMessage", () => {
   it("maps expired_token", () => {
@@ -8,14 +8,14 @@ describe("mapDeviceErrorMessage", () => {
     ).toBe("This code has expired. Go back to your terminal and run the login command again.");
   });
 
-  it("maps access_denied", () => {
+  it("maps access_denied to the locked-to-another-account message", () => {
     expect(
       mapDeviceErrorMessage({
         error: "access_denied",
         error_description: "You are not authorized",
       }),
     ).toBe(
-      "This code isn't associated with your account, so it can't be approved or denied from here.",
+      "This code was already opened by a different account and is locked to it. Go back to your terminal and run the login command again to get a fresh code.",
     );
   });
 
@@ -59,10 +59,59 @@ describe("mapDeviceErrorMessage", () => {
   });
 
   it("falls back to a generic message when there is no description", () => {
-    expect(mapDeviceErrorMessage({ error: "some_new_error" })).toBe(
-      "Something went wrong. Please try again.",
-    );
-    expect(mapDeviceErrorMessage(null)).toBe("Something went wrong. Please try again.");
-    expect(mapDeviceErrorMessage(undefined)).toBe("Something went wrong. Please try again.");
+    const generic =
+      "Something went wrong. Go back to your terminal and run the login command again.";
+    expect(mapDeviceErrorMessage({ error: "some_new_error" })).toBe(generic);
+    expect(mapDeviceErrorMessage(null)).toBe(generic);
+    expect(mapDeviceErrorMessage(undefined)).toBe(generic);
+  });
+});
+
+describe("isRecoverableDeviceError", () => {
+  it("treats a mistyped code as recoverable (re-entering can work)", () => {
+    expect(
+      isRecoverableDeviceError({
+        error: "invalid_request",
+        error_description: "Invalid user code",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats a not-yet-claimed code as recoverable", () => {
+    expect(
+      isRecoverableDeviceError({
+        error: "invalid_request",
+        error_description: "Device code has not been claimed by a verifying session",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats a code locked to another account as terminal (needs a fresh code)", () => {
+    expect(
+      isRecoverableDeviceError({
+        error: "access_denied",
+        error_description: "You are not authorized",
+      }),
+    ).toBe(false);
+  });
+
+  it("treats expired and already-used codes as terminal", () => {
+    expect(
+      isRecoverableDeviceError({
+        error: "expired_token",
+        error_description: "User code has expired",
+      }),
+    ).toBe(false);
+    expect(
+      isRecoverableDeviceError({
+        error: "invalid_request",
+        error_description: "Device code already processed",
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a missing error as terminal", () => {
+    expect(isRecoverableDeviceError(null)).toBe(false);
+    expect(isRecoverableDeviceError(undefined)).toBe(false);
   });
 });

--- a/frontend/ui/src/app/device/device-error-messages.ts
+++ b/frontend/ui/src/app/device/device-error-messages.ts
@@ -26,7 +26,7 @@ export function mapDeviceErrorMessage(err: DeviceErrorLike | null | undefined): 
     return "This code has expired. Go back to your terminal and run the login command again.";
   }
   if (code === "access_denied") {
-    return "This code isn't associated with your account, so it can't be approved or denied from here.";
+    return "This code was already opened by a different account and is locked to it. Go back to your terminal and run the login command again to get a fresh code.";
   }
   if (code === "unauthorized") {
     return "You need to sign in again before continuing.";
@@ -41,5 +41,23 @@ export function mapDeviceErrorMessage(err: DeviceErrorLike | null | undefined): 
     return "That code doesn't match a pending request. Double-check it and try again.";
   }
 
-  return description || "Something went wrong. Please try again.";
+  return (
+    description || "Something went wrong. Go back to your terminal and run the login command again."
+  );
+}
+
+/**
+ * Whether a device error can be recovered by re-entering a code on this page.
+ *
+ * Only a mistyped or not-yet-verified code is fixable here. Everything else —
+ * a code locked to another account (access_denied), an expired code, or one
+ * that's already been used — needs a brand-new code from the CLI, so offering
+ * a "Try again" that just re-checks the same dead code would only loop.
+ *
+ * @param err - The `{ error, error_description }` body from a device endpoint.
+ * @returns True if re-entering a code on the consent page can still succeed.
+ */
+export function isRecoverableDeviceError(err: DeviceErrorLike | null | undefined): boolean {
+  const description = err?.error_description ?? "";
+  return description.includes("Invalid user code") || description.includes("not been claimed");
 }

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -90,8 +90,11 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const projectIdMatch = pathname.match(/^\/projects\/([^/]+)/);
   const projectId = projectIdMatch?.[1];
 
-  // Don't show layout on auth pages
-  if (pathname.startsWith("/auth/")) {
+  // Don't show the app shell (sidebar, header, user menu) on standalone
+  // sign-in surfaces. The device consent page is reachable while signed out,
+  // so wrapping it in the authenticated shell would render a bogus "User"
+  // menu and workspace rail around it.
+  if (pathname.startsWith("/auth/") || pathname === "/device") {
     return <>{children}</>;
   }
 

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Sun,
   Moon,
   Monitor,
+  MonitorSmartphone,
   Settings,
   UserRoundSearch,
   Database,
@@ -459,6 +460,15 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                     </button>
                   </PopoverContent>
                 </Popover>
+
+                {/* Active sessions — the revoke control for CLI/device logins */}
+                <Link
+                  href="/account/settings/sessions"
+                  className="flex w-full items-center justify-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent"
+                >
+                  <span>Active Sessions</span>
+                  <MonitorSmartphone className="h-4 w-4" />
+                </Link>
 
                 {/* Sign out */}
                 <button

--- a/frontend/ui/src/lib/auth.ts
+++ b/frontend/ui/src/lib/auth.ts
@@ -37,20 +37,16 @@ export const auth = betterAuth({
     expiresIn: 30 * 24 * 60 * 60, // 30 days
   },
 
-  advanced: {
-    ipAddress: {
-      // Behind the platform proxy the real client IP arrives in
-      // x-forwarded-for; without this the rate limiter can't key per-client and
-      // degrades to one shared per-path bucket.
-      ipAddressHeaders: ["x-forwarded-for"],
-    },
-  },
-
   rateLimit: {
     // Enabled automatically in production. `/device/code` is unauthenticated and
     // inserts a device_codes row on every call, so a loop would grow the table
-    // unbounded — cap creation per client IP. (Per-instance memory storage by
-    // default: a coarse bound, not a cross-replica guarantee.)
+    // unbounded — cap creation. better-auth keys the limit on the client IP,
+    // read from x-forwarded-for by default; behind a proxy that *appends* to
+    // XFF the address can't be resolved and every caller falls into one shared
+    // bucket, so for reliable per-client keying set
+    // `advanced.ipAddress.trustedProxies` to the edge's CIDRs (a deploy config).
+    // Storage is per-instance memory by default: a coarse bound, not a
+    // cross-replica guarantee.
     customRules: {
       "/device/code": { window: 60, max: 10 },
     },

--- a/frontend/ui/src/lib/auth.ts
+++ b/frontend/ui/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
-import { admin, bearer, deviceAuthorization } from "better-auth/plugins";
+import { admin, deviceAuthorization } from "better-auth/plugins";
 import { prisma } from "@traceroot/core";
 import { env } from "@/env";
 import { DEVICE_CLIENT_IDS } from "@/lib/auth-clients";
@@ -37,15 +37,34 @@ export const auth = betterAuth({
     expiresIn: 30 * 24 * 60 * 60, // 30 days
   },
 
+  advanced: {
+    ipAddress: {
+      // Behind the platform proxy the real client IP arrives in
+      // x-forwarded-for; without this the rate limiter can't key per-client and
+      // degrades to one shared per-path bucket.
+      ipAddressHeaders: ["x-forwarded-for"],
+    },
+  },
+
+  rateLimit: {
+    // Enabled automatically in production. `/device/code` is unauthenticated and
+    // inserts a device_codes row on every call, so a loop would grow the table
+    // unbounded — cap creation per client IP. (Per-instance memory storage by
+    // default: a coarse bound, not a cross-replica guarantee.)
+    customRules: {
+      "/device/code": { window: 60, max: 10 },
+    },
+  },
+
   plugins: [
     admin({
       impersonationSessionDuration: 60 * 60 * 24, // 1 day
     }),
-    // Lets a session token double as an `Authorization: Bearer <token>` header,
-    // which the CLI uses after completing the device flow. requireSignature must
-    // stay false (the default): device-flow tokens are unsigned, and turning on
-    // signature verification would reject every one of them.
-    bearer(),
+    // The CLI credential is a session token, but bearer() is deliberately NOT
+    // enabled: it would let that token authenticate every /api/auth/* endpoint
+    // and would expose session tokens to page JS on sign-in. The backend
+    // introspects the token by a direct session lookup instead (see
+    // internal-session.ts), so it never needs to ride the better-auth header.
     deviceAuthorization({
       expiresIn: "30m", // a sign-up round trip (not just sign-in) needs to fit in the window
       interval: "5s",

--- a/frontend/ui/src/lib/internal-session.test.ts
+++ b/frontend/ui/src/lib/internal-session.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const findUniqueMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: { session: { findUnique: (...args: unknown[]) => findUniqueMock(...args) } },
+}));
+
+import { resolveSessionFromToken } from "./internal-session";
+
+beforeEach(() => {
+  findUniqueMock.mockReset();
+});
+
+describe("resolveSessionFromToken", () => {
+  it("returns the user for a live (unexpired) session, looked up by token", async () => {
+    findUniqueMock.mockResolvedValue({
+      expiresAt: new Date(Date.now() + 60_000),
+      user: { id: "u1", email: "u@example.com" },
+    });
+
+    await expect(resolveSessionFromToken("tok")).resolves.toEqual({
+      user: { id: "u1", email: "u@example.com" },
+    });
+    expect(findUniqueMock.mock.calls[0][0].where).toEqual({ token: "tok" });
+  });
+
+  it("returns null for an expired session", async () => {
+    findUniqueMock.mockResolvedValue({
+      expiresAt: new Date(Date.now() - 1_000),
+      user: { id: "u1", email: "u@example.com" },
+    });
+
+    await expect(resolveSessionFromToken("tok")).resolves.toBeNull();
+  });
+
+  it("returns null when the token is unknown", async () => {
+    findUniqueMock.mockResolvedValue(null);
+
+    await expect(resolveSessionFromToken("nope")).resolves.toBeNull();
+  });
+
+  it("propagates a database error — an outage is a 500, not a bad token", async () => {
+    findUniqueMock.mockRejectedValue(new Error("db down"));
+
+    await expect(resolveSessionFromToken("tok")).rejects.toThrow("db down");
+  });
+});

--- a/frontend/ui/src/lib/internal-session.ts
+++ b/frontend/ui/src/lib/internal-session.ts
@@ -1,22 +1,35 @@
-import { auth } from "@/lib/auth";
+import { prisma } from "@traceroot/core";
+
+export type ResolvedSession = { user: { id: string; email: string } } | null;
 
 /**
- * Resolve a better-auth session from a raw bearer session token.
+ * Resolve a user from a raw session token via a direct database lookup.
  *
  * Shared by the internal routes the Python backend calls to introspect a user's
- * CLI credential (validate-user-token, user-memberships). Resolves via the
- * bearer plugin, which accepts the session token as an Authorization header in
- * place of the cookie. Returns null when the token is invalid/expired or
- * resolution throws (a bad token is not a 500). Never log the token or headers.
+ * CLI credential (validate-user-token, user-memberships). Resolving by a direct
+ * `session.token` lookup deliberately keeps the credential off the public
+ * better-auth surface: enabling the bearer plugin so `auth.api.getSession` would
+ * accept an `Authorization: Bearer <token>` header would also let that same CLI
+ * token drive every `/api/auth/*` endpoint (update-user, revoke-sessions, …) and
+ * would expose session tokens to page JS on sign-in. This resolver only needs to
+ * map a live token to its user.
+ *
+ * Returns null when the token is unknown or expired (a bad token is a 401, not a
+ * 500). A database error propagates so an outage surfaces as a 500 rather than a
+ * misleading "invalid token". Never log the token.
  */
-export async function resolveSessionFromToken(
-  token: string,
-): Promise<Awaited<ReturnType<typeof auth.api.getSession>>> {
-  try {
-    return await auth.api.getSession({
-      headers: new Headers({ Authorization: `Bearer ${token}` }),
-    });
-  } catch {
+export async function resolveSessionFromToken(token: string): Promise<ResolvedSession> {
+  const session = await prisma.session.findUnique({
+    where: { token },
+    select: {
+      expiresAt: true,
+      user: { select: { id: true, email: true } },
+    },
+  });
+
+  if (!session || session.expiresAt.getTime() <= Date.now()) {
     return null;
   }
+
+  return { user: session.user };
 }

--- a/frontend/ui/src/proxy.test.ts
+++ b/frontend/ui/src/proxy.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { config } from "./proxy";
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { config, proxy } from "./proxy";
 
 /**
  * The middleware matcher is Next's negative-lookahead form: a path is PROTECTED
@@ -30,5 +31,39 @@ describe("middleware matcher exemptions", () => {
   it("still protects app pages and session-authed API routes", () => {
     expect(isProtected("/projects/p1/datasets")).toBe(true);
     expect(isProtected("/api/projects/p1/datasets")).toBe(true);
+  });
+});
+
+function request(path: string, opts?: { token?: boolean }): NextRequest {
+  const headers = new Headers();
+  if (opts?.token) {
+    headers.set("cookie", "better-auth.session_token=a-token");
+  }
+  return new NextRequest(new URL(`http://localhost:3000${path}`), { headers });
+}
+
+describe("proxy middleware", () => {
+  it("lets the device page through without a token so it can keep its ?user_code", () => {
+    // The bug this guards: redirecting here would drop the query (pathname-only
+    // callbackUrl), losing the device code across the sign-in round-trip.
+    const res = proxy(request("/device?user_code=ABCD1234"));
+    expect(res.headers.get("location")).toBeNull();
+  });
+
+  it("lets auth pages through without a token", () => {
+    const res = proxy(request("/auth/sign-in"));
+    expect(res.headers.get("location")).toBeNull();
+  });
+
+  it("redirects a protected route to sign-in when unauthenticated", () => {
+    const res = proxy(request("/projects/p1/traces"));
+    const location = res.headers.get("location");
+    expect(location).toContain("/auth/sign-in");
+    expect(location).toContain("callbackUrl=");
+  });
+
+  it("allows a protected route when a session token is present", () => {
+    const res = proxy(request("/projects/p1/traces", { token: true }));
+    expect(res.headers.get("location")).toBeNull();
   });
 });

--- a/frontend/ui/src/proxy.ts
+++ b/frontend/ui/src/proxy.ts
@@ -11,6 +11,15 @@ export function proxy(req: NextRequest) {
     return NextResponse.next();
   }
 
+  // The device consent page owns its own sign-in round-trip: it must preserve
+  // the ?user_code query and stash it across the redirect (this middleware would
+  // otherwise redirect with a pathname-only callbackUrl, dropping the code). The
+  // sensitive action (approve) is enforced server-side to require the claiming
+  // session, so leaving the page reachable without a token is safe.
+  if (req.nextUrl.pathname === "/device") {
+    return NextResponse.next();
+  }
+
   // No token → redirect to sign-in
   if (!token) {
     const signInUrl = new URL("/auth/sign-in", req.url);


### PR DESCRIPTION
**Stacked PR 8 of 11** — part of the CLI-login epic (#1863). Base: `feat/account-rate-limit-keys`.

Device-flow polish: render the consent page outside the middleware auth gate, auto-advance and stop retrying dead codes, thread the sign-in callback through sign-up, and honest device-grant messaging.

Rebased onto latest `main`; drift checks (public OpenAPI + tool registry) are clean at this cut point. Review only the commits added on top of the base branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes device-login UX and hardens CLI auth. Previously the auth middleware dropped the `?user_code` and the page looped on dead codes; now `/device` renders standalone, preserves the full code, auto-advances, and only offers retries that can succeed. We also drop `better-auth`’s `bearer()` and resolve CLI tokens via direct lookup.

- Device consent: `/device` bypasses the middleware and app shell; preserves `?user_code` and `client_id` across sign-in. Signed out → redirect to sign-in with `callbackUrl=/device?...`; signed in → verify to consent. “Try again” only for mistyped/unclaimed codes; expired/used/locked-to-another-account are terminal. Consent names the account, adds “Not you? Sign out,” and Approve honors `?next` (signup continues to onboarding). Adds “Active Sessions” to the user menu.
- Sign-in/up: cross-links carry a validated `callbackUrl`. Sign-up routes device flows back through `/device` with `next=/onboarding`; other sign-ups go straight to onboarding.
- Auth hardening: remove `bearer()`; internal routes use `resolveSessionFromToken` (direct `session.token` lookup). Unknown/expired tokens return 401, database errors propagate (500). Rate limit unauthenticated `/device/code` at 10/min per client IP and index `device_codes.expires_at` for bounded lookups/pruning.
- Public API/docs: reword public read docs to “caller’s project” and clarify endpoints accept an API key or a user session token. Rate-limit docs note per-user read buckets within a workspace; no behavior changes.

- Rollout
  - Run the Prisma migration adding `ix_device_code_expires_at`.
  - If the edge appends `x-forwarded-for`, set `advanced.ipAddress.trustedProxies` so rate limiting keys per client instead of one shared bucket.

<sup>Written for commit 84b9b816e7ca7df8ce5dc913c7e8f39bc2de8abd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

