### PR TITLE
fix(evaluations): show a no-datasets empty state in the dataset picker

### DIFF
--- a/frontend/ui/src/components/ui/select.tsx
+++ b/frontend/ui/src/components/ui/select.tsx
@@ -86,4 +86,19 @@ const SelectItem = React.forwardRef<
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
-export { Select, SelectGroup, SelectValue, SelectTrigger, SelectContent, SelectItem };
+// Non-selectable placeholder row for an empty popover: plain muted text, no
+// focus and no value, so it reads as "nothing here" rather than a choice.
+const SelectEmpty = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, children, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("px-2 py-1.5 text-[12px] text-muted-foreground", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+);
+SelectEmpty.displayName = "SelectEmpty";
+
+export { Select, SelectGroup, SelectValue, SelectTrigger, SelectContent, SelectItem, SelectEmpty };

--- a/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
@@ -8,6 +8,7 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectEmpty,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -195,11 +196,15 @@ export function RunEvaluationDrawer({
                 <SelectValue placeholder={datasets.length ? "Select dataset" : "No datasets yet"} />
               </SelectTrigger>
               <SelectContent>
-                {datasets.map((item) => (
-                  <SelectItem key={item.id} value={item.id} className="text-[12px]">
-                    {item.name}
-                  </SelectItem>
-                ))}
+                {datasets.length ? (
+                  datasets.map((item) => (
+                    <SelectItem key={item.id} value={item.id} className="text-[12px]">
+                      {item.name}
+                    </SelectItem>
+                  ))
+                ) : (
+                  <SelectEmpty>No datasets yet</SelectEmpty>
+                )}
               </SelectContent>
             </Select>
           )}

