### PR TITLE
fix(ui): key AI chat streams by session so switches don't leak deltas

### DIFF
--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
@@ -449,6 +449,55 @@ describe("useAiChat session switching", () => {
     expect(result.current.currentSessionId).toBe("B");
   });
 
+  it("a pre-close send settling does not blank the waiting state of a post-reopen send", async () => {
+    const creations: Array<(r: Response) => void> = [];
+    const messagePosts: string[] = [];
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.endsWith("/ai/sessions")) {
+        return new Promise<Response>((r) => {
+          creations.push(r);
+        });
+      }
+      const messageMatch = url.match(/\/ai\/sessions\/([^/]+)\/messages$/);
+      if (method === "POST" && messageMatch) {
+        messagePosts.push(messageMatch[1]);
+        return createSSE().response;
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+    const { result } = renderChat();
+
+    let first!: Promise<void>;
+    act(() => {
+      first = result.current.handleSend("pre-close", MODEL);
+    });
+    act(() => {
+      result.current.handleClose();
+    });
+    let second!: Promise<void>;
+    act(() => {
+      second = result.current.handleSend("post-reopen", MODEL);
+    });
+
+    // the pre-close creation settles (and its send winds down) while the
+    // post-reopen send is still waiting on its own creation
+    await act(async () => {
+      creations[0](jsonResponse({ id: "A" }));
+      await first;
+    });
+
+    // the panel must still show as busy — one send is genuinely in flight
+    expect(result.current.isStreaming).toBe(true);
+
+    await act(async () => {
+      creations[1](jsonResponse({ id: "B" }));
+      await second;
+    });
+    expect(messagePosts).toEqual(["B"]);
+  });
+
   it("clicking New Session while a session creation is in flight does not restore the old session", async () => {
     let resolveCreation!: (r: Response) => void;
     const messagePosts: string[] = [];

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
@@ -316,6 +316,49 @@ describe("useAiChat session switching", () => {
     expect(messagePosts).toEqual(["A", "A"]);
   });
 
+  it("a project switch discards an in-flight session creation", async () => {
+    const sessionPosts: string[] = [];
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      const createMatch = url.match(/\/api\/projects\/([^/]+)\/ai\/sessions$/);
+      if (method === "POST" && createMatch) {
+        sessionPosts.push(createMatch[1]);
+        if (createMatch[1] === "p1") {
+          // never resolves on its own — only the abort settles it
+          return new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("aborted", "AbortError")),
+            );
+          });
+        }
+        return jsonResponse({ id: "B-session" });
+      }
+      const messageMatch = url.match(/\/ai\/sessions\/([^/]+)\/messages$/);
+      if (method === "POST" && messageMatch) return createSSE().response;
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+    const { result, rerender } = renderHook(({ projectId }) => useAiChat({ projectId }), {
+      initialProps: { projectId: "p1" },
+    });
+
+    // p1's creation is still in flight when the user switches projects
+    let firstSend!: Promise<void>;
+    act(() => {
+      firstSend = result.current.handleSend("hi", MODEL);
+    });
+    rerender({ projectId: "p2" });
+
+    await act(async () => {
+      await result.current.handleSend("hello", MODEL);
+      await firstSend;
+    });
+
+    // p2 got its own session; the aborted p1 creation never leaked in
+    expect(sessionPosts).toEqual(["p1", "p2"]);
+    expect(result.current.currentSessionId).toBe("B-session");
+  });
+
   it("deleting the active session clears the view and stops its stream", async () => {
     const { result } = renderChat();
     await startStreamInA(result);

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
@@ -359,6 +359,208 @@ describe("useAiChat session switching", () => {
     expect(result.current.currentSessionId).toBe("B-session");
   });
 
+  it("clicking New Session while a session creation is in flight does not restore the old session", async () => {
+    let resolveCreation!: (r: Response) => void;
+    const messagePosts: string[] = [];
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.endsWith("/ai/sessions")) {
+        return new Promise<Response>((r) => {
+          resolveCreation = r;
+        });
+      }
+      const messageMatch = url.match(/\/ai\/sessions\/([^/]+)\/messages$/);
+      if (method === "POST" && messageMatch) {
+        messagePosts.push(messageMatch[1]);
+        return createSSE().response;
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+    const { result } = renderChat();
+
+    let send!: Promise<void>;
+    act(() => {
+      send = result.current.handleSend("hi", MODEL);
+    });
+    act(() => {
+      result.current.handleNewSession();
+    });
+    await act(async () => {
+      resolveCreation(jsonResponse({ id: "A" }));
+      await send;
+    });
+
+    // the in-flight message still delivers to the session created for it…
+    expect(messagePosts).toEqual(["A"]);
+    // …but it must not snap the panel back to that session
+    expect(result.current.currentSessionId).toBeNull();
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("a send after New Session creates a fresh session instead of reusing the pending creation", async () => {
+    const creations: Array<(r: Response) => void> = [];
+    const messagePosts: string[] = [];
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.endsWith("/ai/sessions")) {
+        return new Promise<Response>((r) => {
+          creations.push(r);
+        });
+      }
+      const messageMatch = url.match(/\/ai\/sessions\/([^/]+)\/messages$/);
+      if (method === "POST" && messageMatch) {
+        messagePosts.push(messageMatch[1]);
+        return createSSE().response;
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+    const { result } = renderChat();
+
+    let first!: Promise<void>;
+    act(() => {
+      first = result.current.handleSend("one", MODEL);
+    });
+    act(() => {
+      result.current.handleNewSession();
+    });
+    let second!: Promise<void>;
+    act(() => {
+      second = result.current.handleSend("two", MODEL);
+    });
+
+    // the post-boundary send must have started its own creation
+    expect(creations).toHaveLength(2);
+
+    await act(async () => {
+      creations[1](jsonResponse({ id: "B" }));
+      await second;
+      creations[0](jsonResponse({ id: "A" }));
+      await first;
+    });
+
+    expect(messagePosts).toEqual(["B", "A"]);
+    expect(result.current.currentSessionId).toBe("B");
+  });
+
+  it("selecting a history session while a creation is in flight is not clobbered by its late commit", async () => {
+    let resolveCreation!: (r: Response) => void;
+    const messagePosts: string[] = [];
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.endsWith("/ai/sessions")) {
+        return new Promise<Response>((r) => {
+          resolveCreation = r;
+        });
+      }
+      const messageMatch = url.match(/\/ai\/sessions\/([^/]+)\/messages$/);
+      if (method === "POST" && messageMatch) {
+        messagePosts.push(messageMatch[1]);
+        return createSSE().response;
+      }
+      if (method === "GET" && messageMatch) return jsonResponse({ messages: [] });
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+    const { result } = renderChat();
+
+    let send!: Promise<void>;
+    act(() => {
+      send = result.current.handleSend("hi", MODEL);
+    });
+    await act(async () => {
+      await result.current.handleSelectSession(sessionB);
+    });
+    await act(async () => {
+      resolveCreation(jsonResponse({ id: "A" }));
+      await send;
+    });
+
+    expect(messagePosts).toEqual(["A"]);
+    expect(result.current.currentSessionId).toBe("B");
+  });
+
+  it("an RCA session arriving via initialSessionId is not clobbered by an in-flight creation's commit", async () => {
+    let resolveCreation!: (r: Response) => void;
+    const messagePosts: string[] = [];
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.endsWith("/ai/sessions")) {
+        return new Promise<Response>((r) => {
+          resolveCreation = r;
+        });
+      }
+      const messageMatch = url.match(/\/ai\/sessions\/([^/]+)\/messages$/);
+      if (method === "POST" && messageMatch) {
+        messagePosts.push(messageMatch[1]);
+        return createSSE().response;
+      }
+      if (method === "GET" && messageMatch) return jsonResponse({ messages: [] });
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+    const { result, rerender } = renderHook(
+      ({ initialSessionId }: { initialSessionId?: string }) =>
+        useAiChat({ projectId: "p1", initialSessionId }),
+      { initialProps: {} as { initialSessionId?: string } },
+    );
+
+    let send!: Promise<void>;
+    act(() => {
+      send = result.current.handleSend("hi", MODEL);
+    });
+    // the RCA session arrives while the creation is still in flight
+    await act(async () => {
+      rerender({ initialSessionId: "R" });
+    });
+    expect(result.current.currentSessionId).toBe("R");
+
+    await act(async () => {
+      resolveCreation(jsonResponse({ id: "A" }));
+      await send;
+    });
+
+    expect(messagePosts).toEqual(["A"]);
+    expect(result.current.currentSessionId).toBe("R");
+  });
+
+  it("a send immediately after New Session does not reuse the previous active session", async () => {
+    let sessionPosts = 0;
+    const messagePosts: string[] = [];
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.endsWith("/ai/sessions")) {
+        sessionPosts += 1;
+        return jsonResponse({ id: `S${sessionPosts}` });
+      }
+      const messageMatch = url.match(/\/ai\/sessions\/([^/]+)\/messages$/);
+      if (method === "POST" && messageMatch) {
+        messagePosts.push(messageMatch[1]);
+        return createSSE().response;
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+    const { result } = renderChat();
+
+    // establish an active session the normal way
+    await act(async () => {
+      await result.current.handleSend("old chat", MODEL);
+    });
+    expect(result.current.currentSessionId).toBe("S1");
+
+    // New Session and a send in the same tick — before any rerender can sync refs
+    await act(async () => {
+      result.current.handleNewSession();
+      await result.current.handleSend("fresh chat", MODEL);
+    });
+
+    expect(sessionPosts).toBe(2);
+    expect(messagePosts).toEqual(["S1", "S2"]);
+    expect(result.current.currentSessionId).toBe("S2");
+  });
+
   it("deleting the active session clears the view and stops its stream", async () => {
     const { result } = renderChat();
     await startStreamInA(result);

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
@@ -285,6 +285,37 @@ describe("useAiChat session switching", () => {
     expect(sessionPosts).toBe(1);
   });
 
+  it("concurrent sends share one in-flight session creation", async () => {
+    let sessionPosts = 0;
+    const messagePosts: string[] = [];
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.endsWith("/ai/sessions")) {
+        sessionPosts += 1;
+        return jsonResponse({ id: "A" });
+      }
+      const messageMatch = url.match(/\/ai\/sessions\/([^/]+)\/messages$/);
+      if (method === "POST" && messageMatch) {
+        messagePosts.push(messageMatch[1]);
+        return createSSE().response;
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+    const { result } = renderChat();
+
+    // both fired before the first creation resolves — they must share it
+    await act(async () => {
+      await Promise.all([
+        result.current.handleSend("one", MODEL),
+        result.current.handleSend("two", MODEL),
+      ]);
+    });
+
+    expect(sessionPosts).toBe(1);
+    expect(messagePosts).toEqual(["A", "A"]);
+  });
+
   it("deleting the active session clears the view and stops its stream", async () => {
     const { result } = renderChat();
     await startStreamInA(result);

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
@@ -398,6 +398,57 @@ describe("useAiChat session switching", () => {
     expect(result.current.currentSessionId).toBeNull();
   });
 
+  it("a send after close-and-reopen starts a fresh session instead of reusing the pre-close creation", async () => {
+    const creations: Array<(r: Response) => void> = [];
+    const messagePosts: string[] = [];
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.endsWith("/ai/sessions")) {
+        // deliberately ignores the abort signal — the pre-close creation's
+        // response is already on the wire and settles late
+        return new Promise<Response>((r) => {
+          creations.push(r);
+        });
+      }
+      const messageMatch = url.match(/\/ai\/sessions\/([^/]+)\/messages$/);
+      if (method === "POST" && messageMatch) {
+        messagePosts.push(messageMatch[1]);
+        return createSSE().response;
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+    const { result } = renderChat();
+
+    let first!: Promise<void>;
+    act(() => {
+      first = result.current.handleSend("pre-close", MODEL);
+    });
+    act(() => {
+      result.current.handleClose();
+    });
+
+    // the user reopens the panel and starts a new conversation
+    let second!: Promise<void>;
+    act(() => {
+      second = result.current.handleSend("post-reopen", MODEL);
+    });
+
+    // the post-reopen send must not ride the pre-close creation
+    expect(creations).toHaveLength(2);
+
+    await act(async () => {
+      creations[1](jsonResponse({ id: "B" }));
+      await second;
+      creations[0](jsonResponse({ id: "A" }));
+      await first;
+    });
+
+    // the reopened chat runs in its own session; the pre-close send stays dropped
+    expect(messagePosts).toEqual(["B"]);
+    expect(result.current.currentSessionId).toBe("B");
+  });
+
   it("clicking New Session while a session creation is in flight does not restore the old session", async () => {
     let resolveCreation!: (r: Response) => void;
     const messagePosts: string[] = [];

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
@@ -359,6 +359,45 @@ describe("useAiChat session switching", () => {
     expect(result.current.currentSessionId).toBe("B-session");
   });
 
+  it("closing the panel drops a send whose creation resolved across the close", async () => {
+    let resolveCreation!: (r: Response) => void;
+    const messagePosts: string[] = [];
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.endsWith("/ai/sessions")) {
+        // settles only via resolveCreation — deliberately ignores the abort
+        // signal, modeling a response that was already on the wire at close
+        return new Promise<Response>((r) => {
+          resolveCreation = r;
+        });
+      }
+      const messageMatch = url.match(/\/ai\/sessions\/([^/]+)\/messages$/);
+      if (method === "POST" && messageMatch) {
+        messagePosts.push(messageMatch[1]);
+        return createSSE().response;
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+    const { result } = renderChat();
+
+    let send!: Promise<void>;
+    act(() => {
+      send = result.current.handleSend("hi", MODEL);
+    });
+    act(() => {
+      result.current.handleClose();
+    });
+    // the creation succeeds anyway — but the panel is closed: no run may start
+    resolveCreation(jsonResponse({ id: "A" }));
+    await act(async () => {
+      await send;
+    });
+
+    expect(messagePosts).toEqual([]);
+    expect(result.current.currentSessionId).toBeNull();
+  });
+
   it("clicking New Session while a session creation is in flight does not restore the old session", async () => {
     let resolveCreation!: (r: Response) => void;
     const messagePosts: string[] = [];

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
@@ -1,27 +1,311 @@
 // @vitest-environment jsdom
 import { useEffect } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { act, renderHook } from "@testing-library/react";
-
-vi.mock("./use-ai-stream", () => ({
-  useAIStream: () => ({
-    messages: [],
-    isStreaming: false,
-    sendMessage: vi.fn(),
-    abort: vi.fn(),
-    setMessages: vi.fn(),
-  }),
-}));
-
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor, cleanup } from "@testing-library/react";
 import { useAiChat } from "./use-ai-chat";
+import type { AISession } from "../types";
+import type { ModelSelection } from "../components/model-selector";
+
+function createSSE() {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  const encoder = new TextEncoder();
+  return {
+    response: new Response(stream, { status: 200 }),
+    emit(delta: string) {
+      try {
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({
+              type: "message_update",
+              assistantMessageEvent: { type: "text_delta", delta },
+            })}\n`,
+          ),
+        );
+      } catch {
+        // stream cancelled — assertions read hook state
+      }
+    },
+    close() {
+      try {
+        controller.close();
+      } catch {
+        // already cancelled
+      }
+    },
+  };
+}
+
+const MODEL: ModelSelection = {
+  model: "test-model",
+  provider: "test-provider",
+  source: "system",
+  adapter: "anthropic",
+};
+
+const sessionB: AISession = {
+  id: "B",
+  projectId: "p1",
+  title: "older chat",
+  status: "active",
+  createTime: "2026-01-01T00:00:00Z",
+};
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("useAiChat session switching", () => {
+  let sseA: ReturnType<typeof createSSE>;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  /** GET .../sessions/<id>/messages calls, by session id */
+  let historyFetches: string[];
+
+  beforeEach(() => {
+    sseA = createSSE();
+    historyFetches = [];
+    fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.endsWith("/ai/sessions")) {
+        return jsonResponse({ id: "A" });
+      }
+      if (method === "POST" && url.endsWith("/ai/sessions/A/messages")) {
+        return sseA.response;
+      }
+      const historyMatch = url.match(/\/ai\/sessions\/([^/]+)\/messages$/);
+      if (method === "GET" && historyMatch) {
+        historyFetches.push(historyMatch[1]);
+        return jsonResponse({
+          messages: [
+            {
+              id: `${historyMatch[1]}-m1`,
+              role: "user",
+              content: `history of ${historyMatch[1]}`,
+              createTime: "2026-01-01T00:00:00Z",
+            },
+          ],
+        });
+      }
+      if (method === "GET" && url.endsWith("/ai/sessions")) {
+        return jsonResponse({ sessions: [sessionB] });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  const renderChat = () => renderHook(() => useAiChat({ projectId: "p1" }));
+
+  const startStreamInA = async (result: ReturnType<typeof renderChat>["result"]) => {
+    await act(async () => {
+      await result.current.handleSend("hi there", MODEL);
+    });
+    sseA.emit("partial answer");
+    await waitFor(() =>
+      expect(result.current.messages.some((m) => m.content === "partial answer")).toBe(true),
+    );
+  };
+
+  it("keeps a still-streaming session's deltas out of another session's view", async () => {
+    const { result } = renderChat();
+    await startStreamInA(result);
+    expect(result.current.isStreaming).toBe(true);
+
+    await act(async () => {
+      await result.current.handleSelectSession(sessionB);
+    });
+    await waitFor(() =>
+      expect(result.current.messages.some((m) => m.content === "history of B")).toBe(true),
+    );
+
+    // session A's stream keeps producing — nothing may bleed into B's view
+    sseA.emit(" continues");
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.messages.every((m) => !m.content.includes("continues"))).toBe(true);
+    // and the visible session is not "streaming"
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("returning to a still-streaming session shows its accumulated progress without a history fetch", async () => {
+    const { result } = renderChat();
+    await startStreamInA(result);
+
+    await act(async () => {
+      await result.current.handleSelectSession(sessionB);
+    });
+    sseA.emit(" and more");
+
+    await act(async () => {
+      await result.current.handleSelectSession({ ...sessionB, id: "A" });
+    });
+
+    // live bucket is shown as-is: user turn + partial assistant text
+    await waitFor(() =>
+      expect(result.current.messages.some((m) => m.content === "partial answer and more")).toBe(
+        true,
+      ),
+    );
+    expect(result.current.messages.some((m) => m.content === "hi there")).toBe(true);
+    expect(result.current.isStreaming).toBe(true);
+    // the DB (which lacks the in-flight response) must not have been consulted
+    expect(historyFetches).not.toContain("A");
+  });
+
+  it("handleNewSession empties the view but leaves the previous stream running", async () => {
+    const { result } = renderChat();
+    await startStreamInA(result);
+
+    act(() => {
+      result.current.handleNewSession();
+    });
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.currentSessionId).toBeNull();
+
+    // stream A still accumulates in the background
+    sseA.emit(" background");
+    await act(async () => {
+      await result.current.handleSelectSession({ ...sessionB, id: "A" });
+    });
+    await waitFor(() =>
+      expect(result.current.messages.some((m) => m.content === "partial answer background")).toBe(
+        true,
+      ),
+    );
+  });
+
+  it("handleClose aborts every stream and clears all cached sessions", async () => {
+    const { result } = renderChat();
+    await startStreamInA(result);
+
+    act(() => {
+      result.current.handleClose();
+    });
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.currentSessionId).toBeNull();
+
+    // late chunks are dropped: revisiting A hits the DB, not a live bucket
+    sseA.emit(" ghost");
+    await act(async () => {
+      await result.current.handleSelectSession({ ...sessionB, id: "A" });
+    });
+    await waitFor(() => expect(historyFetches).toContain("A"));
+    expect(result.current.messages.every((m) => !m.content.includes("ghost"))).toBe(true);
+  });
+
+  it("a history load resolving after a send does not clobber the live run", async () => {
+    const { result } = renderChat();
+    const sseB = createSSE();
+    let resolveHistory!: (r: Response) => void;
+    const deferredHistory = new Promise<Response>((r) => {
+      resolveHistory = r;
+    });
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (method === "GET" && url.endsWith("/ai/sessions/B/messages")) return deferredHistory;
+      if (method === "POST" && url.endsWith("/ai/sessions/B/messages")) return sseB.response;
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+
+    // select B — its history fetch stays in flight
+    let selectPromise!: Promise<void>;
+    act(() => {
+      selectPromise = result.current.handleSelectSession(sessionB);
+    });
+    // user sends a message in B before the history load resolves
+    await act(async () => {
+      await result.current.handleSend("fresh question", MODEL);
+    });
+    sseB.emit("live reply");
+    await waitFor(() =>
+      expect(result.current.messages.some((m) => m.content === "live reply")).toBe(true),
+    );
+
+    // the stale history resolves now — it must not wipe the live run
+    resolveHistory(
+      new Response(
+        JSON.stringify({
+          messages: [
+            {
+              id: "b-old",
+              role: "user",
+              content: "history of B",
+              createTime: "2026-01-01T00:00:00Z",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    await act(async () => {
+      await selectPromise;
+    });
+
+    expect(result.current.messages.some((m) => m.content === "fresh question")).toBe(true);
+    expect(result.current.messages.some((m) => m.content === "live reply")).toBe(true);
+    expect(result.current.isStreaming).toBe(true);
+  });
+
+  it("a second send right after session creation reuses the session", async () => {
+    let sessionPosts = 0;
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (method === "POST" && url.endsWith("/ai/sessions")) {
+        sessionPosts += 1;
+        return jsonResponse({ id: "A" });
+      }
+      if (method === "POST" && url.endsWith("/ai/sessions/A/messages")) {
+        return createSSE().response;
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+    const { result } = renderChat();
+
+    await act(async () => {
+      await result.current.handleSend("one", MODEL);
+      // fired before any rerender can commit the new session id to state
+      await result.current.handleSend("two", MODEL);
+    });
+
+    expect(sessionPosts).toBe(1);
+  });
+
+  it("deleting the active session clears the view and stops its stream", async () => {
+    const { result } = renderChat();
+    await startStreamInA(result);
+
+    act(() => {
+      result.current.handleDeleteSession("A");
+    });
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.currentSessionId).toBeNull();
+    expect(result.current.isStreaming).toBe(false);
+  });
+});
 
 const PICK = { model: "kimi-k3", provider: "Moonshot", source: "byok" as const, adapter: "openai" };
 
-afterEach(() => {
-  window.localStorage.clear();
-});
-
 describe("useAiChat model selection", () => {
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+  });
+
   it("starts empty and exposes a setter", () => {
     const { result } = renderHook(() => useAiChat({ projectId: "p1" }));
     expect(result.current.modelSelection.model).toBe("");

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -57,10 +57,14 @@ export function useAiChat({
   const hardBoundaryEpochRef = useRef(0);
   const [sessions, setSessions] = useState<AISession[]>([]);
   const [historyOpen, setHistoryOpen] = useState(false);
-  // isSending covers the gap between user hitting send and isStreaming becoming true
-  // (session creation + first network round-trip). Without this, React 19 can batch
-  // setIsStreaming(true) and setIsStreaming(false) into a single frame, hiding the button.
-  const [isSending, setIsSending] = useState(false);
+  // activeSends covers the gap between user hitting send and isStreaming
+  // becoming true (session creation + first network round-trip). Without this,
+  // React 19 can batch setIsStreaming(true) and setIsStreaming(false) into a
+  // single frame, hiding the button. A count rather than a boolean: sends can
+  // overlap (a pre-close send settling after a post-reopen send started), and
+  // the first one finishing must not blank the waiting state of the second.
+  // Functional updaters keep the count exact across overlaps.
+  const [activeSends, setActiveSends] = useState(0);
   // Lives here (not in the input) so the pick survives the panel remounting in a
   // different host, and in localStorage so it survives a reload. Keyed per
   // project — the only id this hook has; the model catalog itself is
@@ -168,7 +172,7 @@ export function useAiChat({
   const handleSend = useCallback(
     async (message: string, modelSelection: ModelSelection) => {
       if (!projectId) return;
-      setIsSending(true);
+      setActiveSends((n) => n + 1);
       try {
         const epoch = sessionEpochRef.current;
         const hardEpoch = hardBoundaryEpochRef.current;
@@ -198,7 +202,7 @@ export function useAiChat({
           traceSessionId,
         });
       } finally {
-        setIsSending(false);
+        setActiveSends((n) => n - 1);
       }
     },
     [projectId, traceId, traceSessionId, ensureSession, sendMessage],
@@ -305,7 +309,7 @@ export function useAiChat({
   return {
     // State
     messages,
-    isStreaming: isSending || activeStreaming || messages.some((m) => m.isStreaming),
+    isStreaming: activeSends > 0 || activeStreaming || messages.some((m) => m.isStreaming),
     sessions,
     historyOpen,
     currentSessionId: activeSessionId,

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -41,6 +41,9 @@ export function useAiChat({
   // Set so concurrent ensureSession calls don't cancel each other; handleClose
   // aborts all in-flight POST /sessions to prevent post-close resurrection.
   const ensureSessionAbortersRef = useRef<Set<AbortController>>(new Set());
+  // The in-flight session creation, shared so sends arriving before the first
+  // one resolves await the same promise instead of creating duplicate sessions.
+  const pendingSessionRef = useRef<Promise<string | null> | null>(null);
   const [sessions, setSessions] = useState<AISession[]>([]);
   const [historyOpen, setHistoryOpen] = useState(false);
   // isSending covers the gap between user hitting send and isStreaming becoming true
@@ -67,6 +70,11 @@ export function useAiChat({
   useEffect(() => {
     if (initialSessionId) return;
     setActiveSessionId(null);
+    // Discard any in-flight session creation too — a send racing the switch
+    // must not hand the new project a session created for the old one.
+    for (const ac of ensureSessionAbortersRef.current) ac.abort();
+    ensureSessionAbortersRef.current.clear();
+    pendingSessionRef.current = null;
     abortAll();
     clearAll();
   }, [projectId]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -108,9 +116,6 @@ export function useAiChat({
   // Lazy session creation — only when first message is sent. The fetch is
   // cancellable so handleClose can prevent a pending response from resurrecting
   // the active session after we've cleared it. Caller commits the id on success.
-  // The in-flight creation is shared: sends arriving before the first one
-  // resolves await the same promise instead of creating duplicate sessions.
-  const pendingSessionRef = useRef<Promise<string | null> | null>(null);
   const ensureSession = useCallback((): Promise<string | null> => {
     if (activeSessionIdRef.current) return Promise.resolve(activeSessionIdRef.current);
     if (!projectId) return Promise.resolve(null);
@@ -133,10 +138,14 @@ export function useAiChat({
         return null;
       } finally {
         ensureSessionAbortersRef.current.delete(ac);
-        pendingSessionRef.current = null;
       }
     })();
     pendingSessionRef.current = creation;
+    // Only clear our own entry: a project switch may have already discarded
+    // this creation and parked a newer one in the ref.
+    creation.finally(() => {
+      if (pendingSessionRef.current === creation) pendingSessionRef.current = null;
+    });
     return creation;
   }, [projectId, traceId, traceSessionId]);
 

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -227,6 +227,11 @@ export function useAiChat({
     hardBoundaryEpochRef.current++;
     for (const ac of ensureSessionAbortersRef.current) ac.abort();
     ensureSessionAbortersRef.current.clear();
+    // Don't wait for the aborted creation to settle and self-clear: if its
+    // response is already on the wire, a send after reopen would ride the
+    // pre-close creation (and its stale trace context). The self-clear's
+    // identity check makes the late settle harmless once this is nulled.
+    pendingSessionRef.current = null;
     abortAll();
     clearAll();
     setActiveSessionId(null);

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -44,6 +44,13 @@ export function useAiChat({
   // The in-flight session creation, shared so sends arriving before the first
   // one resolves await the same promise instead of creating duplicate sessions.
   const pendingSessionRef = useRef<Promise<string | null> | null>(null);
+  // Session-boundary generation. Every action that changes which session the
+  // panel is on (New Session, selecting from history, an externally chosen
+  // initial session, close, project switch) bumps it; a send whose creation
+  // resolves across a boundary must not commit
+  // its session as active — the message still delivers to the session it was
+  // created for, which stays reachable via history.
+  const sessionEpochRef = useRef(0);
   const [sessions, setSessions] = useState<AISession[]>([]);
   const [historyOpen, setHistoryOpen] = useState(false);
   // isSending covers the gap between user hitting send and isStreaming becoming true
@@ -69,6 +76,7 @@ export function useAiChat({
   // below owns session selection, so we bail here to avoid clobbering it.
   useEffect(() => {
     if (initialSessionId) return;
+    sessionEpochRef.current++;
     setActiveSessionId(null);
     // Discard any in-flight session creation too — a send racing the switch
     // must not hand the new project a session created for the old one.
@@ -86,6 +94,9 @@ export function useAiChat({
   // to the bucket of the session it was fetched for.
   useEffect(() => {
     if (!initialSessionId || !projectId) return;
+    // An externally chosen session (e.g. opening an RCA chat) is a session
+    // boundary like any other — fence out commits from in-flight sends.
+    sessionEpochRef.current++;
     setActiveSessionId(initialSessionId);
     if (isSessionStreaming(initialSessionId)) return;
 
@@ -154,12 +165,18 @@ export function useAiChat({
       if (!projectId) return;
       setIsSending(true);
       try {
+        const epoch = sessionEpochRef.current;
         const sessionId = await ensureSession();
         if (!sessionId) return;
         // Commit to the ref synchronously so a second send arriving before
-        // the next render sees the session and doesn't create a duplicate.
-        activeSessionIdRef.current = sessionId;
-        setActiveSessionId(sessionId);
+        // the next render sees the session and doesn't create a duplicate —
+        // unless a session boundary was crossed while the creation was in
+        // flight, in which case the user has moved on and this session must
+        // not be pulled back into view.
+        if (epoch === sessionEpochRef.current) {
+          activeSessionIdRef.current = sessionId;
+          setActiveSessionId(sessionId);
+        }
         sendMessage({
           sessionId,
           message,
@@ -181,6 +198,12 @@ export function useAiChat({
   // reading in the background into its own bucket — it is never rendered here,
   // and the user can return to it via history to watch it live.
   const handleNewSession = useCallback(() => {
+    sessionEpochRef.current++;
+    // Drop the shared in-flight creation (without aborting it — its send still
+    // needs it) so the next send opens a fresh session, and sync the ref now
+    // so a send arriving before the next render doesn't reuse the old id.
+    pendingSessionRef.current = null;
+    activeSessionIdRef.current = null;
     setActiveSessionId(null);
   }, []);
 
@@ -190,6 +213,7 @@ export function useAiChat({
   // Switching traces within the same page does NOT trigger this — the panel
   // stays open in that case.
   const handleClose = useCallback(() => {
+    sessionEpochRef.current++;
     for (const ac of ensureSessionAbortersRef.current) ac.abort();
     ensureSessionAbortersRef.current.clear();
     abortAll();
@@ -211,6 +235,7 @@ export function useAiChat({
 
   const handleSelectSession = useCallback(
     async (session: AISession) => {
+      sessionEpochRef.current++;
       setActiveSessionId(session.id);
       setHistoryOpen(false);
 

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -108,27 +108,36 @@ export function useAiChat({
   // Lazy session creation — only when first message is sent. The fetch is
   // cancellable so handleClose can prevent a pending response from resurrecting
   // the active session after we've cleared it. Caller commits the id on success.
-  const ensureSession = useCallback(async (): Promise<string | null> => {
-    if (activeSessionIdRef.current) return activeSessionIdRef.current;
-    if (!projectId) return null;
-    const ac = new AbortController();
-    ensureSessionAbortersRef.current.add(ac);
-    try {
-      const res = await fetch(`/api/projects/${projectId}/ai/sessions`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ traceId, traceSessionId }),
-        signal: ac.signal,
-      });
-      if (!res.ok) throw new Error(`Failed to create session: ${res.status}`);
-      const data = await res.json();
-      return data.id;
-    } catch (err) {
-      if ((err as Error).name !== "AbortError") console.error(err);
-      return null;
-    } finally {
-      ensureSessionAbortersRef.current.delete(ac);
-    }
+  // The in-flight creation is shared: sends arriving before the first one
+  // resolves await the same promise instead of creating duplicate sessions.
+  const pendingSessionRef = useRef<Promise<string | null> | null>(null);
+  const ensureSession = useCallback((): Promise<string | null> => {
+    if (activeSessionIdRef.current) return Promise.resolve(activeSessionIdRef.current);
+    if (!projectId) return Promise.resolve(null);
+    if (pendingSessionRef.current) return pendingSessionRef.current;
+    const creation = (async () => {
+      const ac = new AbortController();
+      ensureSessionAbortersRef.current.add(ac);
+      try {
+        const res = await fetch(`/api/projects/${projectId}/ai/sessions`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ traceId, traceSessionId }),
+          signal: ac.signal,
+        });
+        if (!res.ok) throw new Error(`Failed to create session: ${res.status}`);
+        const data = await res.json();
+        return data.id;
+      } catch (err) {
+        if ((err as Error).name !== "AbortError") console.error(err);
+        return null;
+      } finally {
+        ensureSessionAbortersRef.current.delete(ac);
+        pendingSessionRef.current = null;
+      }
+    })();
+    pendingSessionRef.current = creation;
+    return creation;
   }, [projectId, traceId, traceSessionId]);
 
   const handleSend = useCallback(

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -51,6 +51,10 @@ export function useAiChat({
   // its session as active — the message still delivers to the session it was
   // created for, which stays reachable via history.
   const sessionEpochRef = useRef(0);
+  // Hard boundaries (close, project switch) additionally invalidate the send
+  // itself: unlike a session switch — where the message still delivers in the
+  // background — a send crossing a hard boundary must not start a run at all.
+  const hardBoundaryEpochRef = useRef(0);
   const [sessions, setSessions] = useState<AISession[]>([]);
   const [historyOpen, setHistoryOpen] = useState(false);
   // isSending covers the gap between user hitting send and isStreaming becoming true
@@ -77,6 +81,7 @@ export function useAiChat({
   useEffect(() => {
     if (initialSessionId) return;
     sessionEpochRef.current++;
+    hardBoundaryEpochRef.current++;
     setActiveSessionId(null);
     // Discard any in-flight session creation too — a send racing the switch
     // must not hand the new project a session created for the old one.
@@ -166,8 +171,13 @@ export function useAiChat({
       setIsSending(true);
       try {
         const epoch = sessionEpochRef.current;
+        const hardEpoch = hardBoundaryEpochRef.current;
         const sessionId = await ensureSession();
         if (!sessionId) return;
+        // A hard boundary crossed while the creation was in flight drops the
+        // send entirely — a closed panel or an abandoned project must not
+        // start a new run.
+        if (hardEpoch !== hardBoundaryEpochRef.current) return;
         // Commit to the ref synchronously so a second send arriving before
         // the next render sees the session and doesn't create a duplicate —
         // unless a session boundary was crossed while the creation was in
@@ -214,6 +224,7 @@ export function useAiChat({
   // stays open in that case.
   const handleClose = useCallback(() => {
     sessionEpochRef.current++;
+    hardBoundaryEpochRef.current++;
     for (const ac of ensureSessionAbortersRef.current) ac.abort();
     ensureSessionAbortersRef.current.clear();
     abortAll();

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -19,8 +19,25 @@ export function useAiChat({
   traceSessionId,
   initialSessionId,
 }: UseAiChatOptions) {
-  const { messages, isStreaming, sendMessage, abort, setMessages } = useAIStream();
-  const sessionIdRef = useRef<string | null>(null);
+  const {
+    messagesBySession,
+    streamingSessions,
+    isSessionStreaming,
+    sendMessage,
+    setSessionMessages,
+    abortSession,
+    abortAll,
+    clearAll,
+    removeSession,
+  } = useAIStream();
+
+  // The session the panel is currently displaying. Streams for OTHER sessions
+  // keep running into their own buckets; only this one is rendered.
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(initialSessionId ?? null);
+  // Ref mirror for reads inside async callbacks without re-binding them.
+  const activeSessionIdRef = useRef(activeSessionId);
+  activeSessionIdRef.current = activeSessionId;
+
   // Set so concurrent ensureSession calls don't cancel each other; handleClose
   // aborts all in-flight POST /sessions to prevent post-close resurrection.
   const ensureSessionAbortersRef = useRef<Set<AbortController>>(new Set());
@@ -39,29 +56,30 @@ export function useAiChat({
     EMPTY_SELECTION,
   );
 
-  // Reset session + messages when the user navigates to a different project so
-  // a session ID from project A can never be replayed against project B's chat
-  // route. Within the same project, traceSessionId / traceId can change while
-  // the chat is active (the user navigates between traces with the panel
-  // open) — those don't reset; the latest values flow into handleSend below
-  // so subsequent messages get the new context. handleNewSession /
-  // handleSelectSession remain the explicit reset paths within a project.
-  // When initialSessionId is set, the loading useEffect below owns session
-  // ownership, so we bail here to avoid clobbering its fetched messages.
+  // Reset chat state when the user navigates to a different project so a
+  // session ID from project A can never be replayed against project B's chat
+  // route. Aborting all runs is deliberate: a project switch is a hard
+  // boundary, unlike session switches within a project which keep streams
+  // alive. Within the same project, traceSessionId / traceId can change while
+  // the chat is active — those don't reset; the latest values flow into
+  // handleSend below. When initialSessionId is set, the loading useEffect
+  // below owns session selection, so we bail here to avoid clobbering it.
   useEffect(() => {
     if (initialSessionId) return;
-    sessionIdRef.current = null;
-    setMessages([]);
+    setActiveSessionId(null);
+    abortAll();
+    clearAll();
   }, [projectId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // When initialSessionId is provided, load that session's messages on mount / change.
-  // AbortController guards against stale fetches: if the user switches between
-  // RCA sessions quickly, an older fetch resolving after a newer one would
-  // otherwise overwrite the current session's messages.
+  // When initialSessionId is provided, load that session's messages on mount /
+  // change — unless it is currently streaming, in which case its live bucket
+  // is more complete than the DB (which only gets the assistant row at run
+  // end). Stale fetches can't clobber other sessions: the response is written
+  // to the bucket of the session it was fetched for.
   useEffect(() => {
     if (!initialSessionId || !projectId) return;
-    sessionIdRef.current = initialSessionId;
-    setMessages([]);
+    setActiveSessionId(initialSessionId);
+    if (isSessionStreaming(initialSessionId)) return;
 
     const ac = new AbortController();
     fetch(`/api/projects/${projectId}/ai/sessions/${initialSessionId}/messages`, {
@@ -70,7 +88,7 @@ export function useAiChat({
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (ac.signal.aborted || !data) return;
-        const all = (data.messages || []).map(
+        const all: AIMessage[] = (data.messages || []).map(
           (m: { id: string; role: string; content: string; createTime: string }) => ({
             id: m.id,
             role: m.role as "user" | "assistant",
@@ -78,7 +96,7 @@ export function useAiChat({
             timestamp: m.createTime,
           }),
         );
-        setMessages(all);
+        setSessionMessages(initialSessionId, all);
       })
       .catch((err) => {
         if (err?.name !== "AbortError")
@@ -89,9 +107,9 @@ export function useAiChat({
 
   // Lazy session creation — only when first message is sent. The fetch is
   // cancellable so handleClose can prevent a pending response from resurrecting
-  // sessionIdRef after we've cleared it. Caller commits the id on success.
+  // the active session after we've cleared it. Caller commits the id on success.
   const ensureSession = useCallback(async (): Promise<string | null> => {
-    if (sessionIdRef.current) return sessionIdRef.current;
+    if (activeSessionIdRef.current) return activeSessionIdRef.current;
     if (!projectId) return null;
     const ac = new AbortController();
     ensureSessionAbortersRef.current.add(ac);
@@ -120,7 +138,10 @@ export function useAiChat({
       try {
         const sessionId = await ensureSession();
         if (!sessionId) return;
-        sessionIdRef.current = sessionId;
+        // Commit to the ref synchronously so a second send arriving before
+        // the next render sees the session and doesn't create a duplicate.
+        activeSessionIdRef.current = sessionId;
+        setActiveSessionId(sessionId);
         sendMessage({
           sessionId,
           message,
@@ -138,27 +159,25 @@ export function useAiChat({
     [projectId, traceId, traceSessionId, ensureSession, sendMessage],
   );
 
+  // Start a fresh chat. A still-running stream from the previous session keeps
+  // reading in the background into its own bucket — it is never rendered here,
+  // and the user can return to it via history to watch it live.
   const handleNewSession = useCallback(() => {
-    // Note: a still-running stream from the previous session keeps reading
-    // in the background. Its SSE deltas may briefly bleed into this fresh
-    // chat view until the backend turn completes — tracked separately as a
-    // follow-up (see the linked discussion / issue on #784).
-    sessionIdRef.current = null;
-    setMessages([]);
-  }, [setMessages]);
+    setActiveSessionId(null);
+  }, []);
 
-  // Closing the panel ends the conversation: any in-flight run is aborted,
-  // and the session id + messages are dropped so the next reopen starts
-  // fresh. History list remains the way back to past sessions (server-side).
+  // Closing the panel ends the conversation: every in-flight run is aborted,
+  // and all cached sessions are dropped so the next reopen starts fresh.
+  // History list remains the way back to past sessions (server-side).
   // Switching traces within the same page does NOT trigger this — the panel
   // stays open in that case.
   const handleClose = useCallback(() => {
     for (const ac of ensureSessionAbortersRef.current) ac.abort();
     ensureSessionAbortersRef.current.clear();
-    abort();
-    sessionIdRef.current = null;
-    setMessages([]);
-  }, [abort, setMessages]);
+    abortAll();
+    clearAll();
+    setActiveSessionId(null);
+  }, [abortAll, clearAll]);
 
   const handleOpenHistory = useCallback(async () => {
     if (!projectId) return;
@@ -174,48 +193,63 @@ export function useAiChat({
 
   const handleSelectSession = useCallback(
     async (session: AISession) => {
-      sessionIdRef.current = session.id;
-      setMessages([]);
+      setActiveSessionId(session.id);
       setHistoryOpen(false);
 
       if (!projectId) return;
+      // A streaming session's live bucket is authoritative — the DB won't have
+      // the in-flight assistant response until the run completes, so loading
+      // history here would make the chat appear frozen.
+      if (isSessionStreaming(session.id)) return;
       try {
         const res = await fetch(`/api/projects/${projectId}/ai/sessions/${session.id}/messages`);
         if (res.ok) {
           const data = await res.json();
-          const loaded = (data.messages || []).map((m: any) => ({
-            id: m.id,
-            role: m.role as "user" | "assistant",
-            content: m.content,
-            timestamp: m.createTime,
-          }));
-          setMessages(loaded);
+          // A run may have started in this session while the fetch was in
+          // flight — the stale load must not wipe the live turn.
+          if (isSessionStreaming(session.id)) return;
+          const loaded: AIMessage[] = (data.messages || []).map(
+            (m: { id: string; role: string; content: string; createTime: string }) => ({
+              id: m.id,
+              role: m.role as "user" | "assistant",
+              content: m.content,
+              timestamp: m.createTime,
+            }),
+          );
+          setSessionMessages(session.id, loaded);
         }
       } catch (err) {
         console.error("[AI Chat] Failed to load session messages:", err);
       }
     },
-    [projectId, setMessages],
+    [projectId, setSessionMessages, isSessionStreaming],
   );
 
   const handleDeleteSession = useCallback(
     (sessionId: string) => {
       setSessions((prev) => prev.filter((s) => s.id !== sessionId));
-      if (sessionIdRef.current === sessionId) {
-        sessionIdRef.current = null;
-        setMessages([]);
+      removeSession(sessionId);
+      if (activeSessionIdRef.current === sessionId) {
+        setActiveSessionId(null);
       }
     },
-    [setMessages],
+    [removeSession],
   );
+
+  const handleAbort = useCallback(() => {
+    if (activeSessionIdRef.current) abortSession(activeSessionIdRef.current);
+  }, [abortSession]);
+
+  const messages: AIMessage[] = activeSessionId ? (messagesBySession[activeSessionId] ?? []) : [];
+  const activeStreaming = activeSessionId ? !!streamingSessions[activeSessionId] : false;
 
   return {
     // State
     messages,
-    isStreaming: isSending || isStreaming || messages.some((m) => m.isStreaming),
+    isStreaming: isSending || activeStreaming || messages.some((m) => m.isStreaming),
     sessions,
     historyOpen,
-    currentSessionId: sessionIdRef.current,
+    currentSessionId: activeSessionId,
     modelSelection,
 
     // Setters
@@ -224,7 +258,7 @@ export function useAiChat({
 
     // Actions
     handleSend,
-    handleAbort: abort,
+    handleAbort,
     handleNewSession,
     handleClose,
     handleOpenHistory,

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-stream.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-stream.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor, cleanup } from "@testing-library/react";
+import { useAIStream } from "./use-ai-stream";
+import type { AIMessage } from "../types";
+
+/**
+ * Controllable SSE response: emit() pushes one `data:` line, close() ends the
+ * stream. enqueue after cancellation throws inside the helper and is
+ * swallowed — the assertion that matters is what landed in the hook state.
+ */
+function createSSE() {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  const encoder = new TextEncoder();
+  return {
+    response: new Response(stream, { status: 200 }),
+    emit(event: Record<string, unknown>) {
+      try {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n`));
+      } catch {
+        // stream already cancelled — fine, tests assert on hook state
+      }
+    },
+    close() {
+      try {
+        controller.close();
+      } catch {
+        // already cancelled
+      }
+    },
+  };
+}
+
+const textDelta = (delta: string) => ({
+  type: "message_update",
+  assistantMessageEvent: { type: "text_delta", delta },
+});
+
+const historyMsg = (id: string, content: string): AIMessage => ({
+  id,
+  role: "user",
+  content,
+  timestamp: "2026-01-01T00:00:00Z",
+});
+
+describe("useAIStream per-session isolation", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  const send = (result: { current: ReturnType<typeof useAIStream> }, sessionId: string) =>
+    act(() => {
+      void result.current.sendMessage({
+        sessionId,
+        message: `hi ${sessionId}`,
+        projectId: "p1",
+      });
+    });
+
+  it("routes stream deltas to the session that started the run, not the visible one", async () => {
+    const sseA = createSSE();
+    fetchMock.mockResolvedValueOnce(sseA.response);
+    const { result } = renderHook(() => useAIStream());
+
+    await send(result, "A");
+    await waitFor(() => expect(result.current.messagesBySession["A"]).toHaveLength(1));
+
+    // user "switches" to session B: its history is loaded into B's bucket
+    act(() => {
+      result.current.setSessionMessages("B", [historyMsg("b1", "old B message")]);
+    });
+
+    sseA.emit(textDelta("Hello"));
+    sseA.emit(textDelta(" world"));
+
+    await waitFor(() => {
+      const a = result.current.messagesBySession["A"];
+      expect(a?.some((m) => m.role === "assistant" && m.content === "Hello world")).toBe(true);
+    });
+
+    // B's bucket is untouched by A's stream
+    expect(result.current.messagesBySession["B"]).toHaveLength(1);
+    expect(result.current.messagesBySession["B"]![0].content).toBe("old B message");
+  });
+
+  it("keeps session A streaming when a send starts in session B", async () => {
+    const sseA = createSSE();
+    const sseB = createSSE();
+    fetchMock.mockResolvedValueOnce(sseA.response).mockResolvedValueOnce(sseB.response);
+    const { result } = renderHook(() => useAIStream());
+
+    await send(result, "A");
+    await send(result, "B");
+    await waitFor(() => {
+      expect(result.current.streamingSessions["A"]).toBe(true);
+      expect(result.current.streamingSessions["B"]).toBe(true);
+    });
+
+    sseA.emit(textDelta("from A"));
+    sseB.emit(textDelta("from B"));
+
+    await waitFor(() => {
+      expect(result.current.messagesBySession["A"]?.some((m) => m.content === "from A")).toBe(true);
+      expect(result.current.messagesBySession["B"]?.some((m) => m.content === "from B")).toBe(true);
+    });
+
+    sseA.close();
+    await waitFor(() => expect(result.current.streamingSessions["A"]).toBeFalsy());
+    expect(result.current.streamingSessions["B"]).toBe(true);
+  });
+
+  it("cancels the prior run when a new send starts in the same session", async () => {
+    const sse1 = createSSE();
+    const sse2 = createSSE();
+    fetchMock.mockResolvedValueOnce(sse1.response).mockResolvedValueOnce(sse2.response);
+    const { result } = renderHook(() => useAIStream());
+
+    await send(result, "A");
+    sse1.emit(textDelta("one"));
+    await waitFor(() =>
+      expect(result.current.messagesBySession["A"]?.some((m) => m.content === "one")).toBe(true),
+    );
+
+    await send(result, "A");
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    // late chunks from the superseded run must not land anywhere
+    sse1.emit(textDelta("LEAK"));
+    sse2.emit(textDelta("two"));
+    await waitFor(() =>
+      expect(result.current.messagesBySession["A"]?.some((m) => m.content === "two")).toBe(true),
+    );
+    expect(result.current.messagesBySession["A"]?.some((m) => m.content.includes("LEAK"))).toBe(
+      false,
+    );
+    // the superseded run's bubble is frozen, not left streaming forever
+    expect(
+      result.current.messagesBySession["A"]?.filter((m) => m.isStreaming).length,
+    ).toBeLessThanOrEqual(1);
+  });
+
+  it("abortSession stops only that session's stream", async () => {
+    const sseA = createSSE();
+    const sseB = createSSE();
+    fetchMock.mockResolvedValueOnce(sseA.response).mockResolvedValueOnce(sseB.response);
+    const { result } = renderHook(() => useAIStream());
+
+    await send(result, "A");
+    await send(result, "B");
+    await waitFor(() => {
+      expect(result.current.streamingSessions["A"]).toBe(true);
+      expect(result.current.streamingSessions["B"]).toBe(true);
+    });
+
+    act(() => {
+      result.current.abortSession("A");
+    });
+    await waitFor(() => expect(result.current.streamingSessions["A"]).toBeFalsy());
+    expect(result.current.streamingSessions["B"]).toBe(true);
+
+    // aborted stream's late chunks are dropped; B still receives
+    sseA.emit(textDelta("ghost"));
+    sseB.emit(textDelta("alive"));
+    await waitFor(() =>
+      expect(result.current.messagesBySession["B"]?.some((m) => m.content === "alive")).toBe(true),
+    );
+    expect(
+      result.current.messagesBySession["A"]?.some((m) => m.content.includes("ghost")),
+    ).toBeFalsy();
+    // no bubble left permanently streaming in the aborted session
+    expect(result.current.messagesBySession["A"]?.some((m) => m.isStreaming)).toBeFalsy();
+  });
+
+  it("abortAll stops every stream and clearAll drops every bucket", async () => {
+    const sseA = createSSE();
+    const sseB = createSSE();
+    fetchMock.mockResolvedValueOnce(sseA.response).mockResolvedValueOnce(sseB.response);
+    const { result } = renderHook(() => useAIStream());
+
+    await send(result, "A");
+    await send(result, "B");
+    await waitFor(() => {
+      expect(result.current.streamingSessions["A"]).toBe(true);
+      expect(result.current.streamingSessions["B"]).toBe(true);
+    });
+
+    act(() => {
+      result.current.abortAll();
+      result.current.clearAll();
+    });
+
+    await waitFor(() => {
+      expect(result.current.streamingSessions).toEqual({});
+      expect(result.current.messagesBySession).toEqual({});
+    });
+  });
+
+  it("setSessionMessages replaces the bucket of a non-streaming session", () => {
+    const { result } = renderHook(() => useAIStream());
+    act(() => {
+      result.current.setSessionMessages("C", [historyMsg("c1", "one"), historyMsg("c2", "two")]);
+    });
+    expect(result.current.messagesBySession["C"]).toHaveLength(2);
+    act(() => {
+      result.current.setSessionMessages("C", [historyMsg("c3", "three")]);
+    });
+    expect(result.current.messagesBySession["C"]).toHaveLength(1);
+    expect(result.current.messagesBySession["C"]![0].content).toBe("three");
+  });
+});

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-stream.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-stream.ts
@@ -15,16 +15,109 @@ function generateId(): string {
   });
 }
 
+/** Freeze any still-streaming bubbles in a message list. */
+function frozen(messages: AIMessage[]): AIMessage[] {
+  return messages.map((m) => (m.isStreaming ? { ...m, isStreaming: false } : m));
+}
+
+interface SessionRun {
+  /** Monotonic id — a bucket write is valid only while this run is still the
+   * session's registered run with the same generation. */
+  gen: number;
+  abortController: AbortController;
+  reader: ReadableStreamDefaultReader<Uint8Array> | null;
+}
+
+/**
+ * Streams agent responses into per-session message buckets.
+ *
+ * Every state element is keyed by sessionId so an in-flight SSE run keeps
+ * writing to the session it belongs to — switching the visible session can
+ * never make another session's deltas bleed into the current view, and a
+ * still-running session shows its accumulated progress when the user returns
+ * to it.
+ */
 export function useAIStream() {
-  const [messages, setMessages] = useState<AIMessage[]>([]);
-  const [isStreaming, setIsStreaming] = useState(false);
-  const abortRef = useRef<AbortController | null>(null);
-  const readerRef = useRef<ReadableStreamDefaultReader<Uint8Array> | null>(null);
-  // Bumped on send AND on abort — invalidates in-flight setMessages from prior streams.
-  const generationRef = useRef(0);
-  // Bumped only on send — finally checks this to distinguish "I was aborted"
-  // from "a newer send superseded me" (only the latter must skip cleanup).
-  const latestSendRef = useRef(0);
+  const [messagesBySession, setMessagesBySession] = useState<Record<string, AIMessage[]>>({});
+  const [streamingSessions, setStreamingSessions] = useState<Record<string, boolean>>({});
+  const runsRef = useRef<Map<string, SessionRun>>(new Map());
+  const genRef = useRef(0);
+
+  const updateBucket = useCallback(
+    (sessionId: string, updater: (prev: AIMessage[]) => AIMessage[]) => {
+      setMessagesBySession((prev) => ({ ...prev, [sessionId]: updater(prev[sessionId] ?? []) }));
+    },
+    [],
+  );
+
+  /** Cancel a session's in-flight run (reader + fetch). State cleanup is the caller's job. */
+  const stopRun = useCallback((sessionId: string) => {
+    const run = runsRef.current.get(sessionId);
+    if (!run) return;
+    runsRef.current.delete(sessionId);
+    run.reader?.cancel().catch(() => {});
+    run.abortController.abort();
+  }, []);
+
+  const clearStreamingFlag = useCallback((sessionId: string) => {
+    setStreamingSessions((prev) => {
+      if (!(sessionId in prev)) return prev;
+      const next = { ...prev };
+      delete next[sessionId];
+      return next;
+    });
+  }, []);
+
+  const abortSession = useCallback(
+    (sessionId: string) => {
+      stopRun(sessionId);
+      clearStreamingFlag(sessionId);
+      updateBucket(sessionId, frozen);
+    },
+    [stopRun, clearStreamingFlag, updateBucket],
+  );
+
+  const abortAll = useCallback(() => {
+    for (const sessionId of [...runsRef.current.keys()]) stopRun(sessionId);
+    setStreamingSessions({});
+    setMessagesBySession((prev) =>
+      Object.fromEntries(Object.entries(prev).map(([id, msgs]) => [id, frozen(msgs)])),
+    );
+  }, [stopRun]);
+
+  const clearAll = useCallback(() => {
+    setMessagesBySession({});
+    setStreamingSessions({});
+  }, []);
+
+  /** Replace a session's cached messages (history loads). */
+  const setSessionMessages = useCallback((sessionId: string, messages: AIMessage[]) => {
+    setMessagesBySession((prev) => ({ ...prev, [sessionId]: messages }));
+  }, []);
+
+  /**
+   * Synchronous truth for "does this session have a live run?". Unlike the
+   * streamingSessions state (which lags until the next render), runsRef is
+   * registered before sendMessage's first await, so callers racing a send —
+   * e.g. a history fetch resolving after the user sent a message — get an
+   * exact answer.
+   */
+  const isSessionStreaming = useCallback((sessionId: string) => runsRef.current.has(sessionId), []);
+
+  /** Drop a session entirely (delete): cancel its run and forget its bucket. */
+  const removeSession = useCallback(
+    (sessionId: string) => {
+      stopRun(sessionId);
+      clearStreamingFlag(sessionId);
+      setMessagesBySession((prev) => {
+        if (!(sessionId in prev)) return prev;
+        const next = { ...prev };
+        delete next[sessionId];
+        return next;
+      });
+    },
+    [stopRun, clearStreamingFlag],
+  );
 
   const sendMessage = useCallback(
     async (params: {
@@ -37,16 +130,23 @@ export function useAIStream() {
       traceId?: string;
       traceSessionId?: string;
     }) => {
-      const myGen = ++generationRef.current;
-      latestSendRef.current = myGen;
-      const safeSetMessages: typeof setMessages = (updater) => {
-        if (generationRef.current !== myGen) return;
-        setMessages(updater);
-      };
+      const { sessionId } = params;
+      const myGen = ++genRef.current;
 
-      // Cancel any prior in-flight stream so its tail chunks can't race with this run.
-      readerRef.current?.cancel();
-      abortRef.current?.abort();
+      // Single-flight per session: cancel a prior run in THIS session only.
+      // Runs in other sessions keep streaming into their own buckets.
+      stopRun(sessionId);
+
+      const abortController = new AbortController();
+      const run: SessionRun = { gen: myGen, abortController, reader: null };
+      runsRef.current.set(sessionId, run);
+
+      // Valid only while this run is still the session's registered run —
+      // superseded/aborted runs' buffered chunks become no-ops.
+      const safeUpdate = (updater: (prev: AIMessage[]) => AIMessage[]) => {
+        if (runsRef.current.get(sessionId)?.gen !== myGen) return;
+        updateBucket(sessionId, updater);
+      };
 
       // Bubble tracking is local to this run so superseded streams cannot
       // mutate the live run's state via shared refs.
@@ -59,16 +159,17 @@ export function useAIStream() {
         content: params.message,
         timestamp: new Date().toISOString(),
       };
-      safeSetMessages((prev) => [...prev, userMsg]);
+      // Freeze any bubble a superseded run left open, then append the user turn.
+      safeUpdate((prev) => [...frozen(prev), userMsg]);
 
-      setIsStreaming(true);
+      setStreamingSessions((prev) => ({ ...prev, [sessionId]: true }));
 
       // Opens a new streaming assistant text bubble and returns its id.
       // Subsequent text deltas append to this bubble until it is frozen.
       const openTextBubble = (): string => {
         const id = generateId();
         currentTextId = id;
-        safeSetMessages((prev) => [
+        safeUpdate((prev) => [
           ...prev,
           {
             id,
@@ -87,7 +188,7 @@ export function useAIStream() {
         const frozenId = currentTextId;
         lastFrozenId = frozenId;
         currentTextId = null;
-        safeSetMessages((prev) =>
+        safeUpdate((prev) =>
           prev.map((m) => (m.id === frozenId ? { ...m, isStreaming: false } : m)),
         );
       };
@@ -95,7 +196,7 @@ export function useAIStream() {
       // Helper: show an error in the current bubble or open a new one.
       const showError = (errorMessage: string) => {
         const targetId = currentTextId ?? openTextBubble();
-        safeSetMessages((prev) =>
+        safeUpdate((prev) =>
           prev.map((m) =>
             m.id === targetId ? { ...m, content: `Error: ${errorMessage}`, isStreaming: false } : m,
           ),
@@ -103,12 +204,9 @@ export function useAIStream() {
         currentTextId = null;
       };
 
-      const abortController = new AbortController();
-      abortRef.current = abortController;
-
       try {
         // Goes through Next.js proxy which handles auth + adds headers
-        const url = `/api/projects/${params.projectId}/ai/sessions/${params.sessionId}/messages`;
+        const url = `/api/projects/${params.projectId}/ai/sessions/${sessionId}/messages`;
         const response = await fetch(url, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -131,7 +229,7 @@ export function useAIStream() {
         if (!response.body) throw new Error("No response body");
 
         const reader = response.body.getReader();
-        readerRef.current = reader;
+        run.reader = reader;
         const decoder = new TextDecoder();
         let buffer = "";
 
@@ -155,7 +253,7 @@ export function useAIStream() {
                     // Open a new bubble if there isn't one (first text, or post-tool text)
                     if (!currentTextId) openTextBubble();
                     const targetId = currentTextId!;
-                    safeSetMessages((prev) =>
+                    safeUpdate((prev) =>
                       prev.map((msg) =>
                         msg.id === targetId ? { ...msg, content: msg.content + delta.delta } : msg,
                       ),
@@ -165,7 +263,7 @@ export function useAIStream() {
                   if (delta?.type === "thinking_delta" && delta.delta) {
                     if (!currentTextId) openTextBubble();
                     const targetId = currentTextId!;
-                    safeSetMessages((prev) =>
+                    safeUpdate((prev) =>
                       prev.map((msg) =>
                         msg.id === targetId
                           ? { ...msg, thinking: (msg.thinking ?? "") + delta.delta }
@@ -186,7 +284,7 @@ export function useAIStream() {
                   if (msg?.usage) {
                     const lastId = currentTextId ?? lastFrozenId;
                     if (lastId) {
-                      safeSetMessages((prev) =>
+                      safeUpdate((prev) =>
                         prev.map((m) =>
                           m.id === lastId
                             ? {
@@ -219,11 +317,11 @@ export function useAIStream() {
                       status: "running",
                     },
                   };
-                  safeSetMessages((prev) => [...prev, toolStepMsg]);
+                  safeUpdate((prev) => [...prev, toolStepMsg]);
                 }
 
                 if (eventData.type === "tool_execution_end") {
-                  safeSetMessages((prev) =>
+                  safeUpdate((prev) =>
                     prev.map((m) =>
                       m.id === eventData.toolCallId
                         ? {
@@ -259,33 +357,39 @@ export function useAIStream() {
       } finally {
         // Freeze the last open bubble (if streaming was cut short).
         freezeCurrentBubble();
-        // Skip cleanup if a newer send already began — would clobber its state.
-        if (latestSendRef.current === myGen) {
-          setIsStreaming(false);
-          abortRef.current = null;
-          readerRef.current = null;
+        // Skip cleanup if a newer run owns this session — would clobber its state.
+        if (runsRef.current.get(sessionId)?.gen === myGen) {
+          runsRef.current.delete(sessionId);
+          clearStreamingFlag(sessionId);
         }
       }
     },
-    [],
+    [stopRun, updateBucket, clearStreamingFlag],
   );
 
-  const abort = useCallback(() => {
-    // Bump first so chunks still buffered in the stream loop noop via safeSetMessages.
-    generationRef.current++;
-    readerRef.current?.cancel();
-    abortRef.current?.abort();
-  }, []);
-
   // Defensive cleanup: if the host component truly unmounts (logout, tab
-  // close, hard route swap), abort any in-flight stream so we don't leak the
-  // SSE connection or keep burning LLM tokens after the UI is gone.
+  // close, hard route swap), abort every in-flight stream so we don't leak
+  // SSE connections or keep burning LLM tokens after the UI is gone.
   useEffect(() => {
+    const runs = runsRef.current;
     return () => {
-      readerRef.current?.cancel();
-      abortRef.current?.abort();
+      for (const run of runs.values()) {
+        run.reader?.cancel().catch(() => {});
+        run.abortController.abort();
+      }
+      runs.clear();
     };
   }, []);
 
-  return { messages, isStreaming, sendMessage, abort, setMessages };
+  return {
+    messagesBySession,
+    streamingSessions,
+    isSessionStreaming,
+    sendMessage,
+    setSessionMessages,
+    abortSession,
+    abortAll,
+    clearAll,
+    removeSession,
+  };
 }


### PR DESCRIPTION
Closes #855

## Problem

The AI chat's streaming hook held a single `messages` array and one reader for the whole chat. An in-flight SSE run kept writing into whatever session the user switched to (deltas from session A bleeding into session B's view), and returning to the streaming session looked frozen — the history load only finds the user message because the assistant row isn't persisted until the run completes.

## Change

Rework `useAIStream` around **per-session state**:

- Each run writes to its own session's message bucket (`Record<sessionId, AIMessage[]>`); streaming flags and run cancellation are per session. A synchronous `isSessionStreaming()` reads the run registry directly so callers racing a send get an exact answer.
- `useAiChat` renders only the active session's bucket. Selecting a still-streaming session shows its live accumulated progress instead of fetching stale history (re-checked after the fetch resolves, so a late response can't wipe a run that started mid-flight).
- New-session and session-switch **no longer abort anything** — background runs keep accumulating and can be watched live by switching back. Close, delete, project switch, and unmount still abort (deliberately: those are hard boundaries).
- The session id is committed synchronously after creation so a rapid second send can't create a duplicate session.

Aborting the SSE on switch was deliberately avoided: the backend run isn't cancellable from a closed stream and an abort leaves the agent service rejecting the session's next message as busy.

## Testing

- 13 new hook tests (`use-ai-stream.test.tsx`, `use-ai-chat.test.tsx`) covering delta routing, background-stream survival, per-session cancellation, the stale-history race, and cleanup paths.
- Full UI suite passes (1263 tests); diff coverage 93%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AI chat delta leakage by keying streams and message state per session, and fences session commits behind a session-boundary epoch so a late-resolving session creation can't flip which chat is shown. Also drops sends that resolve across a close or project switch, so runs never start in a closed panel or the wrong project.

- Bug Fixes
  - Streams and messages live in per-session buckets (`messagesBySession`, `streamingSessions`); `isSessionStreaming` provides race-safe synchronous checks.
  - `useAiChat` renders only the active session's bucket and skips the DB history load for streaming sessions, since the assistant row isn't saved until the run completes.
  - Session boundaries (New Session, history selection, `initialSessionId`, close, project switch) bump an epoch so a late session creation can't change the active session.
  - Session creation is single-flight and shared across concurrent sends; the commit is skipped if a boundary was crossed while it was in flight.
  - New Session clears the view and drops the pending creation without aborting other runs; close and project switch drop in-flight sends that resolve after the boundary.
  - The busy state is a count, not a boolean, so a late-settling send can't blank the waiting state of another in-flight send.

- Migration
  - Replace `messages` with `messagesBySession[sessionId]` and `isStreaming` with `!!streamingSessions[sessionId]`.
  - Replace `setMessages` with `setSessionMessages(sessionId, messages)` and `abort` with `abortSession(sessionId)`.
  - Use `abortAll`/`clearAll` for panel close or hard boundaries; use `removeSession(sessionId)` when deleting a session.

<sup>Written for commit 371425415898238e07ba5dabc60c813064bc49fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

