### PR TITLE
fix(ui): standardize pagination across main lists (#1950)

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -324,8 +324,8 @@ export default function DetectorsPage() {
 
         {meta && (
           <ListPagination
-            page={meta.page}
-            limit={meta.limit}
+            page={state.page}
+            limit={state.limit}
             total={meta.total}
             onPageChange={goToPage}
             onLimitChange={updateLimit}

--- a/frontend/ui/src/components/list-pagination.test.tsx
+++ b/frontend/ui/src/components/list-pagination.test.tsx
@@ -129,4 +129,75 @@ describe("ListPagination", () => {
     );
     expect(screen.getByText("Showing 101–124 of 124")).toBeDefined();
   });
+
+  it("navigates using first, prev, next, and last page buttons", () => {
+    const onPageChange = vi.fn();
+    const { container } = render(
+      <ListPagination
+        page={2}
+        limit={50}
+        total={500} // 10 pages: 0-9
+        onPageChange={onPageChange}
+        onLimitChange={vi.fn()}
+      />,
+    );
+
+    // Prev button
+    fireEvent.click(screen.getByRole("button", { name: /previous page/i }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+
+    // Next button
+    fireEvent.click(screen.getByRole("button", { name: /next page/i }));
+    expect(onPageChange).toHaveBeenCalledWith(3);
+
+    // First and last buttons (the small icon buttons without aria-label)
+    const buttons = container.querySelectorAll("button");
+    // Button order in the button group: [First, Prev, Next, Last]
+    // The first one in the group (disabled when page 0):
+    const navButtons = Array.from(buttons).filter(
+      (b) => b.classList.contains("h-7") && b.classList.contains("w-7"),
+    );
+    // navButtons: [first, prev, next, last]
+    fireEvent.click(navButtons[0]);
+    expect(onPageChange).toHaveBeenCalledWith(0);
+
+    fireEvent.click(navButtons[3]);
+    expect(onPageChange).toHaveBeenCalledWith(9);
+  });
+
+  it("allows selecting a limit from the items-per-page popover", () => {
+    const onLimitChange = vi.fn();
+    render(
+      <ListPagination
+        page={0}
+        limit={50}
+        total={500}
+        onPageChange={vi.fn()}
+        onLimitChange={onLimitChange}
+      />,
+    );
+
+    // Click limit button to open popover
+    fireEvent.click(screen.getByRole("button", { name: "50" }));
+    // Click option "100"
+    fireEvent.click(screen.getByRole("button", { name: "100" }));
+    expect(onLimitChange).toHaveBeenCalledWith(100);
+  });
+
+  it("blurs input on Enter key", () => {
+    render(
+      <ListPagination
+        page={0}
+        limit={50}
+        total={500}
+        onPageChange={vi.fn()}
+        onLimitChange={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    const blurSpy = vi.spyOn(input, "blur");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(blurSpy).toHaveBeenCalled();
+  });
 });

--- a/frontend/ui/src/components/list-pagination.test.tsx
+++ b/frontend/ui/src/components/list-pagination.test.tsx
@@ -116,4 +116,17 @@ describe("ListPagination", () => {
     fireEvent.mouseEnter(screen.getByRole("button", { name: /next page/i }));
     expect(onPrefetchPage).not.toHaveBeenCalled();
   });
+
+  it("renders the Showing X–Y of N readout", () => {
+    render(
+      <ListPagination
+        page={2}
+        limit={50}
+        total={124}
+        onPageChange={vi.fn()}
+        onLimitChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Showing 101–124 of 124")).toBeDefined();
+  });
 });

--- a/frontend/ui/src/components/list-pagination.tsx
+++ b/frontend/ui/src/components/list-pagination.tsx
@@ -71,103 +71,111 @@ export function ListPagination({
     onPrefetchPage(target);
   };
 
+  const from = total > 0 ? page * safeLimit + 1 : 0;
+  const to = Math.min((page + 1) * safeLimit, total);
+
   return (
-    <div className="flex flex-wrap items-center justify-end gap-x-6 gap-y-2 border-t border-border bg-background px-4 py-2.5">
-      <div className="flex items-center gap-2">
-        <span className="text-[12px] text-muted-foreground">Items per page</span>
-        <Popover open={itemsPerPageOpen} onOpenChange={setItemsPerPageOpen}>
-          <PopoverTrigger asChild>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 min-w-[60px] justify-between px-2 text-[12px]"
-            >
-              <span>{limit}</span>
-              <ChevronDown className="ml-1 h-3 w-3 text-muted-foreground" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent side="top" align="start" className="w-[80px] p-1">
-            {itemsPerPageOptions.map((value) => (
-              <button
-                key={value}
-                className={cn(
-                  "w-full rounded-md px-2.5 py-1.5 text-left text-[12px] transition-colors",
-                  limit === value ? "bg-muted" : "hover:bg-muted/50",
-                )}
-                onClick={() => {
-                  onLimitChange(value);
-                  setItemsPerPageOpen(false);
-                }}
+    <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 border-t border-border bg-background px-4 py-2.5">
+      <div className="text-[12px] text-muted-foreground">
+        Showing {from}–{to} of {total}
+      </div>
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+        <div className="flex items-center gap-2">
+          <span className="text-[12px] text-muted-foreground">Items per page</span>
+          <Popover open={itemsPerPageOpen} onOpenChange={setItemsPerPageOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 min-w-[60px] justify-between px-2 text-[12px]"
               >
-                {value}
-              </button>
-            ))}
-          </PopoverContent>
-        </Popover>
-      </div>
-      <div className="flex items-center gap-2">
-        <span className="text-[12px] text-muted-foreground">Page</span>
-        <input
-          type="number"
-          min={1}
-          max={totalPages}
-          value={pageState}
-          onChange={(e) => setPageState(e.target.value)}
-          onBlur={handlePageInputChange}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.currentTarget.blur();
-            }
-          }}
-          className="h-7 w-12 rounded border border-border bg-background px-2 py-1 text-center text-[12px] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-        />
-        <span className="text-[12px] text-muted-foreground">of {totalPages}</span>
-      </div>
-      <div className="flex items-center gap-0.5">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => onPageChange(0)}
-          disabled={page === 0}
-          className="h-7 w-7 p-0"
-        >
-          <ChevronLeft className="h-3.5 w-3.5" />
-          <ChevronLeft className="-ml-2 h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          aria-label="Previous page"
-          onClick={() => onPageChange(Math.max(0, page - 1))}
-          onMouseEnter={() => prefetchPage(page - 1)}
-          onFocus={() => prefetchPage(page - 1)}
-          disabled={page === 0}
-          className="h-7 w-7 p-0"
-        >
-          <ChevronLeft className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          aria-label="Next page"
-          onClick={() => onPageChange(page + 1)}
-          onMouseEnter={() => prefetchPage(page + 1)}
-          onFocus={() => prefetchPage(page + 1)}
-          disabled={page >= totalPages - 1}
-          className="h-7 w-7 p-0"
-        >
-          <ChevronRight className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => onPageChange(totalPages - 1)}
-          disabled={page >= totalPages - 1}
-          className="h-7 w-7 p-0"
-        >
-          <ChevronRight className="h-3.5 w-3.5" />
-          <ChevronRight className="-ml-2 h-3.5 w-3.5" />
-        </Button>
+                <span>{limit}</span>
+                <ChevronDown className="ml-1 h-3 w-3 text-muted-foreground" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent side="top" align="start" className="w-[80px] p-1">
+              {itemsPerPageOptions.map((value) => (
+                <button
+                  key={value}
+                  className={cn(
+                    "w-full rounded-md px-2.5 py-1.5 text-left text-[12px] transition-colors",
+                    limit === value ? "bg-muted" : "hover:bg-muted/50",
+                  )}
+                  onClick={() => {
+                    onLimitChange(value);
+                    setItemsPerPageOpen(false);
+                  }}
+                >
+                  {value}
+                </button>
+              ))}
+            </PopoverContent>
+          </Popover>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-[12px] text-muted-foreground">Page</span>
+          <input
+            type="number"
+            min={1}
+            max={totalPages}
+            value={pageState}
+            onChange={(e) => setPageState(e.target.value)}
+            onBlur={handlePageInputChange}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.currentTarget.blur();
+              }
+            }}
+            className="h-7 w-12 rounded border border-border bg-background px-2 py-1 text-center text-[12px] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          />
+          <span className="text-[12px] text-muted-foreground">of {totalPages}</span>
+        </div>
+        <div className="flex items-center gap-0.5">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(0)}
+            disabled={page === 0}
+            className="h-7 w-7 p-0"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+            <ChevronLeft className="-ml-2 h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            aria-label="Previous page"
+            onClick={() => onPageChange(Math.max(0, page - 1))}
+            onMouseEnter={() => prefetchPage(page - 1)}
+            onFocus={() => prefetchPage(page - 1)}
+            disabled={page === 0}
+            className="h-7 w-7 p-0"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            aria-label="Next page"
+            onClick={() => onPageChange(page + 1)}
+            onMouseEnter={() => prefetchPage(page + 1)}
+            onFocus={() => prefetchPage(page + 1)}
+            disabled={page >= totalPages - 1}
+            className="h-7 w-7 p-0"
+          >
+            <ChevronRight className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(totalPages - 1)}
+            disabled={page >= totalPages - 1}
+            className="h-7 w-7 p-0"
+          >
+            <ChevronRight className="h-3.5 w-3.5" />
+            <ChevronRight className="-ml-2 h-3.5 w-3.5" />
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/ui/src/features/evaluations/dataset-panels.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/dataset-panels.smoke.test.tsx
@@ -12,10 +12,11 @@ import { ToastProvider } from "@/components/ui/toast";
 
 const mockPush = vi.fn();
 
