### PR TITLE
docs(vercel-ai): use @ai-sdk/otel telemetry API for AI SDK v7

### DIFF
--- a/docs/integrations/vercel-ai.mdx
+++ b/docs/integrations/vercel-ai.mdx
@@ -3,12 +3,18 @@ title: Vercel AI SDK
 description: Trace Vercel AI SDK agents — no instrumentModules config required
 ---
 
-Trace [Vercel AI SDK](https://sdk.vercel.ai) agents in TraceRoot. Unlike LangChain, OpenAI, or Anthropic, no `instrumentModules` configuration is needed — the Vercel AI SDK emits OpenTelemetry spans natively when `experimental_telemetry` is enabled, and TraceRoot enriches them via the OpenInference span processor automatically.
+Trace [Vercel AI SDK](https://sdk.vercel.ai) agents in TraceRoot. Unlike LangChain, OpenAI, or Anthropic, no `instrumentModules` configuration is needed — the Vercel AI SDK emits OpenTelemetry spans natively when telemetry is enabled, and TraceRoot enriches them via the OpenInference span processor automatically.
+
+<Note>
+  **AI SDK v7 and later**: telemetry moved to the separate `@ai-sdk/otel` package. Pass
+  `telemetry: { integrations: [new OpenTelemetry()] }` on each call. On AI SDK v6 and
+  earlier, use `experimental_telemetry: { isEnabled: true }` instead.
+</Note>
 
 ## Setup
 
 ```bash
-npm install @traceroot-ai/traceroot ai @ai-sdk/openai zod
+npm install @traceroot-ai/traceroot ai @ai-sdk/otel @ai-sdk/openai zod
 ```
 
 Initialize TraceRoot at your entry point — no `instrumentModules` config:
@@ -24,6 +30,7 @@ TraceRoot.initialize();
 
 ```typescript
 import { generateText, tool } from 'ai';
+import { OpenTelemetry } from '@ai-sdk/otel';
 import { openai } from '@ai-sdk/openai';
 import { z } from 'zod';
 import { observe } from '@traceroot-ai/traceroot';
@@ -35,7 +42,7 @@ const result = await observe({ name: 'my_agent', type: 'agent' }, async () => {
     prompt: 'What is the weather in Tokyo?',
     // This single line activates Vercel AI SDK's built-in OpenTelemetry spans.
     // TraceRoot enriches them automatically.
-    experimental_telemetry: { isEnabled: true },
+    telemetry: { integrations: [new OpenTelemetry()] },
     tools: {
       getWeather: tool({
         description: 'Get current weather for a city',


### PR DESCRIPTION
Fixes #1966

## Summary

`docs/integrations/vercel-ai.mdx` documents `experimental_telemetry: { isEnabled: true }`,
which emits no spans on AI SDK v7. Telemetry moved to the separate `@ai-sdk/otel`
package. This updates the page to the v7 API and notes the v6-and-earlier form.

## Type of Change

- [x] docs - Documentation only changes

## Details

**What changed** — five lines in `docs/integrations/vercel-ai.mdx`:

- Intro: "when `experimental_telemetry` is enabled" → "when telemetry is enabled"
  (version-neutral, since the mechanism differs by major).
- Added a `<Note>` giving the v7 API and the v6-and-earlier form.
- Setup: added `@ai-sdk/otel` to the install line.
- Usage: added the `OpenTelemetry` import and swapped `experimental_telemetry`
  for `telemetry: { integrations: [new OpenTelemetry()] }`.

**Why** — running the page's own example unmodified on `ai` 7.0.68 produces one
span (my own `observe()` wrapper) and nothing from the AI SDK. Silent: no error,
no warning. The data is there — `result.steps` carries 39/11/50 tokens and model
`gpt-4o-mini-2024-07-18` — it just never reaches a span.

**How it was validated** — same example, same model, same prompt, changing only
the telemetry line:

| | `experimental_telemetry` | `@ai-sdk/otel` |
|---|---|---|
| spans | 1 | 5 |
| LLM span | none | `chat gpt-4o-mini` (kind `LLM`) |
| model | — | `llm.model_name: gpt-4o-mini-2024-07-18` |
| tokens | — | prompt 39 / completion 11 / total 50 |
| messages | — | `llm.input_messages.*`, `llm.output_messages.*` |
| tool call | — | `execute_tool getWeather` (kind `TOOL`) |

Span tree under the v7 API:
`my_agent → invoke_agent gpt-4o-mini → step 1 → chat gpt-4o-mini` + `execute_tool getWeather`

Note the "Tool calls" row of the page's own "What Gets Captured" table is only
satisfied under the v7 API. Full output in #1966.

Versions: `ai` 7.0.68 · `@ai-sdk/otel` 1.0.68 · `@ai-sdk/openai` 4.0.43 ·
`@traceroot-ai/traceroot` 0.3.0 (`@arizeai/openinference-vercel` 2.8.1
transitively) · Node 24.18.1.

I saw the same pattern with `@ai-sdk/google` 4.0.45, so this is in `ai` itself,
not a provider package.

**Deliberately out of scope** (happy to follow up in separate PRs):

- `examples/typescript/vercel-ai` pins `ai ^6.0.0` and still uses
  `experimental_telemetry`. Consistent with the note, but the page's example card
  now points at a v6 sample.
- Two other options on the page look inoperative on v7: `maxSteps` (run stopped
  after the tool call, `finishReason: "tool-calls"`, empty text) and
  `tool({ parameters })` (v7 expects `inputSchema` — the tool executed with empty
  arguments, `gen_ai.tool.call.arguments = {}`). The capture table's last row also
  references `maxSteps`.

## Screenshots / Recordings (if applicable)

N/A — no UI changes.

## Checklist

- [x] I have read the CONTRIBUTING.md
- [ ] I have added/updated tests where applicable — N/A, docs only
- [x] I have added screenshots or recordings for UI changes (if applicable) — N/A
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Vercel AI SDK integration docs to the AI SDK v7 telemetry API. The old `experimental_telemetry` guidance emits no spans on v7; the new docs use `@ai-sdk/otel` with `telemetry: { integrations: [new OpenTelemetry()] }` so the examples produce LLM and tool spans.

- For AI SDK v7+: install `@ai-sdk/otel`, import `OpenTelemetry`, and pass `telemetry: { integrations: [new OpenTelemetry()] }` on each call.
- For AI SDK v6 and earlier: continue using `experimental_telemetry: { isEnabled: true }`.

<sup>Written for commit 27cc4afbe45a89d3228b0be26a4360751bba42e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

