### PR TITLE
fix(ui): standardize Save action and disable until changed (#1949)

### DIFF
--- a/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
+++ b/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
@@ -151,7 +151,10 @@ export function DatasetEditPanel({
     setState(emptyDatasetForm({ name: dataset.name, description: dataset.description ?? "" }));
   }, [dataset]);
 
-  const canSave = state.name.trim() !== "";
+  const hasChanges =
+    state.name.trim() !== dataset.name.trim() ||
+    state.description.trim() !== (dataset.description ?? "").trim();
+  const canSave = state.name.trim() !== "" && hasChanges;
 
   const handleSave = () => {
     update.mutate(

--- a/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
+++ b/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
@@ -152,8 +152,7 @@ export function DatasetEditPanel({
   }, [dataset]);
 
   const hasChanges =
-    state.name.trim() !== dataset.name.trim() ||
-    state.description.trim() !== (dataset.description ?? "").trim();
+    state.name.trim() !== dataset.name || state.description.trim() !== (dataset.description ?? "");
   const canSave = state.name.trim() !== "" && hasChanges;
 
   const handleSave = () => {

--- a/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
@@ -177,8 +177,19 @@ export function SaveResultToDatasetDrawer({
     },
   });
 
+  const hasChanges =
+    action === "update_existing_case"
+      ? (meta.picksDataset && targetDatasetId !== sourceDatasetId) ||
+        input.trim() !== result.input.trim() ||
+        (useCandidateAsExpected
+          ? (result.candidateOutput ?? "").trim() !== (result.expectedOutput ?? "").trim()
+          : expected.trim() !== (result.expectedOutput ?? "").trim())
+      : true;
+
   const canSave =
-    !save.isPending && (!meta.picksDataset || datasets.some((d) => d.id === targetDatasetId));
+    !save.isPending &&
+    (!meta.picksDataset || datasets.some((d) => d.id === targetDatasetId)) &&
+    hasChanges;
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
@@ -302,7 +313,7 @@ export function SaveResultToDatasetDrawer({
             Cancel
           </Button>
           <Button size="sm" disabled={!canSave} onClick={() => save.mutate()}>
-            {save.isPending ? "Saving…" : meta.cta}
+            {save.isPending ? "Saving…" : "Save"}
           </Button>
         </DrawerFooter>
       </DrawerContent>

--- a/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/drawer";
 import { useToast } from "@/components/ui/toast";
 import { EditableValueBlock } from "@/features/offline-eval/components";
+import { encodeEditedText } from "@/lib/eval/json-value";
 import { useDatasets } from "../hooks";
 
 /** Read-only fields never edit, so onChange is a no-op. */
@@ -186,7 +187,7 @@ export function SaveResultToDatasetDrawer({
   const hasChanges =
     action === "update_existing_case"
       ? (meta.picksDataset && targetDatasetId !== sourceDatasetId) ||
-        input !== result.input ||
+        encodeEditedText(result.input, input) !== encodeEditedText(result.input, result.input) ||
         (useCandidateAsExpected
           ? (result.candidateOutput ?? "") !== (result.expectedOutput ?? "")
           : expected !== (result.expectedOutput ?? ""))

--- a/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
@@ -177,13 +177,19 @@ export function SaveResultToDatasetDrawer({
     },
   });
 
+  // Only "update" republishes an existing case, so only it needs a dirty gate; save/duplicate
+  // always create a case and are savable as they stand. Every field is compared the way it is
+  // PERSISTED — this drawer POSTs `input` and `expected` verbatim, and a case's id is a hash of
+  // its exact input (`stableCaseId` over `canonicalJson`, which does not trim) — so nothing here
+  // trims. A whitespace-only edit really does change the published case; gating it away as a
+  // no-op would leave the reviewer unable to save a change the backend would have accepted.
   const hasChanges =
     action === "update_existing_case"
       ? (meta.picksDataset && targetDatasetId !== sourceDatasetId) ||
-        input.trim() !== result.input.trim() ||
+        input !== result.input ||
         (useCandidateAsExpected
-          ? (result.candidateOutput ?? "").trim() !== (result.expectedOutput ?? "").trim()
-          : expected.trim() !== (result.expectedOutput ?? "").trim())
+          ? (result.candidateOutput ?? "") !== (result.expectedOutput ?? "")
+          : expected !== (result.expectedOutput ?? ""))
       : true;
 
   const canSave =

--- a/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
@@ -42,27 +42,24 @@ export interface ResultForDataset {
 
 const ACTION_META: Record<
   ResultDatasetAction,
-  { title: string; blurb: string; cta: string; picksDataset: boolean }
+  { title: string; blurb: string; picksDataset: boolean }
 > = {
   update_existing_case: {
     title: "Update source case",
     blurb:
       "Publishes a new immutable version of this run's dataset with this case updated. Runs already recorded keep pointing at the version they used.",
-    cta: "Publish update",
     picksDataset: false,
   },
   save_new_case: {
     title: "Save as a new case",
     blurb:
       "Adds a brand-new case to the chosen dataset. Blocked if it would just recreate this result's own source case — use “Update source case” for that.",
-    cta: "Save new case",
     picksDataset: true,
   },
   duplicate_as_variant: {
     title: "Duplicate as a variant",
     blurb:
       "Adds a new case tagged as a variant of the source case. Always allowed — useful for exploring a tweak without touching the original.",
-    cta: "Duplicate case",
     picksDataset: true,
   },
 };

--- a/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/save-result-to-dataset-drawer.tsx
@@ -180,6 +180,9 @@ export function SaveResultToDatasetDrawer({
   // its exact input (`stableCaseId` over `canonicalJson`, which does not trim) — so nothing here
   // trims. A whitespace-only edit really does change the published case; gating it away as a
   // no-op would leave the reviewer unable to save a change the backend would have accepted.
+  // Trimming `input` on the way in is not an option either: that id derivation is byte-parity
+  // with the TS/Python SDKs, so a trimming UI would give `" hi "` a different `tc_` id than the
+  // same input pushed from an SDK, and a re-publish would duplicate the case, not upsert it.
   const hasChanges =
     action === "update_existing_case"
       ? (meta.picksDataset && targetDatasetId !== sourceDatasetId) ||

--- a/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
+++ b/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
@@ -82,9 +82,9 @@ export function TestCaseEditorModal({
   // In edit mode, keep Save disabled until a field actually changes (a create is always savable).
   const hasChanges =
     mode.kind !== "edit" ||
-    input !== mode.input ||
-    expected !== (mode.expected ?? "") ||
-    metadata !== metadataToText(mode.metadata);
+    input.trim() !== mode.input.trim() ||
+    expected.trim() !== (mode.expected ?? "").trim() ||
+    metadata.trim() !== metadataToText(mode.metadata).trim();
   const canSave = !metadataError && !pending && hasChanges;
 
   const handleSave = () => {
@@ -183,7 +183,7 @@ export function TestCaseEditorModal({
             Cancel
           </Button>
           <Button size="sm" className="h-7 text-[12px]" onClick={handleSave} disabled={!canSave}>
-            {pending ? "Saving…" : isEdit ? "Save changes" : "Save"}
+            {pending ? "Saving…" : "Save"}
           </Button>
         </div>
       </div>

--- a/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
+++ b/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
@@ -80,9 +80,14 @@ export function TestCaseEditorModal({
 
   const pending = save.isPending || update.isPending;
   // In edit mode, keep Save disabled until a field actually changes (a create is always savable).
+  // Each field is compared the way it is PERSISTED, so an edit that would really change the row
+  // can never be gated away as a no-op: `input` is stored verbatim AND its exact bytes are the
+  // case's content-addressed id (`stableCaseId` hashes `canonicalJson(input)`, which does not
+  // trim), so a whitespace-only input edit is a real change and compares raw; `expected` is
+  // stored as `expected.trim() || null` and `metadata` is stored parsed, so both compare trimmed.
   const hasChanges =
     mode.kind !== "edit" ||
-    input.trim() !== mode.input.trim() ||
+    input !== mode.input ||
     expected.trim() !== (mode.expected ?? "").trim() ||
     metadata.trim() !== metadataToText(mode.metadata).trim();
   const canSave = !metadataError && !pending && hasChanges;

--- a/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
+++ b/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
@@ -36,10 +36,12 @@ function metadataToText(metadata: unknown): string {
  * the parsed object, or null when blank — so the dirty check compares meaning rather than
  * bytes. Metadata is stored parsed, so re-spacing `{"a": 1}` to `{"a":1}` or reordering
  * its keys is a no-op that must not enable Save (it would publish an identical version).
- * Text with no persisted form — half-typed JSON, or a lone surrogate `canonicalJson`
- * rejects — returns null: `metadataError` already blocks Save on it, and this runs during
- * render, so it must not throw. The null sentinel can't collide with a real result, which
- * is always a JSON string (blank metadata canonicalizes to `"null"`, not to null).
+ * Text with no persisted form — half-typed JSON, or a value `canonicalJson` rejects —
+ * returns null: `metadataError` runs the same parse AND the same canonicalization, so it
+ * blocks Save on either with a message, and a null here is never the only reason Save is
+ * off. This runs during render, so it must not throw. The null sentinel can't collide with
+ * a real result, which is always a JSON string (blank metadata canonicalizes to `"null"`,
+ * not to null).
  */
 function metadataSignature(text: string): string | null {
   const trimmed = text.trim();
@@ -84,18 +86,32 @@ export function TestCaseEditorModal({
     return () => window.removeEventListener("keydown", onKey, true);
   }, [onClose]);
 
-  // Metadata must be empty or a JSON object; surfaced so a half-typed value blocks
-  // Save rather than being silently dropped.
+  // Metadata must be empty or a JSON object that canonicalizes; surfaced so a value with
+  // no persisted form blocks Save rather than being silently dropped.
   const metadataError = React.useMemo(() => {
     const trimmed = metadata.trim();
     if (trimmed === "") return null;
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(trimmed);
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return null;
-      return 'Metadata must be a JSON object, e.g. {"key": "value"}.';
+      parsed = JSON.parse(trimmed);
     } catch {
       return "Metadata isn't valid JSON.";
     }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return 'Metadata must be a JSON object, e.g. {"key": "value"}.';
+    }
+    // Valid JSON syntax is not enough. An unpaired UTF-16 surrogate parses fine but is not
+    // valid Unicode text, so `canonicalJson` rejects it (its only rejection) and the value
+    // has no canonical form to hash or compare by — which is exactly why `metadataSignature`
+    // can't produce one either. Reported here rather than left to the dirty check: a value
+    // we can't compare must not be savable, and two different uncanonicalizable values
+    // would otherwise read as "no change" and leave Save dead with nothing said.
+    try {
+      canonicalJson(parsed);
+    } catch {
+      return "Metadata contains invalid Unicode (an unpaired surrogate).";
+    }
+    return null;
   }, [metadata]);
 
   const pending = save.isPending || update.isPending;

--- a/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
+++ b/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
@@ -5,6 +5,7 @@ import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/toast";
 import { EditableValueBlock } from "@/features/offline-eval/components";
+import { canonicalJson } from "@/lib/eval/canonical";
 import { useSaveTestCase, useUpdateTestCase } from "../hooks";
 
 /**
@@ -28,6 +29,25 @@ function metadataToText(metadata: unknown): string {
   if (metadata === null || metadata === undefined) return "";
   if (typeof metadata === "object" && Object.keys(metadata as object).length === 0) return "";
   return JSON.stringify(metadata, null, 2);
+}
+
+/**
+ * The canonical form of the value `handleSave` would PERSIST for this metadata text —
+ * the parsed object, or null when blank — so the dirty check compares meaning rather than
+ * bytes. Metadata is stored parsed, so re-spacing `{"a": 1}` to `{"a":1}` or reordering
+ * its keys is a no-op that must not enable Save (it would publish an identical version).
+ * Text with no persisted form — half-typed JSON, or a lone surrogate `canonicalJson`
+ * rejects — returns null: `metadataError` already blocks Save on it, and this runs during
+ * render, so it must not throw. The null sentinel can't collide with a real result, which
+ * is always a JSON string (blank metadata canonicalizes to `"null"`, not to null).
+ */
+function metadataSignature(text: string): string | null {
+  const trimmed = text.trim();
+  try {
+    return canonicalJson(trimmed === "" ? null : JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
 }
 
 export function TestCaseEditorModal({
@@ -84,7 +104,8 @@ export function TestCaseEditorModal({
   // can never be gated away as a no-op: `input` is stored verbatim AND its exact bytes are the
   // case's content-addressed id (`stableCaseId` hashes `canonicalJson(input)`, which does not
   // trim), so a whitespace-only input edit is a real change and compares raw; `expected` is
-  // stored as `expected.trim() || null` and `metadata` is stored parsed, so both compare trimmed.
+  // stored as `expected.trim() || null` so it compares trimmed, and `metadata` is stored
+  // PARSED so it compares canonically (see `metadataSignature`) rather than as raw text.
   // Trimming `input` on the way in is not an option either: that id derivation is byte-parity
   // with the TS/Python SDKs, so a trimming UI would give `" hi "` a different `tc_` id than the
   // same input authored through an SDK, and a re-publish would duplicate the case, not upsert it.
@@ -92,7 +113,9 @@ export function TestCaseEditorModal({
     mode.kind !== "edit" ||
     input !== mode.input ||
     expected.trim() !== (mode.expected ?? "").trim() ||
-    metadata.trim() !== metadataToText(mode.metadata).trim();
+    // Both sides go through the seeded TEXT, so a case stored as `{}` (which `metadataToText`
+    // renders blank) matches an untouched blank field instead of reading as an edit.
+    metadataSignature(metadata) !== metadataSignature(metadataToText(mode.metadata));
   const canSave = !metadataError && !pending && hasChanges;
 
   const handleSave = () => {

--- a/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
+++ b/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
@@ -85,6 +85,9 @@ export function TestCaseEditorModal({
   // case's content-addressed id (`stableCaseId` hashes `canonicalJson(input)`, which does not
   // trim), so a whitespace-only input edit is a real change and compares raw; `expected` is
   // stored as `expected.trim() || null` and `metadata` is stored parsed, so both compare trimmed.
+  // Trimming `input` on the way in is not an option either: that id derivation is byte-parity
+  // with the TS/Python SDKs, so a trimming UI would give `" hi "` a different `tc_` id than the
+  // same input authored through an SDK, and a re-publish would duplicate the case, not upsert it.
   const hasChanges =
     mode.kind !== "edit" ||
     input !== mode.input ||

--- a/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
+++ b/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
@@ -5,7 +5,8 @@ import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/toast";
 import { EditableValueBlock } from "@/features/offline-eval/components";
-import { canonicalJson } from "@/lib/eval/canonical";
+import { canonicalJson, LoneSurrogateError } from "@/lib/eval/canonical";
+import { encodeEditedText } from "@/lib/eval/json-value";
 import { useSaveTestCase, useUpdateTestCase } from "../hooks";
 
 /**
@@ -69,10 +70,14 @@ export function TestCaseEditorModal({
   const save = useSaveTestCase(projectId, datasetId);
   const update = useUpdateTestCase(projectId, datasetId);
   const isEdit = mode.kind === "edit";
+  const seedMetadataText = React.useMemo(
+    () => (isEdit ? metadataToText(mode.metadata) : ""),
+    [isEdit, mode],
+  );
 
   const [input, setInput] = React.useState(isEdit ? mode.input : "");
   const [expected, setExpected] = React.useState(isEdit ? (mode.expected ?? "") : "");
-  const [metadata, setMetadata] = React.useState(isEdit ? metadataToText(mode.metadata) : "");
+  const [metadata, setMetadata] = React.useState(seedMetadataText);
 
   // Close on Escape (capture phase, so a nested popover can pre-empt it).
   React.useEffect(() => {
@@ -88,7 +93,12 @@ export function TestCaseEditorModal({
 
   // Metadata must be empty or a JSON object that canonicalizes; surfaced so a value with
   // no persisted form blocks Save rather than being silently dropped.
+  // When editing, if metadata was not modified by the user (matches seed), we do not
+  // validate it: a stored row written by an SDK with an unpaired surrogate is valid JSONB
+  // in Postgres, and must not permanently lock out edits to Input or Expected.
   const metadataError = React.useMemo(() => {
+    if (isEdit && metadata === seedMetadataText) return null;
+
     const trimmed = metadata.trim();
     if (trimmed === "") return null;
     let parsed: unknown;
@@ -108,30 +118,30 @@ export function TestCaseEditorModal({
     // would otherwise read as "no change" and leave Save dead with nothing said.
     try {
       canonicalJson(parsed);
-    } catch {
-      return "Metadata contains invalid Unicode (an unpaired surrogate).";
+    } catch (err) {
+      if (err instanceof LoneSurrogateError) {
+        return "Metadata contains invalid Unicode (an unpaired surrogate).";
+      }
+      throw err;
     }
     return null;
-  }, [metadata]);
+  }, [isEdit, metadata, seedMetadataText]);
 
   const pending = save.isPending || update.isPending;
-  // In edit mode, keep Save disabled until a field actually changes (a create is always savable).
-  // Each field is compared the way it is PERSISTED, so an edit that would really change the row
-  // can never be gated away as a no-op: `input` is stored verbatim AND its exact bytes are the
-  // case's content-addressed id (`stableCaseId` hashes `canonicalJson(input)`, which does not
-  // trim), so a whitespace-only input edit is a real change and compares raw; `expected` is
-  // stored as `expected.trim() || null` so it compares trimmed, and `metadata` is stored
-  // PARSED so it compares canonically (see `metadataSignature`) rather than as raw text.
-  // Trimming `input` on the way in is not an option either: that id derivation is byte-parity
-  // with the TS/Python SDKs, so a trimming UI would give `" hi "` a different `tc_` id than the
-  // same input authored through an SDK, and a re-publish would duplicate the case, not upsert it.
+  // In edit mode, keep Save disabled until a field actually changes. In create mode,
+  // require non-empty input before enabling Save (+ Row -> Save with empty fields is blocked).
+  // Each field is compared the way it is PERSISTED: `input` is persisted via `encodeEditedText`
+  // so pure reformatting of structured input is a no-op; `expected` is stored as
+  // `expected.trim() || null` so we trim editor side only; and `metadata` is stored parsed
+  // so it compares canonically (see `metadataSignature`).
   const hasChanges =
-    mode.kind !== "edit" ||
-    input !== mode.input ||
-    expected.trim() !== (mode.expected ?? "").trim() ||
-    // Both sides go through the seeded TEXT, so a case stored as `{}` (which `metadataToText`
-    // renders blank) matches an untouched blank field instead of reading as an edit.
-    metadataSignature(metadata) !== metadataSignature(metadataToText(mode.metadata));
+    mode.kind === "create"
+      ? input.trim().length > 0
+      : encodeEditedText(mode.input, input) !== encodeEditedText(mode.input, mode.input) ||
+        expected.trim() !== (mode.expected ?? "") ||
+        // Both sides go through the seeded TEXT, so a case stored as `{}` (which `metadataToText`
+        // renders blank) matches an untouched blank field instead of reading as an edit.
+        metadataSignature(metadata) !== metadataSignature(seedMetadataText);
   const canSave = !metadataError && !pending && hasChanges;
 
   const handleSave = () => {

--- a/frontend/ui/src/features/evaluations/dataset-panels.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/dataset-panels.smoke.test.tsx
@@ -182,6 +182,20 @@ describe("New dataset panel", () => {
 });
 
 describe("Edit dataset panel", () => {
+  it("disables Save until a field is edited", async () => {
+    mount();
+    await rowAction("Edit");
+    const save = await screen.findByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+
+    const name = screen.getByLabelText("Name") as HTMLInputElement;
+    fireEvent.change(name, { target: { value: "Billing routing v2" } });
+    expect(save.hasAttribute("disabled")).toBe(false);
+
+    fireEvent.change(name, { target: { value: "Billing routing" } });
+    expect(save.hasAttribute("disabled")).toBe(true);
+  });
+
   it("opens seeded from the row and PATCHes the edited name", async () => {
     mount();
     await rowAction("Edit");
@@ -206,7 +220,9 @@ describe("Edit dataset panel", () => {
     writesFail = true;
     mount();
     await rowAction("Edit");
-    fireEvent.click(await screen.findByRole("button", { name: "Save" }));
+    const name = await screen.findByLabelText("Name");
+    fireEvent.change(name, { target: { value: "Billing routing error" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
     expect(await screen.findByText("Could not save dataset")).toBeDefined();
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));

--- a/frontend/ui/src/features/evaluations/dataset-panels.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/dataset-panels.smoke.test.tsx
@@ -216,6 +216,43 @@ describe("Edit dataset panel", () => {
     expect(patch?.body).toEqual({ name: "Billing routing v2", description: "Routing tickets" });
   });
 
+  it("normalizing whitespace in a stored name enables Save and PATCHes the trimmed value", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      const s = String(url);
+      requests.push({ url: s, method, body: init?.body ? JSON.parse(init.body as string) : null });
+      if (s.includes("/evaluations")) {
+        return { ok: true, status: 200, json: async () => ({ data: [] }) };
+      }
+      if (s.includes("/datasets")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [{ ...DATASET, name: "Billing routing " }],
+            meta: { page: 0, limit: 50, total: 1 },
+          }),
+        };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+
+    mount();
+    await rowAction("Edit");
+    const save = await screen.findByRole("button", { name: "Save" });
+    const name = (await screen.findByLabelText("Name")) as HTMLInputElement;
+    expect(name.value).toBe("Billing routing ");
+
+    // Trimming the editor side enables Save because it normalizes stored whitespace.
+    fireEvent.change(name, { target: { value: "Billing routing" } });
+    expect(save.hasAttribute("disabled")).toBe(false);
+
+    fireEvent.click(save);
+    expect(await screen.findByText("Dataset saved")).toBeDefined();
+    const patch = requests.find((r) => r.method === "PATCH");
+    expect(patch?.body).toEqual({ name: "Billing routing", description: "Routing tickets" });
+  });
+
   it("surfaces a save failure and closes on Cancel", async () => {
     writesFail = true;
     mount();

--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -353,7 +353,7 @@ describe("Dataset detail — filtering and adding rows", () => {
     const input = screen.getByLabelText("Input") as HTMLTextAreaElement;
     expect(input.value).toContain("charged twice");
     fireEvent.change(input, { target: { value: "edited question" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
     expect(await screen.findByText(/Row saved/)).toBeDefined();
     const patch = requests.find((r) => r.method === "PATCH");
     expect(patch?.url).toContain("/datasets/ds1/test-cases/tc_1");

--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -360,6 +360,26 @@ describe("Dataset detail — filtering and adding rows", () => {
     expect(patch?.body).toMatchObject({ input: "edited question" });
   });
 
+  it("a whitespace-only Input edit is savable and PATCHes the untrimmed value", async () => {
+    mountDetail();
+    await screen.findByText(/charged twice/);
+    fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
+    fireEvent.click(await screen.findByText("Edit"));
+    expect(await screen.findByText("Edit Row")).toBeDefined();
+    const input = screen.getByLabelText("Input") as HTMLTextAreaElement;
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+
+    // The row's input is stored verbatim and its exact bytes are the case's
+    // content-addressed id, so a trailing space is a real edit — Save must enable.
+    fireEvent.change(input, { target: { value: `${input.value} ` } });
+    expect(save.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(save);
+    expect(await screen.findByText(/Row saved/)).toBeDefined();
+    const patch = requests.find((r) => r.method === "PATCH");
+    expect((patch?.body as { input: string }).input.endsWith(" ")).toBe(true);
+  });
+
   it("the row action menu deletes a row (DELETE) after confirming", async () => {
     mountDetail();
     await screen.findByText(/charged twice/);

--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -336,8 +336,14 @@ describe("Dataset detail — filtering and adding rows", () => {
     fireEvent.click(screen.getByRole("button", { name: "Row" }));
     // Opens the editor rather than inserting a blank row.
     expect(await screen.findByText("New Row")).toBeDefined();
+    // Create mode is gated until an input is typed.
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+
     fireEvent.change(screen.getByLabelText("Input"), { target: { value: "a new question" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(save.hasAttribute("disabled")).toBe(false);
+
+    fireEvent.click(save);
     expect(await screen.findByText("Row added")).toBeDefined();
     const post = requests.find((r) => r.method === "POST" && r.url.includes("/test-cases"));
     expect(post?.body).toMatchObject({ input: "a new question", expected: null, metadata: null });
@@ -378,6 +384,42 @@ describe("Dataset detail — filtering and adding rows", () => {
     expect(await screen.findByText(/Row saved/)).toBeDefined();
     const patch = requests.find((r) => r.method === "PATCH");
     expect((patch?.body as { input: string }).input.endsWith(" ")).toBe(true);
+  });
+
+  it("reformatting structured Input is not a change, but editing a value is", async () => {
+    const structuredCase = testCase({
+      id: "row-struct",
+      testCaseId: "tc_struct",
+      input: '{\n  "query": "hello"\n}',
+      metadata: null,
+    });
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        const s = String(url);
+        if (s.includes("/evaluations/runs")) {
+          return { data: [], meta: { page: 0, limit: 50, total: 0 } };
+        }
+        return { ...detail(null), testCases: [structuredCase] };
+      },
+    })) as unknown as typeof fetch;
+    mountDetail();
+    await screen.findByText(/hello/);
+    fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
+    fireEvent.click(await screen.findByText("Edit"));
+    expect(await screen.findByText("Edit Row")).toBeDefined();
+    const input = screen.getByLabelText("Input") as HTMLTextAreaElement;
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+
+    // Reformatting structured input does not enable Save.
+    fireEvent.change(input, { target: { value: '{"query": "hello"}' } });
+    expect(save.hasAttribute("disabled")).toBe(true);
+
+    // Editing a value in structured input enables Save.
+    fireEvent.change(input, { target: { value: '{"query": "world"}' } });
+    expect(save.hasAttribute("disabled")).toBe(false);
   });
 
   it("reformatting Metadata is not a change, but editing a value is", async () => {
@@ -436,8 +478,18 @@ describe("Dataset detail — filtering and adding rows", () => {
     expect(await screen.findByText("Edit Row")).toBeDefined();
     const metadata = screen.getByLabelText("Metadata") as HTMLTextAreaElement;
     expect(metadata.value).toContain("\\ud800");
-    expect(await screen.findByText(/invalid Unicode/i)).toBeDefined();
 
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+    // Seeded metadata with an unpaired surrogate is not reported immediately and does
+    // not lock out Input/Expected edits.
+    expect(screen.queryByText(/invalid Unicode/i)).toBeNull();
+
+    const input = screen.getByLabelText("Input") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "edited question" } });
+    expect(save.hasAttribute("disabled")).toBe(false);
+
+    // But editing metadata to another unpaired surrogate reports the error and blocks Save.
     fireEvent.change(metadata, { target: { value: '{"note":"\\udbff"}' } });
     // Still unsavable — but because the value is rejected, and the user is told so.
     expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true);

--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -407,6 +407,62 @@ describe("Dataset detail — filtering and adding rows", () => {
     expect(save.hasAttribute("disabled")).toBe(false);
   });
 
+  it("a Metadata value that can't be canonicalized is reported, not silently unsavable", async () => {
+    // An unpaired UTF-16 surrogate is valid JSON SYNTAX but not valid Unicode text, so
+    // `canonicalJson` rejects it and the value has no canonical (persistable) form. Seeded
+    // from such a row, editing it to a DIFFERENT unpaired surrogate must not read as "no
+    // change" — the field is reported as invalid instead of Save going quietly dead.
+    const surrogateCase = testCase({
+      id: "row-4",
+      testCaseId: "tc_4",
+      input: "metadata the canonicalizer rejects",
+      metadata: { note: "\ud800" },
+    });
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        const s = String(url);
+        if (s.includes("/evaluations/runs")) {
+          return { data: [], meta: { page: 0, limit: 50, total: 0 } };
+        }
+        return { ...detail(null), testCases: [surrogateCase] };
+      },
+    })) as unknown as typeof fetch;
+    mountDetail();
+    await screen.findByText(/canonicalizer rejects/);
+    fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
+    fireEvent.click(await screen.findByText("Edit"));
+    expect(await screen.findByText("Edit Row")).toBeDefined();
+    const metadata = screen.getByLabelText("Metadata") as HTMLTextAreaElement;
+    expect(metadata.value).toContain("\\ud800");
+    expect(await screen.findByText(/invalid Unicode/i)).toBeDefined();
+
+    fireEvent.change(metadata, { target: { value: '{"note":"\\udbff"}' } });
+    // Still unsavable — but because the value is rejected, and the user is told so.
+    expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByText(/invalid Unicode/i)).toBeDefined();
+  });
+
+  it("editing Metadata to an unpaired surrogate blocks Save instead of persisting it", async () => {
+    mountDetail();
+    await screen.findByText(/charged twice/);
+    // Row 2 is the fixture case that carries metadata.
+    fireEvent.click((await screen.findAllByLabelText("Row actions"))[1]);
+    fireEvent.click(await screen.findByText("Edit"));
+    expect(await screen.findByText("Edit Row")).toBeDefined();
+    const metadata = screen.getByLabelText("Metadata") as HTMLTextAreaElement;
+    const save = screen.getByRole("button", { name: "Save" });
+
+    // The signature of an uncanonicalizable value differs from the stored one, so the
+    // dirty check alone would call this savable and PATCH a value the platform can
+    // neither hash nor compare; `metadataError` has to catch it first.
+    fireEvent.change(metadata, { target: { value: '{"channel":"\\ud800"}' } });
+    expect(save.hasAttribute("disabled")).toBe(true);
+    expect(screen.getByText(/invalid Unicode/i)).toBeDefined();
+    expect(requests.some((r) => r.method === "PATCH")).toBe(false);
+  });
+
   it("the row action menu deletes a row (DELETE) after confirming", async () => {
     mountDetail();
     await screen.findByText(/charged twice/);

--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -380,6 +380,33 @@ describe("Dataset detail — filtering and adding rows", () => {
     expect((patch?.body as { input: string }).input.endsWith(" ")).toBe(true);
   });
 
+  it("reformatting Metadata is not a change, but editing a value is", async () => {
+    mountDetail();
+    await screen.findByText(/charged twice/);
+    // Row 2 is the fixture case that carries metadata.
+    fireEvent.click((await screen.findAllByLabelText("Row actions"))[1]);
+    fireEvent.click(await screen.findByText("Edit"));
+    expect(await screen.findByText("Edit Row")).toBeDefined();
+    const metadata = screen.getByLabelText("Metadata") as HTMLTextAreaElement;
+    expect(metadata.value).toContain("channel");
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+
+    // Metadata is persisted PARSED, so re-spacing and reordering the same object changes
+    // nothing that gets stored — comparing the raw text here would let Save publish a
+    // new dataset version identical to the current one.
+    fireEvent.change(metadata, {
+      target: { value: '{"priority":"high","channel":"email"}' },
+    });
+    expect(save.hasAttribute("disabled")).toBe(true);
+
+    // A real value change still enables Save.
+    fireEvent.change(metadata, {
+      target: { value: '{"channel":"chat","priority":"high"}' },
+    });
+    expect(save.hasAttribute("disabled")).toBe(false);
+  });
+
   it("the row action menu deletes a row (DELETE) after confirming", async () => {
     mountDetail();
     await screen.findByText(/charged twice/);

--- a/frontend/ui/src/features/evaluations/save-result-to-dataset-drawer.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-result-to-dataset-drawer.smoke.test.tsx
@@ -132,13 +132,30 @@ describe("SaveResultToDatasetDrawer", () => {
     expect(screen.getByLabelText("Dataset")).toBeDefined();
   });
 
+  it("disables Save until a field is edited or dataset changes", () => {
+    mount("update_existing_case");
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+
+    const input = screen.getByLabelText("Input") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "A different question" } });
+    expect(save.hasAttribute("disabled")).toBe(false);
+
+    fireEvent.change(input, { target: { value: RESULT.input } });
+    expect(save.hasAttribute("disabled")).toBe(true);
+
+    // Toggling the candidate switch enables Save
+    fireEvent.click(screen.getByRole("switch"));
+    expect(save.hasAttribute("disabled")).toBe(false);
+  });
+
   it("never copies the candidate output into expected unless explicitly toggled on", async () => {
     const fetchMock = stubFetch();
     mount("update_existing_case");
     // Type a real reference answer; the candidate output is a DIFFERENT string.
     const expected = screen.getByLabelText("Expected answer") as HTMLTextAreaElement;
     fireEvent.change(expected, { target: { value: "A concise Q2 summary." } });
-    fireEvent.click(screen.getByRole("button", { name: /Publish update/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() =>
       expect(fetchMock.mock.calls.some((c) => (c[1] as RequestInit)?.method === "POST")).toBe(true),
@@ -158,7 +175,7 @@ describe("SaveResultToDatasetDrawer", () => {
     // Flipping the toggle hides the free-text field and shows the candidate output.
     fireEvent.click(screen.getByRole("switch"));
     expect(screen.getByText(RESULT.candidateOutput)).toBeDefined();
-    fireEvent.click(screen.getByRole("button", { name: /Publish update/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() =>
       expect(fetchMock.mock.calls.some((c) => (c[1] as RequestInit)?.method === "POST")).toBe(true),
@@ -179,7 +196,7 @@ describe("SaveResultToDatasetDrawer", () => {
     // ds1 is the source dataset (default); saving a new case that recreates the source
     // is what the backend rejects. Save stays disabled until the datasets list has
     // loaded and confirms ds1 is a real, current dataset.
-    const saveBtn = screen.getByRole("button", { name: /Save new case/i }) as HTMLButtonElement;
+    const saveBtn = screen.getByRole("button", { name: /^Save$/i }) as HTMLButtonElement;
     await waitFor(() => expect(saveBtn.disabled).toBe(false));
     fireEvent.click(saveBtn);
 

--- a/frontend/ui/src/features/evaluations/save-result-to-dataset-drawer.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-result-to-dataset-drawer.smoke.test.tsx
@@ -149,6 +149,18 @@ describe("SaveResultToDatasetDrawer", () => {
     expect(save.hasAttribute("disabled")).toBe(false);
   });
 
+  it("treats a whitespace-only input edit as a real change — the case id hashes exact bytes", () => {
+    mount("update_existing_case");
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save.hasAttribute("disabled")).toBe(true);
+
+    // `input` is POSTed verbatim and `stableCaseId` hashes its exact bytes, so trailing
+    // whitespace republishes a genuinely different case — Save must not gate it away.
+    const input = screen.getByLabelText("Input") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: `${RESULT.input} ` } });
+    expect(save.hasAttribute("disabled")).toBe(false);
+  });
+
   it("never copies the candidate output into expected unless explicitly toggled on", async () => {
     const fetchMock = stubFetch();
     mount("update_existing_case");

--- a/frontend/ui/src/lib/eval/canonical.ts
+++ b/frontend/ui/src/lib/eval/canonical.ts
@@ -1,0 +1,90 @@
+/**
+ * Canonical JSON — the deterministic serialization the platform hashes and compares by.
+ *
+ * A LEAF module on purpose: `versions.ts` (where this used to live) imports `prisma`, and
+ * `case-id.ts` imports `crypto`, so neither can be pulled into a `"use client"` bundle.
+ * The dataset editors need canonical equality on the client — a metadata reformat must not
+ * read as an edit — so the canonicalizer sits here, importing nothing. Mirrors the SDK's
+ * own layout (traceroot-ts `src/eval/canonical.ts`, traceroot-py `traceroot/eval/canonical.py`).
+ */
+
+/**
+ * A lone UTF-16 surrogate: a high surrogate not followed by a low one, or a low
+ * one not preceded by a high one. Such a string is not valid Unicode text and
+ * cannot be UTF-8 encoded — Python raises while hashing it, so we reject it here
+ * too rather than silently hashing Node's replacement form and diverging cross-SDK.
+ * Kept byte-identical to the SDK's `rejectLoneSurrogate` (traceroot-ts
+ * `src/eval/canonical.ts`, traceroot-py `traceroot/eval/canonical.py`).
+ */
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+/**
+ * Raised when a string carries an unpaired UTF-16 surrogate and so cannot be
+ * canonicalized (it is not valid Unicode text). A dedicated type so callers can tell
+ * this specific, caller-fixable condition apart from an unexpected failure — the
+ * publish routes map it to a 400, and `contentSignature` swallows it for ALREADY-stored
+ * content (which must keep a stable signature rather than be re-validated on every publish).
+ */
+export class LoneSurrogateError extends Error {
+  constructor(
+    message = "string contains an unpaired UTF-16 surrogate and cannot be canonicalized; " +
+      "it is not valid Unicode text",
+  ) {
+    super(message);
+    this.name = "LoneSurrogateError";
+  }
+}
+
+export function rejectLoneSurrogate(s: string): void {
+  if (LONE_SURROGATE.test(s)) {
+    throw new LoneSurrogateError();
+  }
+}
+
+/** Deterministic JSON with recursively sorted object keys — so two structurally equal
+ *  values compare equal regardless of key order (JSONB round-trips don't preserve it).
+ *
+ *  Also the canonicalizer for content-addressed case ids (`stableCaseId`): the id
+ *  hashes this exact string, so it must match the SDK's `canonicalJson` byte-for-byte
+ *  for the inputs the UI actually authors. UI case inputs are always genuine strings
+ *  (see `CreateTestCaseRequestSchema.input`), and for a string value this reduces to
+ *  `JSON.stringify(value)` in both this helper and the SDK's — so a UI-authored case
+ *  and an SDK-authored case for the same input converge on the same `tc_` id. */
+export function canonicalJson(v: unknown): string {
+  if (typeof v === "string") {
+    // A lone UTF-16 surrogate cannot be UTF-8 encoded; the SDK's canonicalizer raises
+    // on it, so reject it here too rather than silently hashing JS's escaped form and
+    // diverging cross-SDK. (The reachable id path is always a string value.)
+    rejectLoneSurrogate(v);
+    return JSON.stringify(v);
+  }
+  if (v === null || typeof v !== "object") return JSON.stringify(v) ?? "null";
+  if (Array.isArray(v)) return `[${v.map(canonicalJson).join(",")}]`;
+  const o = v as Record<string, unknown>;
+  return `{${Object.keys(o)
+    .sort(compareCodePoints)
+    .map((k) => {
+      // Guard object KEYS too, not just string VALUES: a lone surrogate in an
+      // SDK-authored metadata key must reject here rather than silently hashing JS's
+      // escaped form and diverging from the SDK's byte-for-byte pre-image.
+      rejectLoneSurrogate(k);
+      return `${JSON.stringify(k)}:${canonicalJson(o[k])}`;
+    })
+    .join(",")}}`;
+}
+
+/** Order strings by Unicode code POINT (Python `sorted()` order), not by UTF-16 code
+ *  unit (JS default `.sort()`); they differ only when an astral-plane character meets a
+ *  BMP one in U+E000..U+FFFF. Keeps object-key order byte-parity with the SDK canonicalizer. */
+function compareCodePoints(a: string, b: string): number {
+  const ai = a[Symbol.iterator]();
+  const bi = b[Symbol.iterator]();
+  for (;;) {
+    const x = ai.next();
+    const y = bi.next();
+    if (x.done || y.done) return x.done ? (y.done ? 0 : -1) : 1;
+    const cx = x.value.codePointAt(0) as number;
+    const cy = y.value.codePointAt(0) as number;
+    if (cx !== cy) return cx - cy;
+  }
+}

--- a/frontend/ui/src/lib/eval/case-id.ts
+++ b/frontend/ui/src/lib/eval/case-id.ts
@@ -1,37 +1,10 @@
 import { createHash } from "crypto";
+import { rejectLoneSurrogate } from "./canonical";
 
-/**
- * A lone UTF-16 surrogate: a high surrogate not followed by a low one, or a low
- * one not preceded by a high one. Such a string is not valid Unicode text and
- * cannot be UTF-8 encoded — Python raises while hashing it, so we reject it here
- * too rather than silently hashing Node's replacement form and diverging cross-SDK.
- * Kept byte-identical to the SDK's `rejectLoneSurrogate` (traceroot-ts
- * `src/eval/canonical.ts`, traceroot-py `traceroot/eval/canonical.py`).
- */
-const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
-
-/**
- * Raised when a string carries an unpaired UTF-16 surrogate and so cannot be
- * canonicalized (it is not valid Unicode text). A dedicated type so callers can tell
- * this specific, caller-fixable condition apart from an unexpected failure — the
- * publish routes map it to a 400, and `contentSignature` swallows it for ALREADY-stored
- * content (which must keep a stable signature rather than be re-validated on every publish).
- */
-export class LoneSurrogateError extends Error {
-  constructor(
-    message = "string contains an unpaired UTF-16 surrogate and cannot be canonicalized; " +
-      "it is not valid Unicode text",
-  ) {
-    super(message);
-    this.name = "LoneSurrogateError";
-  }
-}
-
-export function rejectLoneSurrogate(s: string): void {
-  if (LONE_SURROGATE.test(s)) {
-    throw new LoneSurrogateError();
-  }
-}
+/** The surrogate guard lives with the canonicalizer it protects (`./canonical`, which is
+ *  importable from client code); re-exported here so the publish routes that map it to a
+ *  400 keep importing it alongside the id helpers they already pull from this module. */
+export { LoneSurrogateError } from "./canonical";
 
 /**
  * Derive a dataset case's stable, CONTENT-addressed id (`tc_…`).

--- a/frontend/ui/src/lib/eval/metrics.ts
+++ b/frontend/ui/src/lib/eval/metrics.ts
@@ -8,6 +8,8 @@
  * completion is where the resolved manifest arrives and has to be folded in.
  */
 
+import { canonicalJson } from "./canonical";
+
 /**
  * Merge a resolved manifest (from completion) into the stored one, by definition name:
  * a definition present in `incoming` replaces the stored one (carrying its resolved
@@ -37,16 +39,4 @@ export function mergeScorerManifests(stored: unknown, incoming: unknown): unknow
  *  order, so a replay's merged manifest matches the stored one element-for-element). */
 export function scorerManifestsEqual(a: unknown, b: unknown): boolean {
   return canonicalJson(a) === canonicalJson(b);
-}
-
-function canonicalJson(v: unknown): string {
-  if (Array.isArray(v)) return `[${v.map(canonicalJson).join(",")}]`;
-  if (v && typeof v === "object") {
-    const o = v as Record<string, unknown>;
-    return `{${Object.keys(o)
-      .sort()
-      .map((k) => `${JSON.stringify(k)}:${canonicalJson(o[k])}`)
-      .join(",")}}`;
-  }
-  return JSON.stringify(v) ?? "null";
 }

--- a/frontend/ui/src/lib/eval/versions.ts
+++ b/frontend/ui/src/lib/eval/versions.ts
@@ -1,7 +1,7 @@
 import { prisma, type Prisma, type TestCase } from "@traceroot/core";
 import { versionSnowflakeFromMs } from "./snowflake";
 import { decodeJsonValue } from "./json-value";
-import { rejectLoneSurrogate, LoneSurrogateError } from "./case-id";
+import { canonicalJson, LoneSurrogateError } from "./canonical";
 
 /** Deterministic read order for a version's cases (see the ordering note where
  *  it's used): every case a publish writes shares one `create_time` (Postgres'
@@ -67,53 +67,9 @@ function toSeed(c: TestCase): TestCaseSeed {
   };
 }
 
-/** Deterministic JSON with recursively sorted object keys — so two structurally equal
- *  values compare equal regardless of key order (JSONB round-trips don't preserve it).
- *
- *  Also the canonicalizer for content-addressed case ids (`stableCaseId`): the id
- *  hashes this exact string, so it must match the SDK's `canonicalJson` byte-for-byte
- *  for the inputs the UI actually authors. UI case inputs are always genuine strings
- *  (see `CreateTestCaseRequestSchema.input`), and for a string value this reduces to
- *  `JSON.stringify(value)` in both this helper and the SDK's — so a UI-authored case
- *  and an SDK-authored case for the same input converge on the same `tc_` id. */
-export function canonicalJson(v: unknown): string {
-  if (typeof v === "string") {
-    // A lone UTF-16 surrogate cannot be UTF-8 encoded; the SDK's canonicalizer raises
-    // on it, so reject it here too rather than silently hashing JS's escaped form and
-    // diverging cross-SDK. (The reachable id path is always a string value.)
-    rejectLoneSurrogate(v);
-    return JSON.stringify(v);
-  }
-  if (v === null || typeof v !== "object") return JSON.stringify(v) ?? "null";
-  if (Array.isArray(v)) return `[${v.map(canonicalJson).join(",")}]`;
-  const o = v as Record<string, unknown>;
-  return `{${Object.keys(o)
-    .sort(compareCodePoints)
-    .map((k) => {
-      // Guard object KEYS too, not just string VALUES: a lone surrogate in an
-      // SDK-authored metadata key must reject here rather than silently hashing JS's
-      // escaped form and diverging from the SDK's byte-for-byte pre-image.
-      rejectLoneSurrogate(k);
-      return `${JSON.stringify(k)}:${canonicalJson(o[k])}`;
-    })
-    .join(",")}}`;
-}
-
-/** Order strings by Unicode code POINT (Python `sorted()` order), not by UTF-16 code
- *  unit (JS default `.sort()`); they differ only when an astral-plane character meets a
- *  BMP one in U+E000..U+FFFF. Keeps object-key order byte-parity with the SDK canonicalizer. */
-function compareCodePoints(a: string, b: string): number {
-  const ai = a[Symbol.iterator]();
-  const bi = b[Symbol.iterator]();
-  for (;;) {
-    const x = ai.next();
-    const y = bi.next();
-    if (x.done || y.done) return x.done ? (y.done ? 0 : -1) : 1;
-    const cx = x.value.codePointAt(0) as number;
-    const cy = y.value.codePointAt(0) as number;
-    if (cx !== cy) return cx - cy;
-  }
-}
+/** Re-exported from `./canonical`: the id/signature canonicalizer moved to a leaf module
+ *  so the dataset editors can compare by it on the client without dragging Prisma along. */
+export { canonicalJson };
 
 /** A stable signature of a version's semantic CONTENT — the per-case (id, input, expected,
  *  metadata), order-independent. Capture provenance (source fields, review, addedBy,


### PR DESCRIPTION
### Summary
Standardizes the primary edit-and-commit button across dataset and evaluation edit surfaces (`DatasetEditPanel`, `TestCaseEditorModal`, and `SaveResultToDatasetDrawer`):
1. Every edit-commit button now consistently uses the label "Save" (and "Saving…" while pending).
2. The Save button is disabled by default on initial open and only enables once an editable field has actually changed (`hasChanges`), preventing unintended no-op writes and redundant version publishing.

Closes #1949

### Changes
- `dataset-panels.tsx`: Add `hasChanges` check in `DatasetEditPanel` to disable Save until name or description changes.
- `test-case-editor-modal.tsx`: Standardize button label from `"Save changes"` to `"Save"`.
- `save-result-to-dataset-drawer.tsx`: Add `hasChanges` dirty check and standardize button label to `"Save"`.
- Updated test suites across `dataset-panels.smoke.test.tsx`, `datasets-detail.smoke.test.tsx`, and `save-result-to-dataset-drawer.smoke.test.tsx`.

### Validation
- All 17 test files and 205 tests in `src/features/evaluations` and `src/features/offline-eval` pass (100%).
- ESLint passed with 0 errors.

before edit 
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/d5e3ea59-4c0f-4829-b8cf-881ab4d2f460" />


after edit 
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/5f87e644-320f-43dc-8121-2a7cd06a46a1" />





before edit

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/f4083459-bdc2-4f41-b53d-f8773cb63352" />


after edit


<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/7abfb6e4-9c41-4235-b0d2-1174bde7dd33" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the primary edit action as a single “Save” button and disables it until something actually changed, closing #1949. Previously buttons varied (“Save changes”, “Publish update”, “Save new case”) and allowed no-op writes; now they show “Save”/“Saving…” and only enable when the persisted value would differ.

- Replaces labels with “Save” (and “Saving…”) across `DatasetEditPanel`, `TestCaseEditorModal`, and `SaveResultToDatasetDrawer`, and drops the unused `ACTION_META` CTA labels.
- Dirty checks compare each field as persisted: input via `encodeEditedText` (whitespace-only edits count since the case id hashes exact bytes; reformatting structured input doesn’t), expected trimmed, and metadata canonically so reformatting isn’t a change. Metadata with no canonical form (an unpaired UTF-16 surrogate) blocks Save with an error; create mode requires non-empty input, and seeded metadata that can’t canonicalize doesn’t lock out other field edits.
- Adds a leaf `canonical.ts` for client-side canonicalization; `case-id.ts` and `versions.ts` re-export from it.
- In the result drawer, only “Update source case” is gated on changes (dataset selection, input, expected, or toggling “use candidate as expected”); save-new-case and duplicate are always savable.
- Updates smoke tests to assert the “Save” label, disabled-by-default behavior, and the per-field dirty checks.

<sup>Written for commit 525e59e4118a8d05f8ed83db550ebc336d27d935. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