+const searchParams = new URLSearchParams();
 vi.mock("next/navigation", () => ({
   useParams: () => ({ projectId: "p1" }),
   useRouter: () => ({ push: mockPush, replace: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => searchParams,
   usePathname: () => "/projects/p1/datasets",
 }));
 vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));

--- a/frontend/ui/src/features/evaluations/evaluations-pagination.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations-pagination.smoke.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 /**
  * View-mount smoke for the Evaluations list's page clamp. The clamp pulls a page
- * back inside a result set that has shrunk; this covers it pulling back a page that
- * is actually valid, because `placeholderData` still holds the previous query's
- * `total`. Driven through the real view (URL in, request + URL rewrite out), since
- * the bug only exists in the interplay between the query cache, the hook, and the
- * view's effect.
+ * back inside a result set that has shrunk; these cover the two ways it can pull
+ * back a page that is actually valid — a stale placeholder `total`, and a
+ * `page_limit` the API caps below what the URL asked for. Both are driven through
+ * the real view (URL in, request + URL rewrite out), since the bug only exists in
+ * the interplay between the query cache, the hook, and the view's effect.
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, cleanup, screen, waitFor } from "@testing-library/react";
@@ -129,5 +129,40 @@ describe("Evaluations list page clamp", () => {
     // at some earlier page.
     expect(rewrittenPages()).toEqual([]);
     expect(new Set(requestedPages)).toEqual(new Set(["3"]));
+  });
+
+  it("sizes the last page by the limit the API serves, not a larger requested one", async () => {
+    // The list routes cap `limit` at 200 and echo the capped value, so ?page_limit=500
+    // is served as 200 -> 1000 runs is pages 0-4 and page 3 has rows. Sizing by the
+    // requested 500 would make page 1 the last page and bounce a valid deep link.
+    currentParams = new URLSearchParams({ page_limit: "500", page_index: "3" });
+    const requestedLimits: (string | null)[] = [];
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      const s = String(url);
+      const params = new URL(s, "http://x").searchParams;
+      if (isRuns(s)) requestedLimits.push(params.get("limit"));
+      const requested = Number(params.get("limit") ?? 50);
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          isRuns(s)
+            ? {
+                data: [row(1)],
+                // Mirrors runs/route.ts: the served limit is the capped one.
+                meta: { page: 3, limit: Math.min(Math.max(requested, 1), 200), total: 1000 },
+              }
+            : {},
+      };
+    }) as unknown as typeof fetch;
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(view(qc));
+    await screen.findByText("git:c1");
+
+    // The request asks for the page size the server will actually serve...
+    expect(new Set(requestedLimits)).toEqual(new Set(["200"]));
+    // ...and page 3 stands rather than being rewritten to 1.
+    expect(rewrittenPages()).toEqual([]);
   });
 });

--- a/frontend/ui/src/features/evaluations/evaluations-pagination.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations-pagination.smoke.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+/**
+ * View-mount smoke for the Evaluations list's page clamp. The clamp pulls a page
+ * back inside a result set that has shrunk; this covers it pulling back a page that
+ * is actually valid, because `placeholderData` still holds the previous query's
+ * `total`. Driven through the real view (URL in, request + URL rewrite out), since
+ * the bug only exists in the interplay between the query cache, the hook, and the
+ * view's effect.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@/components/ui/toast";
+
+let currentParams = new URLSearchParams();
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1" }),
+  useRouter: () => ({ push: vi.fn(), replace }),
+  useSearchParams: () => currentParams,
+  usePathname: () => "/projects/p1/evaluations",
+}));
+// ProjectBreadcrumb pulls layout/workspace context this harness doesn't mount.
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+
+import { EvaluationsView } from "./views/evaluations-view";
+
+/** A list row with the counts the real route emits unconditionally. */
+const row = (n: number) => ({
+  id: `run${n}`,
+  evaluationId: "eval1",
+  datasetId: "ds1",
+  datasetVersionId: "dv1",
+  runNumber: n,
+  candidateVersion: `git:c${n}`,
+  environment: "ci",
+  status: "completed",
+  baselineRunId: null,
+  caseCount: 1,
+  scoredCount: 1,
+  taskErrorCount: 0,
+  scorerErrorCount: 0,
+  passedCount: 1,
+  failedCount: 0,
+  erroredCount: 0,
+  notScoredCount: 0,
+  cost: 0.1,
+  scorers: [],
+  startedAt: "2026-07-17T10:24:00Z",
+  completedAt: "2026-07-17T10:30:00Z",
+  evaluationName: "Billing routing",
+  datasetName: "Billing routing",
+  datasetVersionLabel: "v1",
+  changeFromBaseline: null,
+  errorCount: 0,
+  baselineComparable: true,
+  elapsedMs: 1000,
+  passRate: 1,
+  excludedSummary: null,
+  comparison: null,
+  metadata: null,
+});
+
+const isRuns = (url: string) => url.includes("/evaluations/runs");
+/** The `page_index` each URL rewrite settled on, in order. */
+const rewrittenPages = () =>
+  replace.mock.calls.map((c) => new URL(String(c[0]), "http://x").searchParams.get("page_index"));
+
+function view(qc: QueryClient) {
+  return (
+    <QueryClientProvider client={qc}>
+      <ToastProvider>
+        <EvaluationsView projectId="p1" />
+      </ToastProvider>
+    </QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  replace.mockClear();
+});
+
+describe("Evaluations list page clamp", () => {
+  it("does not clamp against the previous query's total while the next one is in flight", async () => {
+    // Settled on a narrow window: 5 runs, so page 0 is the only page.
+    currentParams = new URLSearchParams({ date_filter: "1h" });
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => ({
+      ok: true,
+      status: 200,
+      json: async () =>
+        isRuns(String(url)) ? { data: [row(1)], meta: { page: 0, limit: 50, total: 5 } } : {},
+    })) as unknown as typeof fetch;
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { rerender } = render(view(qc));
+    await screen.findByText("git:c1");
+    replace.mockClear();
+
+    // A deep link widens the window (1000 runs -> pages 0-19, so page 3 has rows) and
+    // asks for page 3. Hold the response so the placeholder window is observable:
+    // `placeholderData` serves the 5-run `meta` throughout it.
+    let release: (v: unknown) => void = () => {};
+    const held = new Promise((r) => (release = r));
+    const requestedPages: (string | null)[] = [];
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      const s = String(url);
+      if (isRuns(s)) {
+        requestedPages.push(new URL(s, "http://x").searchParams.get("page"));
+        await held;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          isRuns(s) ? { data: [row(2)], meta: { page: 3, limit: 50, total: 1000 } } : {},
+      };
+    }) as unknown as typeof fetch;
+
+    currentParams = new URLSearchParams({ date_filter: "30d", page_index: "3" });
+    rerender(view(qc));
+
+    // In flight: the stale 5-run total must not size the incoming page.
+    await waitFor(() => expect(requestedPages).toContain("3"));
+    expect(rewrittenPages()).toEqual([]);
+
+    release(null);
+    await screen.findByText("git:c2");
+    // Settled: page 3 is inside 1000 runs, so it still stands and was never re-fetched
+    // at some earlier page.
+    expect(rewrittenPages()).toEqual([]);
+    expect(new Set(requestedPages)).toEqual(new Set(["3"]));
+  });
+});

