### PR TITLE
fix(evaluations): content-address UI-authored dataset case ids

### DIFF
--- a/frontend/packages/core/prisma/migrations/20260818000000_test_case_unique_version_case_id/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260818000000_test_case_unique_version_case_id/migration.sql
@@ -11,9 +11,10 @@
 -- empty at any upgrade applying this, and the plain build's ShareLock is held only briefly.
 -- The lock_timeout below is a safety bound: rather than queue behind a long-running writer
 -- transaction and stall writers indefinitely, fail fast (the migrate Job retries per its
--- backoffLimit). SET (non-LOCAL) still takes effect for the CREATE INDEX in this same
--- transaction; on commit it lapses with the one-shot migration connection.
-SET lock_timeout = '5s';
+-- backoffLimit). SET LOCAL scopes the timeout to this migration's own transaction, so it
+-- applies to the CREATE INDEX below but does not leak into later pending migrations that
+-- `migrate deploy` runs on the same connection.
+SET LOCAL lock_timeout = '5s';
 
 -- CreateIndex
 CREATE UNIQUE INDEX "uq_test_case_version_test_case_id" ON "test_cases"("dataset_version_id", "test_case_id");

--- a/frontend/packages/core/prisma/migrations/20260818000000_test_case_unique_version_case_id/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260818000000_test_case_unique_version_case_id/migration.sql
@@ -1,0 +1,7 @@
+-- A stable test-case id must be unique within a dataset version. Content-addressed ids
+-- are assigned by first-free-slot, so a regression that re-mints a live id must fail at
+-- write time rather than silently inserting a duplicate row (which would corrupt
+-- upsert-by-id, run comparison alignment, and the deterministic case read order).
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_test_case_version_test_case_id" ON "test_cases"("dataset_version_id", "test_case_id");

--- a/frontend/packages/core/prisma/migrations/20260818000000_test_case_unique_version_case_id/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260818000000_test_case_unique_version_case_id/migration.sql
@@ -3,5 +3,17 @@
 -- write time rather than silently inserting a duplicate row (which would corrupt
 -- upsert-by-id, run comparison alignment, and the deterministic case read order).
 
+-- This index is built NON-concurrently on purpose. `CREATE INDEX CONCURRENTLY` cannot run
+-- inside a transaction block, but Prisma Migrate (`migrate deploy`, run from the Helm
+-- pre-upgrade hook) wraps every migration file in a transaction on PostgreSQL — so a
+-- CONCURRENTLY build here would abort the whole migration and block the upgrade. `test_cases`
+-- was introduced only one migration earlier (20260814000001_offline_eval), so it is small or
+-- empty at any upgrade applying this, and the plain build's ShareLock is held only briefly.
+-- The lock_timeout below is a safety bound: rather than queue behind a long-running writer
+-- transaction and stall writers indefinitely, fail fast (the migrate Job retries per its
+-- backoffLimit). SET (non-LOCAL) still takes effect for the CREATE INDEX in this same
+-- transaction; on commit it lapses with the one-shot migration connection.
+SET lock_timeout = '5s';
+
 -- CreateIndex
 CREATE UNIQUE INDEX "uq_test_case_version_test_case_id" ON "test_cases"("dataset_version_id", "test_case_id");

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -544,6 +544,11 @@ model TestCase {
 
   version DatasetVersion @relation(fields: [datasetVersionId], references: [id], onDelete: Cascade)
 
+  // A stable case id is unique within a version: ids are content-addressed and assigned
+  // by first-free-slot, so a regression that re-mints a live id must fail at write time
+  // rather than silently inserting a duplicate row (which would corrupt upsert-by-id,
+  // comparison alignment, and the TEST_CASE_ORDER tiebreak).
+  @@unique([datasetVersionId, testCaseId], map: "uq_test_case_version_test_case_id")
   @@index([datasetVersionId], map: "ix_test_case_version_id")
   @@index([projectId], map: "ix_test_case_project_id")
   @@index([sourceTraceId], map: "ix_test_case_source_trace_id")

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts
@@ -186,6 +186,49 @@ describe("PATCH", () => {
     });
   });
 
