### PR TITLE
fix(ui): show the trace-id copy button even without a headerIdentity

### DIFF
--- a/frontend/ui/src/components/ui/copy-button.test.tsx
+++ b/frontend/ui/src/components/ui/copy-button.test.tsx
@@ -136,4 +136,99 @@ describe("CopyButton", () => {
     expect(clearTimeoutSpy.mock.calls.length).toBeGreaterThan(callsBeforeUnmount);
     clearTimeoutSpy.mockRestore();
   });
+
+  it("a stale (older) click's late failure must not override a newer click's success", async () => {
+    // Two overlapping writes can settle out of order — e.g. the older one is
+    // still waiting on a permission prompt when a newer one completes first.
+    // Only the latest click's result may ever apply.
+    let rejectFirst: ((err: Error) => void) | undefined;
+    let resolveSecond: (() => void) | undefined;
+    const writeText = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectFirst = reject;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSecond = resolve;
+          }),
+      );
+    Object.assign(navigator, { clipboard: { writeText } });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { container } = render(<CopyButton value="hello" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button")); // click 1: will fail, but later
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button")); // click 2: will succeed, sooner
+    });
+
+    // The newer click settles first, with success.
+    await act(async () => {
+      resolveSecond?.();
+    });
+    expect(container.querySelector(".text-green-600")).not.toBeNull();
+    expect(container.querySelector(".text-destructive")).toBeNull();
+
+    // The older (stale) click settles after, with a failure — it must be ignored.
+    await act(async () => {
+      rejectFirst?.(new Error("denied"));
+    });
+    expect(container.querySelector(".text-green-600")).not.toBeNull();
+    expect(container.querySelector(".text-destructive")).toBeNull();
+
+    errorSpy.mockRestore();
+  });
+
+  it("clears the pending reset the moment a new click starts, even before it resolves", async () => {
+    vi.useFakeTimers();
+    let resolveSecond: (() => void) | undefined;
+    const writeText = vi
+      .fn()
+      .mockResolvedValueOnce(undefined) // click 1 succeeds immediately, schedules a 2s reset
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSecond = resolve;
+          }),
+      ); // click 2 stays pending
+    Object.assign(navigator, { clipboard: { writeText } });
+    const { container } = render(<CopyButton value="hello" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"));
+    });
+    expect(container.querySelector(".text-green-600")).not.toBeNull();
+
+    // Partway through click 1's reset window.
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // Click 2 starts, still unresolved — must cancel click 1's reset now,
+    // not wait for click 2 to settle.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"));
+    });
+
+    // Advance past click 1's original reset time (1000 + 1500 > 2000) while
+    // click 2 is STILL unresolved. If click 1's timer weren't canceled at
+    // the start of click 2, it would fire here and revert to idle.
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(container.querySelector(".text-green-600")).not.toBeNull();
+
+    await act(async () => {
+      resolveSecond?.();
+    });
+    expect(container.querySelector(".text-green-600")).not.toBeNull();
+
+    vi.useRealTimers();
+  });
 });

--- a/frontend/ui/src/components/ui/copy-button.test.tsx
+++ b/frontend/ui/src/components/ui/copy-button.test.tsx
@@ -41,4 +41,99 @@ describe("CopyButton", () => {
     expect(container.querySelector(".text-green-600")).toBeNull();
     errorSpy.mockRestore();
   });