--- a/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
@@ -11,10 +11,11 @@ import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/re
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastProvider } from "@/components/ui/toast";
 
+const searchParams = new URLSearchParams();
 vi.mock("next/navigation", () => ({
   useParams: () => ({ projectId: "p1", datasetId: "ds1", runId: "run1" }),
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => searchParams,
   usePathname: () => "/projects/p1/evaluations",
 }));
 // ProjectBreadcrumb pulls layout/workspace context we don't mount here.
@@ -307,6 +308,12 @@ describe("real Datasets + Evaluations views render server data", () => {
     mount(<EvaluationsView projectId="p1" />);
     expect(await screen.findByText(/No evaluation runs yet/)).toBeDefined();
     expect(screen.queryByRole("button", { name: /Run evaluation/ })).toBeNull();
+  });
+
+  it("Evaluations list renders standard ListPagination when runs are present", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    expect(await screen.findByText("Items per page")).toBeDefined();
+    expect(screen.getByText("of 1")).toBeDefined();
   });
 
   it("run-centric table shows both runs by run number + candidate version", async () => {

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -5,8 +5,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ListPagination } from "@/components/list-pagination";
-import { useUrlPagination } from "@/lib/hooks/use-url-pagination";
-import { useKeywordSearch } from "@/lib/hooks/use-keyword-search";
+import { useListPageState } from "@/lib/hooks/use-list-page-state";
 import { useToast } from "@/components/ui/toast";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { DatasetActionsMenu, Timestamp } from "@/features/offline-eval/components";
@@ -25,17 +24,14 @@ export function DatasetsView({ projectId }: { projectId: string }) {
   const router = useRouter();
   const { toast } = useToast();
 
-  const { page, limit, goToPage, setLimit, resetPage } = useUrlPagination(50);
-  // Reset to page 0 whenever the (debounced) search changes, so a match on page 0 isn't
-  // hidden behind a stale page carried over from before the search — matching the
-  // traces list. `searchQuery` is the debounced value the API should use.
-  const { keyword, setKeyword, searchQuery } = useKeywordSearch(resetPage);
+  const { page, limit, goToPage, updateLimit, keyword, updateKeyword, queryOptions } =
+    useListPageState({ defaultLimit: 50 });
   const [newOpen, setNewOpen] = React.useState(false);
   const [editing, setEditing] = React.useState<DatasetRow | null>(null);
   const [deleteTarget, setDeleteTarget] = React.useState<DatasetRow | null>(null);
 
   const { data, isLoading, error, refetch } = useDatasets(projectId, {
-    search_query: searchQuery,
+    search_query: queryOptions.search_query,
     page,
     limit,
   });
@@ -83,7 +79,7 @@ export function DatasetsView({ projectId }: { projectId: string }) {
           falsely read as an applied constraint. */}
       <SearchFilterBar
         searchValue={keyword}
-        onSearchChange={setKeyword}
+        onSearchChange={updateKeyword}
         searchPlaceholder="Search..."
       >
         <span className="flex-1" aria-hidden />
@@ -170,7 +166,7 @@ export function DatasetsView({ projectId }: { projectId: string }) {
           limit={meta.limit}
           total={meta.total}
           onPageChange={goToPage}
-          onLimitChange={setLimit}
+          onLimitChange={updateLimit}
         />
       )}
 

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -24,8 +24,8 @@ export function DatasetsView({ projectId }: { projectId: string }) {
   const router = useRouter();
   const { toast } = useToast();
 
-  const { page, limit, goToPage, updateLimit, keyword, updateKeyword, queryOptions } =
-    useListPageState({ defaultLimit: 50 });
+  const { page, limit, goToPage, updateLimit, keyword, updateKeyword, queryOptions, resetPageState } =
+  useListPageState({ defaultLimit: 50 });
   const [newOpen, setNewOpen] = React.useState(false);
   const [editing, setEditing] = React.useState<DatasetRow | null>(null);
   const [deleteTarget, setDeleteTarget] = React.useState<DatasetRow | null>(null);
@@ -57,7 +57,8 @@ export function DatasetsView({ projectId }: { projectId: string }) {
       onSuccess: () => {
         toast({ title: `Deleted ${dataset.name}`, tone: "success" });
         setDeleteTarget(null);
-      },
+        resetPageState();
+},
       onError: (e) => toast({ title: "Could not delete", description: String(e), tone: "warning" }),
     });
   };
