### PR TITLE
feat(agent): persist tool steps and text segments so chat history survives reload

### DIFF
--- a/frontend/ee/agent/src/__tests__/session-build-context.test.ts
+++ b/frontend/ee/agent/src/__tests__/session-build-context.test.ts
@@ -72,5 +72,21 @@ describe("SessionManager.buildContext", () => {
   it("returns an empty context for a missing or empty session", async () => {
     mocks.findUnique.mockResolvedValue(null);
     expect(await new SessionManager("s1").buildContext()).toEqual([]);
+
+    mocks.findUnique.mockResolvedValue({ id: "s1", messages: [] });
+    expect(await new SessionManager("s1").buildContext()).toEqual([]);
+  });
+
+  it("skips content-less assistant rows (usage carriers of tool-only runs)", async () => {
+    mocks.findUnique.mockResolvedValue({
+      id: "s1",
+      messages: [
+        row("1", "user", "check the trace"),
+        row("2", "assistant", "", { model: "test-model", provider: "test-provider" }),
+      ],
+    });
+
+    const context = await new SessionManager("s1").buildContext();
+    expect(context.map((m) => m.role)).toEqual(["user"]);
   });
 });

--- a/frontend/ee/agent/src/__tests__/session-build-context.test.ts
+++ b/frontend/ee/agent/src/__tests__/session-build-context.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+}));
+
+vi.mock("@traceroot/core", () => ({
+  prisma: { aISession: { findUnique: mocks.findUnique } },
+}));
+
+import { SessionManager } from "../session.js";
+
+const row = (id: string, role: string, content: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  role,
+  content,
+  createTime: new Date(`2026-01-01T00:00:0${id}Z`),
+  model: null,
+  provider: null,
+  metadata: null,
+  ...extra,
+});
+
+describe("SessionManager.buildContext", () => {
+  beforeEach(() => {
+    mocks.findUnique.mockReset();
+  });
+
+  it("restores user AND assistant turns in order so the agent keeps its own answers", async () => {
+    mocks.findUnique.mockResolvedValue({
+      id: "s1",
+      messages: [
+        row("1", "user", "what failed?"),
+        row("2", "assistant", "The checkout span timed out.", {
+          model: "test-model",
+          provider: "test-provider",
+        }),
+        row("3", "user", "why?"),
+      ],
+    });
+
+    const context = await new SessionManager("s1").buildContext();
+
+    expect(context.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+    const assistant = context[1] as {
+      role: string;
+      content: Array<{ type: string; text: string }>;
+      stopReason: string;
+      model: string;
+    };
+    expect(assistant.content).toEqual([{ type: "text", text: "The checkout span timed out." }]);
+    expect(assistant.stopReason).toBe("stop");
+    expect(assistant.model).toBe("test-model");
+  });
+
+  it("skips tool_step rows — the agent re-invokes tools rather than replaying results", async () => {
+    mocks.findUnique.mockResolvedValue({
+      id: "s1",
+      messages: [
+        row("1", "user", "check the trace"),
+        row("2", "tool_step", "", {
+          metadata: { toolCallId: "t1", toolName: "get_traces", args: {} },
+        }),
+        row("3", "assistant", "Looked it up."),
+      ],
+    });
+
+    const context = await new SessionManager("s1").buildContext();
+    expect(context.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("returns an empty context for a missing or empty session", async () => {
+    mocks.findUnique.mockResolvedValue(null);
+    expect(await new SessionManager("s1").buildContext()).toEqual([]);
+  });
+});

--- a/frontend/ee/agent/src/__tests__/stream-persister.test.ts
+++ b/frontend/ee/agent/src/__tests__/stream-persister.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
+import { StreamPersister } from "../stream-persister.js";
+import type { TokenUsageData } from "../session.js";
+
+const textDelta = (delta: string): AgentEvent =>
+  ({
+    type: "message_update",
+    message: {} as never,
+    assistantMessageEvent: { type: "text_delta", delta } as never,
+  }) as AgentEvent;
+
+const thinkingDelta = (delta: string): AgentEvent =>
+  ({
+    type: "message_update",
+    message: {} as never,
+    assistantMessageEvent: { type: "thinking_delta", delta } as never,
+  }) as AgentEvent;
+
+const toolStart = (id: string, args: Record<string, unknown> = {}): AgentEvent => ({
+  type: "tool_execution_start",
+  toolCallId: id,
+  toolName: "get_traces",
+  args,
+});
+
+const toolEnd = (id: string, result: unknown = "ok", isError = false): AgentEvent => ({
+  type: "tool_execution_end",
+  toolCallId: id,
+  toolName: "get_traces",
+  result,
+  isError,
+});
+
+const USAGE: TokenUsageData = {
+  model: "test-model",
+  provider: "test-provider",
+  isByok: false,
+  inputTokens: 10,
+  outputTokens: 20,
+  cost: 0.05,
+};
+
+type AppendCall = {
+  role: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  tokenUsage?: TokenUsageData;
+};
+
+function makePersister() {
+  const calls: AppendCall[] = [];
+  const append = vi.fn(
+    async (
+      role: string,
+      content: string,
+      metadata?: Record<string, unknown>,
+      tokenUsage?: TokenUsageData,
+    ) => {
+      calls.push({ role, content, metadata, tokenUsage });
+    },
+  );
+  return { persister: new StreamPersister(append), calls, append };
+}
+
+describe("StreamPersister", () => {
+  it("persists a text-only run as a single assistant row carrying the usage", async () => {
+    const { persister, calls } = makePersister();
+    persister.onEvent(textDelta("Hello"));
+    persister.onEvent(textDelta(" world"));
+    await persister.finish(USAGE);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      role: "assistant",
+      content: "Hello world",
+      tokenUsage: USAGE,
+    });
+  });
+
+  it("flushes text segments at tool boundaries so interleaving survives", async () => {
+    const { persister, calls } = makePersister();
+    persister.onEvent(textDelta("Let me check."));
+    persister.onEvent(toolStart("t1", { traceId: "abc" }));
+    persister.onEvent(toolEnd("t1", { spans: 3 }));
+    persister.onEvent(textDelta("Found it."));
+    await persister.finish(USAGE);
+
+    expect(calls.map((c) => c.role)).toEqual(["assistant", "tool_step", "assistant"]);
+    expect(calls[0].content).toBe("Let me check.");
+    expect(calls[0].tokenUsage).toBeUndefined();
+    expect(calls[2].content).toBe("Found it.");
+    // usage lands on the final segment only
+    expect(calls[2].tokenUsage).toEqual(USAGE);
+  });
+
+  it("records tool args from start and result from end in metadata", async () => {
+    const { persister, calls } = makePersister();
+    persister.onEvent(toolStart("t1", { query: "errors" }));
+    persister.onEvent(toolEnd("t1", { rows: [] }, true));
+    await persister.finish();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].role).toBe("tool_step");
+    expect(calls[0].metadata).toEqual({
+      toolCallId: "t1",
+      toolName: "get_traces",
+      args: { query: "errors" },
+      result: { rows: [] },
+      isError: true,
+    });
+  });
+
+  it("keeps thinking out of content and stores it in metadata", async () => {
+    const { persister, calls } = makePersister();
+    persister.onEvent(thinkingDelta("hmm..."));
+    persister.onEvent(textDelta("The answer."));
+    await persister.finish();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].content).toBe("The answer.");
+    expect(calls[0].metadata).toEqual({ thinking: "hmm..." });
+  });
+
+  it("persists nothing for a run with no text and no tools", async () => {
+    const { persister, calls } = makePersister();
+    await persister.finish(USAGE);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("serializes DB writes: a later row is not inserted until the earlier one lands", async () => {
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((r) => {
+      releaseFirst = r;
+    });
+    let call = 0;
+    const append = vi.fn(async (role: string) => {
+      call += 1;
+      if (call === 1) {
+        order.push(`start:${role}`);
+        await gate;
+        order.push(`end:${role}`);
+      } else {
+        order.push(`start:${role}`);
+        order.push(`end:${role}`);
+      }
+    });
+    const persister = new StreamPersister(append);
+
+    persister.onEvent(textDelta("segment"));
+    persister.onEvent(toolStart("t1"));
+    persister.onEvent(toolEnd("t1"));
+    const done = persister.finish();
+
+    // give the event loop a chance to (incorrectly) start the second insert
+    await new Promise((r) => setTimeout(r, 10));
+    expect(order).toEqual(["start:assistant"]);
+
+    releaseFirst();
+    await done;
+    expect(order).toEqual(["start:assistant", "end:assistant", "start:tool_step", "end:tool_step"]);
+  });
+
+  it("keeps persisting later rows when an earlier insert fails", async () => {
+    const calls: string[] = [];
+    let call = 0;
+    const append = vi.fn(async (role: string) => {
+      call += 1;
+      if (call === 1) throw new Error("db down");
+      calls.push(role);
+    });
+    const persister = new StreamPersister(append);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    persister.onEvent(textDelta("lost segment"));
+    persister.onEvent(toolStart("t1"));
+    persister.onEvent(toolEnd("t1"));
+    await persister.finish();
+
+    expect(calls).toEqual(["tool_step"]);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/frontend/ee/agent/src/__tests__/stream-persister.test.ts
+++ b/frontend/ee/agent/src/__tests__/stream-persister.test.ts
@@ -122,10 +122,31 @@ describe("StreamPersister", () => {
     expect(calls[0].metadata).toEqual({ thinking: "hmm..." });
   });
 
-  it("persists nothing for a run with no text and no tools", async () => {
+  it("persists nothing for a run that produced neither output nor usage", async () => {
     const { persister, calls } = makePersister();
-    await persister.finish(USAGE);
+    await persister.finish();
     expect(calls).toHaveLength(0);
+  });
+
+  it("persists a usage-carrying row for a run that ends at a tool boundary", async () => {
+    const { persister, calls } = makePersister();
+    persister.onEvent(textDelta("Checking."));
+    persister.onEvent(toolStart("t1"));
+    persister.onEvent(toolEnd("t1"));
+    await persister.finish(USAGE);
+
+    // no trailing text, but the run's usage must still land so it is billed
+    expect(calls.map((c) => c.role)).toEqual(["assistant", "tool_step", "assistant"]);
+    expect(calls[2]).toMatchObject({ content: "", tokenUsage: USAGE });
+  });
+
+  it("stores the cumulative session total in the final segment's metadata", async () => {
+    const { persister, calls } = makePersister();
+    persister.onEvent(textDelta("Done."));
+    await persister.finish({ ...USAGE, totalTokens: 1234 });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].metadata).toEqual({ totalTokens: 1234 });
   });
 
   it("serializes DB writes: a later row is not inserted until the earlier one lands", async () => {
@@ -153,8 +174,9 @@ describe("StreamPersister", () => {
     persister.onEvent(toolEnd("t1"));
     const done = persister.finish();
 
-    // give the event loop a chance to (incorrectly) start the second insert
-    await new Promise((r) => setTimeout(r, 10));
+    // drain the microtask queue so a (incorrectly) fire-and-forget second
+    // insert would have started — deterministic, no wall-clock dependency
+    for (let i = 0; i < 10; i += 1) await Promise.resolve();
     expect(order).toEqual(["start:assistant"]);
 
     releaseFirst();

--- a/frontend/ee/agent/src/__tests__/stream-persister.test.ts
+++ b/frontend/ee/agent/src/__tests__/stream-persister.test.ts
@@ -174,7 +174,7 @@ describe("StreamPersister", () => {
     persister.onEvent(toolEnd("t1"));
     const done = persister.finish();
 
-    // drain the microtask queue so a (incorrectly) fire-and-forget second
+    // drain the microtask queue so an (incorrectly) fire-and-forget second
     // insert would have started — deterministic, no wall-clock dependency
     for (let i = 0; i < 10; i += 1) await Promise.resolve();
     expect(order).toEqual(["start:assistant"]);

--- a/frontend/ee/agent/src/__tests__/usage-accumulator.test.ts
+++ b/frontend/ee/agent/src/__tests__/usage-accumulator.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
+
+const mocks = vi.hoisted(() => ({
+  calculateCost: vi.fn(async () => 0.42),
+}));
+
+vi.mock("@traceroot/core", () => ({
+  calculateCost: mocks.calculateCost,
+}));
+
+import { UsageAccumulator } from "../usage-accumulator.js";
+
+const messageEnd = (usage: Record<string, unknown>, model = "test-model"): AgentEvent =>
+  ({
+    type: "message_end",
+    message: {
+      model,
+      provider: "test-provider",
+      usage,
+      stopReason: "stop",
+    } as never,
+  }) as AgentEvent;
+
+describe("UsageAccumulator", () => {
+  beforeEach(() => {
+    mocks.calculateCost.mockClear();
+  });
+
+  it("sums usage across message_end events and uses the stream-reported cost", async () => {
+    const acc = new UsageAccumulator();
+    acc.onEvent(messageEnd({ input: 10, output: 5, cost: { total: 0.01 } }));
+    acc.onEvent(messageEnd({ input: 20, output: 15, cost: { total: 0.02 } }));
+
+    const usage = await acc.toTokenUsage(false);
+    expect(usage).toEqual({
+      model: "test-model",
+      provider: "test-provider",
+      isByok: false,
+      inputTokens: 30,
+      outputTokens: 20,
+      cost: expect.closeTo(0.03),
+    });
+    expect(mocks.calculateCost).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the pricing table when the stream reports zero cost", async () => {
+    const acc = new UsageAccumulator();
+    acc.onEvent(messageEnd({ input: 10, output: 5, cacheRead: 2, cacheWrite: 1 }));
+
+    const usage = await acc.toTokenUsage(true);
+    expect(mocks.calculateCost).toHaveBeenCalledWith("test-model", 10, 5, 2, 1);
+    expect(usage).toMatchObject({ isByok: true, cost: 0.42 });
+  });
+
+  it("warns when pricing is missing so the run is visibly unbilled", async () => {
+    mocks.calculateCost.mockResolvedValueOnce(0);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const acc = new UsageAccumulator();
+    acc.onEvent(messageEnd({ input: 10, output: 5 }));
+
+    const usage = await acc.toTokenUsage(false);
+    expect(usage?.cost).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("test-model"));
+    warnSpy.mockRestore();
+  });
+
+  it("returns undefined when the run produced no model (nothing to bill)", async () => {
+    const acc = new UsageAccumulator();
+    expect(await acc.toTokenUsage(false)).toBeUndefined();
+    expect(mocks.calculateCost).not.toHaveBeenCalled();
+  });
+
+  it("ignores events other than message_end", async () => {
+    const acc = new UsageAccumulator();
+    acc.onEvent({ type: "turn_start" } as AgentEvent);
+    acc.onEvent({
+      type: "message_update",
+      message: {} as never,
+      assistantMessageEvent: { type: "text_delta", delta: "x" } as never,
+    } as AgentEvent);
+    expect(await acc.toTokenUsage(false)).toBeUndefined();
+  });
+});

--- a/frontend/ee/agent/src/__tests__/usage-accumulator.test.ts
+++ b/frontend/ee/agent/src/__tests__/usage-accumulator.test.ts
@@ -65,6 +65,29 @@ describe("UsageAccumulator", () => {
     warnSpy.mockRestore();
   });
 
+  it("survives a failing pricing lookup with a zero-cost fallback", async () => {
+    mocks.calculateCost.mockRejectedValueOnce(new Error("pricing db down"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const acc = new UsageAccumulator();
+    acc.onEvent(messageEnd({ input: 10, output: 5 }));
+
+    const usage = await acc.toTokenUsage(false);
+    expect(usage).toMatchObject({ inputTokens: 10, outputTokens: 5, cost: 0 });
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("carries the last reported cumulative session total", async () => {
+    const acc = new UsageAccumulator();
+    acc.onEvent(messageEnd({ input: 10, output: 5, totalTokens: 100, cost: { total: 0.01 } }));
+    acc.onEvent(messageEnd({ input: 20, output: 15, totalTokens: 250, cost: { total: 0.02 } }));
+
+    const usage = await acc.toTokenUsage(false);
+    expect(usage?.totalTokens).toBe(250);
+  });
+
   it("returns undefined when the run produced no model (nothing to bill)", async () => {
     const acc = new UsageAccumulator();
     expect(await acc.toTokenUsage(false)).toBeUndefined();

--- a/frontend/ee/agent/src/index.ts
+++ b/frontend/ee/agent/src/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
-import { prisma, calculateCost, syncStandardPrices, ModelSource } from "@traceroot/core";
+import { prisma, syncStandardPrices, ModelSource } from "@traceroot/core";
 import {
   createSession,
   getSession,
@@ -11,6 +11,8 @@ import {
   updateSessionTitle,
 } from "./session.js";
 import { getOrCreateAgent, runAgent, removeAgent, invalidateProviderCache } from "./agent.js";
+import { StreamPersister } from "./stream-persister.js";
+import { UsageAccumulator } from "./usage-accumulator.js";
 import { getSystemPrompt } from "./prompts/system.js";
 import { createExecutor } from "./executors/index.js";
 import { createTools } from "./tools/index.js";
@@ -180,17 +182,14 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
   }
 
   return streamSSE(c, async (stream) => {
-    let assistantText = "";
+    // Mirrors the run into AIMessage rows (text segments, tool steps) so
+    // reloaded history matches what the live stream rendered.
+    const persister = new StreamPersister((role, content, metadata, tokenUsage) =>
+      sessionManager.appendMessage(role, content, metadata, tokenUsage),
+    );
+    // Accumulates token usage across all message_end events (tool-use loops)
+    const usageAccumulator = new UsageAccumulator();
     let loggedFirstUpdate = false;
-
-    // Accumulate token usage across all message_end events (tool-use loops)
-    let totalInputTokens = 0;
-    let totalOutputTokens = 0;
-    let totalCacheReadTokens = 0;
-    let totalCacheWriteTokens = 0;
-    let totalCost = 0;
-    let responseModel: string | undefined;
-    let responseProvider: string | undefined;
 
     await new Promise<void>((resolve) => {
       runAgent(agent, body.message, {
@@ -205,7 +204,7 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
             // Skip noisy message_start, log other event types
             console.log(`[Agent] Event: ${event.type}`);
           }
-          // Log error details and accumulate token usage from message_end
+          // Log error details from message_end
           if (event.type === "message_end") {
             const msg = (event as any).message;
             console.log(
@@ -220,17 +219,6 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
             if (msg?.stopReason === "error") {
               console.error(`[Agent] API error:`, msg.errorMessage || "unknown");
             }
-            // Accumulate token usage
-            const usage = msg?.usage;
-            if (usage) {
-              totalInputTokens += usage.input ?? usage.inputTokens ?? 0;
-              totalOutputTokens += usage.output ?? usage.outputTokens ?? 0;
-              totalCacheReadTokens += usage.cacheRead ?? 0;
-              totalCacheWriteTokens += usage.cacheWrite ?? 0;
-              totalCost += usage.cost?.total ?? 0;
-            }
-            if (msg?.model) responseModel = msg.model;
-            if (msg?.provider) responseProvider = msg.provider;
           }
           // Forward all events to the frontend
           stream.writeSSE({
@@ -238,57 +226,26 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
             data: JSON.stringify(event),
           });
 
-          // Accumulate assistant text for DB persistence
-          if (event.type === "message_update") {
-            const msgEvent = event as any;
-            const delta = msgEvent.assistantMessageEvent;
-            if ((delta?.type === "text_delta" || delta?.type === "thinking_delta") && delta.delta) {
-              assistantText += delta.delta;
-            }
-          }
+          // Mirror the event into token totals and durable rows
+          usageAccumulator.onEvent(event);
+          persister.onEvent(event);
         },
-        onError: (error) => {
+        onError: async (error) => {
           console.error(`[Agent] ERROR:`, error.message);
           stream.writeSSE({
             event: "error",
             data: JSON.stringify({ message: error.message }),
           });
+          // Persist whatever the run produced before failing (text so far,
+          // completed tool steps) so reloaded history matches what was shown.
+          await persister.finish();
           resolve();
         },
         onDone: async () => {
-          console.log(`[Agent] Done. Assistant text length: ${assistantText.length}`);
-          // Persist assistant response to DB via SessionManager
-          if (assistantText) {
-            // Use our pricing table if pi-ai returned 0 cost
-            const cost =
-              totalCost > 0
-                ? totalCost
-                : responseModel
-                  ? await calculateCost(
-                      responseModel,
-                      totalInputTokens,
-                      totalOutputTokens,
-                      totalCacheReadTokens,
-                      totalCacheWriteTokens,
-                    )
-                  : 0;
-            if (cost === 0 && responseModel && (totalInputTokens > 0 || totalOutputTokens > 0)) {
-              console.warn(
-                `[Agent] Standard model pricing missing for "${responseModel}", cost recorded as $0`,
-              );
-            }
-            const tokenUsage = responseModel
-              ? {
-                  model: responseModel,
-                  provider: responseProvider || "unknown",
-                  isByok: body.source === ModelSource.BYOK,
-                  inputTokens: totalInputTokens,
-                  outputTokens: totalOutputTokens,
-                  cost,
-                }
-              : undefined;
-            await sessionManager.appendMessage("assistant", assistantText, undefined, tokenUsage);
-          }
+          const tokenUsage = await usageAccumulator.toTokenUsage(body.source === ModelSource.BYOK);
+          // Flush the trailing text segment and wait for all rows to land
+          await persister.finish(tokenUsage);
+          console.log(`[Agent] Done. Run persisted for session ${sessionId}`);
           stream.writeSSE({ event: "done", data: "{}" });
           resolve();
         },

--- a/frontend/ee/agent/src/index.ts
+++ b/frontend/ee/agent/src/index.ts
@@ -237,8 +237,12 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
             data: JSON.stringify({ message: error.message }),
           });
           // Persist whatever the run produced before failing (text so far,
-          // completed tool steps) so reloaded history matches what was shown.
-          await persister.finish();
+          // completed tool steps) so reloaded history matches what was shown,
+          // with the usage accumulated before the failure so those tokens
+          // still count toward the run meters.
+          await persister.finish(
+            await usageAccumulator.toTokenUsage(body.source === ModelSource.BYOK),
+          );
           resolve();
         },
         onDone: async () => {

--- a/frontend/ee/agent/src/session.ts
+++ b/frontend/ee/agent/src/session.ts
@@ -15,6 +15,9 @@ export interface TokenUsageData {
   inputTokens: number;
   outputTokens: number;
   cost: number;
+  // Cumulative session tokens as reported by the stream; persisted in the
+  // final segment's metadata (no dedicated column), not aggregated for billing.
+  totalTokens?: number;
 }
 
 export class SessionManager {
@@ -50,27 +53,31 @@ export class SessionManager {
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     };
 
-    return session.messages
-      .filter((m) => m.role === "user" || m.role === "assistant")
-      .map(
-        (m): Message =>
-          m.role === "user"
-            ? ({
-                role: "user",
-                content: [{ type: "text", text: m.content }],
-                timestamp: m.createTime.getTime(),
-              } satisfies UserMessage)
-            : ({
-                role: "assistant",
-                content: [{ type: "text", text: m.content }],
-                api: "restored",
-                provider: m.provider ?? "unknown",
-                model: m.model ?? "unknown",
-                usage: zeroUsage,
-                stopReason: "stop",
-                timestamp: m.createTime.getTime(),
-              } satisfies AssistantMessage),
-      );
+    return (
+      session.messages
+        // Content-less assistant rows are usage carriers for runs that ended at
+        // a tool boundary — there is no text to restore, so skip them.
+        .filter((m) => m.role === "user" || (m.role === "assistant" && m.content !== ""))
+        .map(
+          (m): Message =>
+            m.role === "user"
+              ? ({
+                  role: "user",
+                  content: [{ type: "text", text: m.content }],
+                  timestamp: m.createTime.getTime(),
+                } satisfies UserMessage)
+              : ({
+                  role: "assistant",
+                  content: [{ type: "text", text: m.content }],
+                  api: "restored",
+                  provider: m.provider ?? "unknown",
+                  model: m.model ?? "unknown",
+                  usage: zeroUsage,
+                  stopReason: "stop",
+                  timestamp: m.createTime.getTime(),
+                } satisfies AssistantMessage),
+        )
+    );
   }
 
   /**

--- a/frontend/ee/agent/src/session.ts
+++ b/frontend/ee/agent/src/session.ts
@@ -56,7 +56,9 @@ export class SessionManager {
     return (
       session.messages
         // Content-less assistant rows are usage carriers for runs that ended at
-        // a tool boundary — there is no text to restore, so skip them.
+        // a tool boundary — there is no text to restore, so skip them. This
+        // also drops thinking-only segments (empty content, thinking in
+        // metadata), which the UI renders but model context never restored.
         .filter((m) => m.role === "user" || (m.role === "assistant" && m.content !== ""))
         .map(
           (m): Message =>

--- a/frontend/ee/agent/src/session.ts
+++ b/frontend/ee/agent/src/session.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@traceroot/core";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { UserMessage, Message } from "@earendil-works/pi-ai";
+import type { AssistantMessage, UserMessage, Message } from "@earendil-works/pi-ai";
 
 // ============================================================
 // SessionManager — follows Mom's SessionManager pattern
@@ -25,10 +25,11 @@ export class SessionManager {
    * Like Mom's sessionManager.buildSessionContext() — loads persisted
    * messages from DB and converts them to AgentMessage format.
    *
-   * We only restore user messages from DB. Assistant messages are not
-   * restored because they require full LLM metadata (api, provider, model,
-   * usage, stopReason). The agent will see user messages as context and
-   * generate fresh responses.
+   * User turns are restored verbatim. Assistant turns are restored as plain
+   * text messages with synthesized LLM metadata (zero usage, "stop") — enough
+   * for the model to see what it previously said, which it cannot infer.
+   * tool_step rows are UI-only and skipped: replaying stale tool results is
+   * worse than letting the agent re-invoke the tool when it needs the data.
    */
   async buildContext(): Promise<AgentMessage[]> {
     const session = await prisma.aISession.findUnique({
@@ -40,15 +41,35 @@ export class SessionManager {
       return [];
     }
 
-    // Only restore user messages — assistant messages lack required LLM metadata
+    const zeroUsage: AssistantMessage["usage"] = {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    };
+
     return session.messages
-      .filter((m) => m.role === "user")
+      .filter((m) => m.role === "user" || m.role === "assistant")
       .map(
-        (m): UserMessage => ({
-          role: "user",
-          content: [{ type: "text", text: m.content }],
-          timestamp: m.createTime.getTime(),
-        }),
+        (m): Message =>
+          m.role === "user"
+            ? ({
+                role: "user",
+                content: [{ type: "text", text: m.content }],
+                timestamp: m.createTime.getTime(),
+              } satisfies UserMessage)
+            : ({
+                role: "assistant",
+                content: [{ type: "text", text: m.content }],
+                api: "restored",
+                provider: m.provider ?? "unknown",
+                model: m.model ?? "unknown",
+                usage: zeroUsage,
+                stopReason: "stop",
+                timestamp: m.createTime.getTime(),
+              } satisfies AssistantMessage),
       );
   }
 

--- a/frontend/ee/agent/src/stream-persister.ts
+++ b/frontend/ee/agent/src/stream-persister.ts
@@ -1,0 +1,90 @@
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
+import type { TokenUsageData } from "./session.js";
+
+/** Signature of SessionManager.appendMessage — injected so the persister is testable. */
+export type AppendMessageFn = (
+  role: string,
+  content: string,
+  metadata?: Record<string, unknown>,
+  tokenUsage?: TokenUsageData,
+) => Promise<void>;
+
+/**
+ * Mirrors a run's agent events into durable AIMessage rows so reloaded
+ * history matches what the live stream rendered:
+ *
+ * - assistant text is flushed as a segment row at every tool boundary (and at
+ *   run end), preserving text → tool → text interleaving;
+ * - each tool call becomes a `tool_step` row whose metadata carries the args
+ *   captured at start and the result/isError from end;
+ * - thinking deltas go to segment metadata, never into content;
+ * - the run's token usage is attached to the final text segment.
+ *
+ * Inserts are chained: the SSE event callback is synchronous, so naive
+ * fire-and-forget writes could land out of order and scramble history. A
+ * failed insert is logged and skipped — later rows still persist.
+ */
+export class StreamPersister {
+  private chain: Promise<void> = Promise.resolve();
+  private text = "";
+  private thinking = "";
+  /** args by toolCallId, captured at tool_execution_start (end events lack args) */
+  private pendingToolArgs = new Map<string, Record<string, unknown>>();
+
+  constructor(private readonly append: AppendMessageFn) {}
+
+  onEvent(event: AgentEvent): void {
+    if (event.type === "message_update") {
+      const delta = event.assistantMessageEvent as { type?: string; delta?: string };
+      if (delta?.type === "text_delta" && delta.delta) this.text += delta.delta;
+      if (delta?.type === "thinking_delta" && delta.delta) this.thinking += delta.delta;
+      return;
+    }
+
+    if (event.type === "tool_execution_start") {
+      this.pendingToolArgs.set(event.toolCallId, event.args ?? {});
+      this.flushTextSegment();
+      return;
+    }
+
+    if (event.type === "tool_execution_end") {
+      const args = this.pendingToolArgs.get(event.toolCallId) ?? {};
+      this.pendingToolArgs.delete(event.toolCallId);
+      this.enqueue("tool_step", "", {
+        toolCallId: event.toolCallId,
+        toolName: event.toolName,
+        args,
+        result: event.result,
+        isError: event.isError,
+      });
+    }
+  }
+
+  /** Flush the trailing text segment (with the run's usage) and wait for all inserts. */
+  async finish(tokenUsage?: TokenUsageData): Promise<void> {
+    this.flushTextSegment(tokenUsage);
+    await this.chain;
+  }
+
+  private flushTextSegment(tokenUsage?: TokenUsageData): void {
+    if (!this.text && !this.thinking) return;
+    const content = this.text;
+    const thinking = this.thinking;
+    this.text = "";
+    this.thinking = "";
+    this.enqueue("assistant", content, thinking ? { thinking } : undefined, tokenUsage);
+  }
+
+  private enqueue(
+    role: string,
+    content: string,
+    metadata?: Record<string, unknown>,
+    tokenUsage?: TokenUsageData,
+  ): void {
+    this.chain = this.chain
+      .then(() => this.append(role, content, metadata, tokenUsage))
+      .catch((error) => {
+        console.error(`[Agent] Failed to persist ${role} message:`, error);
+      });
+  }
+}

--- a/frontend/ee/agent/src/stream-persister.ts
+++ b/frontend/ee/agent/src/stream-persister.ts
@@ -67,12 +67,25 @@ export class StreamPersister {
   }
 
   private flushTextSegment(tokenUsage?: TokenUsageData): void {
-    if (!this.text && !this.thinking) return;
+    // A run can end at a tool boundary with no trailing text; its usage must
+    // still land in a row, else the run escapes run counting and billing.
+    if (!this.text && !this.thinking && !tokenUsage) return;
     const content = this.text;
     const thinking = this.thinking;
     this.text = "";
     this.thinking = "";
-    this.enqueue("assistant", content, thinking ? { thinking } : undefined, tokenUsage);
+    const metadata = {
+      ...(thinking ? { thinking } : {}),
+      // The cumulative session total only exists in stream events — persist it
+      // with the final segment so the reloaded usage footer can show it.
+      ...(tokenUsage?.totalTokens != null ? { totalTokens: tokenUsage.totalTokens } : {}),
+    };
+    this.enqueue(
+      "assistant",
+      content,
+      Object.keys(metadata).length > 0 ? metadata : undefined,
+      tokenUsage,
+    );
   }
 
   private enqueue(

--- a/frontend/ee/agent/src/usage-accumulator.ts
+++ b/frontend/ee/agent/src/usage-accumulator.ts
@@ -1,0 +1,77 @@
+import { calculateCost } from "@traceroot/core";
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
+import type { TokenUsageData } from "./session.js";
+
+/**
+ * Accumulates token usage across a run's message_end events (one per
+ * tool-use loop iteration) and resolves it into the TokenUsageData persisted
+ * on the final assistant segment. Falls back to our pricing table when the
+ * stream reports zero cost, warning when pricing is missing entirely so
+ * unbilled runs are visible in the logs.
+ */
+export class UsageAccumulator {
+  private inputTokens = 0;
+  private outputTokens = 0;
+  private cacheReadTokens = 0;
+  private cacheWriteTokens = 0;
+  private cost = 0;
+  private model?: string;
+  private provider?: string;
+
+  onEvent(event: AgentEvent): void {
+    if (event.type !== "message_end") return;
+    const msg = event.message as {
+      model?: string;
+      provider?: string;
+      usage?: {
+        input?: number;
+        inputTokens?: number;
+        output?: number;
+        outputTokens?: number;
+        cacheRead?: number;
+        cacheWrite?: number;
+        cost?: { total?: number };
+      };
+    };
+    const usage = msg?.usage;
+    if (usage) {
+      this.inputTokens += usage.input ?? usage.inputTokens ?? 0;
+      this.outputTokens += usage.output ?? usage.outputTokens ?? 0;
+      this.cacheReadTokens += usage.cacheRead ?? 0;
+      this.cacheWriteTokens += usage.cacheWrite ?? 0;
+      this.cost += usage.cost?.total ?? 0;
+    }
+    if (msg?.model) this.model = msg.model;
+    if (msg?.provider) this.provider = msg.provider;
+  }
+
+  async toTokenUsage(isByok: boolean): Promise<TokenUsageData | undefined> {
+    if (!this.model) return undefined;
+
+    // Use our pricing table if the stream returned 0 cost
+    const cost =
+      this.cost > 0
+        ? this.cost
+        : await calculateCost(
+            this.model,
+            this.inputTokens,
+            this.outputTokens,
+            this.cacheReadTokens,
+            this.cacheWriteTokens,
+          );
+    if (cost === 0 && (this.inputTokens > 0 || this.outputTokens > 0)) {
+      console.warn(
+        `[Agent] Standard model pricing missing for "${this.model}", cost recorded as $0`,
+      );
+    }
+
+    return {
+      model: this.model,
+      provider: this.provider || "unknown",
+      isByok,
+      inputTokens: this.inputTokens,
+      outputTokens: this.outputTokens,
+      cost,
+    };
+  }
+}

--- a/frontend/ee/agent/src/usage-accumulator.ts
+++ b/frontend/ee/agent/src/usage-accumulator.ts
@@ -15,6 +15,7 @@ export class UsageAccumulator {
   private cacheReadTokens = 0;
   private cacheWriteTokens = 0;
   private cost = 0;
+  private totalTokens?: number;
   private model?: string;
   private provider?: string;
 
@@ -30,6 +31,7 @@ export class UsageAccumulator {
         outputTokens?: number;
         cacheRead?: number;
         cacheWrite?: number;
+        totalTokens?: number;
         cost?: { total?: number };
       };
     };
@@ -40,6 +42,9 @@ export class UsageAccumulator {
       this.cacheReadTokens += usage.cacheRead ?? 0;
       this.cacheWriteTokens += usage.cacheWrite ?? 0;
       this.cost += usage.cost?.total ?? 0;
+      // Cumulative session total — last message_end wins, mirroring how the
+      // live stream updates the usage footer.
+      if (usage.totalTokens != null) this.totalTokens = usage.totalTokens;
     }
     if (msg?.model) this.model = msg.model;
     if (msg?.provider) this.provider = msg.provider;
@@ -48,17 +53,23 @@ export class UsageAccumulator {
   async toTokenUsage(isByok: boolean): Promise<TokenUsageData | undefined> {
     if (!this.model) return undefined;
 
-    // Use our pricing table if the stream returned 0 cost
-    const cost =
-      this.cost > 0
-        ? this.cost
-        : await calculateCost(
-            this.model,
-            this.inputTokens,
-            this.outputTokens,
-            this.cacheReadTokens,
-            this.cacheWriteTokens,
-          );
+    // Use our pricing table if the stream returned 0 cost. A failing pricing
+    // lookup must not lose the run: fall back to $0 and keep the tokens.
+    let cost = this.cost;
+    if (cost <= 0) {
+      try {
+        cost = await calculateCost(
+          this.model,
+          this.inputTokens,
+          this.outputTokens,
+          this.cacheReadTokens,
+          this.cacheWriteTokens,
+        );
+      } catch (err) {
+        console.error(`[Agent] Pricing lookup failed for "${this.model}":`, err);
+        cost = 0;
+      }
+    }
     if (cost === 0 && (this.inputTokens > 0 || this.outputTokens > 0)) {
       console.warn(
         `[Agent] Standard model pricing missing for "${this.model}", cost recorded as $0`,
@@ -72,6 +83,7 @@ export class UsageAccumulator {
       inputTokens: this.inputTokens,
       outputTokens: this.outputTokens,
       cost,
+      ...(this.totalTokens != null ? { totalTokens: this.totalTokens } : {}),
     };
   }
 }

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.tsx
@@ -118,6 +118,15 @@ describe("useAiChat session switching", () => {
     );
   };
 
+  it("loads an initialSessionId's history into its bucket on mount", async () => {
+    const { result } = renderHook(() => useAiChat({ projectId: "p1", initialSessionId: "rca-1" }));
+    expect(result.current.currentSessionId).toBe("rca-1");
+    await waitFor(() =>
+      expect(result.current.messages.some((m) => m.content === "history of rca-1")).toBe(true),
+    );
+    expect(historyFetches).toContain("rca-1");
+  });
+
   it("keeps a still-streaming session's deltas out of another session's view", async () => {
     const { result } = renderChat();
     await startStreamInA(result);

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -3,6 +3,7 @@
 import { useRef, useState, useCallback, useEffect } from "react";
 import { useLocalStorage } from "@/lib/hooks/use-local-storage";
 import { useAIStream } from "./use-ai-stream";
+import { mapDbMessages } from "../utils/map-db-messages";
 import type { AISession, AIMessage, AiTraceContext } from "../types";
 import type { ModelSelection } from "../components/model-selector";
 
@@ -116,15 +117,7 @@ export function useAiChat({
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (ac.signal.aborted || !data) return;
-        const all: AIMessage[] = (data.messages || []).map(
-          (m: { id: string; role: string; content: string; createTime: string }) => ({
-            id: m.id,
-            role: m.role as "user" | "assistant",
-            content: m.content,
-            timestamp: m.createTime,
-          }),
-        );
-        setSessionMessages(initialSessionId, all);
+        setSessionMessages(initialSessionId, mapDbMessages(data.messages || []));
       })
       .catch((err) => {
         if (err?.name !== "AbortError")
@@ -271,15 +264,7 @@ export function useAiChat({
           // A run may have started in this session while the fetch was in
           // flight — the stale load must not wipe the live turn.
           if (isSessionStreaming(session.id)) return;
-          const loaded: AIMessage[] = (data.messages || []).map(
-            (m: { id: string; role: string; content: string; createTime: string }) => ({
-              id: m.id,
-              role: m.role as "user" | "assistant",
-              content: m.content,
-              timestamp: m.createTime,
-            }),
-          );
-          setSessionMessages(session.id, loaded);
+          setSessionMessages(session.id, mapDbMessages(data.messages || []));
         }
       } catch (err) {
         console.error("[AI Chat] Failed to load session messages:", err);

--- a/frontend/ui/src/features/ai-assistant/utils/map-db-messages.test.ts
+++ b/frontend/ui/src/features/ai-assistant/utils/map-db-messages.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { mapDbMessages } from "./map-db-messages";
+
+const base = { createTime: "2026-01-01T00:00:00Z" };
+
+describe("mapDbMessages", () => {
+  it("maps persisted tool_step rows into the bubble shape the live stream produces", () => {
+    const [msg] = mapDbMessages([
+      {
+        ...base,
+        id: "row1",
+        role: "tool_step",
+        content: "",
+        metadata: {
+          toolCallId: "t1",
+          toolName: "get_traces",
+          args: { traceId: "abc" },
+          result: { spans: 3 },
+          isError: false,
+        },
+      },
+    ]);
+    expect(msg.role).toBe("tool_step");
+    expect(msg.toolStep).toEqual({
+      toolCallId: "t1",
+      toolName: "get_traces",
+      args: { traceId: "abc" },
+      result: { spans: 3 },
+      isError: false,
+      status: "done",
+    });
+  });
+
+  it("marks a failed tool step with error status", () => {
+    const [msg] = mapDbMessages([
+      {
+        ...base,
+        id: "row1",
+        role: "tool_step",
+        content: "",
+        metadata: { toolCallId: "t1", toolName: "get_traces", args: {}, isError: true },
+      },
+    ]);
+    expect(msg.toolStep?.status).toBe("error");
+    expect(msg.toolStep?.isError).toBe(true);
+  });
+
+  it("tolerates a tool_step row with missing metadata", () => {
+    const [msg] = mapDbMessages([
+      { ...base, id: "row1", role: "tool_step", content: "", metadata: null },
+    ]);
+    expect(msg.toolStep).toEqual({
+      toolCallId: "row1",
+      toolName: "unknown",
+      args: {},
+      result: undefined,
+      isError: undefined,
+      status: "done",
+    });
+  });
+
+  it("restores thinking from assistant metadata without touching content", () => {
+    const [msg] = mapDbMessages([
+      {
+        ...base,
+        id: "a1",
+        role: "assistant",
+        content: "The answer.",
+        metadata: { thinking: "hmm..." },
+      },
+    ]);
+    expect(msg.content).toBe("The answer.");
+    expect(msg.thinking).toBe("hmm...");
+  });
+
+  it("restores the token/cost footer fields from the persisted usage columns", () => {
+    const [msg] = mapDbMessages([
+      {
+        ...base,
+        id: "a1",
+        role: "assistant",
+        content: "answer",
+        inputTokens: 120,
+        outputTokens: 45,
+        cost: 0.0123,
+      },
+    ]);
+    expect(msg.inputTokens).toBe(120);
+    expect(msg.outputTokens).toBe(45);
+    expect(msg.costUsd).toBe(0.0123);
+  });
+
+  it("leaves footer fields undefined for rows without usage (non-final segments)", () => {
+    const [msg] = mapDbMessages([
+      { ...base, id: "a1", role: "assistant", content: "segment", inputTokens: null, cost: null },
+    ]);
+    expect(msg.inputTokens).toBeUndefined();
+    expect(msg.costUsd).toBeUndefined();
+  });
+
+  it("maps plain user/assistant rows and preserves order", () => {
+    const msgs = mapDbMessages([
+      { ...base, id: "u1", role: "user", content: "hi" },
+      { ...base, id: "a1", role: "assistant", content: "hello" },
+    ]);
+    expect(msgs.map((m) => [m.role, m.content])).toEqual([
+      ["user", "hi"],
+      ["assistant", "hello"],
+    ]);
+    expect(msgs[0].timestamp).toBe("2026-01-01T00:00:00Z");
+  });
+});

--- a/frontend/ui/src/features/ai-assistant/utils/map-db-messages.test.ts
+++ b/frontend/ui/src/features/ai-assistant/utils/map-db-messages.test.ts
@@ -157,6 +157,35 @@ describe("mapDbMessages", () => {
     expect(bubble.costUsd).toBe(0.005);
   });
 
+  it("never folds a carrier across a run boundary onto an earlier run's bubble", () => {
+    const msgs = mapDbMessages([
+      { ...base, id: "u1", role: "user", content: "first question" },
+      {
+        ...base,
+        id: "a1",
+        role: "assistant",
+        content: "First answer.",
+        inputTokens: 100,
+        outputTokens: 40,
+        cost: "0.010000",
+      },
+      { ...base, id: "u2", role: "user", content: "now check the trace" },
+      {
+        ...base,
+        id: "t1",
+        role: "tool_step",
+        content: "",
+        metadata: { toolCallId: "t1", toolName: "get_traces", args: {} },
+      },
+      { ...base, id: "a2", role: "assistant", content: "", inputTokens: 50, outputTokens: 10 },
+    ]);
+    // run 1's usage is untouched; run 2's carrier stays its own row
+    expect(msgs.map((m) => m.id)).toEqual(["u1", "a1", "u2", "t1", "a2"]);
+    expect(msgs[1].inputTokens).toBe(100);
+    expect(msgs[1].costUsd).toBe(0.01);
+    expect(msgs[4].inputTokens).toBe(50);
+  });
+
   it("keeps a usage carrier row when there is no earlier assistant bubble", () => {
     const msgs = mapDbMessages([
       { ...base, id: "u1", role: "user", content: "go" },

--- a/frontend/ui/src/features/ai-assistant/utils/map-db-messages.test.ts
+++ b/frontend/ui/src/features/ai-assistant/utils/map-db-messages.test.ts
@@ -98,6 +98,74 @@ describe("mapDbMessages", () => {
     expect(msg.costUsd).toBeUndefined();
   });
 
+  it("coerces a Decimal-serialized string cost into a number", () => {
+    const [msg] = mapDbMessages([
+      {
+        ...base,
+        id: "a1",
+        role: "assistant",
+        content: "answer",
+        inputTokens: 120,
+        outputTokens: 45,
+        cost: "0.012300",
+      },
+    ]);
+    expect(msg.costUsd).toBe(0.0123);
+  });
+
+  it("restores the cumulative session total from assistant metadata", () => {
+    const [msg] = mapDbMessages([
+      {
+        ...base,
+        id: "a1",
+        role: "assistant",
+        content: "answer",
+        inputTokens: 120,
+        outputTokens: 45,
+        metadata: { totalTokens: 999 },
+      },
+    ]);
+    expect(msg.totalTokens).toBe(999);
+  });
+
+  it("folds a content-less usage carrier row into the previous assistant bubble", () => {
+    const msgs = mapDbMessages([
+      { ...base, id: "u1", role: "user", content: "check the trace" },
+      { ...base, id: "a1", role: "assistant", content: "Checking." },
+      {
+        ...base,
+        id: "t1",
+        role: "tool_step",
+        content: "",
+        metadata: { toolCallId: "t1", toolName: "get_traces", args: {} },
+      },
+      {
+        ...base,
+        id: "a2",
+        role: "assistant",
+        content: "",
+        inputTokens: 50,
+        outputTokens: 10,
+        cost: "0.005000",
+      },
+    ]);
+    // no empty bubble — the usage lands on the last text bubble, like live
+    expect(msgs.map((m) => m.id)).toEqual(["u1", "a1", "t1"]);
+    const bubble = msgs[1];
+    expect(bubble.inputTokens).toBe(50);
+    expect(bubble.outputTokens).toBe(10);
+    expect(bubble.costUsd).toBe(0.005);
+  });
+
+  it("keeps a usage carrier row when there is no earlier assistant bubble", () => {
+    const msgs = mapDbMessages([
+      { ...base, id: "u1", role: "user", content: "go" },
+      { ...base, id: "a1", role: "assistant", content: "", inputTokens: 5, outputTokens: 1 },
+    ]);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[1].inputTokens).toBe(5);
+  });
+
   it("maps plain user/assistant rows and preserves order", () => {
     const msgs = mapDbMessages([
       { ...base, id: "u1", role: "user", content: "hi" },

--- a/frontend/ui/src/features/ai-assistant/utils/map-db-messages.ts
+++ b/frontend/ui/src/features/ai-assistant/utils/map-db-messages.ts
@@ -59,9 +59,17 @@ export function mapDbMessages(rows: DbAiMessageRow[]): AIMessage[] {
     // A content-less assistant row is the usage carrier of a run that ended at
     // a tool boundary. The live stream pins usage on the last text bubble, so
     // fold it into the previous assistant bubble instead of rendering an
-    // empty one.
+    // empty one — but only within the same run: stop at the user turn so a
+    // carrier can never overwrite an earlier run's usage.
     if (m.role === "assistant" && !m.content && !md?.thinking) {
-      const prev = out.findLast((b) => b.role === "assistant");
+      let prev: AIMessage | undefined;
+      for (let i = out.length - 1; i >= 0; i -= 1) {
+        if (out[i].role === "user") break;
+        if (out[i].role === "assistant") {
+          prev = out[i];
+          break;
+        }
+      }
       if (prev) {
         Object.assign(prev, usage);
         continue;

--- a/frontend/ui/src/features/ai-assistant/utils/map-db-messages.ts
+++ b/frontend/ui/src/features/ai-assistant/utils/map-db-messages.ts
@@ -1,0 +1,61 @@
+import type { AIMessage } from "../types";
+
+/** AIMessage row as returned by GET /api/projects/:id/ai/sessions/:id/messages. */
+export interface DbAiMessageRow {
+  id: string;
+  role: string;
+  content: string;
+  createTime: string;
+  metadata?: unknown;
+  // usage columns — set only on the final assistant segment of a run
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  cost?: number | null;
+}
+
+interface ToolStepMetadata {
+  toolCallId?: string;
+  toolName?: string;
+  args?: Record<string, unknown>;
+  result?: unknown;
+  isError?: boolean;
+}
+
+/**
+ * Convert persisted AIMessage rows into the bubble shapes the live stream
+ * produces, so reloaded history renders identically: tool_step rows become
+ * expandable tool bubbles (args/result from metadata), assistant rows pick
+ * their thinking up from metadata.
+ */
+export function mapDbMessages(rows: DbAiMessageRow[]): AIMessage[] {
+  return rows.map((m): AIMessage => {
+    if (m.role === "tool_step") {
+      const md = (m.metadata ?? {}) as ToolStepMetadata;
+      return {
+        id: m.id,
+        role: "tool_step",
+        content: "",
+        timestamp: m.createTime,
+        toolStep: {
+          toolCallId: md.toolCallId ?? m.id,
+          toolName: md.toolName ?? "unknown",
+          args: md.args ?? {},
+          result: md.result,
+          isError: md.isError,
+          status: md.isError ? "error" : "done",
+        },
+      };
+    }
+    const thinking = (m.metadata as { thinking?: string } | null | undefined)?.thinking;
+    return {
+      id: m.id,
+      role: m.role as "user" | "assistant",
+      content: m.content,
+      timestamp: m.createTime,
+      ...(thinking ? { thinking } : {}),
+      ...(m.inputTokens != null ? { inputTokens: m.inputTokens } : {}),
+      ...(m.outputTokens != null ? { outputTokens: m.outputTokens } : {}),
+      ...(m.cost != null ? { costUsd: m.cost } : {}),
+    };
+  });
+}

--- a/frontend/ui/src/features/ai-assistant/utils/map-db-messages.ts
+++ b/frontend/ui/src/features/ai-assistant/utils/map-db-messages.ts
@@ -7,10 +7,11 @@ export interface DbAiMessageRow {
   content: string;
   createTime: string;
   metadata?: unknown;
-  // usage columns — set only on the final assistant segment of a run
+  // usage columns — set only on the final assistant segment of a run.
+  // cost is a Prisma Decimal, which serializes to a string over JSON.
   inputTokens?: number | null;
   outputTokens?: number | null;
-  cost?: number | null;
+  cost?: number | string | null;
 }
 
 interface ToolStepMetadata {
@@ -28,10 +29,11 @@ interface ToolStepMetadata {
  * their thinking up from metadata.
  */
 export function mapDbMessages(rows: DbAiMessageRow[]): AIMessage[] {
-  return rows.map((m): AIMessage => {
+  const out: AIMessage[] = [];
+  for (const m of rows) {
     if (m.role === "tool_step") {
       const md = (m.metadata ?? {}) as ToolStepMetadata;
-      return {
+      out.push({
         id: m.id,
         role: "tool_step",
         content: "",
@@ -44,18 +46,35 @@ export function mapDbMessages(rows: DbAiMessageRow[]): AIMessage[] {
           isError: md.isError,
           status: md.isError ? "error" : "done",
         },
-      };
+      });
+      continue;
     }
-    const thinking = (m.metadata as { thinking?: string } | null | undefined)?.thinking;
-    return {
+    const md = m.metadata as { thinking?: string; totalTokens?: number } | null | undefined;
+    const usage = {
+      ...(m.inputTokens != null ? { inputTokens: m.inputTokens } : {}),
+      ...(m.outputTokens != null ? { outputTokens: m.outputTokens } : {}),
+      ...(md?.totalTokens != null ? { totalTokens: md.totalTokens } : {}),
+      ...(m.cost != null ? { costUsd: Number(m.cost) } : {}),
+    };
+    // A content-less assistant row is the usage carrier of a run that ended at
+    // a tool boundary. The live stream pins usage on the last text bubble, so
+    // fold it into the previous assistant bubble instead of rendering an
+    // empty one.
+    if (m.role === "assistant" && !m.content && !md?.thinking) {
+      const prev = out.findLast((b) => b.role === "assistant");
+      if (prev) {
+        Object.assign(prev, usage);
+        continue;
+      }
+    }
+    out.push({
       id: m.id,
       role: m.role as "user" | "assistant",
       content: m.content,
       timestamp: m.createTime,
-      ...(thinking ? { thinking } : {}),
-      ...(m.inputTokens != null ? { inputTokens: m.inputTokens } : {}),
-      ...(m.outputTokens != null ? { outputTokens: m.outputTokens } : {}),
-      ...(m.cost != null ? { costUsd: m.cost } : {}),
-    };
-  });
+      ...(md?.thinking ? { thinking: md.thinking } : {}),
+      ...usage,
+    });
+  }
+  return out;
 }

--- a/frontend/worker/src/ee/billing/__tests__/usageMetering-run-count.test.ts
+++ b/frontend/worker/src/ee/billing/__tests__/usageMetering-run-count.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Chat runs persist as MULTIPLE assistant rows per run (one text segment per
+// tool boundary); only the final segment carries usage. Billing must count
+// usage-carrying rows, not raw assistant rows, or every tool boundary would
+// bill as an extra run.
+
+type PrismaQuery = { where: Record<string, unknown>; skip?: number };
+
+const mocks = vi.hoisted(() => ({
+  count: vi.fn(async (_query: { where: Record<string, unknown> }) => 0),
+  aggregate: vi.fn(async (_query: { where: Record<string, unknown> }) => ({
+    _count: { id: 0 },
+    _sum: { inputTokens: 0, outputTokens: 0, cost: 0 },
+  })),
+  groupBy: vi.fn(async (_query: { where: Record<string, unknown> }) => []),
+  findMany: vi.fn(async (_query: { where: Record<string, unknown>; skip?: number }) => []),
+}));
+
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    aIMessage: {
+      count: mocks.count,
+      aggregate: mocks.aggregate,
+      groupBy: mocks.groupBy,
+      findMany: mocks.findMany,
+    },
+  },
+  USAGE_CONFIG: { includedUnits: 50_000 },
+  PlanType: { FREE: "free", STARTER: "starter", PRO: "pro", ENTERPRISE: "enterprise" },
+  isAiRunBlocked: () => false,
+  isRcaRunBlocked: () => false,
+  isDetectorRunBlocked: () => false,
+  isIngestionBlocked: () => false,
+  DETECTOR_HOSTED_LLM_FREE_THRESHOLD: 0,
+  AI_RUN_QUOTAS: { free: { included: 30 } },
+  RCA_RUN_QUOTAS: { free: { included: 0 } },
+  DETECTOR_RUN_QUOTAS: { free: { included: 0 } },
+  EVENT_QUOTAS: { free: { included: 50_000 } },
+}));
+
+vi.mock("../clickhouse.js", () => ({ getWorkspaceUsageDetails: vi.fn() }));
+vi.mock("../usageNotifications.js", () => ({ runUsageQuotaNotifications: vi.fn() }));
+
+import { aggregateMessagesForKind, getOverageSystemModelCost } from "../usageMetering.js";
+
+const WINDOW = {
+  createTime: { gte: new Date("2026-08-01T00:00:00Z"), lt: new Date("2026-09-01T00:00:00Z") },
+};
+
+describe("run counting with segmented assistant rows", () => {
+  beforeEach(() => {
+    mocks.count.mockClear();
+    mocks.findMany.mockClear();
+  });
+
+  it("counts a run only when the assistant row carries usage (the final segment)", async () => {
+    await aggregateMessagesForKind("ws-1", "chat", WINDOW);
+    expect(mocks.count).toHaveBeenCalledTimes(1);
+    const where = (mocks.count.mock.calls[0]![0] as PrismaQuery).where;
+    expect(where).toMatchObject({
+      workspaceId: "ws-1",
+      kind: "chat",
+      role: "assistant",
+      inputTokens: { not: null },
+    });
+  });
+
+  it("locates the overage cutoff by skipping usage-carrying rows only", async () => {
+    await getOverageSystemModelCost("ws-1", 100, WINDOW.createTime.gte, WINDOW.createTime.lt);
+    expect(mocks.findMany).toHaveBeenCalledTimes(1);
+    const query = mocks.findMany.mock.calls[0]![0] as PrismaQuery;
+    expect(query.skip).toBe(100);
+    expect(query.where).toMatchObject({
+      workspaceId: "ws-1",
+      kind: "chat",
+      role: "assistant",
+      inputTokens: { not: null },
+    });
+  });
+});

--- a/frontend/worker/src/ee/billing/usageMetering.ts
+++ b/frontend/worker/src/ee/billing/usageMetering.ts
@@ -606,22 +606,31 @@ type MessageKind = "chat" | "rca" | "detector";
 
 /**
  * Aggregate `aIMessage` rows for one `kind` over a billing window. Returns:
- *   - runsUsedCount: total assistant rows (chat uses this for run-count meter;
- *     rca/detector get their canonical counts from elsewhere)
+ *   - runsUsedCount: usage-carrying assistant rows (chat uses this for the
+ *     run-count meter; rca/detector get their canonical counts from elsewhere)
  *   - systemAgg / byokAgg: cost + token sums split by inference source
  *   - systemByModel / byokByModel: per-(model, provider) breakdowns for UI
  *
- * `inputTokens: { not: null }` filters out incomplete writes; rows with null
- * tokens have null cost too, so this is a no-op for cost sums.
+ * `inputTokens: { not: null }` matters everywhere here: a run persists one
+ * assistant row per text segment (segments are split at tool boundaries) and
+ * only the FINAL segment carries usage, so counting raw assistant rows would
+ * bill each tool boundary as an extra run. Rows with null tokens have null
+ * cost too, so the filter is also a no-op for cost sums.
  */
-async function aggregateMessagesForKind(
+export async function aggregateMessagesForKind(
   workspaceId: string,
   kind: MessageKind,
   periodWindow: { createTime: { gte: Date; lt: Date } },
 ) {
-  const baseWhere = { workspaceId, kind, role: "assistant", ...periodWindow };
-  const systemWhere = { ...baseWhere, isByok: false, inputTokens: { not: null } };
-  const byokWhere = { ...baseWhere, isByok: true, inputTokens: { not: null } };
+  const baseWhere = {
+    workspaceId,
+    kind,
+    role: "assistant",
+    inputTokens: { not: null },
+    ...periodWindow,
+  };
+  const systemWhere = { ...baseWhere, isByok: false };
+  const byokWhere = { ...baseWhere, isByok: true };
 
   const [runsUsedCount, systemAgg, byokAgg, systemByModel, byokByModel] = await Promise.all([
     prisma.aIMessage.count({ where: baseWhere }),
@@ -659,21 +668,23 @@ async function aggregateMessagesForKind(
  * 1. Find the cutoff timestamp (createTime of the first overage message)
  * 2. Aggregate system model cost from that timestamp onward
  */
-async function getOverageSystemModelCost(
+export async function getOverageSystemModelCost(
   workspaceId: string,
   includedRuns: number,
   start: Date,
   end: Date,
 ): Promise<number> {
   // Step 1: Find the cutoff timestamp — the createTime of the first chat
-  // message after the included quota (e.g., the 101st message for Starter/Pro).
+  // run after the included quota (e.g., the 101st run for Starter/Pro).
   // kind="chat" so RCA/detector turns living in the same table don't shift
-  // the cutoff or inflate the cost sum.
+  // the cutoff or inflate the cost sum; inputTokens NOT NULL so the skip
+  // walks over runs (final segments), not every persisted text segment.
   const cutoff = await prisma.aIMessage.findMany({
     where: {
       workspaceId,
       kind: "chat",
       role: "assistant",
+      inputTokens: { not: null },
       createTime: { gte: start, lt: end },
     },
     orderBy: { createTime: "asc" },


### PR DESCRIPTION
Closes #1959

**Stacked on #1960** (`fix/session-leakage`) — review only the top commit here.

## Problem

Tool-call bubbles existed only as SSE events: the agent service forwarded them to the client and persisted a single assistant row at run end, so reloading a session dropped every tool step, collapsed interleaved text into one blob, and silently baked thinking deltas into the saved answer. Separately, `buildContext()` restored only user rows, so the model lost its own answers on any agent rebuild (service restart or mid-session model switch).

## Change

- **`StreamPersister`** (agent service): mirrors each run into durable rows — assistant text flushes as a segment at every tool boundary (the final segment carries token usage), each tool call becomes a `tool_step` row with args/result/isError in metadata, thinking goes to segment metadata. Inserts are chained so the synchronous event callback can't interleave them; a failed run still persists what it produced.
- **`UsageAccumulator`**: token/cost accumulation extracted from the SSE handler into a tested module (pricing-table fallback and missing-pricing warning preserved).
- **`mapDbMessages`** (UI): shared by both history loaders; rebuilds the exact live bubble shapes — tool bubbles, thinking, and the token/cost footer.
- **`buildContext()`**: also restores assistant rows as plain text turns (synthesized metadata, zero usage). Tool steps stay UI-only — the agent re-invokes tools rather than replaying stale results.
- **Billing companion fix**: chat runs were counted as raw assistant rows, which would have billed every tool boundary as an extra run once segments landed. `runsUsedCount` and the overage cutoff now count only usage-carrying rows (the final segment — exactly one per run).

## Testing

- 20 new tests: `stream-persister.test.ts` (segmentation, ordering, serialized writes, error paths), `usage-accumulator.test.ts`, `session-build-context.test.ts`, `map-db-messages.test.ts`, `usageMetering-run-count.test.ts`.
- Suites: UI 1271 ✓, agent 57 ✓, worker 247 ✓; diff coverage 92% vs the stack parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists assistant text segments and tool steps so chat history (including tool bubbles and thinking) survives reload, and fixes chat run counting. Before: we saved one assistant row at run end. Now: we segment at tool boundaries, save each tool call, attach usage only to the final segment, and keep tool-only and errored runs billable.

**New Features**
- Mirrors the stream to durable rows: text segments at tool boundaries, `tool_step` rows with args/result/isError, and thinking in segment metadata.
- Tracks usage across `message_end` events, falls back to pricing when stream cost is zero, preserves BYOK, and persists the last cumulative `totalTokens` on the final segment.
- Restores history exactly via `mapDbMessages` (tool bubbles, thinking, token/cost footer), folding content-less usage carriers into the prior assistant bubble within the same run and coercing Decimal string costs.
- `buildContext()` restores assistant turns as plain text with synthesized metadata and skips `tool_step` and content-less assistant rows.
- `useAiChat` now loads an `initialSessionId`'s history on mount.

**Bug Fixes**
- Persists a usage-carrying row when a run ends at a tool boundary and passes accumulated usage on errors so consumed tokens are counted.
- Serializes DB writes; later rows still persist if an earlier insert fails.
- Billing counts only usage-carrying assistant rows for chat run meters and the overage cutoff (`inputTokens: { not: null }`), avoiding overcounting at tool boundaries.

<sup>Written for commit df819fc22dadb4824eaca0afa0bc00422d85938c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