+
+  it("shows a distinct failed-state icon on a rejected write, not the idle Copy icon", async () => {
+    const writeText = vi.fn(async () => {
+      throw new Error("denied");
+    });
+    Object.assign(navigator, { clipboard: { writeText } });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { container } = render(<CopyButton value="hello" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"));
+    });
+
+    expect(container.querySelector(".text-destructive")).not.toBeNull();
+    errorSpy.mockRestore();
+  });
+
+  it("reverts the failed icon to idle after the reset delay", async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn(async () => {
+      throw new Error("denied");
+    });
+    Object.assign(navigator, { clipboard: { writeText } });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { container } = render(<CopyButton value="hello" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"));
+    });
+    expect(container.querySelector(".text-destructive")).not.toBeNull();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(container.querySelector(".text-destructive")).toBeNull();
+
+    errorSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("a second click before the reset cancels the first click's pending reset", async () => {
+    // Regression guard for the timeout-leak fix: copy, fail, copy again
+    // inside the 2s window. Without clearing the first timeout, its
+    // setState("idle") would fire mid-way through and wipe out the second
+    // click's "copied" state early.
+    vi.useFakeTimers();
+    const writeText = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("denied"))
+      .mockResolvedValueOnce(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { container } = render(<CopyButton value="hello" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"));
+    });
+    expect(container.querySelector(".text-destructive")).not.toBeNull();
+
+    // Advance partway through the first reset window, then click again.
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"));
+    });
+    expect(container.querySelector(".text-green-600")).not.toBeNull();
+
+    // The remainder of the first (canceled) timeout elapsing must not
+    // revert the second click's "copied" state early.
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(container.querySelector(".text-green-600")).not.toBeNull();
+
+    errorSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("clears the pending reset timeout on unmount", async () => {
+    const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+    const writeText = vi.fn(async () => {});
+    Object.assign(navigator, { clipboard: { writeText } });
+    const { unmount } = render(<CopyButton value="hello" />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"));
+    });
+    const callsBeforeUnmount = clearTimeoutSpy.mock.calls.length;
+
+    unmount();
+
+    expect(clearTimeoutSpy.mock.calls.length).toBeGreaterThan(callsBeforeUnmount);
+    clearTimeoutSpy.mockRestore();
+  });
 });