--- a/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
@@ -193,7 +193,9 @@ export function RunEvaluationDrawer({
           ) : (
             <Select value={chosen} onValueChange={setChosen}>
               <SelectTrigger className="h-7 text-[13px]">
-                <SelectValue placeholder={datasets.length ? "Select dataset" : "No datasets yet"} />
+                <SelectValue
+                  placeholder={datasets.length ? "Select dataset" : "No datasets found"}
+                />
               </SelectTrigger>
               <SelectContent>
                 {datasets.length ? (
@@ -203,7 +205,7 @@ export function RunEvaluationDrawer({
                     </SelectItem>
                   ))
                 ) : (
-                  <SelectEmpty>No datasets yet</SelectEmpty>
+                  <SelectEmpty>No datasets found</SelectEmpty>
                 )}
               </SelectContent>
             </Select>

--- a/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
@@ -139,7 +139,7 @@ export function RunEvaluationDrawer({
   /** Prefills and hides the picker when opened from a dataset. */
   datasetId?: string;
 }) {
-  const { data, isLoading } = useDatasets(projectId, { limit: 200 });
+  const { data, isLoading, isError } = useDatasets(projectId, { limit: 200 });
   const datasets = data?.data ?? [];
   const [lang, setLang] = React.useState<Lang>("python");
   const [chosen, setChosen] = React.useState(datasetId ?? "");
@@ -197,9 +197,11 @@ export function RunEvaluationDrawer({
                   placeholder={
                     isLoading
                       ? "Loading datasets…"
-                      : datasets.length
-                        ? "Select dataset"
-                        : "No datasets found"
+                      : isError
+                        ? "Couldn't load datasets"
+                        : datasets.length
+                          ? "Select dataset"
+                          : "No datasets found"
                   }
                 />
               </SelectTrigger>
@@ -211,7 +213,13 @@ export function RunEvaluationDrawer({
                     </SelectItem>
                   ))
                 ) : (
-                  <SelectEmpty>{isLoading ? "Loading datasets…" : "No datasets found"}</SelectEmpty>
+                  <SelectEmpty>
+                    {isLoading
+                      ? "Loading datasets…"
+                      : isError
+                        ? "Couldn't load datasets"
+                        : "No datasets found"}
+                  </SelectEmpty>
                 )}
               </SelectContent>
             </Select>

--- a/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
@@ -139,7 +139,7 @@ export function RunEvaluationDrawer({
   /** Prefills and hides the picker when opened from a dataset. */
   datasetId?: string;
 }) {
-  const { data } = useDatasets(projectId, { limit: 200 });
+  const { data, isLoading } = useDatasets(projectId, { limit: 200 });
   const datasets = data?.data ?? [];
   const [lang, setLang] = React.useState<Lang>("python");
   const [chosen, setChosen] = React.useState(datasetId ?? "");
@@ -191,10 +191,16 @@ export function RunEvaluationDrawer({
           {datasetId ? (
             <p className="text-[13px] font-medium">{dataset?.name ?? chosen}</p>
           ) : (
-            <Select value={chosen} onValueChange={setChosen}>
+            <Select value={dataset ? chosen : ""} onValueChange={setChosen}>
               <SelectTrigger className="h-7 text-[13px]">
                 <SelectValue
-                  placeholder={datasets.length ? "Select dataset" : "No datasets found"}
+                  placeholder={
+                    isLoading
+                      ? "Loading datasets…"
+                      : datasets.length
+                        ? "Select dataset"
+                        : "No datasets found"
+                  }
                 />
               </SelectTrigger>
               <SelectContent>
@@ -205,7 +211,7 @@ export function RunEvaluationDrawer({
                     </SelectItem>
                   ))
                 ) : (
-                  <SelectEmpty>No datasets found</SelectEmpty>
+                  <SelectEmpty>{isLoading ? "Loading datasets…" : "No datasets found"}</SelectEmpty>
                 )}
               </SelectContent>
             </Select>

--- a/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
@@ -109,7 +109,7 @@ export function SaveResultToDatasetDrawer({
   const meta = ACTION_META[action];
   const qc = useQueryClient();
   const { toast } = useToast();
-  const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
+  const { data: datasetsData, isLoading: datasetsLoading } = useDatasets(projectId, { limit: 200 });
   const datasets = datasetsData?.data ?? [];
 
   const [targetDatasetId, setTargetDatasetId] = React.useState(sourceDatasetId);
@@ -191,7 +191,10 @@ export function SaveResultToDatasetDrawer({
           <div className="space-y-1.5">
             <div className="text-[11px] font-medium text-muted-foreground">Dataset</div>
             {meta.picksDataset ? (
-              <Select value={targetDatasetId} onValueChange={setTargetDatasetId}>
+              <Select
+                value={datasets.some((d) => d.id === targetDatasetId) ? targetDatasetId : ""}
+                onValueChange={setTargetDatasetId}
+              >
                 <SelectTrigger className="h-8 text-[12px]">
                   <SelectValue placeholder="Choose a dataset" />
                 </SelectTrigger>
@@ -203,7 +206,9 @@ export function SaveResultToDatasetDrawer({
                       </SelectItem>
                     ))
                   ) : (
-                    <SelectEmpty>No datasets found</SelectEmpty>
+                    <SelectEmpty>
+                      {datasetsLoading ? "Loading datasets…" : "No datasets found"}
+                    </SelectEmpty>
                   )}
                 </SelectContent>
               </Select>

--- a/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
@@ -9,6 +9,7 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectEmpty,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -195,11 +196,15 @@ export function SaveResultToDatasetDrawer({
                   <SelectValue placeholder="Choose a dataset" />
                 </SelectTrigger>
                 <SelectContent>
-                  {datasets.map((d) => (
-                    <SelectItem key={d.id} value={d.id} className="text-[12px]">
-                      {d.name}
-                    </SelectItem>
-                  ))}
+                  {datasets.length ? (
+                    datasets.map((d) => (
+                      <SelectItem key={d.id} value={d.id} className="text-[12px]">
+                        {d.name}
+                      </SelectItem>
+                    ))
+                  ) : (
+                    <SelectEmpty>No datasets yet</SelectEmpty>
+                  )}
                 </SelectContent>
               </Select>
             ) : (

--- a/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
@@ -203,7 +203,7 @@ export function SaveResultToDatasetDrawer({
                       </SelectItem>
                     ))
                   ) : (
-                    <SelectEmpty>No datasets yet</SelectEmpty>
+                    <SelectEmpty>No datasets found</SelectEmpty>
                   )}
                 </SelectContent>
               </Select>

--- a/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
@@ -109,7 +109,11 @@ export function SaveResultToDatasetDrawer({
   const meta = ACTION_META[action];
   const qc = useQueryClient();
   const { toast } = useToast();
-  const { data: datasetsData, isLoading: datasetsLoading } = useDatasets(projectId, { limit: 200 });
+  const {
+    data: datasetsData,
+    isLoading: datasetsLoading,
+    isError: datasetsError,
+  } = useDatasets(projectId, { limit: 200 });
   const datasets = datasetsData?.data ?? [];
 
   const [targetDatasetId, setTargetDatasetId] = React.useState(sourceDatasetId);
@@ -173,7 +177,8 @@ export function SaveResultToDatasetDrawer({
     },
   });
 
-  const canSave = !save.isPending && (!meta.picksDataset || !!targetDatasetId);
+  const canSave =
+    !save.isPending && (!meta.picksDataset || datasets.some((d) => d.id === targetDatasetId));
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
@@ -207,7 +212,11 @@ export function SaveResultToDatasetDrawer({
                     ))
                   ) : (
                     <SelectEmpty>
-                      {datasetsLoading ? "Loading datasets…" : "No datasets found"}
+                      {datasetsLoading
+                        ? "Loading datasets…"
+                        : datasetsError
+                          ? "Couldn't load datasets"
+                          : "No datasets found"}
                     </SelectEmpty>
                   )}
                 </SelectContent>

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -330,7 +330,7 @@ export function SaveTestCaseDrawer({
                     </SelectItem>
                   ))
                 ) : (
-                  <SelectEmpty>No datasets yet</SelectEmpty>
+                  <SelectEmpty>No datasets found</SelectEmpty>
                 )}
               </SelectContent>
             </Select>

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -66,7 +66,7 @@ export function SaveTestCaseDrawer({
   onOpenChange: (open: boolean) => void;
 }) {
   const qc = useQueryClient();
-  const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
+  const { data: datasetsData, isLoading: datasetsLoading } = useDatasets(projectId, { limit: 200 });
   const datasets = datasetsData?.data ?? [];
 
   const { data: trace } = useQuery({
@@ -313,7 +313,7 @@ export function SaveTestCaseDrawer({
         <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto px-5 py-4">
           <FormCard label="Dataset">
             <Select
-              value={datasetId}
+              value={datasets.some((d) => d.id === datasetId) ? datasetId : ""}
               onValueChange={(value) => {
                 setDatasetId(value);
                 setDuplicate(null);
@@ -330,7 +330,9 @@ export function SaveTestCaseDrawer({
                     </SelectItem>
                   ))
                 ) : (
-                  <SelectEmpty>No datasets found</SelectEmpty>
+                  <SelectEmpty>
+                    {datasetsLoading ? "Loading datasets…" : "No datasets found"}
+                  </SelectEmpty>
                 )}
               </SelectContent>
             </Select>

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -9,6 +9,7 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectEmpty,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -322,11 +323,15 @@ export function SaveTestCaseDrawer({
                 <SelectValue placeholder="Select dataset" />
               </SelectTrigger>
               <SelectContent>
-                {datasets.map((item) => (
-                  <SelectItem key={item.id} value={item.id} className="text-[12px]">
-                    {item.name}
-                  </SelectItem>
-                ))}
+                {datasets.length ? (
+                  datasets.map((item) => (
+                    <SelectItem key={item.id} value={item.id} className="text-[12px]">
+                      {item.name}
+                    </SelectItem>
+                  ))
+                ) : (
+                  <SelectEmpty>No datasets yet</SelectEmpty>
+                )}
               </SelectContent>
             </Select>
             {duplicate && (

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -66,7 +66,11 @@ export function SaveTestCaseDrawer({
   onOpenChange: (open: boolean) => void;
 }) {
   const qc = useQueryClient();
-  const { data: datasetsData, isLoading: datasetsLoading } = useDatasets(projectId, { limit: 200 });
+  const {
+    data: datasetsData,
+    isLoading: datasetsLoading,
+    isError: datasetsError,
+  } = useDatasets(projectId, { limit: 200 });
   const datasets = datasetsData?.data ?? [];
 
   const { data: trace } = useQuery({
@@ -237,7 +241,12 @@ export function SaveTestCaseDrawer({
     }
   })();
 
-  const canSave = !!span && spanIOReady && !metadataError && datasetId !== "" && !save.isPending;
+  const canSave =
+    !!span &&
+    spanIOReady &&
+    !metadataError &&
+    datasets.some((d) => d.id === datasetId) &&
+    !save.isPending;
 
   const handleSave = async () => {
     if (!span || !canSave) return;
@@ -331,7 +340,11 @@ export function SaveTestCaseDrawer({
                   ))
                 ) : (
                   <SelectEmpty>
-                    {datasetsLoading ? "Loading datasets…" : "No datasets found"}
+                    {datasetsLoading
+                      ? "Loading datasets…"
+                      : datasetsError
+                        ? "Couldn't load datasets"
+                        : "No datasets found"}
                   </SelectEmpty>
                 )}
               </SelectContent>

--- a/frontend/ui/src/features/evaluations/run-evaluation-drawer.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/run-evaluation-drawer.smoke.test.tsx
@@ -156,16 +156,16 @@ describe("RunEvaluationDrawer", () => {
     datasets = [];
     await openDrawer();
     await waitFor(() => expect(panel().textContent).toContain('pull_dataset("ds_...")'));
-    expect(screen.getByText("No datasets yet")).toBeDefined();
+    expect(screen.getByText("No datasets found")).toBeDefined();
   });
 
-  it("opens to a non-selectable 'No datasets yet' row when the project has no datasets", async () => {
+  it("opens to a non-selectable 'No datasets found' row when the project has no datasets", async () => {
     datasets = [];
     await openDrawer();
 
     fireEvent.click(screen.getByRole("combobox"));
     // The popover shows the empty-state copy and offers nothing to pick.
-    await waitFor(() => expect(screen.getAllByText("No datasets yet").length).toBeGreaterThan(1));
+    await waitFor(() => expect(screen.getAllByText("No datasets found").length).toBeGreaterThan(1));
     expect(screen.queryByRole("option")).toBeNull();
   });
 

--- a/frontend/ui/src/features/evaluations/run-evaluation-drawer.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/run-evaluation-drawer.smoke.test.tsx
@@ -159,6 +159,16 @@ describe("RunEvaluationDrawer", () => {
     expect(screen.getByText("No datasets yet")).toBeDefined();
   });
 
+  it("opens to a non-selectable 'No datasets yet' row when the project has no datasets", async () => {
+    datasets = [];
+    await openDrawer();
+
+    fireEvent.click(screen.getByRole("combobox"));
+    // The popover shows the empty-state copy and offers nothing to pick.
+    await waitFor(() => expect(screen.getAllByText("No datasets yet").length).toBeGreaterThan(1));
+    expect(screen.queryByRole("option")).toBeNull();
+  });
+
   it("closes from the X, from Done, and from Escape", async () => {
     const { onOpenChange } = await openDrawer();
 

--- a/frontend/ui/src/features/evaluations/save-result-to-dataset-drawer.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-result-to-dataset-drawer.smoke.test.tsx
@@ -177,8 +177,11 @@ describe("SaveResultToDatasetDrawer", () => {
     });
     mount("save_new_case");
     // ds1 is the source dataset (default); saving a new case that recreates the source
-    // is what the backend rejects.
-    fireEvent.click(screen.getByRole("button", { name: /Save new case/i }));
+    // is what the backend rejects. Save stays disabled until the datasets list has
+    // loaded and confirms ds1 is a real, current dataset.
+    const saveBtn = screen.getByRole("button", { name: /Save new case/i }) as HTMLButtonElement;
+    await waitFor(() => expect(saveBtn.disabled).toBe(false));
+    fireEvent.click(saveBtn);
 
     await waitFor(() =>
       expect(screen.getByRole("alert").textContent).toMatch(/use update instead/i),

--- a/frontend/ui/src/features/evaluations/save-result-to-dataset-drawer.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-result-to-dataset-drawer.smoke.test.tsx
@@ -37,6 +37,9 @@ vi.mock("@/components/ui/select", () => ({
   SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
     <option value={value}>{children}</option>
   ),
+  SelectEmpty: ({ children }: { children: React.ReactNode }) => (
+    <option disabled>{children}</option>
+  ),
 }));
 
 import {

--- a/frontend/ui/src/features/evaluations/save-test-case-drawer.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-test-case-drawer.smoke.test.tsx
@@ -71,6 +71,9 @@ vi.mock("@/components/ui/select", () => ({
   SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
     <option value={value}>{children}</option>
   ),
+  SelectEmpty: ({ children }: { children: React.ReactNode }) => (
+    <option disabled>{children}</option>
+  ),
 }));
 
 import { SaveTestCaseDrawer } from "./components/trace-integration";

--- a/frontend/ui/src/features/evaluations/trace-integration.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/trace-integration.smoke.test.tsx
@@ -99,6 +99,9 @@ vi.mock("@/components/ui/select", () => ({
   SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
     <option value={value}>{children}</option>
   ),
+  SelectEmpty: ({ children }: { children: React.ReactNode }) => (
+    <option disabled>{children}</option>
+  ),
 }));
 
 vi.mock("@/features/projects/hooks", () => ({


### PR DESCRIPTION
## Summary

Closes: #1944

When a project has no datasets, the dataset picker opened to a blank popover. The picker (a Radix `Select`) rendered `SelectContent` as `datasets.map(...)`, so an empty datasets list produced zero items and no message, leaving the user staring at an empty box with nothing to read or click.

This adds a shared, non-selectable empty-state row so the same picker now shows "No datasets found" instead of nothing. Behavior with one or more datasets is unchanged.

## How it works

A new `SelectEmpty` primitive renders a plain muted `<div>`: it has no value, is not a `SelectItem`, and is not focusable, so it reads as "nothing here" rather than an option you can pick. Each dataset picker now branches on whether the list is empty.

Before (empty project):

```
Select dataset  ▾
┌──────────────────┐
│                  │   blank popover, nothing to read or click
└──────────────────┘
```

After (empty project):

```
No datasets found ▾
┌──────────────────┐
│ No datasets found  │   muted text, not selectable
└──────────────────┘
```

## What's included

- `frontend/ui/src/components/ui/select.tsx`: new `SelectEmpty` primitive, exported alongside `SelectItem`. Non-selectable, no value, not focusable; muted text.
- `frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx`: renders `SelectEmpty` when the datasets list is empty.
- `frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx`: same empty-state branch.
- `frontend/ui/src/features/evaluations/components/trace-integration.tsx`: same empty-state branch.
- Tests: a new empty-state smoke test asserts the "No datasets found" row renders and that there is no selectable option (`queryByRole("option")` is null). The other affected smoke tests were updated to mock `SelectEmpty`.

### Screenshots

N/A.

## Test plan

- [x] `tsc` is clean on the touched files
- [x] Prettier `--check` passes on all 8 files
- [x] ESLint exits 0
- [x] Full evaluations vitest suite passes (12 files, 96 tests), including the new empty-state test
- [x] New test confirms the empty picker shows "No datasets found" and offers no selectable option

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a non-selectable empty state and proper loading/error placeholders to all evaluations dataset pickers, and blocks save until the selected dataset exists. Previously the popover was blank and could flash “No datasets found” during fetch, and save could submit a stale/unloaded id.

- Adds `SelectEmpty` to `@/components/ui/select` and exports it with `SelectItem`.
- Run Evaluation, Save Result to Dataset, and Save Test Case: popovers render `SelectEmpty` with “Loading datasets…”, “Couldn't load datasets”, or “No datasets found”; the Run Evaluation trigger shows matching placeholders. Guards the `Select` value so an orphaned id falls back to the placeholder instead of a blank trigger.
- Disables save until the chosen dataset id is present in the loaded list to prevent POSTing invalid ids.
- Tests: adds an empty-state smoke test, updates select mocks to include `SelectEmpty`, and adjusts assertions for the new copy and disabled-to-enabled save behavior.

<sup>Written for commit dff2cb14f9d25c959b578292f8fc419098717388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

