### PR TITLE
feat(api): opaque keyset-cursor pagination for the detector list reads

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -117,7 +117,7 @@
         "type": "object"
       },
       "CursorPaginationMeta": {
-        "description": "Pagination meta plus ``next_cursor``, present only while more pages exist.",
+        "description": "Pagination meta plus ``next_cursor``, set when the page came back full; the following page may be empty.",
         "properties": {
           "limit": {
             "title": "Limit",

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -116,6 +116,41 @@
         "title": "CompleteRunResponse",
         "type": "object"
       },
+      "CursorPaginationMeta": {
+        "description": "Pagination meta plus ``next_cursor``, present only while more pages exist.",
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "page": {
+            "title": "Page",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "page",
+          "limit",
+          "total"
+        ],
+        "title": "CursorPaginationMeta",
+        "type": "object"
+      },
       "DetectorDetail": {
         "description": "A detector's full configuration (Postgres ``detectors`` + optional trigger).\n\n``trigger_conditions`` comes from ``detector_triggers.conditions`` and is\nNone when the detector has no trigger row (it then runs on every sampled\ntrace).",
         "properties": {
@@ -723,7 +758,7 @@
             "type": "array"
           },
           "meta": {
-            "$ref": "#/components/schemas/PaginationMeta"
+            "$ref": "#/components/schemas/CursorPaginationMeta"
           }
         },
         "required": [
@@ -744,7 +779,7 @@
             "type": "array"
           },
           "meta": {
-            "$ref": "#/components/schemas/PaginationMeta"
+            "$ref": "#/components/schemas/CursorPaginationMeta"
           }
         },
         "required": [
@@ -2489,6 +2524,24 @@
               "description": "Only detectors created before this time (exclusive, ISO 8601)",
               "title": "End Before"
             }
+          },
+          {
+            "description": "Opaque pagination cursor from meta.next_cursor; repeat the request unchanged except this param to fetch the next page",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque pagination cursor from meta.next_cursor; repeat the request unchanged except this param to fetch the next page",
+              "title": "Cursor"
+            }
           }
         ],
         "responses": {
@@ -2665,6 +2718,24 @@
               ],
               "description": "Filter to a single trace",
               "title": "Trace Id"
+            }
+          },
+          {
+            "description": "Opaque pagination cursor from meta.next_cursor; repeat the request unchanged except this param to fetch the next page",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque pagination cursor from meta.next_cursor; repeat the request unchanged except this param to fetch the next page",
+              "title": "Cursor"
             }
           }
         ],

--- a/backend/rest/pagination.py
+++ b/backend/rest/pagination.py
@@ -1,0 +1,47 @@
+"""Opaque keyset-pagination cursor for public list reads.
+
+The token encodes the (timestamp, id) of the last row a page returned; the
+next page filters on (timestamp, id) < (cursor) under a total ordering of
+ORDER BY timestamp DESC, id DESC. Base64url keeps it URL-safe; clients must
+treat it as opaque — the encoding may change.
+"""
+
+import base64
+import binascii
+import json
+from datetime import datetime
+
+
+def encode_cursor(timestamp: datetime, item_id: str) -> str:
+    """Encode a keyset position as an opaque URL-safe token.
+
+    Args:
+        timestamp (datetime): The last returned row's timestamp (naive UTC).
+        item_id (str): The last returned row's id (tie-breaker).
+
+    Returns:
+        str: Unpadded base64url token.
+    """
+    payload = json.dumps({"t": timestamp.isoformat(), "i": item_id})
+    return base64.urlsafe_b64encode(payload.encode()).decode().rstrip("=")
+
+
+def decode_cursor(token: str) -> tuple[datetime, str]:
+    """Decode an opaque cursor back to its keyset position.
+
+    Args:
+        token (str): A token previously produced by :func:`encode_cursor`.
+
+    Returns:
+        tuple[datetime, str]: The (timestamp, id) keyset position.
+
+    Raises:
+        ValueError: If the token is not a valid cursor in any way (bad
+            base64, bad JSON, missing keys, unparsable timestamp).
+    """
+    try:
+        padded = token + "=" * (-len(token) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded.encode()).decode())
+        return datetime.fromisoformat(payload["t"]), str(payload["i"])
+    except (binascii.Error, json.JSONDecodeError, KeyError, TypeError, UnicodeDecodeError) as e:
+        raise ValueError("invalid cursor") from e

--- a/backend/rest/pagination.py
+++ b/backend/rest/pagination.py
@@ -7,7 +7,6 @@ treat it as opaque — the encoding may change.
 """
 
 import base64
-import binascii
 import json
 from datetime import datetime
 
@@ -43,5 +42,5 @@ def decode_cursor(token: str) -> tuple[datetime, str]:
         padded = token + "=" * (-len(token) % 4)
         payload = json.loads(base64.urlsafe_b64decode(padded.encode()).decode())
         return datetime.fromisoformat(payload["t"]), str(payload["i"])
-    except (binascii.Error, json.JSONDecodeError, KeyError, TypeError, UnicodeDecodeError) as e:
+    except (KeyError, TypeError, UnicodeDecodeError, ValueError) as e:
         raise ValueError("invalid cursor") from e

--- a/backend/rest/routers/detector_read_common.py
+++ b/backend/rest/routers/detector_read_common.py
@@ -15,9 +15,10 @@ from datetime import datetime
 
 from fastapi import HTTPException, status
 
+from rest.pagination import decode_cursor, encode_cursor
 from rest.retention import clamp_retention_window, enforce_retention_by_time
-from rest.schemas.common import PaginationMeta
 from rest.schemas.public import (
+    CursorPaginationMeta,
     DetectorDetail,
     FindingDetail,
     PublicDetectorListResponse,
@@ -28,12 +29,35 @@ from rest.services.detector_reader import DetectorReaderService
 logger = logging.getLogger(__name__)
 
 
+def _decode_cursor_param(cursor: str | None) -> tuple[datetime, str] | None:
+    """Decode an opaque cursor query param, mapping a bad token to a 422.
+
+    Runs before the reader call so a malformed cursor is rejected as a client
+    error instead of being swallowed by the reader-error -> 500 mapping.
+
+    Args:
+        cursor (str | None): Opaque token from ``meta.next_cursor``, if any.
+
+    Returns:
+        tuple[datetime, str] | None: The decoded keyset position, or None.
+    """
+    if cursor is None:
+        return None
+    try:
+        return decode_cursor(cursor)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Invalid cursor"
+        ) from e
+
+
 async def list_detectors_page(
     service: DetectorReaderService,
     project_id: str,
     limit: int,
     start_after: datetime | None,
     end_before: datetime | None,
+    cursor: str | None,
 ) -> PublicDetectorListResponse:
     """List a project's detectors, mapping reader errors to a clean 500.
 