--- a/frontend/ui/src/components/ui/copy-button.test.tsx
+++ b/frontend/ui/src/components/ui/copy-button.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { CopyButton } from "./copy-button";
+
+afterEach(() => cleanup());
+
+describe("CopyButton", () => {
+  it("copies the value and notifies onCopy on a successful write", async () => {
+    const writeText = vi.fn(async () => {});
+    Object.assign(navigator, { clipboard: { writeText } });
+    const onCopy = vi.fn();
+    render(<CopyButton value="hello" onCopy={onCopy} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"));
+    });
+
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(onCopy).toHaveBeenCalled();
+  });
+
+  it("handles a rejected write instead of throwing an unhandled rejection", async () => {
+    const writeText = vi.fn(async () => {
+      throw new Error("denied");
+    });
+    Object.assign(navigator, { clipboard: { writeText } });
+    const onCopy = vi.fn();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<CopyButton value="hello" onCopy={onCopy} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button"));
+    });
+
+    // Nothing was actually copied, so onCopy must not fire — the failure
+    // is logged (caught), not silently treated as a success.
+    expect(onCopy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/frontend/ui/src/components/ui/copy-button.test.tsx
+++ b/frontend/ui/src/components/ui/copy-button.test.tsx
@@ -27,7 +27,7 @@ describe("CopyButton", () => {
     Object.assign(navigator, { clipboard: { writeText } });
     const onCopy = vi.fn();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    render(<CopyButton value="hello" onCopy={onCopy} />);
+    const { container } = render(<CopyButton value="hello" onCopy={onCopy} />);
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button"));
@@ -37,6 +37,8 @@ describe("CopyButton", () => {
     // is logged (caught), not silently treated as a success.
     expect(onCopy).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalled();
+    // The button must not flip to its "copied" (check icon) state on failure.
+    expect(container.querySelector(".text-green-600")).toBeNull();
     errorSpy.mockRestore();
   });
 });

--- a/frontend/ui/src/components/ui/copy-button.tsx
+++ b/frontend/ui/src/components/ui/copy-button.tsx
@@ -19,10 +19,17 @@ const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
     const [copied, setCopied] = React.useState(false);
 
     const handleCopy = async () => {
-      await navigator.clipboard.writeText(value);
-      setCopied(true);
-      onCopy?.();
-      setTimeout(() => setCopied(false), 2000);
+      try {
+        await navigator.clipboard.writeText(value);
+        setCopied(true);
+        onCopy?.();
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        // A rejected write (denied permission, insecure context, etc.) must
+        // not become an unhandled promise rejection — and copied must stay
+        // false, since nothing was actually copied.
+        console.error("Failed to copy to clipboard:", err);
+      }
     };
 
     return (

--- a/frontend/ui/src/components/ui/copy-button.tsx
+++ b/frontend/ui/src/components/ui/copy-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Copy, Check } from "lucide-react";
+import { Copy, Check, X } from "lucide-react";
 import { Button, type ButtonProps } from "./button";
 import { cn } from "@/lib/utils";
 
@@ -11,24 +11,47 @@ export interface CopyButtonProps extends Omit<ButtonProps, "onClick"> {
   iconClassName?: string;
 }
 
+type CopyStatus = "idle" | "copied" | "failed";
+const STATUS_RESET_DELAY_MS = 2000;
+
 /**
- * Copy button that shows a check icon after copying
+ * Copy button that shows a check icon after copying, or a failed icon if the
+ * clipboard write was rejected (denied permission, insecure context, etc.).
  */
 const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
   ({ value, onCopy, className, iconClassName, variant = "ghost", size = "sm", ...props }, ref) => {
-    const [copied, setCopied] = React.useState(false);
+    const [status, setStatus] = React.useState<CopyStatus>("idle");
+    const resetTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Clear any pending reset on unmount so it never fires setState after
+    // the button is gone.
+    React.useEffect(() => {
+      return () => {
+        if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current);
+      };
+    }, []);
+
+    const scheduleReset = () => {
+      // A prior click's reset must not fire mid-way through this one — e.g.
+      // copy, fail, copy again inside 2s would otherwise let the first
+      // timeout revert the second click's "copied" state early.
+      if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current);
+      resetTimeoutRef.current = setTimeout(() => setStatus("idle"), STATUS_RESET_DELAY_MS);
+    };
 
     const handleCopy = async () => {
       try {
         await navigator.clipboard.writeText(value);
-        setCopied(true);
+        setStatus("copied");
         onCopy?.();
-        setTimeout(() => setCopied(false), 2000);
+        scheduleReset();
       } catch (err) {
-        // A rejected write (denied permission, insecure context, etc.) must
-        // not become an unhandled promise rejection — and copied must stay
-        // false, since nothing was actually copied.
+        // A rejected write must not become an unhandled promise rejection,
+        // and must not be mistaken for success — surface it as its own icon
+        // state instead of silently leaving the idle Copy icon.
         console.error("Failed to copy to clipboard:", err);
+        setStatus("failed");
+        scheduleReset();
       }
     };
 
@@ -41,8 +64,10 @@ const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
         onClick={handleCopy}
         {...props}
       >
-        {copied ? (
+        {status === "copied" ? (
           <Check className={cn("h-3.5 w-3.5 text-green-600", iconClassName)} />
+        ) : status === "failed" ? (
+          <X className={cn("h-3.5 w-3.5 text-destructive", iconClassName)} />
         ) : (
           <Copy className={cn("h-3.5 w-3.5", iconClassName)} />
         )}

--- a/frontend/ui/src/components/ui/copy-button.tsx
+++ b/frontend/ui/src/components/ui/copy-button.tsx
@@ -22,6 +22,10 @@ const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
   ({ value, onCopy, className, iconClassName, variant = "ghost", size = "sm", ...props }, ref) => {
     const [status, setStatus] = React.useState<CopyStatus>("idle");
     const resetTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Identifies the most recent click. A click's async result is only
+    // applied if this still matches the id it captured when it started —
+    // otherwise a newer click has since begun and this one is stale.
+    const clickIdRef = React.useRef(0);
 
     // Clear any pending reset on unmount so it never fires setState after
     // the button is gone.
@@ -40,12 +44,23 @@ const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
     };
 
     const handleCopy = async () => {
+      const clickId = ++clickIdRef.current;
+      // A new click supersedes whatever the previous one was showing —
+      // don't let its reset fire mid-flight of this one, and don't let this
+      // one apply its result if a still-newer click starts before it settles.
+      if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current);
+
       try {
         await navigator.clipboard.writeText(value);
+        // Two overlapping writes can settle out of order (e.g. the older one
+        // is still waiting on a permission prompt when a newer one
+        // completes first): only the latest click's result may apply.
+        if (clickIdRef.current !== clickId) return;
         setStatus("copied");
         onCopy?.();
         scheduleReset();
       } catch (err) {
+        if (clickIdRef.current !== clickId) return;
         // A rejected write must not become an unhandled promise rejection,
         // and must not be mistaken for success — surface it as its own icon
         // state instead of silently leaving the idle Copy icon.

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.interactions.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.interactions.test.tsx
@@ -248,7 +248,7 @@ describe("TraceViewerPanel header actions", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("copies the trace id with no headerIdentity — the default header contract (#1947)", () => {
+  it("copies the trace id with no headerIdentity — the default header contract", () => {
     // This is the production shape: no caller besides offline-eval's
     // run-detail-view ever supplies headerIdentity, so the header falls
     // back to "Trace" + traceId and the copy button must follow the same
@@ -299,7 +299,7 @@ describe("TraceViewerPanel offline-eval extensions", () => {
     renderPanel({ headerIdentity: { label: "Test case", value: "case-1" } });
     expect(screen.getByText("Test case")).toBeTruthy();
     expect(screen.getByText("case-1")).toBeTruthy();
-    const button = screen.getByTitle("Copy Test case id");
+    const button = screen.getByTitle("Copy test case id");
     fireEvent.click(button);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("case-1");
   });

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.interactions.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.interactions.test.tsx
@@ -6,7 +6,7 @@
  *
  * Complements TraceViewerPanel.test.tsx, which covers layout and content states.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, cleanup, screen, fireEvent, act } from "@testing-library/react";
 import type { Span, TraceDetail } from "@/types/api";
 
@@ -160,6 +160,10 @@ function renderPanel(props: Partial<React.ComponentProps<typeof TraceViewerPanel
   );
 }
 
+beforeAll(() => {
+  Object.assign(navigator, { clipboard: { writeText: vi.fn(async () => {}) } });
+});
+
 beforeEach(() => {
   mocks.aiPanelOpen = false;
   mocks.findings = undefined;
@@ -243,6 +247,20 @@ describe("TraceViewerPanel header actions", () => {
     fireEvent.click(close!);
     expect(onClose).toHaveBeenCalled();
   });
+
+  it("copies the trace id with no headerIdentity — the default header contract (#1947)", () => {
+    // This is the production shape: no caller besides offline-eval's
+    // run-detail-view ever supplies headerIdentity, so the header falls
+    // back to "Trace" + traceId and the copy button must follow the same
+    // fallback instead of disappearing. ("Trace" alone isn't asserted here
+    // — it also labels the unrelated Trace/Detectors view-toggle pill
+    // elsewhere in the panel.)
+    renderPanel();
+    expect(screen.getByText("trace-1")).toBeTruthy();
+    const button = screen.getByTitle("Copy trace id");
+    fireEvent.click(button);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("trace-1");
+  });
 });
 
 describe("TraceViewerPanel RCA alert", () => {
@@ -281,7 +299,9 @@ describe("TraceViewerPanel offline-eval extensions", () => {
     renderPanel({ headerIdentity: { label: "Test case", value: "case-1" } });
     expect(screen.getByText("Test case")).toBeTruthy();
     expect(screen.getByText("case-1")).toBeTruthy();
-    expect(screen.getByTitle("Copy test case id")).toBeTruthy();
+    const button = screen.getByTitle("Copy Test case id");
+    fireEvent.click(button);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("case-1");
   });
 
   it("renders a header status badge", () => {

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -369,9 +369,9 @@ export function TraceViewerPanel({
             <DOMAIN_ICONS.trace className="h-4 w-4 shrink-0 text-muted-foreground" />
             <span className="shrink-0 text-sm font-medium">{headerLabel}</span>
             <span className="truncate font-mono text-xs text-muted-foreground">{headerValue}</span>
-            {/* Copy affordance for the header id — always shown (see #1947),
-                reading the same headerLabel/headerValue as the display above
-                so the copied text can never diverge from what's shown. */}
+            {/* Copy affordance for the header id — always shown, reading the
+                same headerLabel/headerValue as the display above so the
+                copied text can never diverge from what's shown. */}
             <CopyButton
               value={headerValue}
               className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -235,6 +235,12 @@ export function TraceViewerPanel({
   const hasRca = !!traceFinding && !!rcaData?.rca;
   const rcaSessionId = rcaData?.rca?.sessionId ?? undefined;
 
+  // Single source of truth for the header's id — the display value and the
+  // copy control must never diverge, so both read from the same two consts.
+  const headerLabel = headerIdentity?.label ?? "Trace";
+  const headerValue = headerIdentity?.value ?? traceId;
+  const headerCopyTitle = headerIdentity ? `Copy ${headerIdentity.label} id` : "Copy trace id";
+
   // Auto-open chat with RCA session loaded when arriving from /detectors.
   // Waits for rcaSessionId so the chat opens already pointing at the session,
   // avoiding a fresh-chat flash before the id resolves.
@@ -359,20 +365,16 @@ export function TraceViewerPanel({
         <div className="flex h-12 items-center justify-between border-b border-border bg-muted/30 px-4">
           <div className="flex min-w-0 items-center gap-1.5">
             <DOMAIN_ICONS.trace className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <span className="shrink-0 text-sm font-medium">{headerIdentity?.label ?? "Trace"}</span>
-            <span className="truncate font-mono text-xs text-muted-foreground">
-              {headerIdentity?.value ?? traceId}
-            </span>
-            {/* Copy affordance for the header id. Only offered when an identity is
-                supplied (offline-eval's test case); the standard trace header is
-                unchanged. */}
-            {headerIdentity && (
-              <CopyButton
-                value={headerIdentity.value}
-                className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
-                title={`Copy ${headerIdentity.label.toLowerCase()} id`}
-              />
-            )}
+            <span className="shrink-0 text-sm font-medium">{headerLabel}</span>
+            <span className="truncate font-mono text-xs text-muted-foreground">{headerValue}</span>
+            {/* Copy affordance for the header id — always shown (see #1947),
+                reading the same headerLabel/headerValue as the display above
+                so the copied text can never diverge from what's shown. */}
+            <CopyButton
+              value={headerValue}
+              className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+              title={headerCopyTitle}
+            />
           </div>
           <div className="flex items-center gap-1">
             {headerStatus}

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -239,7 +239,9 @@ export function TraceViewerPanel({
   // copy control must never diverge, so both read from the same two consts.
   const headerLabel = headerIdentity?.label ?? "Trace";
   const headerValue = headerIdentity?.value ?? traceId;
-  const headerCopyTitle = headerIdentity ? `Copy ${headerIdentity.label} id` : "Copy trace id";
+  const headerCopyTitle = headerIdentity
+    ? `Copy ${headerIdentity.label.toLowerCase()} id`
+    : "Copy trace id";
 
   // Auto-open chat with RCA session loaded when arriving from /detectors.
   // Waits for rcaSessionId so the chat opens already pointing at the session,


### PR DESCRIPTION
Fixes #1947

## Summary

TraceViewerPanel's header already falls back to "Trace" + traceId when no headerIdentity is supplied — which is every offline-eval trace, and in fact every trace in production, since no caller besides offline-eval's run-detail-view ever supplies headerIdentity. The copy button was gated on headerIdentity alone instead of on whether there's actually an id to copy, so those ids had no copy affordance at all.


## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

Extracted headerLabel/headerValue/headerCopyTitle as a single source of truth for the header: the display and the copy control now read the same values, so they can't diverge — which is the exact bug class this issue was about. Replaced a toLowerCase()-based title template with an explicit branch (avoids "Copy test case id id" for a hypothetical multi-word label).

Tests: added a click-to-copy assertion (navigator.clipboard.writeText called with the exact displayed id) for both the headerIdentity and default-header cases — the previous version only checked the button existed, not that it copied the right value. The default-header test lives under "header actions" (the production contract), not "offline-eval extensions", since it guards the absence of that extension.

## Screenshots / Recordings (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1947 by always showing the `TraceViewerPanel` copy button and copying the displayed trace or header identity. Previously, the button was hidden when no `headerIdentity` was provided. Clipboard failures are now caught, logged, and shown with a failure icon instead of becoming unhandled rejections or false successes.

- The header display and copy control share the same label, value, and tooltip.
- `CopyButton` resets its status after two seconds, cancels stale reset timers, cleans them up on unmount, and ignores results from superseded clicks.
- Tests cover default and custom header identities, successful and rejected writes, failure states, timer behavior, and out-of-order clipboard writes.

<sup>Written for commit 672059a14b4f7fbe3b66ce5c3c131f1dd22e1b59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

