### PR TITLE
fix(ui): make key identifiers copyable and selectable app-wide (#1948)

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.test.tsx
@@ -211,8 +211,14 @@ describe("DetectorDetailPage", () => {
     fireEvent.click(screen.getByText("Something went wrong"));
     expect(screen.queryByTestId("trace-panel")).toBeNull();
 
+    // The trace_id cell is the row's only navigating control; the copy buttons
+    // beside the two ids write to the clipboard rather than opening the panel.
     const row = screen.getByText("Something went wrong").closest("tr")!;
-    expect(within(row).getAllByRole("button")).toHaveLength(1);
+    expect(
+      within(row)
+        .getAllByRole("button")
+        .map((b) => b.getAttribute("title")),
+    ).toEqual(["Copy run ID", "trace-abc", "Copy trace ID"]);
   });
 
   it("closes the panel, clearing the selected trace", () => {

--- a/frontend/ui/src/components/ui/copy-button.tsx
+++ b/frontend/ui/src/components/ui/copy-button.tsx
@@ -18,8 +18,9 @@ const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
   ({ value, onCopy, className, iconClassName, variant = "ghost", size = "sm", ...props }, ref) => {
     const [copied, setCopied] = React.useState(false);
 
-    const handleCopy = async () => {
-      await navigator.clipboard.writeText(value);
+    const handleCopy = async (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      await navigator.clipboard?.writeText(value);
       setCopied(true);
       onCopy?.();
       setTimeout(() => setCopied(false), 2000);

--- a/frontend/ui/src/components/ui/copy-button.tsx
+++ b/frontend/ui/src/components/ui/copy-button.tsx
@@ -20,10 +20,11 @@ const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
 
     const handleCopy = async (e: React.MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation();
-      await navigator.clipboard?.writeText(value);
-      setCopied(true);
-      onCopy?.();
-      setTimeout(() => setCopied(false), 2000);
+      try {
+        await navigator.clipboard?.writeText(value);
+      } catch (err) {
+        console.error("Failed to copy text: ", err);
+      }
     };
 
     return (

--- a/frontend/ui/src/components/ui/copy-button.tsx
+++ b/frontend/ui/src/components/ui/copy-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Copy, Check } from "lucide-react";
+import { Copy, Check, X } from "lucide-react";
 import { Button, type ButtonProps } from "./button";
 import { cn } from "@/lib/utils";
 
@@ -11,19 +11,66 @@ export interface CopyButtonProps extends Omit<ButtonProps, "onClick"> {
   iconClassName?: string;
 }
 
+type CopyStatus = "idle" | "copied" | "failed";
+const STATUS_RESET_DELAY_MS = 2000;
+
 /**
- * Copy button that shows a check icon after copying
+ * Copy button that shows a check icon after copying, or a failed icon if the
+ * clipboard write was rejected (denied permission, insecure context, etc.).
  */
 const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
   ({ value, onCopy, className, iconClassName, variant = "ghost", size = "sm", ...props }, ref) => {
-    const [copied, setCopied] = React.useState(false);
+    const [status, setStatus] = React.useState<CopyStatus>("idle");
+    const resetTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Identifies the most recent click. A click's async result is only
+    // applied if this still matches the id it captured when it started —
+    // otherwise a newer click has since begun and this one is stale.
+    const clickIdRef = React.useRef(0);
+
+    // Clear any pending reset on unmount so it never fires setState after
+    // the button is gone.
+    React.useEffect(() => {
+      return () => {
+        if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current);
+      };
+    }, []);
+
+    const scheduleReset = () => {
+      // A prior click's reset must not fire mid-way through this one — e.g.
+      // copy, fail, copy again inside 2s would otherwise let the first
+      // timeout revert the second click's "copied" state early.
+      if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current);
+      resetTimeoutRef.current = setTimeout(() => setStatus("idle"), STATUS_RESET_DELAY_MS);
+    };
 
     const handleCopy = async (e: React.MouseEvent<HTMLButtonElement>) => {
+      // These buttons sit inside rows and headers that are themselves click
+      // targets (a table row that routes, a collapsible section header), so a
+      // copy must not also navigate or toggle whatever encloses it.
       e.stopPropagation();
+      const clickId = ++clickIdRef.current;
+      // A new click supersedes whatever the previous one was showing —
+      // don't let its reset fire mid-flight of this one, and don't let this
+      // one apply its result if a still-newer click starts before it settles.
+      if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current);
+
       try {
-        await navigator.clipboard?.writeText(value);
+        await navigator.clipboard.writeText(value);
+        // Two overlapping writes can settle out of order (e.g. the older one
+        // is still waiting on a permission prompt when a newer one
+        // completes first): only the latest click's result may apply.
+        if (clickIdRef.current !== clickId) return;
+        setStatus("copied");
+        onCopy?.();
+        scheduleReset();
       } catch (err) {
-        console.error("Failed to copy text: ", err);
+        if (clickIdRef.current !== clickId) return;
+        // A rejected write must not become an unhandled promise rejection,
+        // and must not be mistaken for success — surface it as its own icon
+        // state instead of silently leaving the idle Copy icon.
+        console.error("Failed to copy to clipboard:", err);
+        setStatus("failed");
+        scheduleReset();
       }
     };
 
@@ -36,8 +83,10 @@ const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
         onClick={handleCopy}
         {...props}
       >
-        {copied ? (
+        {status === "copied" ? (
           <Check className={cn("h-3.5 w-3.5 text-green-600", iconClassName)} />
+        ) : status === "failed" ? (
+          <X className={cn("h-3.5 w-3.5 text-destructive", iconClassName)} />
         ) : (
           <Copy className={cn("h-3.5 w-3.5", iconClassName)} />
         )}

--- a/frontend/ui/src/components/ui/json-view.tsx
+++ b/frontend/ui/src/components/ui/json-view.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Copy, Check, ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { CopyButton } from "./copy-button";
 import { cn } from "@/lib/utils";
 
 function tryParseJson(value: unknown): unknown {
@@ -153,20 +154,13 @@ interface IOSectionProps {
 
 export function IOSection({ label, value }: IOSectionProps) {
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const [copied, setCopied] = useState(false);
   const parsed = useMemo(() => (value ? deepParseJson(tryParseJson(value)) : null), [value]);
 
   if (!value) return null;
 
   const isJsonObject = typeof parsed === "object" && parsed !== null;
   const isSimpleString = typeof parsed === "string";
-
-  const handleCopy = () => {
-    const text = isJsonObject ? JSON.stringify(parsed, null, 2) : String(parsed);
-    navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
+  const copyText = isJsonObject ? JSON.stringify(parsed, null, 2) : String(parsed);
 
   return (
     <div className="overflow-hidden rounded-md border border-border bg-muted/30">
@@ -179,13 +173,11 @@ export function IOSection({ label, value }: IOSectionProps) {
           {isCollapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
           {label}
         </button>
-        <button
-          onClick={handleCopy}
-          className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        <CopyButton
+          value={copyText}
+          className="h-6 w-6 text-muted-foreground hover:text-foreground"
           title="Copy"
-        >
-          {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-        </button>
+        />
       </div>
 
       {/* Content */}

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
-import { X, Copy, Check, ArrowUp, ArrowDown } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
+import { X, ArrowUp, ArrowDown } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { useDetector, useUpdateDetector } from "../hooks/use-detectors";
 import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
@@ -133,13 +134,6 @@ export function DetectorPanel({
     }
   }, [detectorId, detector]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const [copied, setCopied] = useState(false);
-  const copyId = useCallback(() => {
-    void navigator.clipboard.writeText(detectorId);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  }, [detectorId]);
-
   const updateMutation = useUpdateDetector(projectId, detectorId);
 
   // Block Save while a filter row is incomplete (missing value or metadata
@@ -182,15 +176,14 @@ export function DetectorPanel({
           <span className="truncate text-[13px] text-muted-foreground">
             {detector?.name ?? detectorId}
           </span>
-          <button
-            type="button"
-            onClick={copyId}
-            className="flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground/60 transition-colors hover:bg-muted hover:text-muted-foreground"
-            title="Copy detector ID"
-          >
+          <span className="truncate font-mono text-[11px] text-muted-foreground/60">
             {detectorId}
-            {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
-          </button>
+          </span>
+          <CopyButton
+            value={detectorId}
+            className="h-6 w-6 text-muted-foreground hover:text-foreground"
+            title="Copy detector ID"
+          />
         </div>
         <div className="flex items-center gap-1">
           {onNavigate && (

--- a/frontend/ui/src/features/detectors/components/detector-runs-table.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-runs-table.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, screen, fireEvent, within } from "@testing-library/react";
+import { render, cleanup, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { DetectorRunsTable } from "./detector-runs-table";
 import type { BackendRun } from "@/features/detectors/hooks/use-findings";
 
@@ -87,10 +87,15 @@ describe("DetectorRunsTable", () => {
     fireEvent.click(screen.getByText("Something went wrong"));
     expect(onTraceClick).not.toHaveBeenCalled();
 
-    // The only button in the row is the trace_id cell.
+    // trace_id is the only navigating control — run_id is plain text unless
+    // self_traced, and the two copy buttons write to the clipboard, they don't
+    // route. Titles pin down which button is which.
     const row = screen.getByText("Something went wrong").closest("tr")!;
-    // trace_id is the only link — run_id is plain text unless self_traced.
-    expect(within(row).getAllByRole("button")).toHaveLength(1);
+    expect(
+      within(row)
+        .getAllByRole("button")
+        .map((b) => b.getAttribute("title")),
+    ).toEqual(["Copy run ID", "trace-triggered", "Copy trace ID"]);
   });
 
   it("opens the self-trace when a self_traced row is clicked anywhere", () => {
@@ -152,5 +157,32 @@ describe("DetectorRunsTable", () => {
 
     expect(screen.queryByRole("button", { name: "run-clean" })).toBeNull();
     expect(screen.getByText("run-clean")).toBeTruthy();
+  });
+
+  it("copies the untruncated run and trace ids without navigating", async () => {
+    const writeText = vi.fn(async () => {});
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    const onRunClick = vi.fn();
+    const onTraceClick = vi.fn();
+    const selfRun: BackendRun = { ...triggeredRun, self_traced: true };
+    render(
+      <DetectorRunsTable rows={[selfRun]} onTraceClick={onTraceClick} onRunClick={onRunClick} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy run ID" }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("run-triggered"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy trace ID" }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("trace-triggered"));
+
+    // The row and both cells are click targets; copying must not follow them.
+    expect(onRunClick).not.toHaveBeenCalled();
+    expect(onTraceClick).not.toHaveBeenCalled();
+  });
+
+  it("offers a copy affordance for a run with no self-trace", () => {
+    render(<DetectorRunsTable rows={[cleanRun]} onTraceClick={vi.fn()} onRunClick={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Copy run ID" })).toBeTruthy();
   });
 });

--- a/frontend/ui/src/features/detectors/components/detector-runs-table.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-runs-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CopyButton } from "@/components/ui/copy-button";
 import { cn, formatDate } from "@/lib/utils";
 import { describeRcaStatus, type BackendRun } from "@/features/detectors/hooks/use-findings";
 import { DETECTOR_TH, DETECTOR_TD, IdentifiedBadge, SummaryText } from "./detector-table-cells";
@@ -54,36 +55,50 @@ export function DetectorRunsTable({ rows, onTraceClick, onRunClick }: DetectorRu
                 {formatDate(run.timestamp)}
               </td>
               <td className={cn(DETECTOR_TD, "font-mono text-[11px]")}>
-                {run.self_traced ? (
+                <div className="flex min-w-0 items-center gap-1">
+                  {run.self_traced ? (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        // Same destination as the row click; stop propagation so
+                        // one click doesn't fire the navigation twice.
+                        e.stopPropagation();
+                        onRunClick(run);
+                      }}
+                      title={run.run_id}
+                      className="min-w-0 truncate text-left text-muted-foreground transition-colors hover:text-foreground hover:underline"
+                    >
+                      {run.run_id}
+                    </button>
+                  ) : (
+                    <span className="min-w-0 truncate text-muted-foreground">{run.run_id}</span>
+                  )}
+                  <CopyButton
+                    value={run.run_id}
+                    className="h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
+                    title="Copy run ID"
+                  />
+                </div>
+              </td>
+              <td className={cn(DETECTOR_TD, "font-mono text-[11px]")}>
+                <div className="flex min-w-0 items-center gap-1">
                   <button
                     type="button"
                     onClick={(e) => {
-                      // Same destination as the row click; stop propagation so
-                      // one click doesn't fire the navigation twice.
                       e.stopPropagation();
-                      onRunClick(run);
+                      onTraceClick(run);
                     }}
-                    title={run.run_id}
-                    className="block max-w-full truncate text-left text-muted-foreground transition-colors hover:text-foreground hover:underline"
+                    title={run.trace_id}
+                    className="min-w-0 truncate text-left text-muted-foreground transition-colors hover:text-foreground hover:underline"
                   >
-                    {run.run_id}
+                    {run.trace_id}
                   </button>
-                ) : (
-                  <span className="text-muted-foreground">{run.run_id}</span>
-                )}
-              </td>
-              <td className={cn(DETECTOR_TD, "font-mono text-[11px]")}>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onTraceClick(run);
-                  }}
-                  title={run.trace_id}
-                  className="block max-w-full truncate text-left text-muted-foreground transition-colors hover:text-foreground hover:underline"
-                >
-                  {run.trace_id}
-                </button>
+                  <CopyButton
+                    value={run.trace_id}
+                    className="h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
+                    title="Copy trace ID"
+                  />
+                </div>
               </td>
               <td className={DETECTOR_TD}>
                 <IdentifiedBadge identified={run.finding_id != null} />

--- a/frontend/ui/src/features/evaluations/dataset-panels.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/dataset-panels.smoke.test.tsx
@@ -97,6 +97,16 @@ async function rowAction(name: "Edit" | "Delete") {
   fireEvent.click(await screen.findByText(name));
 }
 
+describe("Datasets list table", () => {
+  it("copies the dataset id without navigating the row", async () => {
+    mount();
+    const copyBtn = await screen.findByTitle("Copy dataset ID");
+    fireEvent.click(copyBtn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ds1");
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});
+
 describe("New dataset panel", () => {
   it("stays disabled until a name is typed, then POSTs name + description", async () => {
     mount();

--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -253,6 +253,17 @@ async function openCase(text: string | RegExp) {
 }
 
 describe("Dataset detail view renders server data", () => {
+  it("renders a copyable dataset id chip and version id copy button in the header", async () => {
+    mountDetail();
+    const datasetCopyBtn = await screen.findByTitle("Copy dataset ID");
+    fireEvent.click(datasetCopyBtn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ds1");
+
+    const versionCopyBtn = await screen.findByTitle("Copy version ID");
+    fireEvent.click(versionCopyBtn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("dv2");
+  });
+
   it("shows every test case of the current version", async () => {
     // The dataset name + id live in the top breadcrumb bar (ProjectBreadcrumb),
     // which this harness mocks out; here we assert the rows themselves.

--- a/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
@@ -6,7 +6,7 @@
  * against a stubbed fetch (server-shaped payloads) is how the browser path is
  * checked, exactly like offline-eval.smoke.test.tsx.
  */
-import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach, beforeAll } from "vitest";
 import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastProvider } from "@/components/ui/toast";
@@ -267,6 +267,10 @@ function payloadFor(url: string): unknown {
   return {};
 }
 
+beforeAll(() => {
+  Object.assign(navigator, { clipboard: { writeText: vi.fn(async () => {}) } });
+});
+
 beforeEach(() => {
   global.fetch = vi.fn(async (url: RequestInfo | URL) => ({
     ok: true,
@@ -296,6 +300,13 @@ describe("real Datasets + Evaluations views render server data", () => {
   it("Evaluations Runs tab shows a run with its candidate version", async () => {
     mount(<EvaluationsView projectId="p1" />);
     expect((await screen.findAllByText("git:4a91c02")).length).toBeGreaterThan(0);
+  });
+
+  it("Evaluations Runs tab provides a CopyButton for the dataset version id", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    const copyBtn = (await screen.findAllByTitle("Copy version ID"))[0];
+    fireEvent.click(copyBtn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("dv1");
   });
 
   it("Evaluations shows an empty state that points at the SDK (no Run evaluation CTA)", async () => {

--- a/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
@@ -6,14 +6,18 @@
  * against a stubbed fetch (server-shaped payloads) is how the browser path is
  * checked, exactly like offline-eval.smoke.test.tsx.
  */
-import { describe, it, expect, vi, afterEach, beforeEach, beforeAll } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastProvider } from "@/components/ui/toast";
 
+// One spy shared by every useRouter() consumer, so a test can assert that a
+// nested control (a copy button inside a navigable row) did NOT navigate. A
+// fresh vi.fn() per call would make that unobservable.
+const routerPush = vi.hoisted(() => vi.fn());
 vi.mock("next/navigation", () => ({
   useParams: () => ({ projectId: "p1", datasetId: "ds1", runId: "run1" }),
-  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRouter: () => ({ push: routerPush, replace: vi.fn() }),
   useSearchParams: () => new URLSearchParams(),
   usePathname: () => "/projects/p1/evaluations",
 }));
@@ -267,11 +271,11 @@ function payloadFor(url: string): unknown {
   return {};
 }
 
-beforeAll(() => {
-  Object.assign(navigator, { clipboard: { writeText: vi.fn(async () => {}) } });
-});
-
 beforeEach(() => {
+  // A fresh clipboard spy per test: a file-wide one keeps its call history, so
+  // any `toHaveBeenCalledWith` below would pass on an earlier test's click.
+  Object.assign(navigator, { clipboard: { writeText: vi.fn(async () => {}) } });
+  routerPush.mockClear();
   global.fetch = vi.fn(async (url: RequestInfo | URL) => ({
     ok: true,
     status: 200,
@@ -306,7 +310,10 @@ describe("real Datasets + Evaluations views render server data", () => {
     mount(<EvaluationsView projectId="p1" />);
     const copyBtn = (await screen.findAllByTitle("Copy version ID"))[0];
     fireEvent.click(copyBtn);
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("dv1");
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith("dv1"));
+    // The button sits inside a row whose onClick pushes the run detail route;
+    // copying an id must not also navigate away from the list.
+    expect(routerPush).not.toHaveBeenCalled();
   });
 
   it("Evaluations shows an empty state that points at the SDK (no Run evaluation CTA)", async () => {

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -238,6 +238,14 @@ export function DatasetDetailView({
             onSearchChange={setKeyword}
             searchPlaceholder="Search..."
           >
+            <div className="flex items-center gap-1 font-mono text-[11px] text-muted-foreground">
+              <span className="truncate">{dataset.clientDatasetId ?? dataset.id}</span>
+              <CopyButton
+                value={dataset.clientDatasetId ?? dataset.id}
+                className="h-5 w-5 text-muted-foreground hover:text-foreground"
+                title="Copy dataset ID"
+              />
+            </div>
             <div className="ml-auto flex items-center gap-2">
               <Button
                 variant="outline"
@@ -279,6 +287,15 @@ export function DatasetDetailView({
                       ))}
                     </SelectContent>
                   </Select>
+                  {(selectedVersion?.id ?? dataset.currentVersionId ?? versions[0]?.id) && (
+                    <CopyButton
+                      value={
+                        selectedVersion?.id ?? dataset.currentVersionId ?? versions[0]?.id ?? ""
+                      }
+                      className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                      title="Copy version ID"
+                    />
+                  )}
                 </div>
               )}
             </div>

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -229,10 +229,11 @@ export function DatasetDetailView({
       />
       <div className="flex h-full flex-col text-[13px]">
         <div className="flex min-h-0 flex-1 flex-col">
-          {/* Single toolbar row: search on the left; the Row action and the
-                version selector pushed to the right (version farthest). The version
-                id lives inside the dropdown, not spelled out in the bar. No date
-                filter: nothing here reads one. */}
+          {/* Single toolbar row: search and the dataset id on the left; the Row
+                action and the version selector pushed to the right (version
+                farthest). Both ids carry a copy button — they are what an SDK
+                call needs and neither is retypable by eye. No date filter:
+                nothing here reads one. */}
           <SearchFilterBar
             searchValue={keyword}
             onSearchChange={setKeyword}

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -239,8 +239,11 @@ export function DatasetDetailView({
             onSearchChange={setKeyword}
             searchPlaceholder="Search..."
           >
-            <div className="flex items-center gap-1 font-mono text-[11px] text-muted-foreground">
-              <span className="truncate">{dataset.clientDatasetId ?? dataset.id}</span>
+            <div className="flex min-w-0 items-center gap-1 font-mono text-[11px] text-muted-foreground">
+              {/* min-w-0 on both the chip and the span: a flex item defaults to
+                  min-width:auto, which would keep a long client dataset id at its
+                  full width and overflow the bar instead of ellipsizing. */}
+              <span className="min-w-0 truncate">{dataset.clientDatasetId ?? dataset.id}</span>
               <CopyButton
                 value={dataset.clientDatasetId ?? dataset.id}
                 className="h-5 w-5 text-muted-foreground hover:text-foreground"

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ListPagination } from "@/components/list-pagination";
 import { useUrlPagination } from "@/lib/hooks/use-url-pagination";
@@ -136,10 +137,17 @@ export function DatasetsView({ projectId }: { projectId: string }) {
                         so there's no competing name link. */}
                     <Td className="text-foreground">{dataset.name}</Td>
                     <Td
-                      className="max-w-[240px] truncate font-mono text-[11px] text-muted-foreground"
+                      className="max-w-[240px] font-mono text-[11px] text-muted-foreground"
                       title={dataset.clientDatasetId ?? dataset.id}
                     >
-                      {dataset.clientDatasetId ?? dataset.id}
+                      <div className="flex items-center gap-1">
+                        <span className="truncate">{dataset.clientDatasetId ?? dataset.id}</span>
+                        <CopyButton
+                          value={dataset.clientDatasetId ?? dataset.id}
+                          className="h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
+                          title="Copy dataset ID"
+                        />
+                      </div>
                     </Td>
                     <Td className="text-right tabular-nums text-muted-foreground">
                       {dataset.caseCount}

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,
@@ -133,7 +134,16 @@ function RunTableRow({
         >
           {r.datasetName}
         </Link>{" "}
-        {datasetVersion && <span className="font-mono text-[11px]">{datasetVersion}</span>}
+        {datasetVersion && (
+          <span className="inline-flex items-center gap-0.5 font-mono text-[11px]">
+            <span>{datasetVersion}</span>
+            <CopyButton
+              value={datasetVersion}
+              className="h-5 w-5 text-muted-foreground hover:text-foreground"
+              title="Copy version ID"
+            />
+          </span>
+        )}
       </Td>
       <Td className="text-right tabular-nums text-muted-foreground">{formatCost(r.cost)}</Td>
       <Td className="text-right tabular-nums text-muted-foreground">{formatCost(avgCost)}</Td>

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import Link from "next/link";
 import { Loader2, Plus, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Input } from "@/components/ui/input";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
@@ -372,8 +373,17 @@ function PendingTracePanel({
         <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-hidden />
         <p className="text-[13px] font-medium">Trace is still being ingested</p>
         <p className="max-w-[360px] leading-relaxed text-muted-foreground">
-          This result reported a trace (<span className="font-mono">{traceId.slice(0, 12)}…</span>),
-          but its telemetry hasn&apos;t finished ingesting yet. It will appear here once it lands.
+          This result reported a trace (
+          <span className="inline-flex items-center gap-1 font-mono">
+            <span>{traceId.slice(0, 12)}…</span>
+            <CopyButton
+              value={traceId}
+              className="h-4 w-4 text-muted-foreground hover:text-foreground"
+              title="Copy trace ID"
+            />
+          </span>
+          ), but its telemetry hasn&apos;t finished ingesting yet. It will appear here once it
+          lands.
         </p>
         <Button
           size="sm"

--- a/frontend/ui/src/features/traces/components/SessionDetailPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SessionDetailPanel.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { X, ArrowUp, ArrowDown, ExternalLink, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { LoadingState } from "@/components/ui/loading-state";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
@@ -52,6 +53,11 @@ function TraceCard({
             </span>
             <ExternalLink className="ml-1 inline h-3 w-3 text-muted-foreground" />
           </Link>
+          <CopyButton
+            value={trace.trace_id}
+            className="h-5 w-5 text-muted-foreground hover:text-foreground"
+            title="Copy trace ID"
+          />
         </div>
       </div>
 
@@ -151,6 +157,11 @@ export function SessionDetailPanel({
           <DOMAIN_ICONS.session className="h-4 w-4 text-muted-foreground" />
           <span className="text-sm font-medium">Session</span>
           <span className="truncate font-mono text-xs text-muted-foreground">{sessionId}</span>
+          <CopyButton
+            value={sessionId}
+            className="h-6 w-6 text-muted-foreground hover:text-foreground"
+            title="Copy session ID"
+          />
         </div>
         <div className="flex items-center gap-1">
           <Button

--- a/frontend/ui/src/features/traces/components/TraceListTable.tsx
+++ b/frontend/ui/src/features/traces/components/TraceListTable.tsx
@@ -12,6 +12,7 @@ import {
   formatExactTokens,
   cn,
 } from "@/lib/utils";
+import { CopyButton } from "@/components/ui/copy-button";
 import { formatContentPreview } from "../utils";
 import { traceMetadataEntries } from "../utils/metadata";
 import { TraceMetadataCell } from "./TraceMetadataCell";
@@ -177,9 +178,16 @@ const FIXED_CELLS: Record<FixedColumnId, (props: FixedCellProps) => ReactElement
         "px-3 py-1.5 font-mono text-[11px] text-muted-foreground",
       )}
     >
-      <span className="block truncate" title={trace.trace_id}>
-        {trace.trace_id}
-      </span>
+      <div className="flex items-center gap-1">
+        <span className="block truncate" title={trace.trace_id}>
+          {trace.trace_id}
+        </span>
+        <CopyButton
+          value={trace.trace_id}
+          className="h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
+          title="Copy trace ID"
+        />
+      </div>
     </td>
   ),
   errors: ({ trace, borderClassName }) => (

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -366,13 +366,11 @@ export function TraceViewerPanel({
             {/* Copy affordance for the header id. Only offered when an identity is
                 supplied (offline-eval's test case); the standard trace header is
                 unchanged. */}
-            {headerIdentity && (
-              <CopyButton
-                value={headerIdentity.value}
-                className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
-                title={`Copy ${headerIdentity.label.toLowerCase()} id`}
-              />
-            )}
+            <CopyButton
+              value={headerIdentity?.value ?? traceId}
+              className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+              title={`Copy ${headerIdentity?.label?.toLowerCase() ?? "trace"} id`}
+            />
           </div>
           <div className="flex items-center gap-1">
             {headerStatus}

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -363,9 +363,9 @@ export function TraceViewerPanel({
             <span className="truncate font-mono text-xs text-muted-foreground">
               {headerIdentity?.value ?? traceId}
             </span>
-            {/* Copy affordance for the header id. Only offered when an identity is
-                supplied (offline-eval's test case); the standard trace header is
-                unchanged. */}
+            {/* Copy affordance for the header id, always offered: the trace id is
+                as worth copying as offline-eval's test case id, and the label
+                follows whichever identity the header is showing. */}
             <CopyButton
               value={headerIdentity?.value ?? traceId}
               className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"


### PR DESCRIPTION
### Summary
Standardizes copy affordances across the app using the canonical `<CopyButton />` component, adds copy buttons/chips for missing key identifiers (Dataset ID, Dataset Version ID, Trace ID, Session ID), and removes all remaining hand-rolled copy implementations.

Closes #1948

### Changes
- `components/ui/copy-button.tsx`: Add `e.stopPropagation()` and safe optional chaining on `navigator.clipboard`.
- `features/evaluations/views/datasets-view.tsx`: Add `CopyButton` to Dataset ID column.
- `features/evaluations/views/dataset-detail-view.tsx`: Add copyable Dataset ID chip in toolbar and `CopyButton` beside Version selector.
- `features/evaluations/views/evaluations-view.tsx`: Add `CopyButton` beside dataset version snowflake in run rows.
- `features/evaluations/views/run-detail-view.tsx`: Add `CopyButton` for trace ID in `PendingTracePanel`.
- `features/traces/components/TraceListTable.tsx` & `TraceViewerPanel.tsx`: Add `CopyButton` to trace ID cell and trace header.
- `features/traces/components/SessionDetailPanel.tsx`: Add `CopyButton` to Session ID header and Trace ID cards.
- `features/detectors/components/detector-panel.tsx` & `components/ui/json-view.tsx`: Replace hand-rolled `useState(copied)` with `<CopyButton />`.
- Added unit tests across `dataset-panels.smoke.test.tsx`, `datasets-detail.smoke.test.tsx`, and `evaluations.smoke.test.tsx`.

### Validation
- 60 test files and 550 tests passed (100%).
- ESLint passed with 0 errors.


before 
<img width="3023" height="1650" alt="Image" src="https://github.com/user-attachments/assets/1cc7390e-d323-4a1c-b47a-962bc00ed2dd" />


after

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/dde0a54c-44d3-402e-807a-3dd29a5b8c13" />

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/23dc409d-6bac-45a3-855c-808693f105f5" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes key identifiers copyable and selectable app-wide by standardizing on `CopyButton`. Copy clicks now stop propagation so they never trigger row or header navigation, and clipboard failures surface an error icon instead of false success feedback.

- Adds `CopyButton` for Dataset ID and Version ID, Trace ID, Session ID, and Run ID/Trace ID in the detector runs table.
- Replaces hand-rolled copy logic in `json-view` and the detector panel with `CopyButton`.
- `CopyButton` shows copied/failed status, ignores stale async results, and clears its reset timer on unmount.
- Adds tests that stub the Clipboard API, verify the full id is copied, and confirm copy clicks don't navigate.

<sup>Written for commit a985ff7f8e35a0ceebc5343f4dceeb8675694da7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