@@ -46,10 +70,13 @@ async def list_detectors_page(
         limit (int): Max items in the returned page.
         start_after (datetime | None): Inclusive lower bound on creation time.
         end_before (datetime | None): Exclusive upper bound on creation time.
+        cursor (str | None): Opaque keyset cursor from a prior page's
+            ``meta.next_cursor``; malformed tokens 422 before the reader runs.
 
     Returns:
         PublicDetectorListResponse: The page plus pagination meta.
     """
+    cursor_key = _decode_cursor_param(cursor)
     try:
         items, total = await asyncio.to_thread(
             service.list_detectors,
@@ -57,6 +84,7 @@ async def list_detectors_page(
             limit=limit,
             start_after=start_after,
             end_before=end_before,
+            cursor=cursor_key,
         )
     except Exception as e:
         logger.exception(f"Error listing detectors: {e}")
@@ -65,8 +93,12 @@ async def list_detectors_page(
             detail="Failed to list detectors",
         ) from e
 
+    next_cursor = (
+        encode_cursor(items[-1].created_at, items[-1].detector_id) if len(items) == limit else None
+    )
     return PublicDetectorListResponse(
-        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
+        data=items,
+        meta=CursorPaginationMeta(page=0, limit=limit, total=total, next_cursor=next_cursor),
     )
 
 
@@ -79,6 +111,7 @@ async def list_findings_page(
     end_before: datetime | None,
     detector: str | None,
     trace_id: str | None,
+    cursor: str | None,
 ) -> PublicFindingListResponse:
     """List a project's findings with the plan's retention clamp applied.
 
@@ -91,10 +124,13 @@ async def list_findings_page(
         end_before (datetime | None): Exclusive upper bound on ``timestamp``.
         detector (str | None): Optional detector id/name/template filter.
         trace_id (str | None): Optional single-trace filter.
+        cursor (str | None): Opaque keyset cursor from a prior page's
+            ``meta.next_cursor``; malformed tokens 422 before the reader runs.
 
     Returns:
         PublicFindingListResponse: The page plus pagination meta.
     """
+    cursor_key = _decode_cursor_param(cursor)
     start_after, end_before = clamp_retention_window(billing_plan, start_after, end_before)
     try:
         items, total = await asyncio.to_thread(
@@ -105,6 +141,7 @@ async def list_findings_page(
             end_before=end_before,
             detector=detector,
             trace_id=trace_id,
+            cursor=cursor_key,
         )
     except Exception as e:
         logger.exception(f"Error listing detector findings: {e}")
@@ -113,8 +150,12 @@ async def list_findings_page(
             detail="Failed to list findings",
         ) from e
 
+    next_cursor = (
+        encode_cursor(items[-1].timestamp, items[-1].finding_id) if len(items) == limit else None
+    )
     return PublicFindingListResponse(
-        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
+        data=items,
+        meta=CursorPaginationMeta(page=0, limit=limit, total=total, next_cursor=next_cursor),
     )
 
 

--- a/backend/rest/routers/detectors.py
+++ b/backend/rest/routers/detectors.py
@@ -55,9 +55,14 @@ async def list_detectors(
     end_before: datetime | None = Query(
         None, description="Only detectors created before this time (exclusive, ISO 8601)"
     ),
+    cursor: str | None = Query(
+        None,
+        description="Opaque pagination cursor from meta.next_cursor; repeat the request "
+        "unchanged except this param to fetch the next page",
+    ),
 ):
     """List the project's detectors (newest first)."""
-    return await list_detectors_page(service, project_id, limit, start_after, end_before)
+    return await list_detectors_page(service, project_id, limit, start_after, end_before, cursor)
 
 
 @router.get("/findings", response_model=PublicFindingListResponse)
@@ -79,6 +84,11 @@ async def list_findings(
     ),
     detector: str | None = Query(None, description="Filter by detector id, name, or template"),
     trace_id: str | None = Query(None, description="Filter to a single trace"),
+    cursor: str | None = Query(
+        None,
+        description="Opaque pagination cursor from meta.next_cursor; repeat the request "
+        "unchanged except this param to fetch the next page",
+    ),
 ):
     """List recent detector findings for the project (newest first)."""
     return await list_findings_page(
@@ -90,6 +100,7 @@ async def list_findings(
         end_before,
         detector,
         trace_id,
+        cursor,
     )
 
 

--- a/backend/rest/routers/public/detectors_read.py
+++ b/backend/rest/routers/public/detectors_read.py
@@ -52,9 +52,16 @@ async def list_detectors(
     end_before: datetime | None = Query(
         None, description="Only detectors created before this time (exclusive, ISO 8601)"
     ),
+    cursor: str | None = Query(
+        None,
+        description="Opaque pagination cursor from meta.next_cursor; repeat the request "
+        "unchanged except this param to fetch the next page",
+    ),
 ):
     """List the detectors in the API key's project (newest first)."""
-    return await list_detectors_page(service, auth.project_id, limit, start_after, end_before)
+    return await list_detectors_page(
+        service, auth.project_id, limit, start_after, end_before, cursor
+    )
 
 
 @router.get("/findings", response_model=PublicFindingListResponse, operation_id="list_findings")
@@ -75,6 +82,11 @@ async def list_findings(
     ),
     detector: str | None = Query(None, description="Filter by detector id, name, or template"),
     trace_id: str | None = Query(None, description="Filter to a single trace"),
+    cursor: str | None = Query(
+        None,
+        description="Opaque pagination cursor from meta.next_cursor; repeat the request "
+        "unchanged except this param to fetch the next page",
+    ),
 ):
     """List recent detector findings for the API key's project (newest first)."""
     return await list_findings_page(
@@ -86,6 +98,7 @@ async def list_findings(
         end_before,
         detector,
         trace_id,
+        cursor,
     )
 
 

--- a/backend/rest/schemas/public.py
+++ b/backend/rest/schemas/public.py
@@ -86,7 +86,7 @@ class PublicTraceExportResponse(BaseModel):
 
 
 class CursorPaginationMeta(PaginationMeta):
-    """Pagination meta plus ``next_cursor``, present only while more pages exist."""
+    """Pagination meta plus ``next_cursor``, set when the page came back full; the following page may be empty."""
 
     next_cursor: str | None = None
 

--- a/backend/rest/schemas/public.py
+++ b/backend/rest/schemas/public.py
@@ -85,6 +85,12 @@ class PublicTraceExportResponse(BaseModel):
     git_context: GitContext
 
 
+class CursorPaginationMeta(PaginationMeta):
+    """Pagination meta plus ``next_cursor``, present only while more pages exist."""
+
+    next_cursor: str | None = None
+
+
 class DetectorResultItem(BaseModel):
     """One detector's result within a finding, normalized from the stored payload.
 
@@ -133,7 +139,7 @@ class PublicFindingListResponse(BaseModel):
     """Paginated list of detector findings for the public API."""
 
     data: list[FindingSummary]
-    meta: PaginationMeta
+    meta: CursorPaginationMeta
 
 
 class DetectorItem(BaseModel):
@@ -173,4 +179,4 @@ class PublicDetectorListResponse(BaseModel):
     """Paginated list of the project's detectors for the public API."""
 
     data: list[DetectorItem]
-    meta: PaginationMeta
+    meta: CursorPaginationMeta

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -81,6 +81,7 @@ class DetectorReaderService:
         limit: int,
         start_after: datetime | None = None,
         end_before: datetime | None = None,
+        cursor: tuple[datetime, str] | None = None,
     ) -> tuple[list[DetectorItem], int]:
         """List the project's detectors from the Postgres catalog, newest first.
 
@@ -93,11 +94,15 @@ class DetectorReaderService:
             limit (int): Max items in the returned page (already validated by the router).
             start_after (datetime | None): Inclusive lower bound on ``create_time``.
             end_before (datetime | None): Exclusive upper bound on ``create_time``.
+            cursor (tuple[datetime, str] | None): Decoded keyset cursor
+                ``(create_time, id)`` of the previous page's last row; when set,
+                only strictly-older rows are returned. Applied to the list query
+                only, so ``total`` stays the filter-wide count across pages.
 
         Returns:
             tuple[list[DetectorItem], int]: The page of :class:`DetectorItem` ordered
-            by ``create_time`` DESC, plus the total number of catalog rows matching
-            the filters (for pagination).
+            by ``(create_time, id)`` DESC, plus the total number of catalog rows
+            matching the filters (for pagination).
         """
         conditions = ["project_id = %s"]
         params: list[Any] = [project_id]
@@ -112,10 +117,19 @@ class DetectorReaderService:
         count_rows = self._pg_rows(f"SELECT count(*) FROM detectors WHERE {where}", tuple(params))
         total = count_rows[0][0] if count_rows else 0
 
+        # The keyset cursor narrows the LIST query only: `total` stays the
+        # filter-wide count so it is constant across pages.
+        list_conditions = list(conditions)
+        list_params = list(params)
+        if cursor is not None:
+            list_conditions.append("(create_time, id) < (%s, %s)")
+            list_params.extend((to_utc_naive(cursor[0]), cursor[1]))
+        list_where = " AND ".join(list_conditions)
+
         rows = self._pg_rows(
             f"SELECT id, name, template, enabled, create_time FROM detectors "
-            f"WHERE {where} ORDER BY create_time DESC LIMIT %s",
-            (*params, limit),
+            f"WHERE {list_where} ORDER BY create_time DESC, id DESC LIMIT %s",
+            (*list_params, limit),
         )
         items = [
             DetectorItem(
@@ -184,6 +198,7 @@ class DetectorReaderService:
         end_before: datetime | None,
         detector: str | None,
         trace_id: str | None,
+        cursor: tuple[datetime, str] | None = None,
     ) -> tuple[list[FindingSummary], int]:
         """List a project's detector findings, newest first, with the total match count.
 
@@ -199,7 +214,10 @@ class DetectorReaderService:
         * ``end_before`` and the payload-based ``detector`` predicate are
           version-sensitive and applied AFTER the dedup; on raw pre-merge rows an
           older version ``< end_before`` (or an outdated payload) could otherwise
-          resurface a finding whose latest version no longer matches.
+          resurface a finding whose latest version no longer matches. The keyset
+          ``cursor`` predicate is version-sensitive in the same way and also
+          applied after the dedup, so an older re-ingested version cannot
+          resurrect a finding at a page boundary.
 
         Args:
             project_id (str): Owning project; every query is scoped to it.
@@ -210,11 +228,16 @@ class DetectorReaderService:
                 server-side to the matching detector names+ids and matched against
                 the stored payload. An unresolved token simply matches nothing.
             trace_id (str | None): Optional restriction to a single trace's finding.
+            cursor (tuple[datetime, str] | None): Decoded keyset cursor
+                ``(timestamp, finding_id)`` of the previous page's last row; when
+                set, only strictly-older findings are returned. Applied to the
+                list query only, so ``total`` stays the filter-wide count across
+                pages.
 
         Returns:
             tuple[list[FindingSummary], int]: The page of :class:`FindingSummary`
-            ordered by ``timestamp`` DESC, plus the total number of distinct findings
-            matching the filters.
+            ordered by ``(timestamp, finding_id)`` DESC, plus the total number of
+            distinct findings matching the filters.
         """
         params: dict[str, Any] = {"project_id": project_id, "limit": limit}
 
@@ -262,10 +285,23 @@ class DetectorReaderService:
         count_result = self._client.query(count_query, parameters=params)
         total = count_result.result_rows[0][0] if count_result.result_rows else 0
 
+        # The keyset cursor is post-dedup like end_before (see the docstring) but
+        # narrows the LIST query only: `total` stays the filter-wide count.
+        list_outer_conditions = list(outer_conditions)
+        if cursor is not None:
+            list_outer_conditions.append(
+                "(timestamp, finding_id) < ({cursor_ts:DateTime64(6)}, {cursor_id:String})"
+            )
+            params["cursor_ts"] = to_utc_naive(cursor[0])
+            params["cursor_id"] = cursor[1]
+        list_outer_where = (
+            (" WHERE " + " AND ".join(list_outer_conditions)) if list_outer_conditions else ""
+        )
+
         list_query = f"""
             SELECT finding_id, project_id, trace_id, summary, payload, timestamp
-            FROM ({deduped}){outer_where}
-            ORDER BY timestamp DESC
+            FROM ({deduped}){list_outer_where}
+            ORDER BY timestamp DESC, finding_id DESC
             LIMIT {{limit:UInt32}}
         """
         result = self._client.query(list_query, parameters=params)

--- a/frontend/packages/agent/src/prompts/__tests__/system.test.ts
+++ b/frontend/packages/agent/src/prompts/__tests__/system.test.ts
@@ -33,6 +33,11 @@ describe("getSystemPrompt", () => {
     expect(prompt).toContain("root-cause analysis");
   });
 
+  it("teaches cursor pagination for the list tools", () => {
+    const prompt = getSystemPrompt({ projectId: "proj-123" });
+    expect(prompt).toContain("repeat the same call with the given cursor");
+  });
+
   it("lists the detector templates so coverage gaps get template recommendations", () => {
     const prompt = getSystemPrompt({ projectId: "proj-123" });
     expect(prompt).toContain("failure, hallucination, logic, task, safety");

--- a/frontend/packages/agent/src/prompts/system.ts
+++ b/frontend/packages/agent/src/prompts/system.ts
@@ -50,6 +50,7 @@ matching template in the Detectors page — don't propose external tooling for g
 Use this to browse detector findings — issues detectors identified on traces.
 Parameters: optional detector (id, name, or template), trace_id, limit, start_after, end_before.
 Each row includes the finding_id to pass to get_finding.
+Lists return at most \`limit\` rows; when the result says more are available, repeat the same call with the given cursor value to fetch the next page.
 
 ### Finding Detail: get_finding and get_finding_by_trace
 Use get_finding with a finding_id, or get_finding_by_trace with a trace_id (findings are 1-per-trace),

--- a/frontend/packages/agent/src/tools/__tests__/registry-tools.test.ts
+++ b/frontend/packages/agent/src/tools/__tests__/registry-tools.test.ts
@@ -341,6 +341,24 @@ describe("formatters", () => {
     );
   });
 
+  it("formatDetectorList appends the pagination hint only when next_cursor is set", () => {
+    const row = {
+      detector_id: "det-1",
+      name: "Error spike",
+      template: "error-rate",
+      enabled: true,
+      created_at: "2026-08-01T12:00:00Z",
+    };
+    expect(formatDetectorList({ data: [row], meta: { total: 9, next_cursor: "abc123" } })).toBe(
+      "Found 1 detectors (9 total, showing 1):\n" +
+        "- det-1 | Error spike | template: error-rate | enabled | created 2026-08-01T12:00:00Z\n" +
+        'More results available — call again with cursor="abc123" to continue.',
+    );
+    expect(formatDetectorList({ data: [row], meta: { total: 9 } })).not.toContain(
+      "More results available",
+    );
+  });
+
   it("formatDetectorDetail renders the full config", () => {
     expect(
       formatDetectorDetail({
@@ -419,6 +437,25 @@ describe("formatters", () => {
     );
     expect(text).toContain("y".repeat(200));
     expect(text).not.toContain("y".repeat(201));
+  });
+
+  it("formatFindingList appends the pagination hint only when next_cursor is set", () => {
+    const row = {
+      finding_id: "f-1",
+      trace_id: "t-1",
+      timestamp: "2026-08-11T09:00:00Z",
+      detectors: ["Error spike"],
+      summary: "Elevated error rate",
+    };
+    expect(formatFindingList({ data: [row], meta: { total: 9, next_cursor: "abc123" } })).toBe(
+      "Found 1 findings (9 total, showing 1):\n" +
+        "- f-1 | trace t-1 | 2026-08-11T09:00:00Z | detectors: Error spike\n" +
+        "  Elevated error rate\n" +
+        'More results available — call again with cursor="abc123" to continue.',
+    );
+    expect(formatFindingList({ data: [row], meta: { total: 9 } })).not.toContain(
+      "More results available",
+    );
   });
 
   it("formatFindingDetail renders header, per-detector results, and RCA text", () => {

--- a/frontend/packages/agent/src/tools/formatters.ts
+++ b/frontend/packages/agent/src/tools/formatters.ts
@@ -90,7 +90,7 @@ export function formatSessionList(data: unknown): string {
 export function formatDetectorList(data: unknown): string {
   const body = (data ?? {}) as { data?: unknown; meta?: unknown };
   const detectors = (body.data || []) as any[];
-  const meta = (body.meta || {}) as { total?: number };
+  const meta = (body.meta || {}) as { total?: number; next_cursor?: string };
 
   if (!Array.isArray(detectors) || detectors.length === 0) {
     return "No detectors found.";
@@ -102,8 +102,11 @@ export function formatDetectorList(data: unknown): string {
   });
 
   const totalInfo = meta.total ? ` (${meta.total} total, showing ${detectors.length})` : "";
+  const more = meta.next_cursor
+    ? `\nMore results available — call again with cursor="${meta.next_cursor}" to continue.`
+    : "";
 
-  return `Found ${detectors.length} detectors${totalInfo}:\n${lines.join("\n")}`;
+  return `Found ${detectors.length} detectors${totalInfo}:\n${lines.join("\n")}${more}`;
 }
 
 /** Render one detector's full configuration for the model. */
@@ -144,7 +147,7 @@ export function formatDetectorDetail(data: unknown): string {
 export function formatFindingList(data: unknown): string {
   const body = (data ?? {}) as { data?: unknown; meta?: unknown };
   const findings = (body.data || []) as any[];
-  const meta = (body.meta || {}) as { total?: number };
+  const meta = (body.meta || {}) as { total?: number; next_cursor?: string };
 
   if (!Array.isArray(findings) || findings.length === 0) {
     return "No detector findings found matching the given filters.";
@@ -159,8 +162,11 @@ export function formatFindingList(data: unknown): string {
   });
 
   const totalInfo = meta.total ? ` (${meta.total} total, showing ${findings.length})` : "";
+  const more = meta.next_cursor
+    ? `\nMore results available — call again with cursor="${meta.next_cursor}" to continue.`
+    : "";
 
-  return `Found ${findings.length} findings${totalInfo}:\n${lines.join("\n")}`;
+  return `Found ${findings.length} findings${totalInfo}:\n${lines.join("\n")}${more}`;
 }
 
 /** Render a finding detail: header, per-detector results, then the RCA text. */

--- a/frontend/packages/tools/src/__tests__/registry-drift.test.ts
+++ b/frontend/packages/tools/src/__tests__/registry-drift.test.ts
@@ -30,4 +30,11 @@ describe("committed registry", () => {
       "whoami",
     ]);
   });
+
+  it("exposes the pagination cursor on the detector list tools", () => {
+    const findings = REGISTRY.find((entry) => entry.name === "list_findings")!;
+    expect(findings.inputSchema.properties).toHaveProperty("cursor");
+    const detectors = REGISTRY.find((entry) => entry.name === "list_detectors")!;
+    expect(detectors.inputSchema.properties).toHaveProperty("cursor");
+  });
 });

--- a/frontend/packages/tools/src/registry.generated.ts
+++ b/frontend/packages/tools/src/registry.generated.ts
@@ -147,6 +147,11 @@ export const REGISTRY: readonly RegistryEntry[] = [
           type: "string",
           description: "Only detectors created before this time (exclusive, ISO 8601)",
         },
+        cursor: {
+          type: "string",
+          description:
+            "Opaque pagination cursor from meta.next_cursor; repeat the request unchanged except this param to fetch the next page",
+        },
       },
       required: [],
       additionalProperties: false,
@@ -185,6 +190,11 @@ export const REGISTRY: readonly RegistryEntry[] = [
         trace_id: {
           type: "string",
           description: "Filter to a single trace",
+        },
+        cursor: {
+          type: "string",
+          description:
+            "Opaque pagination cursor from meta.next_cursor; repeat the request unchanged except this param to fetch the next page",
         },
       },
       required: [],

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -299,6 +299,65 @@ def test_list_detectors_applies_create_time_window(reader, monkeypatch):
         assert "create_time < %s" in sql
 
 
+def test_list_detectors_cursor_adds_keyset_predicate_and_tiebreak_order(reader, monkeypatch):
+    captured = {}
+
+    def fake_pg_rows(sql, params):
+        captured.setdefault("calls", []).append((sql, params))
+        return []
+
+    monkeypatch.setattr(reader, "_pg_rows", fake_pg_rows)
+    ts = datetime(2026, 8, 17, 19, 3, 46, 820000)
+    reader.list_detectors(project_id="p", limit=5, cursor=(ts, "det-9"))
+
+    list_sql, list_params = captured["calls"][-1]
+    assert "(create_time, id) < (%s, %s)" in list_sql
+    assert "ORDER BY create_time DESC, id DESC" in list_sql
+    assert ts in list_params and "det-9" in list_params
+
+    count_sql, _ = captured["calls"][0]
+    assert "(create_time, id)" not in count_sql  # total ignores the cursor
+
+
+def test_list_detectors_without_cursor_keeps_plain_query(reader, monkeypatch):
+    captured = {}
+
+    def fake_pg_rows(sql, params):
+        captured.setdefault("calls", []).append((sql, params))
+        return []
+
+    monkeypatch.setattr(reader, "_pg_rows", fake_pg_rows)
+    reader.list_detectors(project_id="p", limit=5)
+    list_sql, _ = captured["calls"][-1]
+    assert "(create_time, id) <" not in list_sql
+    assert "ORDER BY create_time DESC, id DESC" in list_sql
+
+
+def test_list_findings_cursor_applies_post_dedup(reader):
+    ts = datetime(2026, 8, 17, 19, 3, 46, 820000)
+    reader.list_findings(
+        project_id="p",
+        limit=5,
+        start_after=None,
+        end_before=None,
+        detector=None,
+        trace_id=None,
+        cursor=(ts, "f-9"),
+    )
+    ch = reader._client
+    list_query, params = ch.calls[-1]
+    # predicate lands in the OUTER where (post-dedup), with the tie-break order
+    inner, outer = list_query.split("LIMIT 1 BY finding_id", 1)
+    assert "(timestamp, finding_id) < ({cursor_ts:DateTime64(6)}, {cursor_id:String})" in outer
+    assert "(timestamp, finding_id)" not in inner
+    assert "ORDER BY timestamp DESC, finding_id DESC" in outer
+    assert params["cursor_ts"] == ts and params["cursor_id"] == "f-9"
+
+    count_query, _ = ch.calls[0]
+    assert "count(" in count_query.lower()
+    assert "(timestamp, finding_id)" not in count_query  # total ignores the cursor
+
+
 def test_get_detector_reader_service_is_singleton(monkeypatch):
     import rest.services.detector_reader as mod
 

--- a/tests/rest/test_detectors_router.py
+++ b/tests/rest/test_detectors_router.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from rest.main import app
+from rest.pagination import encode_cursor
 from rest.retention import get_retention_cutoff
 from rest.routers.deps import ProjectAccessInfo, get_project_access
 from rest.schemas.public import (
@@ -13,6 +14,7 @@ from rest.schemas.public import (
     DetectorItem,
     DetectorResultItem,
     FindingDetail,
+    FindingSummary,
     RCAResult,
 )
 from rest.services.detector_reader import get_detector_reader_service
@@ -78,6 +80,17 @@ def _detector(i: int = 1) -> DetectorItem:
         template="error-rate",
         enabled=True,
         created_at=datetime(2026, 8, 1, 12, 0, 0),
+    )
+
+
+def _finding_summary(finding_id: str = "f-1", timestamp: datetime | None = None) -> FindingSummary:
+    return FindingSummary(
+        finding_id=finding_id,
+        project_id="proj-A",
+        trace_id="t-1",
+        summary="Elevated error rate",
+        timestamp=timestamp or _now_naive(),
+        detectors=["Detector 1"],
     )
 
 
@@ -202,6 +215,68 @@ class TestListFindings:
         resp = client.get("/api/v1/projects/proj-A/detectors/findings")
         assert resp.status_code == 500
         assert resp.json()["detail"] == "Failed to list findings"
+
+
+class TestListFindingsPagination:
+    def test_full_page_emits_next_cursor_of_last_row(self, client, reader):
+        rows = [
+            _finding_summary(
+                finding_id=f"f-{i}", timestamp=datetime(2026, 8, 17, 19, 3, 46, 820000)
+            )
+            for i in range(3)
+        ]
+        reader.list_return = (rows, 10)
+        resp = client.get("/api/v1/projects/proj-A/detectors/findings", params={"limit": 3})
+        meta = resp.json()["meta"]
+        expected = encode_cursor(datetime(2026, 8, 17, 19, 3, 46, 820000), "f-2")
+        assert meta["next_cursor"] == expected
+
+    def test_partial_page_has_no_next_cursor(self, client, reader):
+        reader.list_return = ([_finding_summary(finding_id="f-1")], 10)
+        resp = client.get("/api/v1/projects/proj-A/detectors/findings", params={"limit": 3})
+        assert resp.json()["meta"]["next_cursor"] is None
+
+    def test_cursor_param_is_decoded_and_passed_to_reader(self, client, reader):
+        ts = datetime(2026, 8, 17, 19, 3, 46, 820000)
+        token = encode_cursor(ts, "f-5")
+        resp = client.get("/api/v1/projects/proj-A/detectors/findings", params={"cursor": token})
+        assert resp.status_code == 200
+        assert reader.list_args["cursor"] == (ts, "f-5")
+
+    def test_invalid_cursor_is_422(self, client, reader):
+        resp = client.get(
+            "/api/v1/projects/proj-A/detectors/findings", params={"cursor": "garbage!!"}
+        )
+        assert resp.status_code == 422
+        assert resp.json()["detail"] == "Invalid cursor"
+        assert reader.list_args is None  # rejected before the reader ran
+
+
+class TestListDetectorsPagination:
+    def test_full_page_emits_next_cursor_of_last_row(self, client, reader):
+        reader.detectors_return = ([_detector(i) for i in range(3)], 10)
+        resp = client.get("/api/v1/projects/proj-A/detectors", params={"limit": 3})
+        meta = resp.json()["meta"]
+        expected = encode_cursor(datetime(2026, 8, 1, 12, 0, 0), "det-2")
+        assert meta["next_cursor"] == expected
+
+    def test_partial_page_has_no_next_cursor(self, client, reader):
+        reader.detectors_return = ([_detector()], 10)
+        resp = client.get("/api/v1/projects/proj-A/detectors", params={"limit": 3})
+        assert resp.json()["meta"]["next_cursor"] is None
+
+    def test_cursor_param_is_decoded_and_passed_to_reader(self, client, reader):
+        ts = datetime(2026, 8, 17, 19, 3, 46, 820000)
+        token = encode_cursor(ts, "det-5")
+        resp = client.get("/api/v1/projects/proj-A/detectors", params={"cursor": token})
+        assert resp.status_code == 200
+        assert reader.detectors_args["cursor"] == (ts, "det-5")
+
+    def test_invalid_cursor_is_422(self, client, reader):
+        resp = client.get("/api/v1/projects/proj-A/detectors", params={"cursor": "garbage!!"})
+        assert resp.status_code == 422
+        assert resp.json()["detail"] == "Invalid cursor"
+        assert reader.detectors_args is None  # rejected before the reader ran
 
 
 class TestGetFinding:

--- a/tests/rest/test_pagination.py
+++ b/tests/rest/test_pagination.py
@@ -1,0 +1,38 @@
+"""Unit tests for the opaque list-pagination cursor codec."""
+
+from datetime import datetime
+
+import pytest
+
+from rest.pagination import decode_cursor, encode_cursor
+
+
+def test_round_trip_preserves_timestamp_and_id():
+    ts = datetime(2026, 8, 17, 19, 3, 46, 820000)
+    token = encode_cursor(ts, "f-123")
+    assert isinstance(token, str)
+    assert "=" not in token  # url-safe, unpadded
+    decoded_ts, decoded_id = decode_cursor(token)
+    assert decoded_ts == ts
+    assert decoded_id == "f-123"
+
+
+def test_token_is_opaque_but_stable():
+    ts = datetime(2026, 1, 1)
+    assert encode_cursor(ts, "a") == encode_cursor(ts, "a")
+    assert encode_cursor(ts, "a") != encode_cursor(ts, "b")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "not-base64!!",
+        "aGVsbG8",
+        "eyJ0Ijoibm9wZSIsImkiOiJ4In0",
+        "eyJ0IjoiMjAyNi0wMS0wMVQwMDowMDowMCJ9",
+    ],
+)
+def test_malformed_tokens_raise_value_error(bad):
+    with pytest.raises(ValueError):
+        decode_cursor(bad)

--- a/tests/rest/test_public_detector_schemas.py
+++ b/tests/rest/test_public_detector_schemas.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from rest.schemas.common import PaginationMeta
 from rest.schemas.public import (
+    CursorPaginationMeta,
     DetectorDetail,
     DetectorItem,
     DetectorResultItem,
@@ -13,6 +14,15 @@ from rest.schemas.public import (
     PublicFindingListResponse,
     RCAResult,
 )
+
+
+def test_cursor_pagination_meta_defaults_to_none_and_dumps_the_field():
+    meta = CursorPaginationMeta(page=0, limit=50, total=1)
+    assert isinstance(meta, PaginationMeta)
+    assert meta.next_cursor is None
+    assert meta.model_dump() == {"page": 0, "limit": 50, "total": 1, "next_cursor": None}
+    full = CursorPaginationMeta(page=0, limit=50, total=10, next_cursor="abc")
+    assert full.model_dump()["next_cursor"] == "abc"
 
 
 def test_detector_item_fields_are_snake_case():
@@ -41,9 +51,10 @@ def test_public_detector_list_response_wraps_items_with_pagination():
                 created_at=datetime(2026, 6, 29),
             )
         ],
-        meta=PaginationMeta(page=0, limit=50, total=1),
+        meta=CursorPaginationMeta(page=0, limit=50, total=1),
     )
     assert resp.meta.total == 1
+    assert resp.meta.next_cursor is None
     assert resp.data[0].detector_id == "d1"
     assert resp.data[0].enabled is False
 
@@ -122,7 +133,7 @@ def test_public_finding_list_response_wraps_summaries_with_pagination():
                 detectors=["failure", "logic"],
             )
         ],
-        meta=PaginationMeta(page=0, limit=50, total=1),
+        meta=CursorPaginationMeta(page=0, limit=50, total=1),
     )
     assert resp.meta.page == 0
     assert resp.data[0].detectors == ["failure", "logic"]

--- a/tests/rest/test_public_detectors_read.py
+++ b/tests/rest/test_public_detectors_read.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from rest.main import app
+from rest.pagination import encode_cursor
 from rest.routers.public.deps import AuthResult, authenticate_api_key
 from rest.schemas.public import (
     DetectorDetail,
@@ -151,7 +152,7 @@ def test_list_detectors_returns_items_with_pagination_meta(client, reader):
     resp = client.get("/api/v1/public/detectors")
     assert resp.status_code == 200
     body = resp.json()
-    assert body["meta"] == {"page": 0, "limit": 50, "total": 1}
+    assert body["meta"] == {"page": 0, "limit": 50, "total": 1, "next_cursor": None}
     assert body["data"][0]["detector_id"] == "d1"
     assert body["data"][0]["template"] == "hallucination"
     assert body["data"][0]["enabled"] is True
@@ -197,7 +198,7 @@ def test_list_returns_findings_with_pagination_meta(client, reader):
     resp = client.get("/api/v1/public/detectors/findings")
     assert resp.status_code == 200
     body = resp.json()
-    assert body["meta"] == {"page": 0, "limit": 50, "total": 1}
+    assert body["meta"] == {"page": 0, "limit": 50, "total": 1, "next_cursor": None}
     assert body["data"][0]["finding_id"] == "f1"
     assert body["data"][0]["detectors"] == ["hallucination"]
 
@@ -208,7 +209,7 @@ def test_list_empty_returns_200_with_empty_data(client, reader):
     assert resp.status_code == 200
     body = resp.json()
     assert body["data"] == []
-    assert body["meta"] == {"page": 0, "limit": 50, "total": 0}
+    assert body["meta"] == {"page": 0, "limit": 50, "total": 0, "next_cursor": None}
 
 
 def test_list_forwards_filters_and_project_scope(client, reader):
@@ -237,6 +238,62 @@ def test_list_reader_failure_returns_sanitized_500(client, reader):
     assert resp.status_code == 500
     assert resp.json()["detail"] == "Failed to list findings"
     assert "boom" not in resp.text
+
+
+class TestListFindingsPagination:
+    def test_full_page_emits_next_cursor_of_last_row(self, client, reader):
+        ts = datetime(2026, 8, 17, 19, 3, 46, 820000)
+        rows = [_summary(finding_id=f"f-{i}", timestamp=ts) for i in range(3)]
+        reader.list_return = (rows, 10)
+        resp = client.get("/api/v1/public/detectors/findings", params={"limit": 3})
+        expected = encode_cursor(ts, "f-2")
+        assert resp.json()["meta"]["next_cursor"] == expected
+
+    def test_partial_page_has_no_next_cursor(self, client, reader):
+        reader.list_return = ([_summary()], 10)
+        resp = client.get("/api/v1/public/detectors/findings", params={"limit": 3})
+        assert resp.json()["meta"]["next_cursor"] is None
+
+    def test_cursor_param_is_decoded_and_passed_to_reader(self, client, reader):
+        ts = datetime(2026, 8, 17, 19, 3, 46, 820000)
+        token = encode_cursor(ts, "f-5")
+        resp = client.get("/api/v1/public/detectors/findings", params={"cursor": token})
+        assert resp.status_code == 200
+        assert reader.list_args["cursor"] == (ts, "f-5")
+
+    def test_invalid_cursor_is_422(self, client, reader):
+        resp = client.get("/api/v1/public/detectors/findings", params={"cursor": "garbage!!"})
+        assert resp.status_code == 422
+        assert resp.json()["detail"] == "Invalid cursor"
+        assert reader.list_args is None  # rejected before the reader ran
+
+
+class TestListDetectorsPagination:
+    def test_full_page_emits_next_cursor_of_last_row(self, client, reader):
+        created = datetime(2026, 6, 29, 10, 42)
+        rows = [_detector(detector_id=f"d-{i}", created_at=created) for i in range(3)]
+        reader.detectors_return = (rows, 10)
+        resp = client.get("/api/v1/public/detectors", params={"limit": 3})
+        expected = encode_cursor(created, "d-2")
+        assert resp.json()["meta"]["next_cursor"] == expected
+
+    def test_partial_page_has_no_next_cursor(self, client, reader):
+        reader.detectors_return = ([_detector()], 10)
+        resp = client.get("/api/v1/public/detectors", params={"limit": 3})
+        assert resp.json()["meta"]["next_cursor"] is None
+
+    def test_cursor_param_is_decoded_and_passed_to_reader(self, client, reader):
+        ts = datetime(2026, 8, 17, 19, 3, 46, 820000)
+        token = encode_cursor(ts, "d-5")
+        resp = client.get("/api/v1/public/detectors", params={"cursor": token})
+        assert resp.status_code == 200
+        assert reader.detectors_args["cursor"] == (ts, "d-5")
+
+    def test_invalid_cursor_is_422(self, client, reader):
+        resp = client.get("/api/v1/public/detectors", params={"cursor": "garbage!!"})
+        assert resp.status_code == 422
+        assert resp.json()["detail"] == "Invalid cursor"
+        assert reader.detectors_args is None  # rejected before the reader ran
 
 
 def test_detail_by_finding_id_returns_results_and_rca(client, reader):


### PR DESCRIPTION
## What

Closes the "can't page past the first N results" gap on the detector list reads, for the agent and API-key clients alike: both `list_detectors` and `list_findings` (public + internal surfaces) now accept an opaque `cursor` param and return `meta.next_cursor` while further pages exist.

## How

- **Codec** (`backend/rest/pagination.py`): unpadded base64url of `(timestamp, id)`; decode raises on any malformed input, uniformly surfaced as `422 "Invalid cursor"` before the reader runs.
- **Keyset queries**: total ordering `ORDER BY (timestamp, id) DESC` on both lists; strict tuple/row-comparison predicate so tied timestamps can't skip or duplicate rows across pages (ties are real — detection batches land within one millisecond). Postgres row comparison for the catalog; ClickHouse tuple comparison applied **post-dedup** for findings so a re-ingested finding version can't resurface at a page boundary. Count queries stay cursor-free — `total` remains the filter-wide count, constant across pages.
- **Contract**: `CursorPaginationMeta` subclass (shared `PaginationMeta` untouched — trace/session responses unaffected); `next_cursor` emitted iff the page came back full (an exact-multiple final page yields one empty follow-up — consumers treat an empty page as terminal).
- **Propagation**: OpenAPI artifact + registry regenerated, so the agent's and future CLI/MCP tool schemas inherit `cursor` automatically; agent list formatters append "More results available — call again with cursor=…" and the system prompt teaches the loop.

## Verification

Backend suite green (16 new contract tests across both surfaces: full-page cursor emission of the last row's key, partial-page absence, decoded passthrough, invalid-cursor 422 with the reader never invoked; SQL-shape tests pin predicate placement and count/list scoping). Artifact `--check` clean; registry drift test green; agent/tools suites green; diff coverage vs the stack base 100% on both sides.

## Notes

- Stacked on the get_detector PR (base branch of this PR) — merge that first. Third PR of the detector-reads stack.
- Traces/sessions list reads adopt the same contract in a follow-up; this PR deliberately scopes to the detector surface where the epic lives.

Closes #1919. Part of epic #1877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opaque keyset-cursor pagination to `list_detectors` and `list_findings` on both agent and public API surfaces. Previously pages ended at the first N results; now responses include `meta.next_cursor` and requests accept `cursor`. Invalid cursors return 422. Closes #1919. Part of epic #1877.

- Review notes
  - Codec: unpadded base64url of `(timestamp, id)`; treat the token as opaque. Decode errors are uniformly surfaced as 422 “Invalid cursor” before the reader runs.
  - Queries: total ordering `ORDER BY (timestamp, id) DESC`. Postgres row comparison for detectors, ClickHouse tuple comparison applied post-dedup for findings so re-ingested versions cannot resurface at page boundaries. `total` remains the filter-wide count and ignores `cursor`.
  - Contract: new `CursorPaginationMeta` adds `next_cursor`, emitted only for full pages; an exact-multiple final page yields one empty follow-up.
  - Routers: add `cursor` query param, decode early, and pass the keyset to the reader.
  - OpenAPI/registry: schemas regenerated; tool registry exposes `cursor`. Agent prompt and formatters append a pagination hint only when `next_cursor` is set.
  - Tests: codec round-trip and error cases, router 422 path, predicate placement and ordering, and schema changes are covered.
  - Stacking: based on the get_detector PR; merge that first.

- Rollout
  - Clients must handle `meta.next_cursor` and repeat the same request with `cursor=<value>` to fetch subsequent pages. Treat `cursor` as opaque. Expect a possible empty terminal page when the final page size is an exact multiple of `limit`. No changes required for `total` usage.

<sup>Written for commit 7c73bceb8d14b6c72c908ead473381369e506f2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