@@ -162,8 +163,8 @@ export function DatasetsView({ projectId }: { projectId: string }) {
 
       {meta && meta.total > 0 && (
         <ListPagination
-          page={meta.page}
-          limit={meta.limit}
+          page={page}
+          limit={limit}
           total={meta.total}
           onPageChange={goToPage}
           onLimitChange={updateLimit}

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -24,8 +24,16 @@ export function DatasetsView({ projectId }: { projectId: string }) {
   const router = useRouter();
   const { toast } = useToast();
 
-  const { page, limit, goToPage, updateLimit, keyword, updateKeyword, queryOptions, resetPageState } =
-  useListPageState({ defaultLimit: 50 });
+  const {
+    page,
+    limit,
+    goToPage,
+    updateLimit,
+    keyword,
+    updateKeyword,
+    queryOptions,
+    resetPageState,
+  } = useListPageState({ defaultLimit: 50 });
   const [newOpen, setNewOpen] = React.useState(false);
   const [editing, setEditing] = React.useState<DatasetRow | null>(null);
   const [deleteTarget, setDeleteTarget] = React.useState<DatasetRow | null>(null);
@@ -58,7 +66,7 @@ export function DatasetsView({ projectId }: { projectId: string }) {
         toast({ title: `Deleted ${dataset.name}`, tone: "success" });
         setDeleteTarget(null);
         resetPageState();
-},
+      },
       onError: (e) => toast({ title: "Could not delete", description: String(e), tone: "warning" }),
     });
   };

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -5,7 +5,8 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ListPagination } from "@/components/list-pagination";
-import { useListPageState } from "@/lib/hooks/use-list-page-state";
+import { useUrlPagination } from "@/lib/hooks/use-url-pagination";
+import { useKeywordSearch } from "@/lib/hooks/use-keyword-search";
 import { useToast } from "@/components/ui/toast";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { DatasetActionsMenu, Timestamp } from "@/features/offline-eval/components";
@@ -28,23 +29,29 @@ export function DatasetsView({ projectId }: { projectId: string }) {
     page,
     limit,
     goToPage,
-    updateLimit,
-    keyword,
-    updateKeyword,
-    queryOptions,
-    resetPageState,
-  } = useListPageState({ defaultLimit: 50 });
+    setLimit: updateLimit,
+    resetPage,
+    clampToTotal,
+  } = useUrlPagination(50);
+  const { keyword, setKeyword: updateKeyword, searchQuery } = useKeywordSearch(resetPage);
   const [newOpen, setNewOpen] = React.useState(false);
   const [editing, setEditing] = React.useState<DatasetRow | null>(null);
   const [deleteTarget, setDeleteTarget] = React.useState<DatasetRow | null>(null);
 
