### PR TITLE
fix(docs): restore the star history chart

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -207,11 +207,11 @@ Agentic Debugging Runtime의 기반을 제공하는 [pi-mono](https://github.com
 
 ## Star History
 
-<a href="https://star-history.com/#traceroot-ai/traceroot&Date">
+<a href="https://star-history.dera.page/#traceroot-ai/traceroot&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" style="border-radius: 15px;" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=traceroot-ai/traceroot&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=traceroot-ai/traceroot&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=traceroot-ai/traceroot&type=Date" style="border-radius: 15px;" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -207,11 +207,11 @@ This project is licensed under [Apache 2.0](LICENSE) with additional [Enterprise
 
 ## Star History
 
-<a href="https://star-history.com/#traceroot-ai/traceroot&Date">
+<a href="https://star-history.dera.page/#traceroot-ai/traceroot&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" style="border-radius: 15px;" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=traceroot-ai/traceroot&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=traceroot-ai/traceroot&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=traceroot-ai/traceroot&type=Date" style="border-radius: 15px;" />
  </picture>
 </a>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -207,11 +207,11 @@ main().catch(console.error);
 
 ## Star 趋势
 
-<a href="https://star-history.com/#traceroot-ai/traceroot&Date">
+<a href="https://star-history.dera.page/#traceroot-ai/traceroot&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" style="border-radius: 15px;" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=traceroot-ai/traceroot&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=traceroot-ai/traceroot&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=traceroot-ai/traceroot&type=Date" style="border-radius: 15px;" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart on the README is currently broken. The upstream star history service can no longer render charts because of GitHub stargazer API restrictions, so the chart fails to load for anyone landing on the project page.

This change points the chart links and images in the English, Korean, and Chinese READMEs to a working mirror of the star history service that needs no API token and serves both the chart and the frontend from the same domain. No configuration or credentials are required.

Please merge this fix so the README chart renders again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Star History chart in all READMEs by switching from the broken upstream service to a working mirror. Previously the chart failed to load due to GitHub stargazer API restrictions; now it renders again without tokens or config, with both page and SVG served from the same domain.

**Review notes**
- Replaces `https://star-history.com` and `https://api.star-history.com/svg` with `https://star-history.dera.page` in `README.md`, `README.ko.md`, and `README.zh.md` (anchor and image sources).
- Verify the chart loads in GitHub preview for both light and dark themes.

<sup>Written for commit 82ab5433e49fc4a7d36d935ddb45a3bdb7c3321f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

