### PR TITLE
fix(tools): make registry tool schemas acceptable to every model provider — safe numeric bounds, typed filter props

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -3886,13 +3886,15 @@
                         "properties": {
                           "field": {
                             "const": "trace_id",
-                            "title": "Trace ID"
+                            "title": "Trace ID",
+                            "type": "string"
                           },
                           "op": {
                             "enum": [
                               "eq",
                               "contains"
-                            ]
+                            ],
+                            "type": "string"
                           },
                           "value": {
                             "maxLength": 1024,
@@ -3912,12 +3914,14 @@
                         "properties": {
                           "field": {
                             "const": "model_name",
-                            "title": "Model"
+                            "title": "Model",
+                            "type": "string"
                           },
                           "op": {
                             "enum": [
                               "in"
-                            ]
+                            ],
+                            "type": "string"
                           },
                           "value": {
                             "items": {
@@ -3940,12 +3944,14 @@
                         "properties": {
                           "field": {
                             "const": "environment",
-                            "title": "Environment"
+                            "title": "Environment",
+                            "type": "string"
                           },
                           "op": {
                             "enum": [
                               "in"
-                            ]
+                            ],
+                            "type": "string"
                           },
                           "value": {
                             "items": {
@@ -3968,7 +3974,8 @@
                         "properties": {
                           "field": {
                             "const": "cost",
-                            "title": "Cost"
+                            "title": "Cost",
+                            "type": "string"
                           },
                           "op": {
                             "enum": [
@@ -3977,7 +3984,8 @@
                               "gte",
                               "lt",
                               "lte"
-                            ]
+                            ],
+                            "type": "string"
                           },
                           "value": {
                             "maximum": 999999999,
@@ -3997,7 +4005,8 @@
                         "properties": {
                           "field": {
                             "const": "total_tokens",
-                            "title": "Tokens"
+                            "title": "Tokens",
+                            "type": "string"
                           },
                           "op": {
                             "enum": [
@@ -4006,7 +4015,8 @@
                               "gte",
                               "lt",
                               "lte"
-                            ]
+                            ],
+                            "type": "string"
                           },
                           "value": {
                             "maximum": 9223372036854775807,
@@ -4026,7 +4036,8 @@
                         "properties": {
                           "field": {
                             "const": "duration_ms",
-                            "title": "Latency"
+                            "title": "Latency",
+                            "type": "string"
                           },
                           "op": {
                             "enum": [
@@ -4035,7 +4046,8 @@
                               "gte",
                               "lt",
                               "lte"
-                            ]
+                            ],
+                            "type": "string"
                           },
                           "value": {
                             "maximum": 9223372036854775807,
@@ -4055,7 +4067,8 @@
                         "properties": {
                           "field": {
                             "const": "errors",
-                            "title": "Errors"
+                            "title": "Errors",
+                            "type": "string"
                           },
                           "op": {
                             "enum": [
@@ -4064,7 +4077,8 @@
                               "gte",
                               "lt",
                               "lte"
-                            ]
+                            ],
+                            "type": "string"
                           },
                           "value": {
                             "maximum": 18446744073709551615,
@@ -4084,7 +4098,8 @@
                         "properties": {
                           "field": {
                             "const": "metadata",
-                            "title": "Metadata"
+                            "title": "Metadata",
+                            "type": "string"
                           },
                           "key": {
                             "description": "Which metadata key the value is compared against",
@@ -4096,7 +4111,8 @@
                             "enum": [
                               "eq",
                               "contains"
-                            ]
+                            ],
+                            "type": "string"
                           },
                           "value": {
                             "maxLength": 1024,

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -180,9 +180,11 @@ def _filter_predicate_variants() -> list[dict[str, Any]]:
             # A new FilterType member must get an explicit value schema here;
             # failing the build beats silently typing it as free text.
             raise ValueError(f"unhandled filter type for schema generation: {col.type!r}")
+        # Explicit `type` alongside const/enum: the schema also feeds model tool
+        # definitions, and some providers reject properties without one.
         properties: dict[str, Any] = {
-            "field": {"const": col.name, "title": col.label},
-            "op": {"enum": [str(o) for o in col.operators]},
+            "field": {"type": "string", "const": col.name, "title": col.label},
+            "op": {"type": "string", "enum": [str(o) for o in col.operators]},
             "value": value_schema,
         }
         required = ["field", "op", "value"]

--- a/frontend/packages/tools/src/__tests__/generate.test.ts
+++ b/frontend/packages/tools/src/__tests__/generate.test.ts
@@ -171,6 +171,35 @@ describe("generateRegistry", () => {
     expect(listTraces.inputSchema.required).toEqual([]);
   });
 
+  it("drops column-range (int64/uint64) maxima but keeps small bounds", () => {
+    const doc = fakeDoc();
+    doc.paths["/api/v1/public/whoami"].get.parameters = [
+      {
+        name: "min_tokens",
+        in: "query",
+        schema: { type: "integer", minimum: 0, maximum: 9223372036854776000 },
+      },
+      {
+        name: "filters",
+        in: "query",
+        content: {
+          "application/json": {
+            schema: {
+              type: "array",
+              items: { properties: { value: { type: "integer", maximum: 18446744073709552000 } } },
+            },
+          },
+        },
+      },
+    ];
+    const whoami = generateRegistry(doc).find((entry) => entry.name === "whoami")!;
+    expect(whoami.inputSchema.properties.min_tokens).toEqual({ type: "integer", minimum: 0 });
+    expect(whoami.inputSchema.properties.filters).toEqual({
+      type: "array",
+      items: { properties: { value: { type: "integer" } } },
+    });
+  });
+
   it("normalizes multi-variant anyOf params (null variant and titles dropped) and tolerates schema-less params", () => {
     const doc = fakeDoc();
     doc.paths["/api/v1/public/whoami"].get.parameters = [

--- a/frontend/packages/tools/src/__tests__/registry-schema.test.ts
+++ b/frontend/packages/tools/src/__tests__/registry-schema.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { REGISTRY } from "../registry.generated.js";
+
+/** Collect "tool.path" for every property schema that declares no `type`. */
+function untypedProperties(node: unknown, path: string, acc: string[]): void {
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => untypedProperties(item, `${path}[${i}]`, acc));
+    return;
+  }
+  if (node === null || typeof node !== "object") return;
+  const schema = node as Record<string, unknown>;
+  if (schema.properties && typeof schema.properties === "object") {
+    for (const [name, prop] of Object.entries(schema.properties as Record<string, unknown>)) {
+      if (!(prop as Record<string, unknown>).type) acc.push(`${path}.${name}`);
+      untypedProperties(prop, `${path}.${name}`, acc);
+    }
+  }
+  for (const key of ["items", "anyOf", "allOf", "oneOf"]) {
+    if (key in schema) untypedProperties(schema[key], `${path}.${key}`, acc);
+  }
+}
+
+describe("registry tool schemas", () => {
+  // Some model providers reject tool parameters whose properties carry only
+  // const/enum without a type; the public schema emits a type everywhere.
+  it("declare a type on every property", () => {
+    const missing: string[] = [];
+    for (const entry of REGISTRY) {
+      untypedProperties(entry.inputSchema, entry.name, missing);
+    }
+    expect(missing).toEqual([]);
+  });
+});

--- a/frontend/packages/tools/src/__tests__/sanitize.test.ts
+++ b/frontend/packages/tools/src/__tests__/sanitize.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { ApiClient } from "../client.js";
+import { toPiAgentTool } from "../pi.js";
+import { REGISTRY } from "../registry.generated.js";
+import { stripOversizedNumericBounds } from "../sanitize.js";
+
+// int64 / uint64 maxima as JSON renders them (already rounded past 2^53).
+const INT64_MAX = 9223372036854776000;
+const UINT64_MAX = 18446744073709552000;
+
+type Props = { properties: Record<string, unknown> };
+
+describe("stripOversizedNumericBounds", () => {
+  it("drops int64/uint64-sized bounds while keeping small ones", () => {
+    const cleaned = stripOversizedNumericBounds({
+      type: "object",
+      properties: {
+        big: { type: "integer", minimum: 0, maximum: INT64_MAX },
+        huge: { type: "integer", minimum: 0, maximum: UINT64_MAX },
+        page: { type: "integer", minimum: 1, maximum: 200 },
+        okBig: { type: "integer", maximum: 999999999 },
+      },
+    }) as Props;
+
+    expect(cleaned.properties.big).toEqual({ type: "integer", minimum: 0 });
+    expect(cleaned.properties.huge).toEqual({ type: "integer", minimum: 0 });
+    // legitimate small bounds are preserved untouched
+    expect(cleaned.properties.page).toEqual({ type: "integer", minimum: 1, maximum: 200 });
+    expect(cleaned.properties.okBig).toEqual({ type: "integer", maximum: 999999999 });
+  });
+
+  it("strips bounds nested deep inside anyOf/array/object variants", () => {
+    const cleaned = stripOversizedNumericBounds({
+      anyOf: [
+        {
+          type: "object",
+          properties: { value: { type: "integer", minimum: 0, maximum: INT64_MAX } },
+        },
+      ],
+    }) as { anyOf: Props[] };
+    expect(cleaned.anyOf[0]!.properties.value).toEqual({ type: "integer", minimum: 0 });
+  });
+
+  it("does not mutate the input", () => {
+    const input = { maximum: INT64_MAX, type: "integer" };
+    stripOversizedNumericBounds(input);
+    expect(input.maximum).toBe(INT64_MAX);
+  });
+});
+
+describe("toPiAgentTool never emits an oversized numeric bound (OpenAI-safe)", () => {
+  const client = new ApiClient({ baseUrl: "http://localhost:8000", headers: {} });
+
+  const BOUND_KEYS = ["maximum", "minimum", "exclusiveMaximum", "exclusiveMinimum", "multipleOf"];
+
+  function hasOversizedBound(value: unknown): boolean {
+    if (Array.isArray(value)) return value.some(hasOversizedBound);
+    if (value !== null && typeof value === "object") {
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        if (
+          BOUND_KEYS.includes(k) &&
+          typeof v === "number" &&
+          Math.abs(v) > Number.MAX_SAFE_INTEGER
+        ) {
+          return true;
+        }
+        if (hasOversizedBound(v)) return true;
+      }
+    }
+    return false;
+  }
+
+  it("holds for every tool in the registry", () => {
+    for (const entry of REGISTRY) {
+      const tool = toPiAgentTool(entry, { client });
+      expect(
+        hasOversizedBound(tool.parameters),
+        `tool ${entry.name} carries an oversized bound`,
+      ).toBe(false);
+    }
+  });
+
+  it("strips oversized bounds from a hand-authored entry at the model boundary", () => {
+    const tool = toPiAgentTool(
+      {
+        name: "t",
+        description: "t",
+        method: "get",
+        path: "/t",
+        inputSchema: {
+          type: "object",
+          properties: { n: { type: "integer", minimum: 0, maximum: INT64_MAX } },
+          required: [],
+          additionalProperties: false,
+        },
+      },
+      { client },
+    );
+    expect(tool.parameters.properties.n).toEqual({ type: "integer", minimum: 0 });
+  });
+});

--- a/frontend/packages/tools/src/__tests__/sanitize.test.ts
+++ b/frontend/packages/tools/src/__tests__/sanitize.test.ts
@@ -41,6 +41,26 @@ describe("stripOversizedNumericBounds", () => {
     expect(cleaned.anyOf[0]!.properties.value).toEqual({ type: "integer", minimum: 0 });
   });
 
+  it("leaves instance values (default/const/enum/examples) untouched", () => {
+    // A data value may legitimately contain a field named like a bound keyword.
+    const data = { maximum: INT64_MAX, minimum: -INT64_MAX };
+    const cleaned = stripOversizedNumericBounds({
+      type: "object",
+      maximum: INT64_MAX,
+      default: data,
+      const: data,
+      enum: [data, 1],
+      examples: [data],
+      properties: { n: { type: "integer", maximum: INT64_MAX } },
+    }) as Record<string, unknown>;
+    expect(cleaned).not.toHaveProperty("maximum");
+    expect(cleaned.default).toEqual(data);
+    expect(cleaned.const).toEqual(data);
+    expect(cleaned.enum).toEqual([data, 1]);
+    expect(cleaned.examples).toEqual([data]);
+    expect((cleaned.properties as Record<string, unknown>).n).toEqual({ type: "integer" });
+  });
+
   it("does not mutate the input", () => {
     const input = { maximum: INT64_MAX, type: "integer" };
     stripOversizedNumericBounds(input);

--- a/frontend/packages/tools/src/generate.ts
+++ b/frontend/packages/tools/src/generate.ts
@@ -1,3 +1,4 @@
+import { stripOversizedNumericBounds } from "./sanitize.js";
 import type { InputSchema, ParamSchema, RegistryEntry } from "./types.js";
 
 interface OpenApiParameter {
@@ -73,7 +74,8 @@ function buildInputSchema(op: OpenApiOperation): InputSchema {
     if (param.description !== undefined) {
       flattened.description = param.description;
     }
-    properties[param.name] = flattened;
+    // Column-range maxima are API-correct but break OpenAI tools; see sanitize.ts.
+    properties[param.name] = stripOversizedNumericBounds(flattened);
     if (param.required === true || param.in === "path") {
       required.push(param.name);
     }

--- a/frontend/packages/tools/src/pi.ts
+++ b/frontend/packages/tools/src/pi.ts
@@ -1,5 +1,6 @@
 import type { ApiClient } from "./client.js";
 import { dispatch } from "./dispatch.js";
+import { stripOversizedNumericBounds } from "./sanitize.js";
 import type { ParamSchema, RegistryEntry } from "./types.js";
 
 /** One text block of a pi tool result. */
@@ -67,7 +68,8 @@ export function toPiAgentTool(entry: RegistryEntry, options: ToPiAgentToolOption
     if (name in fixedArgs) {
       continue;
     }
-    properties[name] = schema;
+    // Generated entries are already clean; this also covers hand-authored ones.
+    properties[name] = stripOversizedNumericBounds(schema);
   }
   const required = ["label", ...entry.inputSchema.required.filter((name) => !(name in fixedArgs))];
 

--- a/frontend/packages/tools/src/registry.generated.ts
+++ b/frontend/packages/tools/src/registry.generated.ts
@@ -393,7 +393,6 @@ export const REGISTRY: readonly RegistryEntry[] = [
                     enum: ["eq", "gt", "gte", "lt", "lte"],
                   },
                   value: {
-                    maximum: 9223372036854776000,
                     minimum: 0,
                     type: "integer",
                   },
@@ -412,7 +411,6 @@ export const REGISTRY: readonly RegistryEntry[] = [
                     enum: ["eq", "gt", "gte", "lt", "lte"],
                   },
                   value: {
-                    maximum: 9223372036854776000,
                     minimum: 0,
                     type: "integer",
                   },
@@ -431,7 +429,6 @@ export const REGISTRY: readonly RegistryEntry[] = [
                     enum: ["eq", "gt", "gte", "lt", "lte"],
                   },
                   value: {
-                    maximum: 18446744073709552000,
                     minimum: 0,
                     type: "integer",
                   },

--- a/frontend/packages/tools/src/registry.generated.ts
+++ b/frontend/packages/tools/src/registry.generated.ts
@@ -306,9 +306,11 @@ export const REGISTRY: readonly RegistryEntry[] = [
                   field: {
                     const: "trace_id",
                     title: "Trace ID",
+                    type: "string",
                   },
                   op: {
                     enum: ["eq", "contains"],
+                    type: "string",
                   },
                   value: {
                     maxLength: 1024,
@@ -325,9 +327,11 @@ export const REGISTRY: readonly RegistryEntry[] = [
                   field: {
                     const: "model_name",
                     title: "Model",
+                    type: "string",
                   },
                   op: {
                     enum: ["in"],
+                    type: "string",
                   },
                   value: {
                     items: {
@@ -347,9 +351,11 @@ export const REGISTRY: readonly RegistryEntry[] = [
                   field: {
                     const: "environment",
                     title: "Environment",
+                    type: "string",
                   },
                   op: {
                     enum: ["in"],
+                    type: "string",
                   },
                   value: {
                     items: {
@@ -369,9 +375,11 @@ export const REGISTRY: readonly RegistryEntry[] = [
                   field: {
                     const: "cost",
                     title: "Cost",
+                    type: "string",
                   },
                   op: {
                     enum: ["eq", "gt", "gte", "lt", "lte"],
+                    type: "string",
                   },
                   value: {
                     maximum: 999999999,
@@ -388,9 +396,11 @@ export const REGISTRY: readonly RegistryEntry[] = [
                   field: {
                     const: "total_tokens",
                     title: "Tokens",
+                    type: "string",
                   },
                   op: {
                     enum: ["eq", "gt", "gte", "lt", "lte"],
+                    type: "string",
                   },
                   value: {
                     minimum: 0,
@@ -406,9 +416,11 @@ export const REGISTRY: readonly RegistryEntry[] = [
                   field: {
                     const: "duration_ms",
                     title: "Latency",
+                    type: "string",
                   },
                   op: {
                     enum: ["eq", "gt", "gte", "lt", "lte"],
+                    type: "string",
                   },
                   value: {
                     minimum: 0,
@@ -424,9 +436,11 @@ export const REGISTRY: readonly RegistryEntry[] = [
                   field: {
                     const: "errors",
                     title: "Errors",
+                    type: "string",
                   },
                   op: {
                     enum: ["eq", "gt", "gte", "lt", "lte"],
+                    type: "string",
                   },
                   value: {
                     minimum: 0,
@@ -442,6 +456,7 @@ export const REGISTRY: readonly RegistryEntry[] = [
                   field: {
                     const: "metadata",
                     title: "Metadata",
+                    type: "string",
                   },
                   key: {
                     description: "Which metadata key the value is compared against",
@@ -451,6 +466,7 @@ export const REGISTRY: readonly RegistryEntry[] = [
                   },
                   op: {
                     enum: ["eq", "contains"],
+                    type: "string",
                   },
                   value: {
                     maxLength: 1024,

--- a/frontend/packages/tools/src/sanitize.ts
+++ b/frontend/packages/tools/src/sanitize.ts
@@ -1,0 +1,44 @@
+// The public OpenAPI schema publishes each filterable numeric column's real
+// ClickHouse type maximum (int64 / uint64) as a JSON-schema `maximum`. That is
+// correct for the API contract but unusable in a model-facing tool schema:
+// OpenAI's function-calling API rejects a tool whose parameter schema carries a
+// numeric literal that large (400 "a numeric value in the function parameters
+// is too large"), while Anthropic accepts it — so the same tools work on Claude
+// and 400 on every OpenAI model. No model is going to emit a 9e18 argument
+// anyway, so the bound is dropped from the model's view. Small, legitimate
+// bounds (e.g. a 1..200 page size) are kept.
+
+const NUMERIC_BOUND_KEYS = new Set([
+  "maximum",
+  "minimum",
+  "exclusiveMaximum",
+  "exclusiveMinimum",
+  "multipleOf",
+]);
+
+/**
+ * Deep-clone `value` (any JSON-schema fragment), dropping numeric range keywords
+ * whose magnitude exceeds the JS safe-integer range, wherever they are nested
+ * (object properties, array items, anyOf/oneOf/allOf variants, ...). The input
+ * is never mutated: the registry is shared data.
+ */
+export function stripOversizedNumericBounds<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => stripOversizedNumericBounds(item)) as unknown as T;
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      if (
+        NUMERIC_BOUND_KEYS.has(key) &&
+        typeof child === "number" &&
+        Math.abs(child) > Number.MAX_SAFE_INTEGER
+      ) {
+        continue;
+      }
+      out[key] = stripOversizedNumericBounds(child);
+    }
+    return out as T;
+  }
+  return value;
+}

--- a/frontend/packages/tools/src/sanitize.ts
+++ b/frontend/packages/tools/src/sanitize.ts
@@ -16,6 +16,10 @@ const NUMERIC_BOUND_KEYS = new Set([
   "multipleOf",
 ]);
 
+// Keywords whose values are data, not schema: copied as-is so a data field
+// that happens to be named like a bound keyword is never touched.
+const INSTANCE_KEYS = new Set(["default", "const", "enum", "examples", "example"]);
+
 /**
  * Deep-clone `value` (any JSON-schema fragment), dropping numeric range keywords
  * whose magnitude exceeds the JS safe-integer range, wherever they are nested
@@ -36,7 +40,9 @@ export function stripOversizedNumericBounds<T>(value: T): T {
       ) {
         continue;
       }
-      out[key] = stripOversizedNumericBounds(child);
+      out[key] = INSTANCE_KEYS.has(key)
+        ? structuredClone(child)
+        : stripOversizedNumericBounds(child);
     }
     return out as T;
   }

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -392,6 +392,22 @@ def test_filters_param_is_json_content_with_registry_variants():
             assert "key" not in v["properties"]
 
 
+def test_filters_param_properties_all_declare_a_type():
+    """Every predicate property carries an explicit ``type``.
+
+    ``const``/``enum`` alone are valid JSON Schema, but the registry feeds
+    model tool schemas and some providers reject properties without a type.
+    """
+    param = _filters_param(_schema())
+    variants = param["content"]["application/json"]["schema"]["items"]["anyOf"]
+    for v in variants:
+        field = v["properties"]["field"]["const"]
+        for name, prop in v["properties"].items():
+            assert prop.get("type"), f"{field}.{name} declares no type"
+        assert v["properties"]["field"]["type"] == "string"
+        assert v["properties"]["op"]["type"] == "string"
+
+
 def test_filters_param_value_types_match_field_kinds():
     from rest.services.filters.translate import MAX_VALUE_LENGTH
 


### PR DESCRIPTION
Two fixes for tool schemas the registry sends to model providers. Both are "the tool schemas ride on every request" failures, so they broke plain agent chat — and detector/RCA — not just tool use. (The OpenAI Responses-API default that was briefly stacked here is now its own PR, #1977.)

## 1. Strip oversized numeric bounds from model-facing tool schemas (`packages/tools`)

The tool registry is generated from the public OpenAPI schema, which publishes each filterable numeric column's real ClickHouse type maximum (int64 / uint64) as a JSON-schema `maximum`. OpenAI's function-calling API rejects tool schemas holding numeric literals that large (`400 Invalid function parameters for 'tools[0].function.parameters': a numeric value in the function parameters is too large`); Anthropic accepts them, which hid the problem on Claude models.

- Add `stripOversizedNumericBounds` (`packages/tools/src/sanitize.ts`): deep-clones a schema fragment and drops `maximum`/`minimum`/`exclusiveMaximum`/`exclusiveMinimum`/`multipleOf` whose magnitude exceeds `Number.MAX_SAFE_INTEGER`; never mutates the shared registry; copies instance-valued keywords (`default`/`const`/`enum`/`examples`) as-is so a data field named like a bound keyword is never touched.
- Apply it at generation (`generate.ts`) and at the model boundary (`toPiAgentTool` in `pi.ts`, covers hand-authored entries).
- Regenerate `registry.generated.ts` — only the three int64/uint64 maxima are removed.

The public OpenAPI schema and backend validation are unchanged: the bounds are correct for the API contract, just unusable in a model-facing tool schema.

Closes #1971

(Part 2 below closes #1979.)

## 2. Declare a `type` on filter predicate `field`/`op` schemas (`backend/rest`)

The filter predicate variants in the public schema described `field` with a bare `const` and `op` with a bare `enum`. Valid JSON Schema, but the same schema feeds the tool registry, and Moonshot rejects tool parameters whose properties carry no `type` (`400 tools.function.parameters is not a valid moonshot flavored json schema, details: <At path 'properties.filters.items.anyOf.properties.op': type is not defined>`), so every Kimi agent request failed.

- `openapi_public.py` emits `"type": "string"` alongside the const/enum; `public.json` and `registry.generated.ts` regenerated (16 `type` additions each, nothing else).
- New backend test pins the invariant over every variant; new `packages/tools` oracle test asserts every registry property declares a type (verified to fail against the old registry).

Closes #1979

## Screenshots
### OpenAI 5.6* fix
<img width="1728" height="994" alt="image" src="https://github.com/user-attachments/assets/c44eb113-f61f-444b-98c9-c7a4c7695bfa" />

### Kimi tools fix
<img width="1728" height="998" alt="image" src="https://github.com/user-attachments/assets/b8de1231-f700-4fd1-b586-3f893ff4a75b" />


## Test plan

- [x] `pnpm --filter @traceroot-ai/tools test` — 35/35 incl. registry-wide "no oversized bound" and "every property typed" oracles, instance-value preservation, generation-level and `toPiAgentTool` tests, and the registry-drift test
- [x] `uv run pytest tests/rest/test_public_openapi.py` — 31/31 incl. the committed-artifact drift guard
- [x] lint / tsc / prettier / ruff clean; `pnpm --filter @traceroot-ai/tools generate` and `scripts/sync_public_openapi.py --check` are clean
- [x] Live, full registry tools attached via `resolvePiModel` + `toPiAgentTool`: `kimi-k3` and `kimi-k2.5` answer and `kimi-k2.5` makes a real `list_traces` tool call; `gpt-5` tool-calls with the new schema
- [x] Local stack: agent chat on `gpt-5` no longer 400s after (1); Kimi chat works after (2)
- [ ] Not live-probed: Anthropic with the new schema (the local key has no credit — the change only adds `type` next to `const`/`enum`, plain JSON Schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