-  const { data, isLoading, error, refetch } = useDatasets(projectId, {
-    search_query: queryOptions.search_query,
+  const { data, isLoading, error, refetch, isPlaceholderData } = useDatasets(projectId, {
+    search_query: searchQuery,
     page,
     limit,
   });
   const datasets = React.useMemo(() => data?.data ?? [], [data]);
   const meta = data?.meta;
+  const total = meta?.total ?? datasets.length;
+
+  React.useEffect(() => {
+    if (isPlaceholderData) return;
+    clampToTotal(total);
+  }, [clampToTotal, total, isPlaceholderData]);
+
   const del = useDeleteDataset(projectId);
 
   // Evaluations-per-dataset comes from the lineage list (one row per evaluation
@@ -65,7 +72,7 @@ export function DatasetsView({ projectId }: { projectId: string }) {
       onSuccess: () => {
         toast({ title: `Deleted ${dataset.name}`, tone: "success" });
         setDeleteTarget(null);
-        resetPageState();
+        resetPage();
       },
       onError: (e) => toast({ title: "Could not delete", description: String(e), tone: "warning" }),
     });

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -3,9 +3,10 @@
 import * as React from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,
@@ -16,8 +17,8 @@ import {
 import { useToast } from "@/components/ui/toast";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { DateFilterSelect } from "@/components/date-filter-select";
-import { DATE_FILTER_OPTIONS, toTimestampBounds, type DateFilterOption } from "@/lib/date-filter";
-import { useKeywordSearch } from "@/lib/hooks/use-keyword-search";
+import { ListPagination } from "@/components/list-pagination";
+import { useListPageState } from "@/lib/hooks/use-list-page-state";
 import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
 import { DatasetActionsMenu, EmptyState, Timestamp } from "@/features/offline-eval/components";
 import { ProjectBreadcrumb } from "@/features/projects/components";
@@ -44,9 +45,6 @@ export function RunStatusBadge({ status }: { status: EvalRunStatus }) {
 }
 
 const RUNS_COLUMN_COUNT = 10;
-// Matches the route's default `limit` (runs/route.ts) so the page-count math lines
-// up with what the server actually returns per page.
-const RUNS_PAGE_LIMIT = 50;
 
 /** Human elapsed duration; "—" when unknown (never 0). */
 export function formatElapsed(ms: number | null | undefined): string {
@@ -68,10 +66,14 @@ export function formatCost(cost: number | null | undefined): React.ReactNode {
 export function EvaluationsView({ projectId }: { projectId: string }) {
   return (
     <div className="flex h-full flex-col text-[13px]">
-      {/* Populates the app's top breadcrumb bar (workspace / project). Without a
+      {/* Top breadcrumb bar */}
+      {/* ProjectBreadcrumb mounts into the app header (#project-breadcrumb-portal).
+          Must render unconditionally: if unmounted on an empty state or while a
           mounted ProjectBreadcrumb the header goes blank on this route. */}
       <ProjectBreadcrumb projectId={projectId} current="Evaluations" />
-      <RunsTab projectId={projectId} />
+      <div className="flex min-h-0 flex-1 flex-col">
+        <RunsTab projectId={projectId} />
+      </div>
     </div>
   );
 }
@@ -133,7 +135,16 @@ function RunTableRow({
         >
           {r.datasetName}
         </Link>{" "}
-        {datasetVersion && <span className="font-mono text-[11px]">{datasetVersion}</span>}
+        {datasetVersion && (
+          <span className="inline-flex items-center gap-0.5 font-mono text-[11px]">
+            <span>{datasetVersion}</span>
+            <CopyButton
+              value={datasetVersion}
+              className="h-5 w-5 text-muted-foreground hover:text-foreground"
+              title="Copy version ID"
+            />
+          </span>
+        )}
       </Td>
       <Td className="text-right tabular-nums text-muted-foreground">{formatCost(r.cost)}</Td>
       <Td className="text-right tabular-nums text-muted-foreground">{formatCost(avgCost)}</Td>
@@ -158,48 +169,38 @@ function RunsTab({ projectId }: { projectId: string }) {
   // Row selection for bulk actions (compare / delete).
   const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
   const [bulkDeleteOpen, setBulkDeleteOpen] = React.useState(false);
-  const { keyword, setKeyword, searchQuery } = useKeywordSearch();
-  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
-    DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0],
-  );
-  const [customStart, setCustomStart] = React.useState<Date | null>(null);
-  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
-  const [page, setPage] = React.useState(0);
-  // A narrower filter/date-range can otherwise land on a page past the end of its
-  // (now shorter) result set, so reset to the first page whenever ANY server query
-  // input changes — the search text OR the date window.
-  React.useEffect(() => {
-    setPage(0);
-  }, [searchQuery, dateFilter.id, customStart, customEnd]);
 
-  // Resolve the selected range to actual bounds. Memoized on the filter/custom-range
-  // inputs: `toTimestampBounds` reads `new Date()` for preset windows, so recomputing
-  // every render would churn the query key and refetch forever.
-  const { startAfter, endBefore } = React.useMemo(
-    () => toTimestampBounds(dateFilter.id, customStart ?? undefined, customEnd ?? undefined),
-    [dateFilter.id, customStart, customEnd],
-  );
-  const { data, isLoading, error } = useEvaluationRuns(projectId, {
-    search_query: searchQuery,
-    started_after: startAfter,
-    started_before: endBefore,
+  const {
     page,
-    limit: RUNS_PAGE_LIMIT,
+    limit,
+    goToPage,
+    updateLimit,
+    dateFilter,
+    customStartDate,
+    customEndDate,
+    updateDateFilter,
+    updateCustomRange,
+    keyword,
+    updateKeyword,
+    queryOptions,
+  } = useListPageState({
+    defaultLimit: 50,
+    defaultDateFilterId: "14d",
+  });
+
+  const { data, isLoading, error } = useEvaluationRuns(projectId, {
+    search_query: queryOptions.search_query,
+    started_after: queryOptions.start_after,
+    started_before: queryOptions.end_before,
+    page,
+    limit,
   });
   const runs = React.useMemo(() => data?.data ?? [], [data]);
+  const meta = data?.meta;
   // Keyed off the immediate `keyword`, not the debounced `searchQuery`, so the
   // empty-state copy doesn't flicker for the 300ms before the debounce catches up.
   const filtered = !!keyword;
-  const total = data?.meta?.total ?? runs.length;
-
-  // After a delete shrinks the result set, the current page can point past the new
-  // end (empty table + invalid "showing X–Y of N" range). Clamp back to the last
-  // page that still has rows.
-  React.useEffect(() => {
-    if (isLoading || total === 0) return;
-    const lastPage = Math.max(0, Math.ceil(total / RUNS_PAGE_LIMIT) - 1);
-    if (page > lastPage) setPage(lastPage);
-  }, [total, page, isLoading]);
+  const total = meta?.total ?? runs.length;
 
   const confirmDelete = () => {
     if (!deleteRun) return;
@@ -218,7 +219,7 @@ function RunsTab({ projectId }: { projectId: string }) {
   // ride along into a bulk delete of a different result set.
   React.useEffect(() => {
     setSelectedIds(new Set());
-  }, [page, searchQuery, dateFilter.id, customStart, customEnd]);
+  }, [page, limit, queryOptions.search_query, dateFilter.id, customStartDate, customEndDate]);
 
   const allSelected = runs.length > 0 && runs.every((r) => selectedIds.has(r.id));
   const toggleSelect = (id: string) =>
@@ -272,7 +273,7 @@ function RunsTab({ projectId }: { projectId: string }) {
     <>
       <SearchFilterBar
         searchValue={keyword}
-        onSearchChange={setKeyword}
+        onSearchChange={updateKeyword}
         searchPlaceholder="Search..."
       >
         {/* The bulk-Actions button and the date filter form one right-aligned group
@@ -311,13 +312,10 @@ function RunsTab({ projectId }: { projectId: string }) {
           )}
           <DateFilterSelect
             dateFilter={dateFilter}
-            customStartDate={customStart}
-            customEndDate={customEnd}
-            onDateFilterChange={setDateFilter}
-            onCustomRangeChange={(s, e) => {
-              setCustomStart(s);
-              setCustomEnd(e);
-            }}
+            customStartDate={customStartDate}
+            customEndDate={customEndDate}
+            onDateFilterChange={updateDateFilter}
+            onCustomRangeChange={updateCustomRange}
           />
         </div>
       </SearchFilterBar>
@@ -378,33 +376,14 @@ function RunsTab({ projectId }: { projectId: string }) {
         </Table>
       </div>
 
-      {!isLoading && !error && total > 0 && (
-        <div className="flex shrink-0 items-center justify-between border-t border-border px-3 py-1.5 text-[11px] text-muted-foreground">
-          <span>
-            Showing {page * RUNS_PAGE_LIMIT + 1}–{Math.min((page + 1) * RUNS_PAGE_LIMIT, total)} of{" "}
-            {total}
-          </span>
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={() => setPage((p) => Math.max(0, p - 1))}
-              disabled={page === 0}
-              aria-label="Previous page"
-              className="rounded p-1 hover:bg-muted disabled:pointer-events-none disabled:opacity-40"
-            >
-              <ChevronLeft className="h-3.5 w-3.5" />
-            </button>
-            <button
-              type="button"
-              onClick={() => setPage((p) => p + 1)}
-              disabled={(page + 1) * RUNS_PAGE_LIMIT >= total}
-              aria-label="Next page"
-              className="rounded p-1 hover:bg-muted disabled:pointer-events-none disabled:opacity-40"
-            >
-              <ChevronRight className="h-3.5 w-3.5" />
-            </button>
-          </div>
-        </div>
+      {meta && meta.total > 0 && (
+        <ListPagination
+          page={meta.page}
+          limit={meta.limit}
+          total={meta.total}
+          onPageChange={goToPage}
+          onLimitChange={updateLimit}
+        />
       )}
 
       {deleteRun && (

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -181,6 +181,7 @@ function RunsTab({ projectId }: { projectId: string }) {
     limit,
     goToPage,
     updateLimit,
+    clampToTotal,
     dateFilter,
     customStartDate,
     customEndDate,
@@ -207,6 +208,13 @@ function RunsTab({ projectId }: { projectId: string }) {
   // empty-state copy doesn't flicker for the 300ms before the debounce catches up.
   const filtered = !!keyword;
   const total = meta?.total ?? runs.length;
+
+  // Deleting the last page's rows (or a deep link past the end) leaves `page` beyond
+  // the shortened result set — an empty table showing the first-run onboarding copy
+  // for a project that still has runs. Pull it back to the last page that has rows.
+  React.useEffect(() => {
+    clampToTotal(total);
+  }, [clampToTotal, total]);
 
   const confirmDelete = () => {
     if (!deleteRun) return;

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -138,11 +138,17 @@ function RunTableRow({
         {datasetVersion && (
           <span className="inline-flex items-center gap-0.5 font-mono text-[11px]">
             <span>{datasetVersion}</span>
-            <CopyButton
-              value={datasetVersion}
-              className="h-5 w-5 text-muted-foreground hover:text-foreground"
-              title="Copy version ID"
-            />
+            {/* Copying must not also open the run detail (the row's own onClick).
+                Activating the button from the keyboard dispatches a click too, so
+                stopping the click covers both paths — TR already ignores keydown
+                from nested targets. */}
+            <span className="inline-flex" onClick={(e) => e.stopPropagation()}>
+              <CopyButton
+                value={datasetVersion}
+                className="h-5 w-5 text-muted-foreground hover:text-foreground"
+                title="Copy version ID"
+              />
+            </span>
           </span>
         )}
       </Td>

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -66,10 +66,9 @@ export function formatCost(cost: number | null | undefined): React.ReactNode {
 export function EvaluationsView({ projectId }: { projectId: string }) {
   return (
     <div className="flex h-full flex-col text-[13px]">
-      {/* Top breadcrumb bar */}
-      {/* ProjectBreadcrumb mounts into the app header (#project-breadcrumb-portal).
-          Must render unconditionally: if unmounted on an empty state or while a
-          mounted ProjectBreadcrumb the header goes blank on this route. */}
+      {/* Populates the app's top breadcrumb bar (workspace / project) through the
+          layout's `setHeaderContent`. Must render unconditionally — unmounting it
+          (e.g. behind an empty state) runs its cleanup and blanks the header. */}
       <ProjectBreadcrumb projectId={projectId} current="Evaluations" />
       <div className="flex min-h-0 flex-1 flex-col">
         <RunsTab projectId={projectId} />

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -378,8 +378,12 @@ function RunsTab({ projectId }: { projectId: string }) {
 
       {meta && meta.total > 0 && (
         <ListPagination
-          page={meta.page}
-          limit={meta.limit}
+          /* Client state, not the server echo: `placeholderData` keeps the previous
+             response's `meta` while a page/limit request is in flight, so `meta.page`
+             would render the old page and a second Next click would recompute
+             `page + 1` from it and re-request the page already on its way. */
+          page={page}
+          limit={limit}
           total={meta.total}
           onPageChange={goToPage}
           onLimitChange={updateLimit}

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -192,6 +192,7 @@ function RunsTab({ projectId }: { projectId: string }) {
   } = useListPageState({
     defaultLimit: 50,
     defaultDateFilterId: "14d",
+    syncStorage: false,
   });
 
   const { data, isLoading, error, isPlaceholderData } = useEvaluationRuns(projectId, {
@@ -203,9 +204,8 @@ function RunsTab({ projectId }: { projectId: string }) {
   });
   const runs = React.useMemo(() => data?.data ?? [], [data]);
   const meta = data?.meta;
-  // Keyed off the immediate `keyword`, not the debounced `searchQuery`, so the
-  // empty-state copy doesn't flicker for the 300ms before the debounce catches up.
-  const filtered = !!keyword;
+  // Considered filtered if keyword is entered or a non-default date range is active
+  const filtered = !!keyword || dateFilter.id !== "14d" || !!customStartDate || !!customEndDate;
   const total = meta?.total ?? runs.length;
 
   // Deleting the last page's rows (or a deep link past the end) leaves `page` beyond

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -194,7 +194,7 @@ function RunsTab({ projectId }: { projectId: string }) {
     defaultDateFilterId: "14d",
   });
 
-  const { data, isLoading, error } = useEvaluationRuns(projectId, {
+  const { data, isLoading, error, isPlaceholderData } = useEvaluationRuns(projectId, {
     search_query: queryOptions.search_query,
     started_after: queryOptions.start_after,
     started_before: queryOptions.end_before,
@@ -211,9 +211,14 @@ function RunsTab({ projectId }: { projectId: string }) {
   // Deleting the last page's rows (or a deep link past the end) leaves `page` beyond
   // the shortened result set — an empty table showing the first-run onboarding copy
   // for a project that still has runs. Pull it back to the last page that has rows.
+  // Only ever measured against a SETTLED response: `placeholderData` keeps the previous
+  // query's `meta` while the next one is in flight, so clamping then sizes the incoming
+  // page against the outgoing result set — which rewrites a valid deep-linked page (a
+  // filter change that widens the list) back to an earlier one before its data lands.
   React.useEffect(() => {
+    if (isPlaceholderData) return;
     clampToTotal(total);
-  }, [clampToTotal, total]);
+  }, [clampToTotal, total, isPlaceholderData]);
 
   const confirmDelete = () => {
     if (!deleteRun) return;

--- a/frontend/ui/src/lib/hooks/use-list-page-state.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-list-page-state.test.tsx
@@ -67,4 +67,48 @@ describe("useListPageState clampToTotal", () => {
     act(() => result.current.clampToTotal(0));
     expect(result.current.page).toBe(3);
   });
+
+  it("sizes the last page by the API's limit cap, not a larger requested page_limit", () => {
+    // The list routes cap `limit` at 200, so ?page_limit=500 is served as 200: 1000
+    // rows is pages 0-4 and page 3 has rows. Dividing the total by the requested 500
+    // would make page 1 the last page and bounce a deep link that is actually valid.
+    currentParams = new URLSearchParams({ page_limit: "500", page_index: "3" });
+    const { result } = renderHook(() => useListPageState());
+    expect(result.current.limit).toBe(200);
+    const writesBefore = replace.mock.calls.length;
+    act(() => result.current.clampToTotal(1000));
+    expect(result.current.page).toBe(3);
+    expect(replace.mock.calls.length).toBe(writesBefore);
+  });
+
+  it("still clamps a page past the end once the limit is capped", () => {
+    // The cap must not disable the clamp: 1000 rows at the served 200 ends at page 4.
+    currentParams = new URLSearchParams({ page_limit: "500", page_index: "9" });
+    const { result } = renderHook(() => useListPageState());
+    act(() => result.current.clampToTotal(1000));
+    expect(result.current.page).toBe(4);
+  });
+});
+
+describe("useUrlPagination limit cap", () => {
+  it("caps an over-large page_limit so the request matches what the API serves", () => {
+    currentParams = new URLSearchParams({ page_limit: "5000" });
+    const { result } = renderHook(() => useListPageState());
+    expect(result.current.limit).toBe(200);
+    expect(result.current.queryOptions.limit).toBe(200);
+  });
+
+  it("caps a programmatic updateLimit and writes the capped value to the URL", () => {
+    const { result } = renderHook(() => useListPageState());
+    act(() => result.current.updateLimit(1000));
+    expect(result.current.limit).toBe(200);
+    const url = new URL(replace.mock.calls.at(-1)![0] as string, "http://x");
+    expect(url.searchParams.get("page_limit")).toBe("200");
+  });
+
+  it("leaves a page_limit at or under the cap untouched", () => {
+    currentParams = new URLSearchParams({ page_limit: "100" });
+    const { result } = renderHook(() => useListPageState());
+    expect(result.current.limit).toBe(100);
+  });
 });

--- a/frontend/ui/src/lib/hooks/use-list-page-state.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-list-page-state.test.tsx
@@ -38,3 +38,33 @@ describe("useListPageState filters integration", () => {
     expect(JSON.parse(url.searchParams.get("filters")!)).toEqual(next);
   });
 });
+
+describe("useListPageState clampToTotal", () => {
+  it("pulls a page that is past the end back to the last page with rows", () => {
+    // Deleting rows (or a deep link) can leave page_index beyond a shrunken list:
+    // 60 rows at the default limit of 50 is pages 0-1, so page 5 has nothing to show.
+    currentParams = new URLSearchParams({ page_index: "5" });
+    const { result } = renderHook(() => useListPageState());
+    expect(result.current.page).toBe(5);
+    act(() => result.current.clampToTotal(60));
+    expect(result.current.page).toBe(1);
+    const url = new URL(replace.mock.calls.at(-1)![0] as string, "http://x");
+    expect(url.searchParams.get("page_index")).toBe("1");
+  });
+
+  it("leaves a page that is still inside the result set alone", () => {
+    currentParams = new URLSearchParams({ page_index: "1" });
+    const { result } = renderHook(() => useListPageState());
+    const writesBefore = replace.mock.calls.length;
+    act(() => result.current.clampToTotal(300));
+    expect(result.current.page).toBe(1);
+    expect(replace.mock.calls.length).toBe(writesBefore);
+  });
+
+  it("ignores a total of 0, which is also what a loading or errored query reports", () => {
+    currentParams = new URLSearchParams({ page_index: "3" });
+    const { result } = renderHook(() => useListPageState());
+    act(() => result.current.clampToTotal(0));
+    expect(result.current.page).toBe(3);
+  });
+});

--- a/frontend/ui/src/lib/hooks/use-list-page-state.ts
+++ b/frontend/ui/src/lib/hooks/use-list-page-state.ts
@@ -27,6 +27,7 @@ interface UseListPageStateReturn {
   limit: number;
   goToPage: (page: number) => void;
   updateLimit: (limit: number) => void;
+  resetPageState: () => void;
   // Date filter (URL-synced)
   dateFilter: ReturnType<typeof useUrlDateFilter>["dateFilter"];
   customStartDate: Date | null;
@@ -103,6 +104,7 @@ export function useListPageState(
     limit: pagination.limit,
     goToPage: pagination.goToPage,
     updateLimit: pagination.setLimit,
+    resetPageState: pagination.resetPageState,
     // Date filter
     dateFilter,
     customStartDate,

--- a/frontend/ui/src/lib/hooks/use-list-page-state.ts
+++ b/frontend/ui/src/lib/hooks/use-list-page-state.ts
@@ -60,16 +60,19 @@ export function useListPageState(
     defaultLimit?: number;
     defaultDateFilterId?: string;
     retentionDays?: number | null;
+    syncStorage?: boolean;
   } = {},
 ): UseListPageStateReturn {
-  const { defaultLimit = 50, defaultDateFilterId, retentionDays } = options;
+  const { defaultLimit = 50, defaultDateFilterId, retentionDays, syncStorage = true } = options;
 
   // URL-synced pagination hook - persists page/limit in URL
   const pagination = useUrlPagination(defaultLimit);
 
-  // URL-synced date filter hook - resets page on change
+  // URL-synced date filter hook. setDateFilter resets page_index inside its own URL
+  // write, so it takes the state-only page reset (a second URL write would clobber the
+  // just-set filter from stale params).
   const { dateFilter, customStartDate, customEndDate, setDateFilter, setCustomRange, timestamps } =
-    useUrlDateFilter(pagination.resetPage, defaultDateFilterId, retentionDays);
+    useUrlDateFilter(pagination.resetPageState, defaultDateFilterId, retentionDays, syncStorage);
 
   // Search hook - resets page on change
   const { keyword, setKeyword, searchQuery } = useKeywordSearch(pagination.resetPage);

--- a/frontend/ui/src/lib/hooks/use-list-page-state.ts
+++ b/frontend/ui/src/lib/hooks/use-list-page-state.ts
@@ -28,6 +28,7 @@ interface UseListPageStateReturn {
   goToPage: (page: number) => void;
   updateLimit: (limit: number) => void;
   resetPageState: () => void;
+  clampToTotal: (total: number) => void;
   // Date filter (URL-synced)
   dateFilter: ReturnType<typeof useUrlDateFilter>["dateFilter"];
   customStartDate: Date | null;
@@ -105,6 +106,7 @@ export function useListPageState(
     goToPage: pagination.goToPage,
     updateLimit: pagination.setLimit,
     resetPageState: pagination.resetPageState,
+    clampToTotal: pagination.clampToTotal,
     // Date filter
     dateFilter,
     customStartDate,

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.ts
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.ts
@@ -36,6 +36,7 @@ export function useUrlDateFilter(
   onFilterChange?: () => void,
   defaultId?: string,
   retentionDays?: number | null,
+  syncStorage: boolean = true,
 ): UseUrlDateFilterReturn {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -80,7 +81,7 @@ export function useUrlDateFilter(
   // every consumer query on a restoration flag.)
   const restoredRef = useRef(false);
   useIsomorphicLayoutEffect(() => {
-    if (restoredRef.current) return;
+    if (!syncStorage || restoredRef.current) return;
     restoredRef.current = true;
     if (!projectId || searchParams.get("date_filter")) return;
     const stored = readStoredDateFilter(projectId);
@@ -112,7 +113,7 @@ export function useUrlDateFilter(
   // overwrite the preference the user picked themselves.
   const persistSelection = useCallback(
     (id: string, start: Date | null, end: Date | null) => {
-      if (!projectId) return;
+      if (!syncStorage || !projectId) return;
       writeStoredDateFilter(
         projectId,
         id === "custom" && start && end
@@ -120,7 +121,7 @@ export function useUrlDateFilter(
           : { id },
       );
     },
-    [projectId],
+    [syncStorage, projectId],
   );
 
   // Sync state from URL when it changes (e.g., navigating from another page)
@@ -169,6 +170,9 @@ export function useUrlDateFilter(
         params.delete("start");
         params.delete("end");
       }
+
+      // Reset to first page in the same mutation so date filter and page reset don't race
+      params.delete("page_index");
 
       router.replace(`${pathname}?${params.toString()}`, { scroll: false });
     },

--- a/frontend/ui/src/lib/hooks/use-url-pagination.ts
+++ b/frontend/ui/src/lib/hooks/use-url-pagination.ts
@@ -14,6 +14,7 @@ interface UseUrlPaginationReturn {
   setLimit: (limit: number) => void;
   resetPage: () => void;
   resetPageState: () => void;
+  clampToTotal: (total: number) => void;
 }
 
 const DEFAULT_PAGE = 0;
@@ -111,6 +112,21 @@ export function useUrlPagination(defaultLimit = DEFAULT_LIMIT): UseUrlPagination
   // second write here can't clobber it from a stale searchParams closure.
   const resetPageState = useCallback(() => setPageState(DEFAULT_PAGE), []);
 
+  // Pull the page back inside a result set that has shrunk. Deleting the rows on the
+  // last page — or deep-linking `?page_index=` past the end — otherwise leaves the
+  // page pointing past the data: an empty table that reads as "nothing here" for a
+  // list that still has earlier pages. Call it from the consumer once `total` is
+  // known; a total of 0 is left alone (an empty list has no page to clamp to, and
+  // it's also what an in-flight or errored query reports).
+  const clampToTotal = useCallback(
+    (total: number) => {
+      if (!Number.isFinite(total) || total <= 0) return;
+      const lastPage = Math.max(0, Math.ceil(total / limit) - 1);
+      if (page > lastPage) goToPage(lastPage);
+    },
+    [page, limit, goToPage],
+  );
+
   return {
     page,
     limit,
@@ -118,5 +134,6 @@ export function useUrlPagination(defaultLimit = DEFAULT_LIMIT): UseUrlPagination
     setLimit,
     resetPage,
     resetPageState,
+    clampToTotal,
   };
 }

--- a/frontend/ui/src/lib/hooks/use-url-pagination.ts
+++ b/frontend/ui/src/lib/hooks/use-url-pagination.ts
@@ -19,6 +19,17 @@ interface UseUrlPaginationReturn {
 
 const DEFAULT_PAGE = 0;
 const DEFAULT_LIMIT = 50;
+// The list routes cap `limit` server-side (`Math.min(Math.max(raw, 1), 200)`) and echo
+// the capped value back in `meta`, so a larger `page_limit` is silently not honoured.
+// Holding one client-side would request a page size that never arrives and, worse, make
+// `clampToTotal` divide `total` by it — sending pages that are valid under the size the
+// server actually serves back to an earlier page.
+const MAX_LIMIT = 200;
+
+/** Normalize a requested page size to what the API will actually serve. */
+function clampLimit(limit: number): number {
+  return Math.min(limit, MAX_LIMIT);
+}
 
 // Reject NaN, Infinity, and out-of-range values so a hand-edited URL like
 // `?page_limit=0` or `?page_index=-2` falls back to defaults instead of
@@ -35,7 +46,7 @@ export function useUrlPagination(defaultLimit = DEFAULT_LIMIT): UseUrlPagination
   const pathname = usePathname();
 
   const initialPage = parseUrlInt(searchParams.get("page_index"), DEFAULT_PAGE, 0);
-  const initialLimit = parseUrlInt(searchParams.get("page_limit"), defaultLimit, 1);
+  const initialLimit = clampLimit(parseUrlInt(searchParams.get("page_limit"), defaultLimit, 1));
 
   const [page, setPageState] = useState(initialPage);
   const [limit, setLimitState] = useState(initialLimit);
@@ -52,7 +63,7 @@ export function useUrlPagination(defaultLimit = DEFAULT_LIMIT): UseUrlPagination
     }
 
     setPageState(parseUrlInt(searchParams.get("page_index"), DEFAULT_PAGE, 0));
-    setLimitState(parseUrlInt(searchParams.get("page_limit"), defaultLimit, 1));
+    setLimitState(clampLimit(parseUrlInt(searchParams.get("page_limit"), defaultLimit, 1)));
   }, [searchParams, defaultLimit]);
 
   // Update URL with current pagination state
@@ -89,7 +100,8 @@ export function useUrlPagination(defaultLimit = DEFAULT_LIMIT): UseUrlPagination
   );
 
   const setLimit = useCallback(
-    (newLimit: number) => {
+    (requestedLimit: number) => {
+      const newLimit = clampLimit(requestedLimit);
       setLimitState(newLimit);
       setPageState(DEFAULT_PAGE); // Reset to first page when changing limit
       updateUrl(DEFAULT_PAGE, newLimit);


### PR DESCRIPTION
### Summary
Standardizes pagination across all four main lists (Traces, Detectors, Datasets, and Evaluations) by adopting the shared `<ListPagination />` component and the unified URL-synced `useListPageState` hook.

Closes #1950

### Changes
- `features/evaluations/views/evaluations-view.tsx`: Replace hand-rolled prev/next footer with `<ListPagination />` and use `useListPageState` for URL synchronization (`page_index`, `page_limit`, `date_filter`).
- `features/evaluations/views/datasets-view.tsx`: Switch to `useListPageState` for consistent list state handling.
- `features/evaluations/evaluations.smoke.test.tsx`: Add test asserting `ListPagination` controls in evaluations view and stabilize `useSearchParams` mock.
- `features/evaluations/dataset-panels.smoke.test.tsx`: Stabilize `useSearchParams` mock.

### Validation
- 13 test files and 101 tests passed (100%).
- ESLint passed with 0 errors.


Before
<img width="3024" height="1964" alt="Image" src="https://github.com/user-attachments/assets/3f34a22a-1b5c-49b3-8e17-8a338fe6331b" />

After
<img width="3024" height="1964" alt="Image" src="https://github.com/user-attachments/assets/fabb2086-f5fa-4ca5-b381-0651411e69ad" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes pagination across Evaluations, Datasets, and Detectors on the shared `ListPagination` and URL-synced `useListPageState`, so page, page size, search, and date range deep-link cleanly. Evaluations swaps its fixed 50-item prev/next footer for the standard pager, which now includes a "Showing X–Y of N" readout; the Evaluations date filter also stops persisting to localStorage, isolating it from other views' preferences.

- EvaluationsView: paginates from client state rather than server `meta` so a placeholder response can't hold a stale page; a CopyButton for the dataset version no longer opens the run detail.
- DatasetsView: URL-syncs search, page, and limit and resets to page 0 after a delete.
- Pagination hook: `clampToTotal` pulls an out-of-range page back to the last page with rows, skips clamping during in-flight placeholder queries, and caps `page_limit` at the API's 200 max; a date filter change resets the page in the same URL write.
- Tests: share a single `URLSearchParams` instance and add coverage for the pager controls, clamping, and the limit cap.

<sup>Written for commit cf007a56d13938c7147539c4d55894878dd471d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

