### PR TITLE
feat(api): mint short-lived CLI access JWTs from the session token

### DIFF
--- a/frontend/packages/core/prisma/migrations/20260813010000_add_jwks/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260813010000_add_jwks/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+-- EdDSA signing keys for the better-auth jwt() plugin (private key signs the
+-- CLI access JWTs; public key is served at /api/auth/jwks for offline verify).
+CREATE TABLE "jwks" (
+    "id" VARCHAR NOT NULL,
+    "public_key" VARCHAR NOT NULL,
+    "private_key" VARCHAR NOT NULL,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(6),
+
+    CONSTRAINT "jwks_pkey" PRIMARY KEY ("id")
+);

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -274,6 +274,20 @@ model DeviceCode {
   @@map("device_codes")
 }
 
+// EdDSA signing keys for the better-auth jwt() plugin. The private key signs the
+// short-lived CLI access JWTs; the public key is served at /api/auth/jwks so the
+// Python backend can verify them offline. A handful of rows (rotated over time),
+// never per-user or per-token.
+model Jwks {
+  id         String    @id @default(cuid()) @db.VarChar
+  publicKey  String    @map("public_key") @db.VarChar
+  privateKey String    @map("private_key") @db.VarChar
+  createdAt  DateTime  @default(now()) @db.Timestamp(6)
+  expiresAt  DateTime? @map("expires_at") @db.Timestamp(6)
+
+  @@map("jwks")
+}
+
 // Workspace-level GitHub App installations.
 // One row per (workspace, GitHub installation). Multiple rows per workspace
 // supports the multi-org case (e.g. workspace has projects under github.com/acme