+  it("backfills key = the OLD name when renaming a legacy null-key dataset", async () => {
+    // A legacy dataset (key === null) derives its content-addressed case ids from its
+    // name; renaming it must freeze the id pre-image to the ORIGINAL name so ids stay
+    // convergent with an SDK author who addressed it by that name.
+    prismaMock.dataset.findFirst.mockImplementation(
+      async ({ where }: { where: Record<string, unknown> }) =>
+        "name" in where ? null : { id: "ds1", key: null, name: "support" },
+    );
+    prismaMock.dataset.update.mockResolvedValue({ id: "ds1", name: "renamed", key: "support" });
+
+    const res = await PATCH(jsonReq({ name: "renamed" }), params);
+    expect(res.status).toBe(200);
+    expect(prismaMock.dataset.update).toHaveBeenCalledWith({
+      where: { id: "ds1" },
+      data: { name: "renamed", key: "support" },
+    });
+  });
+
+  it("does NOT touch key when renaming a dataset that already has one", async () => {
+    prismaMock.dataset.findFirst.mockImplementation(
+      async ({ where }: { where: Record<string, unknown> }) =>
+        "name" in where ? null : { id: "ds1", key: "support", name: "support" },
+    );
+    prismaMock.dataset.update.mockResolvedValue({ id: "ds1", name: "renamed" });
+
+    await PATCH(jsonReq({ name: "renamed" }), params);
+    expect(prismaMock.dataset.update).toHaveBeenCalledWith({
+      where: { id: "ds1" },
+      data: { name: "renamed" }, // key left frozen as-is
+    });
+  });
+
+  it("does not backfill key on a description-only update of a null-key dataset", async () => {
+    prismaMock.dataset.findFirst.mockResolvedValue({ id: "ds1", key: null, name: "support" });
+    prismaMock.dataset.update.mockResolvedValue({ id: "ds1" });
+
+    await PATCH(jsonReq({ description: "d" }), params);
+    expect(prismaMock.dataset.update).toHaveBeenCalledWith({
+      where: { id: "ds1" },
+      data: { description: "d" }, // no rename → identity not touched
+    });
+  });
+
   it("409s a rename onto a name another dataset in the project already uses", async () => {
     prismaMock.dataset.findFirst.mockImplementation(
       async ({ where }: { where: Record<string, unknown> }) =>

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.test.ts
@@ -186,13 +186,13 @@ describe("PATCH", () => {
     });
   });
 
-  it("backfills key = the OLD name when renaming a legacy null-key dataset", async () => {
-    // A legacy dataset (key === null) derives its content-addressed case ids from its
-    // name; renaming it must freeze the id pre-image to the ORIGINAL name so ids stay
-    // convergent with an SDK author who addressed it by that name.
+  it("backfills key = the OLD name when renaming a legacy UI-only null-key dataset", async () => {
+    // A legacy UI-only dataset (key === null AND clientDatasetId === null) derives its
+    // content-addressed case ids from its name; renaming it must freeze the id pre-image to
+    // the ORIGINAL name so ids stay convergent with an SDK author who addressed it by that name.
     prismaMock.dataset.findFirst.mockImplementation(
       async ({ where }: { where: Record<string, unknown> }) =>
-        "name" in where ? null : { id: "ds1", key: null, name: "support" },
+        "name" in where ? null : { id: "ds1", key: null, name: "support", clientDatasetId: null },
     );
     prismaMock.dataset.update.mockResolvedValue({ id: "ds1", name: "renamed", key: "support" });
 
@@ -201,6 +201,24 @@ describe("PATCH", () => {
     expect(prismaMock.dataset.update).toHaveBeenCalledWith({
       where: { id: "ds1" },
       data: { name: "renamed", key: "support" },
+    });
+  });
+
+  it("does NOT backfill key when renaming a public SDK null-key dataset", async () => {
+    // A public SDK dataset can carry a null key alongside a non-null clientDatasetId (the
+    // public upsert permits an omitted key and later supplies `c.key`). Writing the display
+    // name as its key would freeze the WRONG hash pre-image and diverge the UI case ids from
+    // the SDK's real key, so the rename must leave key untouched.
+    prismaMock.dataset.findFirst.mockImplementation(
+      async ({ where }: { where: Record<string, unknown> }) =>
+        "name" in where ? null : { id: "ds1", key: null, name: "support", clientDatasetId: "cds1" },
+    );
+    prismaMock.dataset.update.mockResolvedValue({ id: "ds1", name: "renamed" });
+
+    await PATCH(jsonReq({ name: "renamed" }), params);
+    expect(prismaMock.dataset.update).toHaveBeenCalledWith({
+      where: { id: "ds1" },
+      data: { name: "renamed" }, // key left null — the SDK owns the real key
     });
   });
 

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
@@ -84,7 +84,7 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
 
   const existing = await prisma.dataset.findFirst({
     where: { id: datasetId, projectId },
-    select: { id: true },
+    select: { id: true, key: true, name: true },
   });
   if (!existing) return errorResponse("Dataset not found", 404);
 
@@ -109,12 +109,21 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     }
   }
 
+  // Freeze identity before a rename changes it: a legacy dataset with a null key derives
+  // its content-addressed case ids from `key ?? name` (see resolveDatasetKey), so renaming
+  // it would silently shift every future case id away from an SDK author who addressed the
+  // dataset by its ORIGINAL name. Backfill `key` to the current name at the moment of the
+  // rename so the id pre-image stays pinned to that name. (`key` has no unique constraint,
+  // and a non-null key is already frozen, so this only ever touches a legacy null-key row.)
+  const backfillKey = parsed.data.name !== undefined && existing.key === null;
+
   try {
     const dataset = await prisma.dataset.update({
       where: { id: datasetId },
       data: {
         ...(parsed.data.name !== undefined ? { name: parsed.data.name } : {}),
         ...(parsed.data.description !== undefined ? { description: parsed.data.description } : {}),
+        ...(backfillKey ? { key: existing.name } : {}),
       },
     });
     return successResponse({ dataset });

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
@@ -84,7 +84,7 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
 
   const existing = await prisma.dataset.findFirst({
     where: { id: datasetId, projectId },
-    select: { id: true, key: true, name: true },
+    select: { id: true, key: true, name: true, clientDatasetId: true },
   });
   if (!existing) return errorResponse("Dataset not found", 404);
 
@@ -109,13 +109,17 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     }
   }
 
-  // Freeze identity before a rename changes it: a legacy dataset with a null key derives
-  // its content-addressed case ids from `key ?? name` (see resolveDatasetKey), so renaming
-  // it would silently shift every future case id away from an SDK author who addressed the
-  // dataset by its ORIGINAL name. Backfill `key` to the current name at the moment of the
-  // rename so the id pre-image stays pinned to that name. (`key` has no unique constraint,
-  // and a non-null key is already frozen, so this only ever touches a legacy null-key row.)
-  const backfillKey = parsed.data.name !== undefined && existing.key === null;
+  // Freeze identity before a rename changes it: a legacy UI-only dataset with a null key
+  // derives its content-addressed case ids from `key ?? name` (see resolveDatasetKey), so
+  // renaming it would silently shift every future case id away from an SDK author who
+  // addressed the dataset by its ORIGINAL name. Backfill `key` to the current name at the
+  // moment of the rename so the id pre-image stays pinned to that name. Restricted to a
+  // legacy UI-only dataset (null key AND null clientDatasetId): a public SDK dataset can
+  // carry a null key alongside a non-null clientDatasetId (the public upsert permits an
+  // omitted key and later supplies `c.key`), and writing the display name as its key would
+  // freeze the WRONG hash pre-image and diverge the UI case ids from the SDK's real key.
+  const backfillKey =
+    parsed.data.name !== undefined && existing.key === null && existing.clientDatasetId === null;
 
   try {
     const dataset = await prisma.dataset.update({

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
@@ -8,11 +8,12 @@ import {
 } from "@/lib/auth-helpers";
 import {
   publishDatasetVersion,
-  newTestCaseId,
+  canonicalJson,
   DatasetNotFound,
   VersionConflict,
 } from "@/lib/eval/versions";
-import { encodeJsonValue } from "@/lib/eval/json-value";
+import { stableCaseId } from "@/lib/eval/case-id";
+import { encodeJsonValue, decodeJsonValue } from "@/lib/eval/json-value";
 
 type RouteParams = { params: Promise<{ projectId: string; datasetId: string }> };
 
@@ -39,9 +40,15 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
 
   const dataset = await prisma.dataset.findFirst({
     where: { id: datasetId, projectId },
-    select: { id: true, currentVersionId: true },
+    select: { id: true, currentVersionId: true, key: true, name: true },
   });
   if (!dataset) return errorResponse("Dataset not found", 404);
+
+  // The pre-image the case id is hashed from — the dataset's stable key, which by
+  // convention defaults to its display name (see the SDK's `key = key ?? name`).
+  // A UI-created dataset stores `key = name`; legacy rows with a null key fall back
+  // to the name so the derivation still matches an SDK author using the same key.
+  const datasetKey = dataset.key ?? dataset.name;
 
   // Explicit duplicate handling: same source span already in the current version.
   if (dataset.currentVersionId && c.source_trace_id && c.source_span_id) {
@@ -62,38 +69,54 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     }
   }
 
-  const testCaseId = newTestCaseId();
+  // Stored JSON-ENCODED, the one on-disk encoding for these columns (the public
+  // publish path and the pull path agree on it). Written raw, a case authored here
+  // as the text "123" would come back from the public API as the number 123 — a type
+  // change inside a snapshot a run scores against.
+  const encodedInput = encodeJsonValue(c.input);
+  // The canonical-JSON of the case's input is what the id is hashed from — computed on
+  // the DECODED value so it matches an SDK author (whose SDK canonicalizes the native
+  // input) and matches the occurrence comparison against existing cases below.
+  const canonicalInput = canonicalJson(decodeJsonValue(encodedInput));
   try {
     const result = await publishDatasetVersion({
       datasetId,
       projectId,
       createdBy: authResult.user.email ?? null,
       note: "Added a test case from a trace",
-      transform: (current) => ({
-        focusTestCaseId: testCaseId,
-        cases: [
-          ...current,
-          {
-            testCaseId,
-            // Stored JSON-ENCODED, the one on-disk encoding for these columns
-            // (the public publish path and the pull path agree on it). Written
-            // raw, a case authored here as the text "123" would come back from
-            // the public API as the number 123 — a type change inside a snapshot
-            // a run scores against.
-            input: encodeJsonValue(c.input),
-            expected:
-              c.expected === null || c.expected === undefined ? null : encodeJsonValue(c.expected),
-            metadata: (c.metadata ?? null) as Record<string, unknown> | null,
-            review: c.review,
-            captureReason: c.capture_reason,
-            sourceTraceId: c.source_trace_id ?? null,
-            sourceSpanId: c.source_span_id ?? null,
-            sourceSpanName: c.source_span_name ?? null,
-            sourceSpanKind: c.source_span_kind ?? null,
-            addedBy: authResult.user.email ?? null,
-          },
-        ],
-      }),
+      transform: (current) => {
+        // CONTENT-addressed id (parity with the SDK's `stableCaseId`): the same input
+        // authored in the UI and pushed from the SDK under the same dataset key converge
+        // on one `tc_` id, so re-publishing matches (upsert on id) instead of duplicating.
+        // `occurrence` disambiguates duplicate inputs — the first free slot after the
+        // cases already present with this exact canonical input.
+        const occurrence = current.filter(
+          (s) => canonicalJson(decodeJsonValue(s.input)) === canonicalInput,
+        ).length;
+        const testCaseId = stableCaseId(datasetKey, canonicalInput, occurrence);
+        return {
+          focusTestCaseId: testCaseId,
+          cases: [
+            ...current,
+            {
+              testCaseId,
+              input: encodedInput,
+              expected:
+                c.expected === null || c.expected === undefined
+                  ? null
+                  : encodeJsonValue(c.expected),
+              metadata: (c.metadata ?? null) as Record<string, unknown> | null,
+              review: c.review,
+              captureReason: c.capture_reason,
+              sourceTraceId: c.source_trace_id ?? null,
+              sourceSpanId: c.source_span_id ?? null,
+              sourceSpanName: c.source_span_name ?? null,
+              sourceSpanKind: c.source_span_kind ?? null,
+              addedBy: authResult.user.email ?? null,
+            },
+          ],
+        };
+      },
     });
     return successResponse({ duplicate: false, ...result }, 201);
   } catch (err) {

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
@@ -12,7 +12,7 @@ import {
   DatasetNotFound,
   VersionConflict,
 } from "@/lib/eval/versions";
-import { stableCaseId } from "@/lib/eval/case-id";
+import { nextCaseId } from "@/lib/eval/case-id";
 import { encodeJsonValue, decodeJsonValue } from "@/lib/eval/json-value";
 
 type RouteParams = { params: Promise<{ projectId: string; datasetId: string }> };
@@ -88,12 +88,10 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
         // CONTENT-addressed id (parity with the SDK's `stableCaseId`): the same input
         // authored in the UI and pushed from the SDK under the same dataset key converge
         // on one `tc_` id, so re-publishing matches (upsert on id) instead of duplicating.
-        // `occurrence` disambiguates duplicate inputs — the first free slot after the
-        // cases already present with this exact canonical input.
-        const occurrence = current.filter(
-          (s) => canonicalJson(decodeJsonValue(s.input)) === canonicalInput,
-        ).length;
-        const testCaseId = stableCaseId(datasetKey, canonicalInput, occurrence);
+        // `occurrence` disambiguates duplicate inputs — the first slot whose id is still
+        // free, mirroring the SDK so a gap left by a delete never re-mints a live id.
+        const existingIds = new Set(current.map((s) => s.testCaseId));
+        const { testCaseId } = nextCaseId(existingIds, datasetKey, canonicalInput);
         return {
           focusTestCaseId: testCaseId,
           cases: [

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
@@ -12,8 +12,8 @@ import {
   DatasetNotFound,
   VersionConflict,
 } from "@/lib/eval/versions";
-import { nextCaseId } from "@/lib/eval/case-id";
-import { encodeJsonValue, decodeJsonValue } from "@/lib/eval/json-value";
+import { nextCaseId, LoneSurrogateError } from "@/lib/eval/case-id";
+import { encodeJsonValue } from "@/lib/eval/json-value";
 
 type RouteParams = { params: Promise<{ projectId: string; datasetId: string }> };
 
@@ -74,10 +74,20 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   // as the text "123" would come back from the public API as the number 123 — a type
   // change inside a snapshot a run scores against.
   const encodedInput = encodeJsonValue(c.input);
-  // The canonical-JSON of the case's input is what the id is hashed from — computed on
-  // the DECODED value so it matches an SDK author (whose SDK canonicalizes the native
-  // input) and matches the occurrence comparison against existing cases below.
-  const canonicalInput = canonicalJson(decodeJsonValue(encodedInput));
+  // The canonical-JSON of the case's input is what the id is hashed from. `c.input` is
+  // already the native value (a genuine string), so canonicalize it directly instead of
+  // round-tripping through encode/decode. A lone UTF-16 surrogate can't be canonicalized;
+  // reject it as a 400 here rather than letting it throw an uncaught 500 (this runs before
+  // the publish try below).
+  let canonicalInput: string;
+  try {
+    canonicalInput = canonicalJson(c.input);
+  } catch (e) {
+    if (e instanceof LoneSurrogateError) {
+      return errorResponse("Input contains invalid Unicode", 400);
+    }
+    throw e;
+  }
   try {
     const result = await publishDatasetVersion({
       datasetId,

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
@@ -12,7 +12,7 @@ import {
   DatasetNotFound,
   VersionConflict,
 } from "@/lib/eval/versions";
-import { nextCaseId, LoneSurrogateError } from "@/lib/eval/case-id";
+import { nextCaseId, resolveDatasetKey, LoneSurrogateError } from "@/lib/eval/case-id";
 import { encodeJsonValue } from "@/lib/eval/json-value";
 
 type RouteParams = { params: Promise<{ projectId: string; datasetId: string }> };
@@ -44,11 +44,8 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   });
   if (!dataset) return errorResponse("Dataset not found", 404);
 
-  // The pre-image the case id is hashed from — the dataset's stable key, which by
-  // convention defaults to its display name (see the SDK's `key = key ?? name`).
-  // A UI-created dataset stores `key = name`; legacy rows with a null key fall back
-  // to the name so the derivation still matches an SDK author using the same key.
-  const datasetKey = dataset.key ?? dataset.name;
+  // The pre-image the case id is hashed from — the dataset's stable key (see resolveDatasetKey).
+  const datasetKey = resolveDatasetKey(dataset);
 
   // Explicit duplicate handling: same source span already in the current version.
   if (dataset.currentVersionId && c.source_trace_id && c.source_span_id) {
@@ -100,8 +97,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
         // on one `tc_` id, so re-publishing matches (upsert on id) instead of duplicating.
         // `occurrence` disambiguates duplicate inputs — the first slot whose id is still
         // free, mirroring the SDK so a gap left by a delete never re-mints a live id.
-        const existingIds = new Set(current.map((s) => s.testCaseId));
-        const { testCaseId } = nextCaseId(existingIds, datasetKey, canonicalInput);
+        const { testCaseId } = nextCaseId(current, datasetKey, canonicalInput);
         return {
           focusTestCaseId: testCaseId,
           cases: [

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/dataset-case/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/dataset-case/route.ts
@@ -13,6 +13,7 @@ import {
   CircularSaveConflict,
 } from "@/lib/eval/result-to-dataset";
 import { DatasetNotFound, VersionConflict } from "@/lib/eval/versions";
+import { LoneSurrogateError } from "@/lib/eval/case-id";
 
 type RouteParams = { params: Promise<{ projectId: string; resultId: string }> };
 
@@ -73,6 +74,10 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     // Actionable conflict: the message directs the client to update_existing_case.
     if (e instanceof CircularSaveConflict) return errorResponse(e.message, 409);
     if (e instanceof VersionConflict) return errorResponse("Dataset version conflict", 409);
+    // A lone UTF-16 surrogate in the case input can't be canonicalized into a stable id;
+    // that's a caller-fixable 400, not an unhandled 500 falling through to `throw e`.
+    if (e instanceof LoneSurrogateError)
+      return errorResponse("Input contains invalid Unicode", 400);
     throw e;
   }
 }

--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -40,7 +40,6 @@ vi.mock("@/features/ai-assistant/components/ai-assistant-panel", () => ({
 }));
 
 import { DatasetDetailView } from "./views/dataset-detail-view";
-import { caseDisplayId } from "@/features/offline-eval/utils";
 
 // ---------------------------------------------------------------------------
 // Server-shaped fixtures
@@ -403,9 +402,10 @@ describe("Dataset detail — the slide-in case panel", () => {
     // First row: up is disabled, down moves to the second case.
     expect(screen.getByTitle("Previous row").hasAttribute("disabled")).toBe(true);
     fireEvent.click(screen.getByTitle("Next row"));
-    expect(await screen.findByText(caseDisplayId("tc_2"))).toBeDefined();
+    // The panel header shows the real, content-addressed testCaseId verbatim.
+    expect(await screen.findByText("tc_2")).toBeDefined();
     fireEvent.click(screen.getByTitle("Previous row"));
-    expect(await screen.findByText(caseDisplayId("tc_1"))).toBeDefined();
+    expect(await screen.findByText("tc_1")).toBeDefined();
   });
 
   it("expands to full screen and opens the row in a new tab", async () => {
@@ -471,7 +471,7 @@ describe("Dataset detail — deep link", () => {
     mountDetail();
     // The panel opens on the matching stable testCaseId, not the per-version row id.
     expect(await screen.findByTitle("Copy ID")).toBeDefined();
-    expect(await screen.findByText(caseDisplayId("tc_2"))).toBeDefined();
+    expect(await screen.findByText("tc_2")).toBeDefined();
   });
   it("ignores a ?case that no row matches", async () => {
     searchParams = new URLSearchParams("case=tc_missing");

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -36,7 +36,7 @@ import {
 } from "@/features/offline-eval/components";
 import { TraceIOSection } from "@/features/traces/components/TraceIOValue";
 import { formatCost, formatElapsed } from "./evaluations-view";
-import { caseDisplayId, truncate } from "@/features/offline-eval/utils";
+import { truncate } from "@/features/offline-eval/utils";
 import { useDataset, useTestCaseRuns, useDeleteTestCase } from "../hooks";
 import { TestCaseEditorModal, type TestCaseEditorMode } from "../components/test-case-editor-modal";
 import { DeleteTestCaseDialog } from "../components/delete-test-case-dialog";
@@ -397,7 +397,7 @@ export function DatasetDetailView({
 
       {deleteRow && (
         <DeleteTestCaseDialog
-          rowLabel={caseDisplayId(deleteRow.testCaseId)}
+          rowLabel={deleteRow.testCaseId}
           isOpen
           onClose={() => setDeleteRow(null)}
           onConfirm={confirmDelete}
@@ -509,7 +509,7 @@ function CasePanel({
       ref={panelRef}
       role="dialog"
       aria-modal="true"
-      aria-label={`Test case ${caseDisplayId(testCase.testCaseId)}`}
+      aria-label={`Test case ${testCase.testCaseId}`}
       tabIndex={-1}
       className={cn(
         "animate-slide-in-right fixed bottom-0 right-0 z-50 flex flex-col border-l border-border bg-background shadow-xl transition-[width,top] duration-200 focus:outline-none",
@@ -525,8 +525,14 @@ function CasePanel({
         <div className="flex min-w-0 items-center gap-2">
           <Database className="h-4 w-4 shrink-0 text-muted-foreground" />
           <span className="text-sm font-medium">Row</span>
-          <span className="truncate font-mono text-xs text-muted-foreground">
-            {caseDisplayId(testCase.testCaseId)}
+          {/* The real, content-addressed testCaseId — byte-identical to the SDK's
+              stable_case_id and pull_dataset output. CSS truncates for overflow;
+              the title carries the full id and the copy button copies it verbatim. */}
+          <span
+            className="truncate font-mono text-xs text-muted-foreground"
+            title={testCase.testCaseId}
+          >
+            {testCase.testCaseId}
           </span>
           <CopyButton
             value={testCase.testCaseId}

--- a/frontend/ui/src/features/offline-eval/utils.test.ts
+++ b/frontend/ui/src/features/offline-eval/utils.test.ts
@@ -3,7 +3,6 @@ import {
   REVIEW_STATUS_VARIANT,
   RESULT_STATUS_VARIANT,
   SENTIMENT_CLASS,
-  caseDisplayId,
   changeSentiment,
   datasetInitCode,
   datasetInitCodeTs,
@@ -99,23 +98,6 @@ describe("scoreDisplay", () => {
 describe("formatStamp", () => {
   it("delegates to the app-wide absolute timestamp format", () => {
     expect(formatStamp("2026-07-16T15:41:12Z")).toMatch(/2026-07-16/);
-  });
-});
-
-describe("caseDisplayId", () => {
-  it("produces a stable trace-id-looking id", () => {
-    const id = caseDisplayId("case-001");
-    expect(id).toMatch(/^tc_[0-9a-f]{12}$/);
-    expect(id).toHaveLength(15);
-    expect(caseDisplayId("case-001")).toBe(id);
-  });
-
-  it("distinguishes different case ids", () => {
-    expect(caseDisplayId("case-001")).not.toBe(caseDisplayId("case-002"));
-  });
-
-  it("handles an empty id", () => {
-    expect(caseDisplayId("")).toMatch(/^tc_/);
   });
 });
 

--- a/frontend/ui/src/features/offline-eval/utils.ts
+++ b/frontend/ui/src/features/offline-eval/utils.ts
@@ -76,21 +76,6 @@ export function formatStamp(iso: string): string {
   return formatDate(iso);
 }
 
-/**
- * A stable, trace-id-looking display id for a dataset row, derived from its
- * internal case id (which stays "case-001" for lookups/routes/refs).
- */
-export function caseDisplayId(id: string): string {
-  let h = 2166136261;
-  for (let i = 0; i < id.length; i++) {
-    h ^= id.charCodeAt(i);
-    h = Math.imul(h, 16777619);
-  }
-  const a = (h >>> 0).toString(16).padStart(8, "0");
-  const b = (Math.imul(h ^ 0x9e3779b9, 16777619) >>> 0).toString(16).padStart(8, "0");
-  return `tc_${a}${b}`.slice(0, 15);
-}
-
 export function truncate(text: string, max = 80): string {
   return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
 }

--- a/frontend/ui/src/lib/eval/case-id.test.ts
+++ b/frontend/ui/src/lib/eval/case-id.test.ts
@@ -1,0 +1,105 @@
+/**
+ * `stableCaseId` must stay byte-for-byte identical to the SDK derivation
+ * (traceroot-ts `src/eval/ids.ts::stableCaseId`, traceroot-py
+ * `traceroot/eval/ids.py::stable_case_id`) so a case authored in the UI and one
+ * pushed from the SDK under the same dataset key converge on the same `tc_` id.
+ *
+ * The vectors below are lifted verbatim from the SDK's cross-SDK parity fixture
+ * (traceroot-ts `packages/traceroot/tests/fixtures/case_id_parity.json`), which
+ * BOTH SDKs assert against. Feeding each case's exact `canonical_json` (the value
+ * the SDK's canonicalizer produced for that input) into our port must reproduce
+ * the fixture's `id` — proving identical separators, NUL bytes, slice length, hex
+ * casing, and occurrence handling.
+ */
+import { createHash } from "crypto";
+import { describe, it, expect } from "vitest";
+import { stableCaseId } from "./case-id";
+import { canonicalJson } from "./versions";
+
+// dataset_key from the fixture. add()-ing these inputs IN ORDER yields these ids.
+const DATASET_KEY = "weather";
+
+// [canonical_json, expected tc_ id] in fixture order. Case index 2 is a duplicate of
+// index 0, so it takes occurrence 1; every other input is unique (occurrence 0).
+const VECTORS: [string, string][] = [
+  ['{"n":1,"q":"a"}', "tc_0d4a8155fd3d8a4615da"],
+  ["[1,2,3]", "tc_9dc099ff66e00c2888e2"],
+  ['{"n":1,"q":"a"}', "tc_8066f7118c4649807c19"], // duplicate → occurrence 1
+  ['{"score":1}', "tc_4a15edfa5a7b9ce61c3b"],
+  ['{"a":0}', "tc_29c2fedf5b31cc205373"],
+  ['{"a":2.5}', "tc_2e3d48d5036a628da770"],
+  ['{"a":1e-7}', "tc_05c8278510f16bf312e6"],
+  ['{"a":0.00001}', "tc_b7e2369d46cdc878c03e"],
+  ['{"a":10000000000000000}', "tc_b2c299d63e147a1c74cc"],
+  ['{"a":1e+21}', "tc_a3cfd7b825555f31d95e"],
+  ['{"a":-1.5e-9}', "tc_4abbc789165ded5fb805"],
+  ['{"f":7,"i":7}', "tc_a3f3d1129def3b43d8aa"],
+  ['{"1":"c","10":"a","2":"b"}', "tc_8d0abd1fa71a2dad83d3"],
+  ['{"":2,"𝄞":1}', "tc_fecdc4d7e7fc93fd45d0"],
+  ['{"s":"héllo 𝄞 ünïcødé"}', "tc_900732cd2aea48ba274e"],
+  ['"2020-01-01T00:00:00.000Z"', "tc_7edf45f9589f403f0b4c"],
+  ['{"d":"2021-06-30T23:59:59.123Z"}', "tc_2dee231a75aa266ac648"],
+  ['{"nan":"NaN","ninf":"-Infinity","pinf":"Infinity"}', "tc_9ddb24ea17182a9de720"],
+  ['{"set":["B","a",1,2,3]}', "tc_b556e08d750de24d3ba7"],
+  ['{"bytes":[104,105,0,255]}', "tc_3aa49e6430e3db870720"],
+  ['{"a":[],"o":{},"s":[]}', "tc_98a5857d91772c37e809"],
+  [
+    '{"outer":{"list":[{"a":[true,null,"x"],"z":1},[2,0]],"m":{"k10":10.5,"k2":2}}}',
+    "tc_875b69560cf7aa8f3485",
+  ],
+];
+
+describe("stableCaseId — byte parity with the SDK", () => {
+  it("reproduces every cross-SDK fixture id from its canonical input + occurrence", () => {
+    const seen = new Map<string, number>();
+    for (const [canonical, expectedId] of VECTORS) {
+      const occurrence = seen.get(canonical) ?? 0;
+      seen.set(canonical, occurrence + 1);
+      expect(stableCaseId(DATASET_KEY, canonical, occurrence)).toBe(expectedId);
+    }
+  });
+
+  it("uses \\x00 separators and a 20-hex-char slice (independent recomputation)", () => {
+    // Recompute the SDK formula from scratch to pin separators + slice length.
+    const key = "support";
+    const canonical = '"hello"';
+    const NUL = "\x00"; // explicit so the separator is visible in source, not an invisible byte
+    const material = `${key}${NUL}${canonical}${NUL}0`;
+    const expected =
+      "tc_" + createHash("sha256").update(material, "utf8").digest("hex").slice(0, 20);
+    expect(stableCaseId(key, canonical, 0)).toBe(expected);
+    expect(stableCaseId(key, canonical, 0)).toMatch(/^tc_[0-9a-f]{20}$/);
+  });
+
+  it("disambiguates duplicate inputs by occurrence", () => {
+    const a = stableCaseId("k", '"x"', 0);
+    const b = stableCaseId("k", '"x"', 1);
+    expect(a).not.toBe(b);
+    expect(a).toBe(stableCaseId("k", '"x"', 0)); // deterministic
+  });
+
+  it("rejects a lone UTF-16 surrogate in the dataset key (parity with the SDK guard)", () => {
+    expect(() => stableCaseId("\ud834", '"x"', 0)).toThrow(/surrogate/);
+  });
+});
+
+describe("UI ↔ SDK convergence for the inputs the UI actually authors", () => {
+  // UI case inputs are always genuine strings (CreateTestCaseRequestSchema.input), and
+  // the versions.ts canonicalizer reduces a string to JSON.stringify(value) — identical
+  // to the SDK's canonical form for a string — so both sides feed the SAME pre-image.
+  it("a string input canonicalizes to the SDK's canonical form", () => {
+    expect(canonicalJson("hello")).toBe('"hello"');
+    // Same id whether the canonical string is produced by the UI canonicalizer or given.
+    expect(stableCaseId("weather", canonicalJson("hello"), 0)).toBe(
+      stableCaseId("weather", '"hello"', 0),
+    );
+  });
+
+  it("an ASCII object input matches the SDK's sorted-key canonical form", () => {
+    // Fixture case 0: input {q:"a", n:1} → canonical {"n":1,"q":"a"} → tc_0d4a8155fd3d8a4615da.
+    expect(canonicalJson({ q: "a", n: 1 })).toBe('{"n":1,"q":"a"}');
+    expect(stableCaseId("weather", canonicalJson({ q: "a", n: 1 }), 0)).toBe(
+      "tc_0d4a8155fd3d8a4615da",
+    );
+  });
+});

--- a/frontend/ui/src/lib/eval/case-id.test.ts
+++ b/frontend/ui/src/lib/eval/case-id.test.ts
@@ -137,3 +137,19 @@ describe("nextCaseId picks the first FREE occurrence, not a count", () => {
     expect(r).toEqual({ testCaseId: id0, occurrence: 0 });
   });
 });
+
+describe("canonicalJson stays parity with the SDK canonicalizer", () => {
+  it("orders object keys by Unicode code point, not UTF-16 code unit", () => {
+    // U+E000 (BMP private-use) sorts BEFORE U+1D11E (astral) by code point, but AFTER it
+    // by UTF-16 code unit (0xD834 < 0xE000). The SDK uses code-point order; a JS `.sort()`
+    // would put the astral key first and diverge from the SDK's pre-image.
+    const s = canonicalJson({ "\u{1D11E}": 1, "\uE000": 2 });
+    expect(s.indexOf("\uE000")).toBeLessThan(s.indexOf("\u{1D11E}"));
+  });
+
+  it("rejects a lone surrogate the way the SDK does", () => {
+    // The SDK's canonicalizer raises on a value the UI must not silently accept and hash.
+    expect(() => canonicalJson("\uD800")).toThrow();
+    expect(() => canonicalJson("ok")).not.toThrow();
+  });
+});

--- a/frontend/ui/src/lib/eval/case-id.test.ts
+++ b/frontend/ui/src/lib/eval/case-id.test.ts
@@ -13,7 +13,7 @@
  */
 import { createHash } from "crypto";
 import { describe, it, expect } from "vitest";
-import { stableCaseId, nextCaseId } from "./case-id";
+import { stableCaseId, nextCaseId, resolveDatasetKey } from "./case-id";
 import { canonicalJson } from "./versions";
 
 // dataset_key from the fixture. add()-ing these inputs IN ORDER yields these ids.
@@ -111,12 +111,12 @@ describe("nextCaseId picks the first FREE occurrence, not a count", () => {
   const id1 = stableCaseId(key, input, 1);
 
   it("a brand-new input takes occurrence 0", () => {
-    const r = nextCaseId(new Set<string>(), key, input);
+    const r = nextCaseId([], key, input);
     expect(r).toEqual({ testCaseId: id0, occurrence: 0 });
   });
 
   it("a duplicate of a contiguous group takes the next slot", () => {
-    const r = nextCaseId(new Set([id0]), key, input);
+    const r = nextCaseId([{ testCaseId: id0 }], key, input);
     expect(r).toEqual({ testCaseId: id1, occurrence: 1 });
   });
 
@@ -124,17 +124,27 @@ describe("nextCaseId picks the first FREE occurrence, not a count", () => {
     // The delete-gap that a count-based occurrence gets wrong: add "X" twice (id0, id1),
     // delete id0, then add "X" again. A count would see one "X" case and mint occurrence 1
     // = id1 — a duplicate testCaseId in the same version. First-free-slot picks id0.
-    const afterDeletingId0 = new Set([id1]);
+    const afterDeletingId0 = [{ testCaseId: id1 }];
     const r = nextCaseId(afterDeletingId0, key, input);
     expect(r).toEqual({ testCaseId: id0, occurrence: 0 });
-    expect(afterDeletingId0.has(r.testCaseId)).toBe(false); // no collision
+    expect(afterDeletingId0.some((c) => c.testCaseId === r.testCaseId)).toBe(false); // no collision
   });
 
   it("skips a legacy random id and converges on occurrence 0 (the SDK slot)", () => {
     // A legacy UI case for the same input carries a random tc_ id, never a content id.
     // The content id must still be occurrence 0 so a later SDK push of "X" upserts onto it.
-    const r = nextCaseId(new Set(["tc_legacyrandomxxxxxx"]), key, input);
+    const r = nextCaseId([{ testCaseId: "tc_legacyrandomxxxxxx" }], key, input);
     expect(r).toEqual({ testCaseId: id0, occurrence: 0 });
+  });
+});
+
+describe("resolveDatasetKey — SDK `key ?? name` convention", () => {
+  it("prefers an explicit key over the name", () => {
+    expect(resolveDatasetKey({ key: "support", name: "Support QA" })).toBe("support");
+  });
+
+  it("falls back to the name for a legacy null key", () => {
+    expect(resolveDatasetKey({ key: null, name: "Support QA" })).toBe("Support QA");
   });
 });
 

--- a/frontend/ui/src/lib/eval/case-id.test.ts
+++ b/frontend/ui/src/lib/eval/case-id.test.ts
@@ -13,7 +13,7 @@
  */
 import { createHash } from "crypto";
 import { describe, it, expect } from "vitest";
-import { stableCaseId } from "./case-id";
+import { stableCaseId, nextCaseId } from "./case-id";
 import { canonicalJson } from "./versions";
 
 // dataset_key from the fixture. add()-ing these inputs IN ORDER yields these ids.
@@ -101,5 +101,39 @@ describe("UI ↔ SDK convergence for the inputs the UI actually authors", () => 
     expect(stableCaseId("weather", canonicalJson({ q: "a", n: 1 }), 0)).toBe(
       "tc_0d4a8155fd3d8a4615da",
     );
+  });
+});
+
+describe("nextCaseId picks the first FREE occurrence, not a count", () => {
+  const key = "capitals-qa";
+  const input = '{"country":"X"}'; // already-canonical input
+  const id0 = stableCaseId(key, input, 0);
+  const id1 = stableCaseId(key, input, 1);
+
+  it("a brand-new input takes occurrence 0", () => {
+    const r = nextCaseId(new Set<string>(), key, input);
+    expect(r).toEqual({ testCaseId: id0, occurrence: 0 });
+  });
+
+  it("a duplicate of a contiguous group takes the next slot", () => {
+    const r = nextCaseId(new Set([id0]), key, input);
+    expect(r).toEqual({ testCaseId: id1, occurrence: 1 });
+  });
+
+  it("re-adding after the occurrence-0 case was deleted REUSES slot 0, not a collision", () => {
+    // The delete-gap that a count-based occurrence gets wrong: add "X" twice (id0, id1),
+    // delete id0, then add "X" again. A count would see one "X" case and mint occurrence 1
+    // = id1 — a duplicate testCaseId in the same version. First-free-slot picks id0.
+    const afterDeletingId0 = new Set([id1]);
+    const r = nextCaseId(afterDeletingId0, key, input);
+    expect(r).toEqual({ testCaseId: id0, occurrence: 0 });
+    expect(afterDeletingId0.has(r.testCaseId)).toBe(false); // no collision
+  });
+
+  it("skips a legacy random id and converges on occurrence 0 (the SDK slot)", () => {
+    // A legacy UI case for the same input carries a random tc_ id, never a content id.
+    // The content id must still be occurrence 0 so a later SDK push of "X" upserts onto it.
+    const r = nextCaseId(new Set(["tc_legacyrandomxxxxxx"]), key, input);
+    expect(r).toEqual({ testCaseId: id0, occurrence: 0 });
   });
 });

--- a/frontend/ui/src/lib/eval/case-id.ts
+++ b/frontend/ui/src/lib/eval/case-id.ts
@@ -63,22 +63,34 @@ export function stableCaseId(datasetKey: string, inputCanonical: string, occurre
 }
 
 /**
- * Pick the content-addressed id for a NEW case with the given canonical input: the
- * first `occurrence` whose id is not already present in `existingIds` (the ids of the
- * cases already in the version). This mirrors the SDK's `Dataset._content_id` probe
- * (`occurrence = 0; while cid in cases: occurrence += 1`), so it is robust to gaps
- * left by deletes and never collides with a legacy random id — the same input placed
- * in the same version by the UI, TypeScript, or Python lands in the same slot.
+ * The stable key a dataset's case ids are hashed from — the SDK convention `key ?? name`.
+ * A UI-created dataset stores `key = name`; a legacy row with a null key falls back to the
+ * name so a `tc_` id derived here still matches an SDK author addressing the same key.
+ * (A rename should freeze a legacy null key to the OLD name before it changes — see the
+ * dataset PATCH route — so this fallback only ever sees a not-yet-renamed legacy row.)
+ */
+export function resolveDatasetKey(dataset: { key: string | null; name: string }): string {
+  return dataset.key ?? dataset.name;
+}
+
+/**
+ * Pick the content-addressed id for a NEW case with the given canonical input: the first
+ * `occurrence` whose id is not already present among `current` (the cases already in the
+ * version). This mirrors the SDK's `Dataset._content_id` probe (`occurrence = 0; while cid
+ * in cases: occurrence += 1`), so it is robust to gaps left by deletes and never collides
+ * with a legacy random id — the same input placed in the same version by the UI, TypeScript,
+ * or Python lands in the same slot.
  *
  * A plain count of same-input cases only equals this when the existing occurrences
  * are a contiguous `0..n-1` range; a delete leaves a gap, and a count would then
  * re-mint an id that is already taken.
  */
 export function nextCaseId(
-  existingIds: Set<string>,
+  current: ReadonlyArray<{ testCaseId: string }>,
   datasetKey: string,
   inputCanonical: string,
 ): { testCaseId: string; occurrence: number } {
+  const existingIds = new Set(current.map((c) => c.testCaseId));
   let occurrence = 0;
   let testCaseId = stableCaseId(datasetKey, inputCanonical, occurrence);
   while (existingIds.has(testCaseId)) {

--- a/frontend/ui/src/lib/eval/case-id.ts
+++ b/frontend/ui/src/lib/eval/case-id.ts
@@ -1,0 +1,49 @@
+import { createHash } from "crypto";
+
+/**
+ * A lone UTF-16 surrogate: a high surrogate not followed by a low one, or a low
+ * one not preceded by a high one. Such a string is not valid Unicode text and
+ * cannot be UTF-8 encoded — Python raises while hashing it, so we reject it here
+ * too rather than silently hashing Node's replacement form and diverging cross-SDK.
+ * Kept byte-identical to the SDK's `rejectLoneSurrogate` (traceroot-ts
+ * `src/eval/canonical.ts`, traceroot-py `traceroot/eval/canonical.py`).
+ */
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+function rejectLoneSurrogate(s: string): void {
+  if (LONE_SURROGATE.test(s)) {
+    throw new Error(
+      "string contains an unpaired UTF-16 surrogate and cannot be canonicalized; " +
+        "it is not valid Unicode text",
+    );
+  }
+}
+
+/**
+ * Derive a dataset case's stable, CONTENT-addressed id (`tc_…`).
+ *
+ * MUST stay byte-identical to the SDK derivation (traceroot-ts
+ * `src/eval/ids.ts::stableCaseId`, traceroot-py
+ * `traceroot/eval/ids.py::stable_case_id`):
+ *   `"tc_" + sha256(`${datasetKey}\x00${inputCanonical}\x00${occurrence}`, utf-8).hex[:20]`,
+ * lowercase hex, first 20 chars, NUL (`\x00`) separators, occurrence rendered as
+ * a base-10 integer.
+ *
+ * A case's identity is its INPUT content, not its position: re-authoring the same
+ * input — in the UI, in TypeScript, or in Python — yields the SAME id, so the
+ * platform matches it on re-publish (upsert on id) instead of duplicating it, and
+ * inserting/removing/reordering other cases never shifts this case's id.
+ * `occurrence` disambiguates duplicate inputs (0 for the first case with a given
+ * input, 1 for the next, ...). `inputCanonical` is the canonical-JSON of the input
+ * (recursively sorted keys); the caller must produce it with the SAME canonicalizer
+ * the SDK uses so the pre-image — and therefore the id — is byte-for-byte identical.
+ */
+export function stableCaseId(datasetKey: string, inputCanonical: string, occurrence = 0): string {
+  // `inputCanonical` already went through canonicalization; the raw `datasetKey` has
+  // not, so guard it (parity with the SDK, which would raise UTF-8-encoding it).
+  rejectLoneSurrogate(datasetKey);
+  const digest = createHash("sha256")
+    .update(`${datasetKey}\x00${inputCanonical}\x00${occurrence}`, "utf8")
+    .digest("hex");
+  return `tc_${digest.slice(0, 20)}`;
+}

--- a/frontend/ui/src/lib/eval/case-id.ts
+++ b/frontend/ui/src/lib/eval/case-id.ts
@@ -10,7 +10,7 @@ import { createHash } from "crypto";
  */
 const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
 
-function rejectLoneSurrogate(s: string): void {
+export function rejectLoneSurrogate(s: string): void {
   if (LONE_SURROGATE.test(s)) {
     throw new Error(
       "string contains an unpaired UTF-16 surrogate and cannot be canonicalized; " +
@@ -46,4 +46,30 @@ export function stableCaseId(datasetKey: string, inputCanonical: string, occurre
     .update(`${datasetKey}\x00${inputCanonical}\x00${occurrence}`, "utf8")
     .digest("hex");
   return `tc_${digest.slice(0, 20)}`;
+}
+
+/**
+ * Pick the content-addressed id for a NEW case with the given canonical input: the
+ * first `occurrence` whose id is not already present in `existingIds` (the ids of the
+ * cases already in the version). This mirrors the SDK's `Dataset._content_id` probe
+ * (`occurrence = 0; while cid in cases: occurrence += 1`), so it is robust to gaps
+ * left by deletes and never collides with a legacy random id — the same input placed
+ * in the same version by the UI, TypeScript, or Python lands in the same slot.
+ *
+ * A plain count of same-input cases only equals this when the existing occurrences
+ * are a contiguous `0..n-1` range; a delete leaves a gap, and a count would then
+ * re-mint an id that is already taken.
+ */
+export function nextCaseId(
+  existingIds: Set<string>,
+  datasetKey: string,
+  inputCanonical: string,
+): { testCaseId: string; occurrence: number } {
+  let occurrence = 0;
+  let testCaseId = stableCaseId(datasetKey, inputCanonical, occurrence);
+  while (existingIds.has(testCaseId)) {
+    occurrence += 1;
+    testCaseId = stableCaseId(datasetKey, inputCanonical, occurrence);
+  }
+  return { testCaseId, occurrence };
 }

--- a/frontend/ui/src/lib/eval/case-id.ts
+++ b/frontend/ui/src/lib/eval/case-id.ts
@@ -10,12 +10,26 @@ import { createHash } from "crypto";
  */
 const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
 
+/**
+ * Raised when a string carries an unpaired UTF-16 surrogate and so cannot be
+ * canonicalized (it is not valid Unicode text). A dedicated type so callers can tell
+ * this specific, caller-fixable condition apart from an unexpected failure — the
+ * publish routes map it to a 400, and `contentSignature` swallows it for ALREADY-stored
+ * content (which must keep a stable signature rather than be re-validated on every publish).
+ */
+export class LoneSurrogateError extends Error {
+  constructor(
+    message = "string contains an unpaired UTF-16 surrogate and cannot be canonicalized; " +
+      "it is not valid Unicode text",
+  ) {
+    super(message);
+    this.name = "LoneSurrogateError";
+  }
+}
+
 export function rejectLoneSurrogate(s: string): void {
   if (LONE_SURROGATE.test(s)) {
-    throw new Error(
-      "string contains an unpaired UTF-16 surrogate and cannot be canonicalized; " +
-        "it is not valid Unicode text",
-    );
+    throw new LoneSurrogateError();
   }
 }
 

--- a/frontend/ui/src/lib/eval/result-to-dataset.test.ts
+++ b/frontend/ui/src/lib/eval/result-to-dataset.test.ts
@@ -15,12 +15,15 @@ const prismaMock = vi.hoisted(() => ({
 const publishMock = vi.hoisted(() => vi.fn(async (_opts: unknown) => ({}) as unknown));
 
 vi.mock("@traceroot/core", () => ({ prisma: prismaMock }));
-vi.mock("./versions", () => ({
-  publishDatasetVersion: publishMock,
-  newTestCaseId: () => "tc_new",
-}));
+// Mock only the network-bound publish; keep the REAL `canonicalJson` so the
+// content-addressed id derivation (and its occurrence counting) runs for real.
+vi.mock("./versions", async () => {
+  const actual = await vi.importActual<typeof import("./versions")>("./versions");
+  return { ...actual, publishDatasetVersion: publishMock };
+});
 
 import { saveResultToDataset } from "./result-to-dataset";
+import { stableCaseId } from "./case-id";
 
 type Seed = { testCaseId: string; input: string; expected: string | null; metadata: unknown };
 /** Run the transform the code handed to publishDatasetVersion over a given current set. */
@@ -108,5 +111,65 @@ describe("saveResultToDataset — values are JSON-encoded on write", () => {
       { testCaseId: "tc_src", input: '"old"', expected: null, metadata: null },
     ]).find((c) => c.testCaseId === "tc_src")!;
     expect(updated.input).toBe('"99"');
+  });
+});
+
+describe("saveResultToDataset — new cases get content-addressed ids", () => {
+  it("derives a stable tc_ id from the target dataset key + canonical input", async () => {
+    prismaMock.evaluationResult.findFirst.mockResolvedValue({
+      id: "r1",
+      runId: "run1",
+      testCaseId: "tc_src",
+      traceId: "t1",
+      input: "hello",
+      candidateOutput: null,
+    });
+    // Target dataset carries an explicit key (the pre-image the SDK hashes).
+    prismaMock.dataset.findFirst.mockResolvedValue({ currentVersionId: null, key: "support" });
+
+    await saveResultToDataset({
+      projectId: "p1",
+      resultId: "r1",
+      action: "save_new_case",
+      datasetId: "ds2",
+    });
+
+    // input "hello" is stored as the string '"hello"'; its canonical form is the same
+    // string a canonical-JSON of the string value produces (JSON.stringify("hello")).
+    const added = casesFrom([]).at(-1)!;
+    // Deterministic content-addressed id — not the old random UUID slice.
+    expect(added.testCaseId).toBe(stableCaseId("support", '"hello"', 0));
+  });
+
+  it("disambiguates a duplicate input with the next occurrence", async () => {
+    prismaMock.evaluationResult.findFirst.mockResolvedValue({
+      id: "r1",
+      runId: "run1",
+      testCaseId: "tc_src",
+      traceId: null,
+      input: "dup",
+      candidateOutput: null,
+    });
+    prismaMock.dataset.findFirst.mockResolvedValue({ currentVersionId: null, key: "support" });
+
+    await saveResultToDataset({
+      projectId: "p1",
+      resultId: "r1",
+      action: "save_new_case",
+      datasetId: "ds2",
+    });
+
+    // No existing case with this input → occurrence 0.
+    expect(casesFrom([]).at(-1)!.testCaseId).toBe(stableCaseId("support", '"dup"', 0));
+    // One existing case already has the identical canonical input → occurrence 1.
+    const withDup = casesFrom([
+      {
+        testCaseId: stableCaseId("support", '"dup"', 0),
+        input: '"dup"',
+        expected: null,
+        metadata: null,
+      },
+    ]).at(-1)!;
+    expect(withDup.testCaseId).toBe(stableCaseId("support", '"dup"', 1));
   });
 });

--- a/frontend/ui/src/lib/eval/result-to-dataset.test.ts
+++ b/frontend/ui/src/lib/eval/result-to-dataset.test.ts
@@ -23,7 +23,7 @@ vi.mock("./versions", async () => {
 });
 
 import { saveResultToDataset } from "./result-to-dataset";
-import { stableCaseId } from "./case-id";
+import { stableCaseId, LoneSurrogateError } from "./case-id";
 
 type Seed = { testCaseId: string; input: string; expected: string | null; metadata: unknown };
 /** Run the transform the code handed to publishDatasetVersion over a given current set. */
@@ -171,5 +171,28 @@ describe("saveResultToDataset — new cases get content-addressed ids", () => {
       },
     ]).at(-1)!;
     expect(withDup.testCaseId).toBe(stableCaseId("support", '"dup"', 1));
+  });
+
+  it("rejects an input with a lone UTF-16 surrogate with a typed error (route maps to 400)", async () => {
+    prismaMock.evaluationResult.findFirst.mockResolvedValue({
+      id: "r1",
+      runId: "run1",
+      testCaseId: "tc_src",
+      traceId: null,
+      input: "\uD800", // a lone high surrogate — not canonicalizable into a stable id
+      candidateOutput: null,
+    });
+    prismaMock.dataset.findFirst.mockResolvedValue({ currentVersionId: null, key: "support" });
+
+    await expect(
+      saveResultToDataset({
+        projectId: "p1",
+        resultId: "r1",
+        action: "save_new_case",
+        datasetId: "ds2",
+      }),
+    ).rejects.toBeInstanceOf(LoneSurrogateError);
+    // Rejected before any publish is attempted — nothing is written.
+    expect(publishMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ui/src/lib/eval/result-to-dataset.ts
+++ b/frontend/ui/src/lib/eval/result-to-dataset.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@traceroot/core";
-import { publishDatasetVersion, canonicalJson, type TestCaseSeed } from "./versions";
+import { publishDatasetVersion, canonicalJson, DatasetNotFound, type TestCaseSeed } from "./versions";
 import { nextCaseId } from "./case-id";
 import { encodeEditedText, decodeJsonValue } from "./json-value";
 
@@ -161,7 +161,10 @@ export async function saveResultToDataset(opts: {
     where: { id: targetDatasetId, projectId: opts.projectId },
     select: { key: true, name: true },
   });
-  const targetDatasetKey = targetDataset?.key ?? targetDataset?.name ?? targetDatasetId;
+  // Fail fast rather than fabricating a key from the id: a made-up key would hash a
+  // `tc_` id no SDK author could reproduce. (publishDatasetVersion re-validates too.)
+  if (!targetDataset) throw new DatasetNotFound();
+  const targetDatasetKey = targetDataset.key ?? targetDataset.name;
 
   const newSeedBase: Omit<TestCaseSeed, "testCaseId"> = {
     // No prior stored value, so encode the raw text as-is (a JSON-looking string like

--- a/frontend/ui/src/lib/eval/result-to-dataset.ts
+++ b/frontend/ui/src/lib/eval/result-to-dataset.ts
@@ -5,7 +5,7 @@ import {
   DatasetNotFound,
   type TestCaseSeed,
 } from "./versions";
-import { nextCaseId } from "./case-id";
+import { nextCaseId, resolveDatasetKey } from "./case-id";
 import { encodeEditedText } from "./json-value";
 
 /**
@@ -158,10 +158,8 @@ export async function saveResultToDataset(opts: {
     throw new CircularSaveConflict(result.testCaseId);
   }
 
-  // The pre-image the case id is hashed from — the target dataset's stable key, which
-  // by convention defaults to its display name (the SDK's `key = key ?? name`). Legacy
-  // rows with a null key fall back to the name so the derivation still matches an SDK
-  // author using the same key. (publishDatasetVersion re-validates the dataset exists.)
+  // The pre-image the case id is hashed from — the target dataset's stable key
+  // (see resolveDatasetKey). (publishDatasetVersion re-validates the dataset exists.)
   const targetDataset = await prisma.dataset.findFirst({
     where: { id: targetDatasetId, projectId: opts.projectId },
     select: { key: true, name: true },
@@ -169,7 +167,7 @@ export async function saveResultToDataset(opts: {
   // Fail fast rather than fabricating a key from the id: a made-up key would hash a
   // `tc_` id no SDK author could reproduce. (publishDatasetVersion re-validates too.)
   if (!targetDataset) throw new DatasetNotFound();
-  const targetDatasetKey = targetDataset.key ?? targetDataset.name;
+  const targetDatasetKey = resolveDatasetKey(targetDataset);
 
   // The raw text of a brand-new case's input: the caller's value, or the result's own.
   const rawInputText = inputProvided ? (opts.input ?? "") : result.input;
@@ -209,8 +207,7 @@ export async function saveResultToDataset(opts: {
       // so re-publishing matches (upsert on id) instead of duplicating. `occurrence` is the
       // first slot whose id is still free, mirroring the SDK so a gap left by a delete
       // never re-mints a live id.
-      const existingIds = new Set(current.map((s) => s.testCaseId));
-      const { testCaseId } = nextCaseId(existingIds, targetDatasetKey, canonicalInput);
+      const { testCaseId } = nextCaseId(current, targetDatasetKey, canonicalInput);
       const newSeed: TestCaseSeed = { testCaseId, ...newSeedBase };
       return { cases: [...current, newSeed], focusTestCaseId: testCaseId };
     },

--- a/frontend/ui/src/lib/eval/result-to-dataset.ts
+++ b/frontend/ui/src/lib/eval/result-to-dataset.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@traceroot/core";
 import { publishDatasetVersion, canonicalJson, type TestCaseSeed } from "./versions";
-import { stableCaseId } from "./case-id";
+import { nextCaseId } from "./case-id";
 import { encodeEditedText, decodeJsonValue } from "./json-value";
 
 /**
@@ -194,11 +194,10 @@ export async function saveResultToDataset(opts: {
       // CONTENT-addressed id (parity with the SDK's `stableCaseId`): the same input saved
       // here and pushed from the SDK under the same dataset key converge on one `tc_` id,
       // so re-publishing matches (upsert on id) instead of duplicating. `occurrence` is the
-      // first free slot after the cases already present with this exact canonical input.
-      const occurrence = current.filter(
-        (s) => canonicalJson(decodeJsonValue(s.input)) === canonicalInput,
-      ).length;
-      const testCaseId = stableCaseId(targetDatasetKey, canonicalInput, occurrence);
+      // first slot whose id is still free, mirroring the SDK so a gap left by a delete
+      // never re-mints a live id.
+      const existingIds = new Set(current.map((s) => s.testCaseId));
+      const { testCaseId } = nextCaseId(existingIds, targetDatasetKey, canonicalInput);
       const newSeed: TestCaseSeed = { testCaseId, ...newSeedBase };
       return { cases: [...current, newSeed], focusTestCaseId: testCaseId };
     },

--- a/frontend/ui/src/lib/eval/result-to-dataset.ts
+++ b/frontend/ui/src/lib/eval/result-to-dataset.ts
@@ -108,10 +108,12 @@ export async function saveResultToDataset(opts: {
     return currentExpected;
   };
 
-  // Is the result still backed by a live case in its originating dataset?
+  // Is the result still backed by a live case in its originating dataset? Also pull the
+  // key/name here so a save back into this same dataset reuses this row (the common case)
+  // instead of issuing a second identical lookup for the id-hash key below.
   const dataset = await prisma.dataset.findFirst({
     where: { id: originatingDatasetId, projectId: opts.projectId },
-    select: { currentVersionId: true },
+    select: { currentVersionId: true, key: true, name: true },
   });
   const originatingCaseLive =
     dataset?.currentVersionId != null &&
@@ -159,11 +161,16 @@ export async function saveResultToDataset(opts: {
   }
 
   // The pre-image the case id is hashed from — the target dataset's stable key
-  // (see resolveDatasetKey). (publishDatasetVersion re-validates the dataset exists.)
-  const targetDataset = await prisma.dataset.findFirst({
-    where: { id: targetDatasetId, projectId: opts.projectId },
-    select: { key: true, name: true },
-  });
+  // (see resolveDatasetKey). Reuse the row already fetched above when the target IS the
+  // originating dataset; only a save into a DIFFERENT dataset needs a fresh lookup.
+  // (publishDatasetVersion re-validates the dataset exists.)
+  const targetDataset =
+    targetDatasetId === originatingDatasetId
+      ? dataset
+      : await prisma.dataset.findFirst({
+          where: { id: targetDatasetId, projectId: opts.projectId },
+          select: { key: true, name: true },
+        });
   // Fail fast rather than fabricating a key from the id: a made-up key would hash a
   // `tc_` id no SDK author could reproduce. (publishDatasetVersion re-validates too.)
   if (!targetDataset) throw new DatasetNotFound();

--- a/frontend/ui/src/lib/eval/result-to-dataset.ts
+++ b/frontend/ui/src/lib/eval/result-to-dataset.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@traceroot/core";
-import { publishDatasetVersion, newTestCaseId, type TestCaseSeed } from "./versions";
-import { encodeEditedText } from "./json-value";
+import { publishDatasetVersion, canonicalJson, type TestCaseSeed } from "./versions";
+import { stableCaseId } from "./case-id";
+import { encodeEditedText, decodeJsonValue } from "./json-value";
 
 /**
  * Save an evaluation result into a dataset — the three explicit result-driven
@@ -152,8 +153,17 @@ export async function saveResultToDataset(opts: {
     throw new CircularSaveConflict(result.testCaseId);
   }
 
-  const newSeed: TestCaseSeed = {
-    testCaseId: newTestCaseId(),
+  // The pre-image the case id is hashed from — the target dataset's stable key, which
+  // by convention defaults to its display name (the SDK's `key = key ?? name`). Legacy
+  // rows with a null key fall back to the name so the derivation still matches an SDK
+  // author using the same key. (publishDatasetVersion re-validates the dataset exists.)
+  const targetDataset = await prisma.dataset.findFirst({
+    where: { id: targetDatasetId, projectId: opts.projectId },
+    select: { key: true, name: true },
+  });
+  const targetDatasetKey = targetDataset?.key ?? targetDataset?.name ?? targetDatasetId;
+
+  const newSeedBase: Omit<TestCaseSeed, "testCaseId"> = {
     // No prior stored value, so encode the raw text as-is (a JSON-looking string like
     // "42" stays the string "42" instead of decoding to the number 42 on pull).
     input: encodeEditedText(null, inputProvided ? (opts.input ?? "") : result.input),
@@ -170,15 +180,27 @@ export async function saveResultToDataset(opts: {
     sourceResultId: result.id,
     addedBy: opts.addedBy ?? null,
   };
+  // Canonical-JSON of the case's input, computed on the DECODED value — what the id is
+  // hashed from, matching an SDK author (whose SDK canonicalizes the native input) and
+  // the occurrence comparison against existing cases below.
+  const canonicalInput = canonicalJson(decodeJsonValue(newSeedBase.input));
 
   return publishDatasetVersion({
     datasetId: targetDatasetId,
     projectId: opts.projectId,
     createdBy: opts.addedBy ?? null,
     idempotencyKey: opts.idempotencyKey ?? null,
-    transform: (current) => ({
-      cases: [...current, newSeed],
-      focusTestCaseId: newSeed.testCaseId,
-    }),
+    transform: (current) => {
+      // CONTENT-addressed id (parity with the SDK's `stableCaseId`): the same input saved
+      // here and pushed from the SDK under the same dataset key converge on one `tc_` id,
+      // so re-publishing matches (upsert on id) instead of duplicating. `occurrence` is the
+      // first free slot after the cases already present with this exact canonical input.
+      const occurrence = current.filter(
+        (s) => canonicalJson(decodeJsonValue(s.input)) === canonicalInput,
+      ).length;
+      const testCaseId = stableCaseId(targetDatasetKey, canonicalInput, occurrence);
+      const newSeed: TestCaseSeed = { testCaseId, ...newSeedBase };
+      return { cases: [...current, newSeed], focusTestCaseId: testCaseId };
+    },
   });
 }

--- a/frontend/ui/src/lib/eval/result-to-dataset.ts
+++ b/frontend/ui/src/lib/eval/result-to-dataset.ts
@@ -6,7 +6,7 @@ import {
   type TestCaseSeed,
 } from "./versions";
 import { nextCaseId } from "./case-id";
-import { encodeEditedText, decodeJsonValue } from "./json-value";
+import { encodeEditedText } from "./json-value";
 
 /**
  * Save an evaluation result into a dataset — the three explicit result-driven
@@ -171,10 +171,13 @@ export async function saveResultToDataset(opts: {
   if (!targetDataset) throw new DatasetNotFound();
   const targetDatasetKey = targetDataset.key ?? targetDataset.name;
 
+  // The raw text of a brand-new case's input: the caller's value, or the result's own.
+  const rawInputText = inputProvided ? (opts.input ?? "") : result.input;
+
   const newSeedBase: Omit<TestCaseSeed, "testCaseId"> = {
     // No prior stored value, so encode the raw text as-is (a JSON-looking string like
     // "42" stays the string "42" instead of decoding to the number 42 on pull).
-    input: encodeEditedText(null, inputProvided ? (opts.input ?? "") : result.input),
+    input: encodeEditedText(null, rawInputText),
     // A brand-new case: expected defaults to null (never the candidate) unless set.
     expected: resolveExpected(null),
     metadata: metadataProvided ? opts.metadata : null,
@@ -188,10 +191,12 @@ export async function saveResultToDataset(opts: {
     sourceResultId: result.id,
     addedBy: opts.addedBy ?? null,
   };
-  // Canonical-JSON of the case's input, computed on the DECODED value — what the id is
-  // hashed from, matching an SDK author (whose SDK canonicalizes the native input) and
-  // the occurrence comparison against existing cases below.
-  const canonicalInput = canonicalJson(decodeJsonValue(newSeedBase.input));
+  // Canonical-JSON of the case's input, computed on the raw string value (identical to the
+  // stored value decoded, without the encode/decode round-trip) — what the id is hashed
+  // from, matching an SDK author whose SDK canonicalizes the native input. A lone UTF-16
+  // surrogate can't be canonicalized; the LoneSurrogateError it throws propagates to the
+  // route, which maps it to a 400 (a caller-fixable input) instead of an uncaught 500.
+  const canonicalInput = canonicalJson(rawInputText);
 
   return publishDatasetVersion({
     datasetId: targetDatasetId,

--- a/frontend/ui/src/lib/eval/result-to-dataset.ts
+++ b/frontend/ui/src/lib/eval/result-to-dataset.ts
@@ -1,5 +1,10 @@
 import { prisma } from "@traceroot/core";
-import { publishDatasetVersion, canonicalJson, DatasetNotFound, type TestCaseSeed } from "./versions";
+import {
+  publishDatasetVersion,
+  canonicalJson,
+  DatasetNotFound,
+  type TestCaseSeed,
+} from "./versions";
 import { nextCaseId } from "./case-id";
 import { encodeEditedText, decodeJsonValue } from "./json-value";
 

--- a/frontend/ui/src/lib/eval/versions.test.ts
+++ b/frontend/ui/src/lib/eval/versions.test.ts
@@ -208,4 +208,25 @@ describe("contentSignature — canonicalizes DECODED input/expected", () => {
       contentSignature([seed({ input: "42" })]),
     );
   });
+
+  it("does NOT throw on a pre-existing row whose stored content holds a lone surrogate", () => {
+    // A row stored (before the guards, or via another path) with an unpaired UTF-16
+    // surrogate must keep a stable signature — an unrelated publish that never touches
+    // it must not blow up because every row is re-canonicalized on every publish.
+    const bad = seed({ testCaseId: "tcbad", input: "\uD800", expected: "\uDC00" });
+    expect(() => contentSignature([bad])).not.toThrow();
+    // Stable: the same stored bad content signs identically on both sides of the
+    // content-addressed upsert comparison, so unchanged content still short-circuits.
+    expect(contentSignature([bad])).toBe(contentSignature([bad]));
+  });
+
+  it("a lone surrogate in one row does not poison a sibling row's signature", () => {
+    const good = seed({ testCaseId: "tcgood", input: '{"a":1}' });
+    const bad = seed({ testCaseId: "tcbad", input: "\uD800" });
+    expect(() => contentSignature([good, bad])).not.toThrow();
+    // Editing only the bad row still changes the signature; the good row is unaffected.
+    expect(contentSignature([good, bad])).not.toBe(
+      contentSignature([good, seed({ testCaseId: "tcbad", input: "\uDBFF" })]),
+    );
+  });
 });

--- a/frontend/ui/src/lib/eval/versions.test.ts
+++ b/frontend/ui/src/lib/eval/versions.test.ts
@@ -224,9 +224,17 @@ describe("contentSignature — canonicalizes DECODED input/expected", () => {
     const good = seed({ testCaseId: "tcgood", input: '{"a":1}' });
     const bad = seed({ testCaseId: "tcbad", input: "\uD800" });
     expect(() => contentSignature([good, bad])).not.toThrow();
-    // Editing only the bad row still changes the signature; the good row is unaffected.
-    expect(contentSignature([good, bad])).not.toBe(
+    // Editing only the bad row still changes the signature; the good row's own entry is
+    // untouched (sibling corruption must not silently alter a neighbour's signature).
+    const before = JSON.parse(contentSignature([good, bad])) as Array<{ id: string }>;
+    const after = JSON.parse(
       contentSignature([good, seed({ testCaseId: "tcbad", input: "\uDBFF" })]),
+    ) as Array<{ id: string }>;
+    expect(after.find((row) => row.id === "tcgood")).toEqual(
+      before.find((row) => row.id === "tcgood"),
+    );
+    expect(after.find((row) => row.id === "tcbad")).not.toEqual(
+      before.find((row) => row.id === "tcbad"),
     );
   });
 });

--- a/frontend/ui/src/lib/eval/versions.ts
+++ b/frontend/ui/src/lib/eval/versions.ts
@@ -1,7 +1,7 @@
 import { prisma, type Prisma, type TestCase } from "@traceroot/core";
 import { versionSnowflakeFromMs } from "./snowflake";
 import { decodeJsonValue } from "./json-value";
-import { rejectLoneSurrogate } from "./case-id";
+import { rejectLoneSurrogate, LoneSurrogateError } from "./case-id";
 
 /** Deterministic read order for a version's cases (see the ordering note where
  *  it's used): every case a publish writes shares one `create_time` (Postgres'
@@ -89,7 +89,13 @@ export function canonicalJson(v: unknown): string {
   const o = v as Record<string, unknown>;
   return `{${Object.keys(o)
     .sort(compareCodePoints)
-    .map((k) => `${JSON.stringify(k)}:${canonicalJson(o[k])}`)
+    .map((k) => {
+      // Guard object KEYS too, not just string VALUES: a lone surrogate in an
+      // SDK-authored metadata key must reject here rather than silently hashing JS's
+      // escaped form and diverging from the SDK's byte-for-byte pre-image.
+      rejectLoneSurrogate(k);
+      return `${JSON.stringify(k)}:${canonicalJson(o[k])}`;
+    })
     .join(",")}}`;
 }
 
@@ -121,12 +127,35 @@ export function contentSignature(seeds: TestCaseSeed[]): string {
   const rows = seeds
     .map((s) => ({
       id: s.testCaseId,
-      input: decodeJsonValue(s.input),
-      expected: s.expected == null ? null : decodeJsonValue(s.expected),
-      metadata: s.metadata ?? null,
+      input: signatureField(decodeJsonValue(s.input), s.input),
+      expected: s.expected == null ? null : signatureField(decodeJsonValue(s.expected), s.expected),
+      metadata: signatureField(s.metadata ?? null, null),
     }))
     .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
-  return canonicalJson(rows);
+  // `rows` now holds only strings/null, so this can't throw on stored content.
+  return JSON.stringify(rows);
+}
+
+/**
+ * Canonical string for ONE stored field, used only inside `contentSignature`'s equality
+ * check. Existing content must always yield a stable signature: if a value already stored
+ * in this dataset can't be canonicalized (a lone surrogate written before the guards, or
+ * via another path), we must NOT let it fail an unrelated publish that doesn't even touch
+ * that row. So fall back to the raw stored text (or a well-formed JSON rendering) — stable
+ * and identical on both sides of the old-vs-new comparison for an unchanged row. NEW content
+ * is still rejected up front where its id is derived; this only protects the signature scan.
+ */
+function signatureField(decoded: unknown, rawStored: string | null): string {
+  try {
+    return canonicalJson(decoded);
+  } catch (e) {
+    if (e instanceof LoneSurrogateError) {
+      // `JSON.stringify` escapes lone surrogates (well-formed since ES2019), so this
+      // never throws; `rawStored` is the exact stored text, preferred when available.
+      return rawStored ?? JSON.stringify(decoded) ?? "null";
+    }
+    throw e;
+  }
 }
 
 /**

--- a/frontend/ui/src/lib/eval/versions.ts
+++ b/frontend/ui/src/lib/eval/versions.ts
@@ -1,5 +1,4 @@
 import { prisma, type Prisma, type TestCase } from "@traceroot/core";
-import { randomUUID } from "crypto";
 import { versionSnowflakeFromMs } from "./snowflake";
 import { decodeJsonValue } from "./json-value";
 
@@ -67,13 +66,16 @@ function toSeed(c: TestCase): TestCaseSeed {
   };
 }
 
-export function newTestCaseId(): string {
-  return `tc_${randomUUID().replace(/-/g, "").slice(0, 20)}`;
-}
-
 /** Deterministic JSON with recursively sorted object keys — so two structurally equal
- *  values compare equal regardless of key order (JSONB round-trips don't preserve it). */
-function canonicalJson(v: unknown): string {
+ *  values compare equal regardless of key order (JSONB round-trips don't preserve it).
+ *
+ *  Also the canonicalizer for content-addressed case ids (`stableCaseId`): the id
+ *  hashes this exact string, so it must match the SDK's `canonicalJson` byte-for-byte
+ *  for the inputs the UI actually authors. UI case inputs are always genuine strings
+ *  (see `CreateTestCaseRequestSchema.input`), and for a string value this reduces to
+ *  `JSON.stringify(value)` in both this helper and the SDK's — so a UI-authored case
+ *  and an SDK-authored case for the same input converge on the same `tc_` id. */
+export function canonicalJson(v: unknown): string {
   if (v === null || typeof v !== "object") return JSON.stringify(v) ?? "null";
   if (Array.isArray(v)) return `[${v.map(canonicalJson).join(",")}]`;
   const o = v as Record<string, unknown>;

--- a/frontend/ui/src/lib/eval/versions.ts
+++ b/frontend/ui/src/lib/eval/versions.ts
@@ -1,6 +1,7 @@
 import { prisma, type Prisma, type TestCase } from "@traceroot/core";
 import { versionSnowflakeFromMs } from "./snowflake";
 import { decodeJsonValue } from "./json-value";
+import { rejectLoneSurrogate } from "./case-id";
 
 /** Deterministic read order for a version's cases (see the ordering note where
  *  it's used): every case a publish writes shares one `create_time` (Postgres'
@@ -76,13 +77,36 @@ function toSeed(c: TestCase): TestCaseSeed {
  *  `JSON.stringify(value)` in both this helper and the SDK's — so a UI-authored case
  *  and an SDK-authored case for the same input converge on the same `tc_` id. */
 export function canonicalJson(v: unknown): string {
+  if (typeof v === "string") {
+    // A lone UTF-16 surrogate cannot be UTF-8 encoded; the SDK's canonicalizer raises
+    // on it, so reject it here too rather than silently hashing JS's escaped form and
+    // diverging cross-SDK. (The reachable id path is always a string value.)
+    rejectLoneSurrogate(v);
+    return JSON.stringify(v);
+  }
   if (v === null || typeof v !== "object") return JSON.stringify(v) ?? "null";
   if (Array.isArray(v)) return `[${v.map(canonicalJson).join(",")}]`;
   const o = v as Record<string, unknown>;
   return `{${Object.keys(o)
-    .sort()
+    .sort(compareCodePoints)
     .map((k) => `${JSON.stringify(k)}:${canonicalJson(o[k])}`)
     .join(",")}}`;
+}
+
+/** Order strings by Unicode code POINT (Python `sorted()` order), not by UTF-16 code
+ *  unit (JS default `.sort()`); they differ only when an astral-plane character meets a
+ *  BMP one in U+E000..U+FFFF. Keeps object-key order byte-parity with the SDK canonicalizer. */
+function compareCodePoints(a: string, b: string): number {
+  const ai = a[Symbol.iterator]();
+  const bi = b[Symbol.iterator]();
+  for (;;) {
+    const x = ai.next();
+    const y = bi.next();
+    if (x.done || y.done) return x.done ? (y.done ? 0 : -1) : 1;
+    const cx = x.value.codePointAt(0) as number;
+    const cy = y.value.codePointAt(0) as number;
+    if (cx !== cy) return cx - cy;
+  }
 }
 
 /** A stable signature of a version's semantic CONTENT — the per-case (id, input, expected,


### PR DESCRIPTION
## Summary

Closes: #1941

Dataset case ids are `tc_…` everywhere, but the UI minted them **randomly** while the SDK derives them from the case content. So a case authored in the UI never converged with an SDK-authored case of the same input — on re-publish the platform duplicated the row instead of matching it on id. This PR makes the UI compute the **same content-addressed id the SDK does**, byte-for-byte, so UI- and SDK-authored cases with the same input resolve to the same `tc_` id.

## How it works

```
UI authors a case (add-case route, or save-result → dataset)
  → id = stableCaseId(datasetKey, inputCanonical, occurrence)
         = "tc_" + sha256(datasetKey ␀ inputCanonical ␀ occurrence).hex[:20]
       ├─ datasetKey    = Dataset.key (falls back to name, matching the SDK's key ?? name)
       ├─ inputCanonical = canonicalJson(decodeJsonValue(input))
       └─ occurrence    = # existing cases in the dataset with the same canonical input (0,1,…)
```

This mirrors the SDK's `stableCaseId` (TypeScript and Python) exactly — same `\x00` separators, same 20-char hex slice, same lone-surrogate guard. `datasetKey` and `occurrence` are both available at the write site: the publish transform already receives the current version's cases, so `occurrence` is counted there. `newTestCaseId()` (the random generator) is removed — every write path has an input.

## What's included

### Frontend lib
- `frontend/ui/src/lib/eval/case-id.ts` — **new**; `stableCaseId(datasetKey, inputCanonical, occurrence)`, a byte-for-byte port of the SDK's, incl. the lone-surrogate guard
- `frontend/ui/src/lib/eval/versions.ts` — remove `newTestCaseId()` + its `randomUUID` import; export the existing `canonicalJson` for reuse

### API / write paths
- `frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts` — add-case: derive the id via `stableCaseId` inside the transform
- `frontend/ui/src/lib/eval/result-to-dataset.ts` — `save_new_case` / `duplicate_as_variant`: derive the id via `stableCaseId`

### Tests
- `frontend/ui/src/lib/eval/case-id.test.ts` — **new**
- `frontend/ui/src/lib/eval/result-to-dataset.test.ts` — updated mock + id assertions

## Test plan

- [x] **Byte-parity against the SDK's own cross-SDK fixture** `case_id_parity.json` (the 22 vectors both Python and TypeScript assert against, incl. astral-plane/PUA keys, number-normalization, and the occurrence-1 duplicate) — every fixture id reproduced exactly
- [x] Occurrence disambiguation — two identical inputs advance occurrence 0 → 1
- [x] UI ↔ SDK convergence — the same `(datasetKey, input)` yields the same id in the UI path and the SDK spec
- [x] Lone-surrogate guard fires as in the SDK
- [x] `result-to-dataset` derives the id via `stableCaseId` (mock keeps the real canonicalizer)
- [x] `vitest run src/lib/eval` → 138 passed; `tsc --noEmit` clean on changed files; prettier + hooks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
UI-authored dataset cases now use the same content-addressed `tc_` IDs as the SDK so identical inputs converge and re-publishes upsert by id instead of duplicating. Previously the UI minted random IDs; now IDs hash `key ?? name`, canonicalized input, and the first free occurrence; invalid Unicode returns 400 instead of 500.

- Adds SDK-parity ID derivation: `stableCaseId` and `nextCaseId` (NUL separators, SHA-256, first 20 hex). Occurrence uses the first free slot to avoid collisions after deletes.
- Replaces random IDs in add-case and `saveResultToDataset`; canonicalizes native string input; maps `LoneSurrogateError` to 400 in both routes; `saveResultToDataset` fails fast if the target dataset is missing.
- Canonicalizer parity: `canonicalJson` orders object keys by Unicode code point and rejects lone surrogates in string values and keys; `contentSignature` stays stable for already-stored bad surrogates via per-row fallback (only new content is rejected).
- Dataset identity: `resolveDatasetKey` uses `key ?? name`. Renaming a legacy UI-only null-key dataset backfills `key` to the old name; no change when `key` is set, when `clientDatasetId` is present, or on description-only edits.
- DB guard: unique index on (`dataset_version_id`, `test_case_id`) built non-concurrently with `SET LOCAL lock_timeout = '5s'`. No API changes; existing case IDs unchanged.

<sup>Written for commit ebe42c020c2c77aa4bbbf48bb9ca7673be1ed9b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

