### PR TITLE
fix(tools): strip unsafe model schema bounds

### DIFF
--- a/frontend/packages/tools/src/__tests__/generate.test.ts
+++ b/frontend/packages/tools/src/__tests__/generate.test.ts
@@ -171,6 +171,69 @@ describe("generateRegistry", () => {
     expect(listTraces.inputSchema.required).toEqual([]);
   });
 
+  it("removes unsafe numeric bounds recursively while preserving safe bounds", () => {
+    const doc = fakeDoc();
+    doc.paths["/api/v1/public/whoami"].get.parameters = [
+      {
+        name: "filters",
+        in: "query",
+        content: {
+          "application/json": {
+            schema: {
+              type: "array",
+              items: {
+                anyOf: [
+                  {
+                    type: "object",
+                    properties: {
+                      too_large: {
+                        type: "integer",
+                        minimum: 0,
+                        maximum: Number.MAX_SAFE_INTEGER + 1,
+                      },
+                      too_small: {
+                        type: "integer",
+                        minimum: Number.MIN_SAFE_INTEGER - 1,
+                        maximum: 200,
+                      },
+                      safe_integer: {
+                        type: "integer",
+                        minimum: Number.MIN_SAFE_INTEGER,
+                        maximum: Number.MAX_SAFE_INTEGER,
+                      },
+                      safe_decimal: {
+                        type: "number",
+                        minimum: -0.25,
+                        maximum: 3.5,
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    const registry = generateRegistry(doc);
+    const whoami = registry.find((entry) => entry.name === "whoami")!;
+    const filters = whoami.inputSchema.properties.filters as {
+      items: { anyOf: Array<{ properties: Record<string, unknown> }> };
+    };
+
+    expect(filters.items.anyOf[0]!.properties).toEqual({
+      too_large: { type: "integer", minimum: 0 },
+      too_small: { type: "integer", maximum: 200 },
+      safe_integer: {
+        type: "integer",
+        minimum: Number.MIN_SAFE_INTEGER,
+        maximum: Number.MAX_SAFE_INTEGER,
+      },
+      safe_decimal: { type: "number", minimum: -0.25, maximum: 3.5 },
+    });
+  });
+
   it("normalizes multi-variant anyOf params (null variant and titles dropped) and tolerates schema-less params", () => {
     const doc = fakeDoc();
     doc.paths["/api/v1/public/whoami"].get.parameters = [

--- a/frontend/packages/tools/src/__tests__/pi.test.ts
+++ b/frontend/packages/tools/src/__tests__/pi.test.ts
@@ -64,6 +64,52 @@ describe("toPiAgentTool", () => {
     );
   });
 
+  it("removes unsafe bounds from model parameters without mutating the registry entry", () => {
+    const entry = structuredClone(listTracesEntry);
+    entry.inputSchema.properties.filters = {
+      type: "array",
+      items: {
+        anyOf: [
+          {
+            type: "object",
+            properties: {
+              too_large: {
+                type: "integer",
+                minimum: 0,
+                maximum: Number.MAX_SAFE_INTEGER + 1,
+              },
+              too_small: {
+                type: "integer",
+                minimum: Number.MIN_SAFE_INTEGER - 1,
+                maximum: 200,
+              },
+              safe: { type: "number", minimum: -0.5, maximum: Number.MAX_SAFE_INTEGER },
+            },
+          },
+        ],
+      },
+    };
+    const before = structuredClone(entry);
+    const client = new ApiClient({
+      baseUrl: "http://x",
+      headers: {},
+      fetchImpl: fakeFetch(200, {}),
+    });
+
+    const tool = toPiAgentTool(entry, { client });
+    const filters = tool.parameters.properties.filters as {
+      items: { anyOf: Array<{ properties: Record<string, unknown> }> };
+    };
+
+    expect(filters.items.anyOf[0]!.properties).toEqual({
+      too_large: { type: "integer", minimum: 0 },
+      too_small: { type: "integer", maximum: 200 },
+      safe: { type: "number", minimum: -0.5, maximum: Number.MAX_SAFE_INTEGER },
+    });
+    expect(entry).toEqual(before);
+    expect(tool.parameters.properties.filters).not.toBe(entry.inputSchema.properties.filters);
+  });
+
   it("hides fixedArgs from the model schema but sends them, honoring pathOverride", async () => {
     const fetchImpl = fakeFetch(200, { data: [] });
     const client = new ApiClient({ baseUrl: "http://x", headers: {}, fetchImpl });

--- a/frontend/packages/tools/src/__tests__/schema.test.ts
+++ b/frontend/packages/tools/src/__tests__/schema.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeSchemaForModel } from "../schema.js";
+
+describe("sanitizeSchemaForModel", () => {
+  it("preserves instance-valued metadata while sanitizing nested subschemas", () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 1;
+    const schema = {
+      type: "object",
+      properties: {
+        payload: {
+          type: "object",
+          maximum: unsafe,
+          default: { minimum: -unsafe, nested: [{ maximum: unsafe }] },
+          example: [{ minimum: -unsafe }, { maximum: unsafe }],
+          examples: [{ minimum: -unsafe }, [{ maximum: unsafe }]],
+          enum: [{ minimum: -unsafe }, [{ maximum: unsafe }]],
+          const: { maximum: unsafe, nested: [{ minimum: -unsafe }] },
+          allOf: [
+            { minimum: -unsafe },
+            {
+              items: {
+                anyOf: [{ maximum: unsafe }, { properties: { deep: { minimum: -unsafe } } }],
+              },
+            },
+          ],
+        },
+      },
+    };
+    const before = structuredClone(schema);
+
+    const sanitized = sanitizeSchemaForModel(schema);
+    const payload = sanitized.properties.payload;
+
+    expect(payload).not.toHaveProperty("maximum");
+    expect(payload.allOf).toEqual([
+      {},
+      {
+        items: {
+          anyOf: [{}, { properties: { deep: {} } }],
+        },
+      },
+    ]);
+    expect(payload.default).toEqual(before.properties.payload.default);
+    expect(payload.example).toEqual(before.properties.payload.example);
+    expect(payload.examples).toEqual(before.properties.payload.examples);
+    expect(payload.enum).toEqual(before.properties.payload.enum);
+    expect(payload.const).toEqual(before.properties.payload.const);
+    expect(schema).toEqual(before);
+    expect(payload.default).not.toBe(schema.properties.payload.default);
+  });
+});

--- a/frontend/packages/tools/src/generate.ts
+++ b/frontend/packages/tools/src/generate.ts
@@ -1,3 +1,4 @@
+import { sanitizeSchemaForModel } from "./schema.js";
 import type { InputSchema, ParamSchema, RegistryEntry } from "./types.js";
 
 interface OpenApiParameter {
@@ -78,7 +79,12 @@ function buildInputSchema(op: OpenApiOperation): InputSchema {
       required.push(param.name);
     }
   }
-  return { type: "object", properties, required, additionalProperties: false };
+  return sanitizeSchemaForModel({
+    type: "object",
+    properties,
+    required,
+    additionalProperties: false,
+  });
 }
 
 /**

--- a/frontend/packages/tools/src/pi.ts
+++ b/frontend/packages/tools/src/pi.ts
@@ -1,5 +1,6 @@
 import type { ApiClient } from "./client.js";
 import { dispatch } from "./dispatch.js";
+import { sanitizeSchemaForModel } from "./schema.js";
 import type { ParamSchema, RegistryEntry } from "./types.js";
 
 /** One text block of a pi tool result. */
@@ -67,7 +68,7 @@ export function toPiAgentTool(entry: RegistryEntry, options: ToPiAgentToolOption
     if (name in fixedArgs) {
       continue;
     }
-    properties[name] = schema;
+    properties[name] = sanitizeSchemaForModel(schema);
   }
   const required = ["label", ...entry.inputSchema.required.filter((name) => !(name in fixedArgs))];
 

--- a/frontend/packages/tools/src/registry.generated.ts
+++ b/frontend/packages/tools/src/registry.generated.ts
@@ -393,7 +393,6 @@ export const REGISTRY: readonly RegistryEntry[] = [
                     enum: ["eq", "gt", "gte", "lt", "lte"],
                   },
                   value: {
-                    maximum: 9223372036854776000,
                     minimum: 0,
                     type: "integer",
                   },
@@ -412,7 +411,6 @@ export const REGISTRY: readonly RegistryEntry[] = [
                     enum: ["eq", "gt", "gte", "lt", "lte"],
                   },
                   value: {
-                    maximum: 9223372036854776000,
                     minimum: 0,
                     type: "integer",
                   },
@@ -431,7 +429,6 @@ export const REGISTRY: readonly RegistryEntry[] = [
                     enum: ["eq", "gt", "gte", "lt", "lte"],
                   },
                   value: {
-                    maximum: 18446744073709552000,
                     minimum: 0,
                     type: "integer",
                   },

--- a/frontend/packages/tools/src/schema.ts
+++ b/frontend/packages/tools/src/schema.ts
@@ -1,14 +1,64 @@
 const NUMERIC_BOUND_KEYS = new Set(["minimum", "maximum"]);
+const SUBSCHEMA_MAP_KEYS = new Set([
+  "$defs",
+  "definitions",
+  "dependencies",
+  "dependentSchemas",
+  "patternProperties",
+  "properties",
+]);
+const SUBSCHEMA_KEYS = new Set([
+  "additionalItems",
+  "additionalProperties",
+  "allOf",
+  "anyOf",
+  "contains",
+  "contentSchema",
+  "else",
+  "if",
+  "items",
+  "not",
+  "oneOf",
+  "prefixItems",
+  "propertyNames",
+  "then",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+]);
 
-/** Clone a JSON schema while dropping numeric bounds models cannot represent safely. */
-export function sanitizeSchemaForModel<T>(value: T): T {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function cloneJsonValue<T>(value: T): T {
   if (Array.isArray(value)) {
-    return value.map((item) => sanitizeSchemaForModel(item)) as T;
+    return value.map((item) => cloneJsonValue(item)) as T;
   }
-  if (value === null || typeof value !== "object") {
+  if (!isRecord(value)) {
     return value;
   }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [key, cloneJsonValue(child)]),
+  ) as T;
+}
 
+function sanitizeSubschema(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeSubschema(item));
+  }
+  return isRecord(value) ? sanitizeSchemaObject(value) : value;
+}
+
+function sanitizeSubschemaMap(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return cloneJsonValue(value);
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([name, schema]) => [name, sanitizeSubschema(schema)]),
+  );
+}
+
+function sanitizeSchemaObject(value: Record<string, unknown>): Record<string, unknown> {
   const sanitized = Object.entries(value).flatMap(([key, child]) => {
     if (
       NUMERIC_BOUND_KEYS.has(key) &&
@@ -17,7 +67,18 @@ export function sanitizeSchemaForModel<T>(value: T): T {
     ) {
       return [];
     }
-    return [[key, sanitizeSchemaForModel(child)] as const];
+    if (SUBSCHEMA_MAP_KEYS.has(key)) {
+      return [[key, sanitizeSubschemaMap(child)] as const];
+    }
+    if (SUBSCHEMA_KEYS.has(key)) {
+      return [[key, sanitizeSubschema(child)] as const];
+    }
+    return [[key, cloneJsonValue(child)] as const];
   });
-  return Object.fromEntries(sanitized) as T;
+  return Object.fromEntries(sanitized);
+}
+
+/** Clone a JSON schema while dropping numeric bounds models cannot represent safely. */
+export function sanitizeSchemaForModel<T>(value: T): T {
+  return sanitizeSubschema(value) as T;
 }

--- a/frontend/packages/tools/src/schema.ts
+++ b/frontend/packages/tools/src/schema.ts
@@ -1,0 +1,23 @@
+const NUMERIC_BOUND_KEYS = new Set(["minimum", "maximum"]);
+
+/** Clone a JSON schema while dropping numeric bounds models cannot represent safely. */
+export function sanitizeSchemaForModel<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeSchemaForModel(item)) as T;
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  const sanitized = Object.entries(value).flatMap(([key, child]) => {
+    if (
+      NUMERIC_BOUND_KEYS.has(key) &&
+      typeof child === "number" &&
+      Math.abs(child) > Number.MAX_SAFE_INTEGER
+    ) {
+      return [];
+    }
+    return [[key, sanitizeSchemaForModel(child)] as const];
+  });
+  return Object.fromEntries(sanitized) as T;
+}


### PR DESCRIPTION
## Summary

- recursively remove `minimum` and `maximum` values outside JavaScript's safe integer range from generated model tool schemas
- apply the same sanitization at the Pi tool projection boundary without mutating registry entries
- regenerate the tool registry to drop the three current int64/uint64 maxima rejected by OpenAI function calling

Safe integer bounds, decimal bounds, nested schema structure, and all unrelated fields remain unchanged. The public OpenAPI schema and backend validation contracts are not modified.

## Test plan

- `pnpm --filter @traceroot-ai/tools test`
- `pnpm --filter @traceroot-ai/tools build`
- `pnpm --filter @traceroot-ai/tools exec tsc --noEmit`
- `pnpm --filter @traceroot-ai/tools lint`
- `pnpm exec prettier --check packages/tools/src/schema.ts packages/tools/src/generate.ts packages/tools/src/pi.ts packages/tools/src/__tests__/generate.test.ts packages/tools/src/__tests__/pi.test.ts packages/tools/src/registry.generated.ts`
- `pnpm --filter @traceroot-ai/tools generate` (registry output remained byte-identical)

Closes #1971

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips numeric minimum/maximum outside JavaScript’s safe integer range from model-facing tool schemas so OpenAI function calling no longer rejects tools. Previously we emitted int64/uint64 bounds beyond `Number.MAX_SAFE_INTEGER`; now we drop those for model schemas while preserving safe bounds and instance-valued metadata.

- Adds `sanitizeSchemaForModel`: recursively sanitizes subschemas, removing out-of-range `minimum`/`maximum`, deep-cloning values and leaving instance metadata (`default`, `example(s)`, `enum`, `const`) untouched.
- Applies sanitization in `generate` (input schemas) and in Pi tool projection; registry entries are not mutated.
- Regenerates `registry.generated.ts` to remove three unsafe maxima; no changes to the public OpenAPI schema or backend validation.
- Closes #1971.

<sup>Written for commit b6066cc507ee8e1f55d80b2805bbb61eb954fe5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