--- a/frontend/ui/src/app/api/cli/token/route.test.ts
+++ b/frontend/ui/src/app/api/cli/token/route.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  signJWT: vi.fn(),
+  resolveSession: vi.fn(),
+  rateLimitOk: vi.fn(() => true),
+}));
+
+vi.mock("next/server", () => ({
+  NextRequest: class {},
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { signJWT: (...args: unknown[]) => mocks.signJWT(...args) } },
+}));
+
+vi.mock("@/lib/internal-session", () => ({
+  resolveSessionFromToken: (...args: unknown[]) => mocks.resolveSession(...args),
+}));
+
+vi.mock("@/lib/mint-rate-limit", () => ({
+  checkMintRateLimit: () => mocks.rateLimitOk(),
+  rateLimitClientKey: () => "test-key",
+}));
+
+import { POST } from "./route";
+
+function makeRequest(headers?: Record<string, string>) {
+  return { headers: new Headers(headers ?? {}) } as unknown as Parameters<typeof POST>[0];
+}
+
+beforeEach(() => {
+  mocks.signJWT.mockReset();
+  mocks.resolveSession.mockReset();
+  mocks.rateLimitOk.mockReset();
+  mocks.rateLimitOk.mockReturnValue(true);
+});
+
+describe("POST /api/cli/token", () => {
+  it("mints a JWT for a valid session token, carrying sub/email/aud/sid explicitly", async () => {
+    mocks.resolveSession.mockResolvedValue({
+      sessionId: "sess-1",
+      user: { id: "u1", email: "u@example.com" },
+    });
+    mocks.signJWT.mockResolvedValue({ token: "the.jwt.token" });
+
+    const res = await POST(makeRequest({ authorization: "Bearer sess-abc" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ accessToken: "the.jwt.token", tokenType: "Bearer", expiresIn: 600 });
+    expect(mocks.resolveSession).toHaveBeenCalledWith("sess-abc");
+
+    // sub must be in the payload — auth.api.signJWT only sets it when present.
+    const payload = mocks.signJWT.mock.calls[0][0].body.payload;
+    expect(payload.sub).toBe("u1");
+    expect(payload.email).toBe("u@example.com");
+    expect(payload.aud).toBe("traceroot-api");
+    // sid carries the session row id for the future write-path revocation check.
+    expect(payload.sid).toBe("sess-1");
+  });
+
+  it("401s when no bearer token is present, without a lookup", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(401);
+    expect(mocks.resolveSession).not.toHaveBeenCalled();
+  });
+
+  it("401s when the session is invalid or expired, without minting", async () => {
+    mocks.resolveSession.mockResolvedValue(null);
+    const res = await POST(makeRequest({ authorization: "Bearer nope" }));
+    expect(res.status).toBe(401);
+    expect(mocks.signJWT).not.toHaveBeenCalled();
+  });
+
+  it("429s when rate limited, before touching the session lookup", async () => {
+    mocks.rateLimitOk.mockReturnValue(false);
+    const res = await POST(makeRequest({ authorization: "Bearer sess-abc" }));
+    expect(res.status).toBe(429);
+    expect(mocks.resolveSession).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/cli/token/route.ts
+++ b/frontend/ui/src/app/api/cli/token/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { resolveSessionFromToken } from "@/lib/internal-session";
+import { checkMintRateLimit, rateLimitClientKey } from "@/lib/mint-rate-limit";
+
+// POST /api/cli/token
+//
+// Exchanges the CLI's long-lived session token (its refresh credential) for a
+// short-lived EdDSA JWT that is the actual request bearer. The session token is
+// validated by a direct database lookup (never via bearer() on /api/auth), so
+// the session credential stays off the better-auth surface; only a 10-minute
+// JWT carrying identity goes on the wire, and the Python backend verifies it
+// offline against /api/auth/jwks. The CLI calls this again to refresh before
+// expiry. Public endpoint — rate-limited, and 401 without a valid session.
+
+// Must track the jwt() plugin's `expirationTime` in auth.ts (10m). Advisory only
+// (the JWT's own `exp` is authoritative); returned so the CLI can schedule refresh.
+const ACCESS_TOKEN_TTL_SECONDS = 10 * 60;
+
+// The issuer + audience the backend pins when verifying. Explicit, purpose-
+// specific constants rather than better-auth's default (the app base URL), so
+// backend validation doesn't couple to URL config. MUST match the constants the
+// backend checks (backend/rest/routers/public/deps.py).
+const ACCESS_TOKEN_ISSUER = "traceroot";
+const ACCESS_TOKEN_AUDIENCE = "traceroot-api";
+
+export async function POST(request: NextRequest) {
+  if (!checkMintRateLimit(rateLimitClientKey(request.headers), 60, 60_000)) {
+    return NextResponse.json({ error: "rate limited" }, { status: 429 });
+  }
+
+  const authorization = request.headers.get("authorization") ?? "";
+  const sessionToken = authorization.toLowerCase().startsWith("bearer ")
+    ? authorization.slice(7).trim()
+    : "";
+  if (!sessionToken) {
+    return NextResponse.json({ error: "missing bearer session token" }, { status: 401 });
+  }
+
+  const session = await resolveSessionFromToken(sessionToken);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "invalid or expired session" }, { status: 401 });
+  }
+
+  // Build the claims explicitly: auth.api.signJWT signs the payload verbatim and
+  // only sets `sub` when it is present (definePayload is not consulted here).
+  const { token } = await auth.api.signJWT({
+    body: {
+      payload: {
+        sub: session.user.id,
+        email: session.user.email,
+        // The session row id (not the token). Lets the backend's future
+        // write-path revocation check confirm this session is still live.
+        sid: session.sessionId,
+        iss: ACCESS_TOKEN_ISSUER,
+        aud: ACCESS_TOKEN_AUDIENCE,
+        iat: Math.floor(Date.now() / 1000),
+      },
+    },
+  });
+
+  return NextResponse.json({
+    accessToken: token,
+    tokenType: "Bearer",
+    expiresIn: ACCESS_TOKEN_TTL_SECONDS,
+  });
+}

--- a/frontend/ui/src/app/api/internal/user-project-access/route.test.ts
+++ b/frontend/ui/src/app/api/internal/user-project-access/route.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextRequest: class {},
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+const projectFindUniqueMock = vi.fn();
+const memberFindUniqueMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    project: { findUnique: (...args: unknown[]) => projectFindUniqueMock(...args) },
+    workspaceMember: { findUnique: (...args: unknown[]) => memberFindUniqueMock(...args) },
+  },
+  PlanType: { FREE: "free" },
+}));
+
+const verifyInternalSecretMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  verifyInternalSecret: (...args: unknown[]) => verifyInternalSecretMock(...args),
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: unknown) {
+  return { json: async () => body } as unknown as Parameters<typeof POST>[0];
+}
+
+beforeEach(() => {
+  projectFindUniqueMock.mockReset();
+  memberFindUniqueMock.mockReset();
+  verifyInternalSecretMock.mockReset();
+  verifyInternalSecretMock.mockReturnValue(true);
+});
+
+describe("POST /api/internal/user-project-access", () => {
+  it("rejects an unauthorized caller before any lookup", async () => {
+    verifyInternalSecretMock.mockReturnValue(false);
+
+    const res = await POST(makeRequest({ userId: "u1", projectId: "p1" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body).toEqual({ error: "Unauthorized" });
+    expect(projectFindUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when userId or projectId is missing", async () => {
+    const res = await POST(makeRequest({ userId: "u1" }));
+    expect(res.status).toBe(400);
+    expect(projectFindUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves role/workspace/plan for a member", async () => {
+    projectFindUniqueMock.mockResolvedValue({
+      id: "proj-123",
+      workspaceId: "ws-456",
+      workspace: { billingPlan: "pro" },
+    });
+    memberFindUniqueMock.mockResolvedValue({ role: "admin" });
+
+    const res = await POST(makeRequest({ userId: "user-1", projectId: "proj-123" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      valid: true,
+      hasAccess: true,
+      userId: "user-1",
+      role: "admin",
+      workspaceId: "ws-456",
+      billingPlan: "pro",
+      projectId: "proj-123",
+    });
+    // keyed on the passed userId, not a session
+    const memberArgs = memberFindUniqueMock.mock.calls[0][0];
+    expect(memberArgs.where.workspaceId_userId).toEqual({
+      workspaceId: "ws-456",
+      userId: "user-1",
+    });
+  });
+
+  it("falls back to the FREE plan when the workspace has no billingPlan", async () => {
+    projectFindUniqueMock.mockResolvedValue({
+      id: "proj-123",
+      workspaceId: "ws-456",
+      workspace: { billingPlan: null },
+    });
+    memberFindUniqueMock.mockResolvedValue({ role: "viewer" });
+
+    const res = await POST(makeRequest({ userId: "user-1", projectId: "proj-123" }));
+    const body = await res.json();
+
+    expect(body.billingPlan).toBe("free");
+  });
+
+  it("returns 403 hasAccess:false when the project is not found", async () => {
+    projectFindUniqueMock.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ userId: "user-1", projectId: "missing" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body).toEqual({ hasAccess: false });
+    expect(memberFindUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 hasAccess:false when the user is not a member", async () => {
+    projectFindUniqueMock.mockResolvedValue({
+      id: "proj-123",
+      workspaceId: "ws-456",
+      workspace: { billingPlan: "pro" },
+    });
+    memberFindUniqueMock.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ userId: "user-1", projectId: "proj-123" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body).toEqual({ hasAccess: false });
+  });
+});

--- a/frontend/ui/src/app/api/internal/user-project-access/route.ts
+++ b/frontend/ui/src/app/api/internal/user-project-access/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma, PlanType } from "@traceroot/core";
+import { verifyInternalSecret } from "@/lib/auth-helpers";
+
+const userProjectAccessSchema = z.object({
+  userId: z.string().min(1, "userId is required"),
+  projectId: z.string().min(1, "projectId is required"),
+});
+
+// POST /api/internal/user-project-access
+//
+// Resolves a user's access + role + billing plan for one project, given a
+// userId the caller has ALREADY authenticated. Used by the Python backend on
+// the CLI JWT path: it verifies the access JWT offline (so identity is
+// established by signature, not a session lookup) and then calls this to fill in
+// the project-scoped fields a JWT doesn't carry. Unlike validate-user-token this
+// does NOT validate a session token — trust is the X-Internal-Secret plus the
+// backend's verified JWT. It reuses the same project + membership queries as
+// validate-user-token's project-scope branch. Never log ids.
+export async function POST(request: NextRequest) {
+  if (!verifyInternalSecret(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const result = userProjectAccessSchema.safeParse(body);
+  if (!result.success) {
+    return NextResponse.json({ error: result.error.issues[0].message }, { status: 400 });
+  }
+
+  const { userId, projectId } = result.data;
+
+  const project = await prisma.project.findUnique({
+    where: { id: projectId, deleteTime: null },
+    select: {
+      id: true,
+      workspaceId: true,
+      workspace: { select: { billingPlan: true } },
+    },
+  });
+
+  if (!project) {
+    return NextResponse.json({ hasAccess: false }, { status: 403 });
+  }
+
+  const membership = await prisma.workspaceMember.findUnique({
+    where: {
+      workspaceId_userId: {
+        workspaceId: project.workspaceId,
+        userId,
+      },
+    },
+    select: { role: true },
+  });
+
+  if (!membership) {
+    return NextResponse.json({ hasAccess: false }, { status: 403 });
+  }
+
+  return NextResponse.json({
+    // `valid` mirrors the other internal auth routes so the backend's shared
+    // response handler treats a 200 as success.
+    valid: true,
+    hasAccess: true,
+    userId,
+    role: membership.role,
+    workspaceId: project.workspaceId,
+    billingPlan: project.workspace?.billingPlan || PlanType.FREE,
+    projectId: project.id,
+  });
+}

--- a/frontend/ui/src/lib/auth.ts
+++ b/frontend/ui/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
-import { admin, deviceAuthorization } from "better-auth/plugins";
+import { admin, deviceAuthorization, jwt } from "better-auth/plugins";
 import { prisma } from "@traceroot/core";
 import { env } from "@/env";
 import { DEVICE_CLIENT_IDS } from "@/lib/auth-clients";
@@ -67,6 +67,17 @@ export const auth = betterAuth({
       generateUserCode,
       validateClient: (clientId) => DEVICE_CLIENT_IDS.has(clientId),
       verificationUri: "/device",
+    }),
+    // Signs the short-lived CLI access tokens. The CLI stores the long-lived
+    // session token as a refresh credential and exchanges it (via
+    // /api/cli/token) for a 10-minute EdDSA JWT that is the actual request
+    // bearer; the Python backend verifies that JWT offline against /api/auth/jwks
+    // (no per-request introspection for the identity check). Keys live in the
+    // `jwks` table. bearer() stays off — the exchange route validates the
+    // session by a direct lookup, so the session token never rides /api/auth.
+    jwt({
+      jwt: { expirationTime: "10m" },
+      jwks: { keyPairConfig: { alg: "EdDSA" } },
     }),
   ],
 });

--- a/frontend/ui/src/lib/internal-session.test.ts
+++ b/frontend/ui/src/lib/internal-session.test.ts
@@ -12,13 +12,15 @@ beforeEach(() => {
 });
 
 describe("resolveSessionFromToken", () => {
-  it("returns the user for a live (unexpired) session, looked up by token", async () => {
+  it("returns the session id + user for a live (unexpired) session, looked up by token", async () => {
     findUniqueMock.mockResolvedValue({
+      id: "sess-1",
       expiresAt: new Date(Date.now() + 60_000),
       user: { id: "u1", email: "u@example.com" },
     });
 
     await expect(resolveSessionFromToken("tok")).resolves.toEqual({
+      sessionId: "sess-1",
       user: { id: "u1", email: "u@example.com" },
     });
     expect(findUniqueMock.mock.calls[0][0].where).toEqual({ token: "tok" });

--- a/frontend/ui/src/lib/internal-session.ts
+++ b/frontend/ui/src/lib/internal-session.ts
@@ -1,6 +1,12 @@
 import { prisma } from "@traceroot/core";
 
-export type ResolvedSession = { user: { id: string; email: string } } | null;
+export type ResolvedSession = {
+  // The session row id (NOT the token). Rides in the CLI access JWT as `sid` so
+  // a future write-path revocation check can verify this specific session is
+  // still live (revoking it in Active Sessions deletes the row).
+  sessionId: string;
+  user: { id: string; email: string };
+} | null;
 
 /**
  * Resolve a user from a raw session token via a direct database lookup.
@@ -22,6 +28,7 @@ export async function resolveSessionFromToken(token: string): Promise<ResolvedSe
   const session = await prisma.session.findUnique({
     where: { token },
     select: {
+      id: true,
       expiresAt: true,
       user: { select: { id: true, email: true } },
     },
@@ -31,5 +38,5 @@ export async function resolveSessionFromToken(token: string): Promise<ResolvedSe
     return null;
   }
 
-  return { user: session.user };
+  return { sessionId: session.id, user: session.user };
 }

--- a/frontend/ui/src/lib/mint-rate-limit.test.ts
+++ b/frontend/ui/src/lib/mint-rate-limit.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { checkMintRateLimit, rateLimitClientKey, __resetMintRateLimit } from "./mint-rate-limit";
+
+beforeEach(() => {
+  __resetMintRateLimit();
+});
+
+describe("checkMintRateLimit", () => {
+  it("allows up to max within the window, then blocks", () => {
+    const t = 1000;
+    expect(checkMintRateLimit("k", 2, 1000, t)).toBe(true);
+    expect(checkMintRateLimit("k", 2, 1000, t)).toBe(true);
+    expect(checkMintRateLimit("k", 2, 1000, t)).toBe(false);
+  });
+
+  it("resets once the window elapses", () => {
+    expect(checkMintRateLimit("k", 1, 1000, 1000)).toBe(true); // window resets at 2000
+    expect(checkMintRateLimit("k", 1, 1000, 1500)).toBe(false); // still in window
+    expect(checkMintRateLimit("k", 1, 1000, 2000)).toBe(true); // new window
+  });
+
+  it("keys buckets independently", () => {
+    expect(checkMintRateLimit("a", 1, 1000, 1000)).toBe(true);
+    expect(checkMintRateLimit("b", 1, 1000, 1000)).toBe(true);
+    expect(checkMintRateLimit("a", 1, 1000, 1000)).toBe(false);
+  });
+});
+
+describe("rateLimitClientKey", () => {
+  it("prefers x-real-ip", () => {
+    const key = rateLimitClientKey(
+      new Headers({ "x-real-ip": "1.2.3.4", "x-forwarded-for": "9.9.9.9" }),
+    );
+    expect(key).toBe("1.2.3.4");
+  });
+
+  it("uses the LAST x-forwarded-for hop (ALB-appended client, not the spoofable leftmost)", () => {
+    const key = rateLimitClientKey(new Headers({ "x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3" }));
+    expect(key).toBe("3.3.3.3");
+  });
+
+  it("falls back to a shared bucket when no forwarding header is present", () => {
+    expect(rateLimitClientKey(new Headers())).toBe("local");
+  });
+});

--- a/frontend/ui/src/lib/mint-rate-limit.ts
+++ b/frontend/ui/src/lib/mint-rate-limit.ts
@@ -1,0 +1,74 @@
+// In-memory fixed-window rate limiter for the public JWT-mint endpoint
+// (`/api/cli/token`). better-auth's own rate limiter only covers `/api/auth/*`,
+// so this route needs its own bound. Per-instance memory is fine at the current
+// single replica; the robust, cross-replica control — and reliable per-client
+// keying that app-level XFF parsing can't guarantee behind the ALB — is a WAF
+// rate rule at the edge, which is also the right layer to resolve the true
+// client IP behind the load balancer.
+//
+// Minting requires a valid session (the route 401s otherwise), so the real
+// concern this bounds is an unauthenticated flood forcing a session lookup per
+// request — not credential minting itself.
+
+type FixedWindow = { count: number; resetAt: number };
+
+const windows = new Map<string, FixedWindow>();
+
+/**
+ * Fixed-window rate check. Returns true if the request is allowed and records it.
+ *
+ * @param key - Bucket key (a client identifier).
+ * @param max - Max requests permitted per window.
+ * @param windowMs - Window length in milliseconds.
+ * @param now - Current epoch ms (injectable for tests).
+ * @returns True if allowed, false if the window is exhausted.
+ */
+export function checkMintRateLimit(
+  key: string,
+  max: number,
+  windowMs: number,
+  now: number = Date.now(),
+): boolean {
+  const existing = windows.get(key);
+  if (!existing || now >= existing.resetAt) {
+    windows.set(key, { count: 1, resetAt: now + windowMs });
+    if (windows.size > 10_000) {
+      for (const [k, w] of windows) {
+        if (now >= w.resetAt) windows.delete(k);
+      }
+    }
+    return true;
+  }
+  if (existing.count >= max) {
+    return false;
+  }
+  existing.count += 1;
+  return true;
+}
+
+/**
+ * Best-effort client identifier for rate limiting.
+ *
+ * Behind the internet-facing ALB the real client is the LAST `X-Forwarded-For`
+ * entry — the ALB appends it, and a client can prepend fakes but can't remove
+ * it, so (unlike the spoofable leftmost value) the last hop is trustworthy for
+ * this topology. `x-real-ip` wins when the edge sets it. Falls back to a shared
+ * bucket only when no forwarding header is present (e.g. direct/local requests).
+ */
+export function rateLimitClientKey(headers: Headers): string {
+  const realIp = headers.get("x-real-ip");
+  if (realIp) {
+    return realIp.trim();
+  }
+  const forwardedFor = headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const hops = forwardedFor.split(",");
+    return hops[hops.length - 1]!.trim();
+  }
+  return "local";
+}
+
+// Exposed for tests to reset shared state between cases.
+export function __resetMintRateLimit(): void {
+  windows.clear();
+}

--- a/frontend/ui/src/proxy.ts
+++ b/frontend/ui/src/proxy.ts
@@ -36,10 +36,11 @@ export const config = {
     // - api/auth (auth routes)
     // - api/public (API-key-authed SDK routes; auth via requireApiKeyProject, not a session cookie)
     // - api/internal (internal API for Python backend, uses X-Internal-Secret)
+    // - api/cli (CLI token exchange, authenticates by bearer session token, no cookie)
     // - api/billing/webhook (Stripe webhook, uses signature verification)
     // - auth/* (sign-in, sign-up pages)
     // - _next (Next.js internals)
     // - static files
-    "/((?!api/auth|api/public|api/internal|api/billing/webhook|api/github/token|api/github/callback|api/github/install-callback|auth/|_next/static|_next/image|images/|favicon.ico).*)",
+    "/((?!api/auth|api/public|api/internal|api/cli|api/billing/webhook|api/github/token|api/github/callback|api/github/install-callback|auth/|_next/static|_next/image|images/|favicon.ico).*)",
   ],
 };


### PR DESCRIPTION
**Stacked PR 9 of 11** — part of the CLI-login epic (#1863). Base: `feat/public-user-credential`.

Adds the jwt() plugin (EdDSA/JWKS) and the /api/cli/token route that exchanges a live session token for a short-lived access JWT — the working bearer for the CLI.

Rebased onto latest `main`; drift checks (public OpenAPI + tool registry) are clean at this cut point. Review only the commits added on top of the base branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mints short-lived EdDSA JWTs for the CLI from a live session token to reduce credential exposure and enable offline verification. Previously the CLI sent the 30‑day session token as the bearer; now it exchanges that token for a 10‑minute JWT (with pinned iss/aud) and uses the JWT as the bearer.

- Adds `better-auth` `jwt()` plugin (10m, EdDSA). Keys live in `jwks`; the public key is served at /api/auth/jwks. `bearer()` remains off.
- New POST /api/cli/token: validates a Bearer session token via direct DB lookup, then returns { accessToken, tokenType: "Bearer", expiresIn: 600 }. JWT payload includes sub, email, sid (session row id), iss: "traceroot", aud: "traceroot-api". Public route, fixed‑window rate limited (60 req/60s per client, keyed by X‑Real‑IP or the last X‑Forwarded‑For hop), middleware‑exempt.
- New POST /api/internal/user-project-access: authorized by `X-Internal-Secret`. Given userId and projectId, returns hasAccess, role, workspaceId, and billingPlan (or 403). Used after the backend verifies the access JWT offline.
- Session resolution now returns sessionId so minted JWTs carry sid for future revocation checks. Tests cover the exchange path, internal access route, and rate limiter. Proxy excludes `/api/cli/*` from the auth middleware.

**Rollout / migration**
- Run database migrations to create the `jwks` table.
- Backend must verify access JWTs against /api/auth/jwks and pin issuer "traceroot" and audience "traceroot-api".
- Backend must send `X-Internal-Secret` when calling `/api/internal/user-project-access`.

<sup>Written for commit ff1c3e115f921a379b766666fed072a315b321a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

