### PR TITLE
fix(core): default OpenAI models to the Responses API

### DIFF
--- a/frontend/packages/core/src/__tests__/llm-providers.test.ts
+++ b/frontend/packages/core/src/__tests__/llm-providers.test.ts
@@ -6,7 +6,26 @@ import {
   ADAPTER_API_PROTOCOL,
   LLMAdapter,
   DETECTOR_SYSTEM_DEFAULT_MODEL_ID,
+  defaultApiProtocol,
 } from "../llm-providers.ts";
+
+describe("defaultApiProtocol", () => {
+  it("prefers the catalog entry's own protocol over the adapter default", () => {
+    expect(defaultApiProtocol("openai", "o3")).toBe("openai-completions");
+    expect(defaultApiProtocol("openai", "o4-mini")).toBe("openai-completions");
+    expect(defaultApiProtocol("openai", "gpt-5")).toBe("openai-responses");
+  });
+
+  it("falls back to the adapter default for unknown models and no model", () => {
+    expect(defaultApiProtocol("openai", "some-future-model")).toBe("openai-responses");
+    expect(defaultApiProtocol("openai")).toBe("openai-responses");
+    expect(defaultApiProtocol("deepseek", "deepseek-chat")).toBe("openai-completions");
+  });
+
+  it("is empty for an unknown adapter", () => {
+    expect(defaultApiProtocol("nope", "x")).toBe("");
+  });
+});
 
 describe("ADAPTER_MODELS", () => {
   it("contains no duplicate model IDs within a single adapter", () => {

--- a/frontend/packages/core/src/__tests__/model-resolver.test.ts
+++ b/frontend/packages/core/src/__tests__/model-resolver.test.ts
@@ -32,11 +32,38 @@ describe("resolvePiModel", () => {
     expect(m.provider).toBe("anthropic");
   });
 
-  it("uses openai-responses for system gpt-5.3-codex (per-model override)", () => {
-    const m = resolvePiModel("gpt-5.3-codex", null);
+  it("uses openai-responses for system OpenAI models", () => {
+    for (const id of ["gpt-5", "gpt-5.4", "gpt-5.3-codex"]) {
+      const m = resolvePiModel(id, null);
+      expect(m.api, id).toBe("openai-responses");
+      expect(m.provider).toBe("openai");
+      expect(m.id).toBe(id);
+    }
+  });
+
+  it("keeps the o-series on openai-completions (per-model catalog override)", () => {
+    for (const id of ["o3", "o4-mini"]) {
+      expect(resolvePiModel(id, null).api, `system ${id}`).toBe("openai-completions");
+      const cfg: ProviderModelConfig = {
+        adapter: "openai",
+        key: "sk-test",
+        baseUrl: null,
+        config: null,
+      };
+      expect(resolvePiModel(id, cfg).api, `byok ${id}`).toBe("openai-completions");
+    }
+  });
+
+  it("uses openai-responses for BYOK OpenAI with no override", () => {
+    const cfg: ProviderModelConfig = {
+      adapter: "openai",
+      key: "sk-test",
+      baseUrl: null,
+      config: null,
+    };
+    const m = resolvePiModel("gpt-5.6-sol", cfg);
     expect(m.api).toBe("openai-responses");
     expect(m.provider).toBe("openai");
-    expect(m.id).toBe("gpt-5.3-codex");
   });
 
   it("uses openai-completions for BYOK DeepSeek with provider mapped to openai", () => {
@@ -76,27 +103,15 @@ describe("resolvePiModel", () => {
   });
 
   it("respects per-model modelProtocols override over adapter default", () => {
+    // The escape hatch for OpenAI-compatible proxies that only speak chat completions.
     const cfg: ProviderModelConfig = {
       adapter: "openai",
       key: "sk-test",
-      baseUrl: null,
-      config: { modelProtocols: { "gpt-5": "openai-responses" } },
+      baseUrl: "https://proxy.example.com/v1",
+      config: { modelProtocols: { "gpt-5": "openai-completions" } },
     };
     const m = resolvePiModel("gpt-5", cfg);
-    expect(m.api).toBe("openai-responses");
-  });
-
-  it("uses catalog apiProtocol for BYOK Codex when no modelProtocols override is set", () => {
-    // gpt-5.3-codex has apiProtocol: "openai-responses" in ADAPTER_MODELS.openai;
-    // resolver should pick that up before the openai adapter default ("openai-completions").
-    const cfg: ProviderModelConfig = {
-      adapter: "openai",
-      key: "sk-test",
-      baseUrl: null,
-      config: null,
-    };
-    const m = resolvePiModel("gpt-5.3-codex", cfg);
-    expect(m.api).toBe("openai-responses");
+    expect(m.api).toBe("openai-completions");
   });
 
   it("uses caller-supplied baseUrl over adapter default", () => {

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -222,6 +222,18 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
   ],
 };
 
+/**
+ * The protocol a model runs on under an adapter when the workspace has not
+ * overridden it: the catalog entry's own `apiProtocol` when it sets one, else
+ * the adapter default. Shared by the resolver and the provider dialog so what
+ * the dialog shows as the default is what the resolver will use.
+ */
+export function defaultApiProtocol(adapter: string, modelId?: string): string {
+  const catalog = ADAPTER_MODELS[adapter as LLMAdapter];
+  const perModel = modelId ? catalog?.find((m) => m.id === modelId)?.apiProtocol : undefined;
+  return perModel ?? ADAPTER_API_PROTOCOL[adapter] ?? "";
+}
+
 // Available API protocols per adapter — shown in provider settings UI
 // When multiple protocols are available, user can choose; otherwise the default is used.
 export const ADAPTER_AVAILABLE_PROTOCOLS: Record<string, { value: string; label: string }[]> = {

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -48,8 +48,12 @@ export const ADAPTER_DEFAULT_BASE_URL: Record<string, string> = {
 
 // API protocol per adapter — used to build fallback model objects for BYOK models
 // not found in pi-ai's registry. Must match pi-ai's registered API providers.
+// OpenAI proper defaults to the Responses API: newer model families reject
+// function tools on chat completions unless reasoning is explicitly disabled.
+// Chat completions stays selectable per model (modelProtocols) for
+// OpenAI-compatible proxies that only implement that endpoint.
 export const ADAPTER_API_PROTOCOL: Record<string, string> = {
-  openai: "openai-completions",
+  openai: "openai-responses",
   anthropic: "anthropic-messages",
   azure: "azure-openai-responses",
   google: "google-generative-ai",
@@ -113,7 +117,7 @@ export const SYSTEM_MODELS: {
     provider: "OpenAI",
     envVar: "OPENAI_API_KEY",
     piAIProvider: "openai",
-    apiProtocol: "openai-completions",
+    apiProtocol: "openai-responses",
     models: [
       { id: "gpt-5.5", label: "gpt-5.5" },
       { id: "gpt-5.4", label: "gpt-5.4" },
@@ -121,10 +125,11 @@ export const SYSTEM_MODELS: {
       { id: "gpt-5.4-nano", label: "gpt-5.4-nano" },
       { id: "gpt-5", label: "gpt-5" },
       { id: "gpt-5-mini", label: "gpt-5-mini" },
-      { id: "o3", label: "o3" },
-      { id: "o4-mini", label: "o4-mini" },
-      // Codex models require the Responses API (not Chat Completions)
-      { id: "gpt-5.3-codex", label: "gpt-5.3-codex", apiProtocol: "openai-responses" },
+      // The o-series rejects reasoning effort "none", which the Responses client
+      // sends when no effort is requested; chat completions sends nothing for them.
+      { id: "o3", label: "o3", apiProtocol: "openai-completions" },
+      { id: "o4-mini", label: "o4-mini", apiProtocol: "openai-completions" },
+      { id: "gpt-5.3-codex", label: "gpt-5.3-codex" },
     ],
   },
 ];
@@ -160,12 +165,13 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "gpt-5.4-pro", label: "gpt-5.4-pro" },
     { id: "gpt-5.4-mini", label: "gpt-5.4-mini" },
     { id: "gpt-5.4-nano", label: "gpt-5.4-nano" },
-    { id: "gpt-5.3-codex", label: "gpt-5.3-codex", apiProtocol: "openai-responses" },
+    { id: "gpt-5.3-codex", label: "gpt-5.3-codex" },
     { id: "gpt-5.2", label: "gpt-5.2" },
     { id: "gpt-5", label: "gpt-5" },
     { id: "gpt-5-mini", label: "gpt-5-mini" },
-    { id: "o3", label: "o3" },
-    { id: "o4-mini", label: "o4-mini" },
+    // See the o-series note on SYSTEM_MODELS.
+    { id: "o3", label: "o3", apiProtocol: "openai-completions" },
+    { id: "o4-mini", label: "o4-mini", apiProtocol: "openai-completions" },
   ],
   anthropic: [
     { id: "claude-opus-5", label: "claude-opus-5" },
@@ -220,8 +226,8 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
 // When multiple protocols are available, user can choose; otherwise the default is used.
 export const ADAPTER_AVAILABLE_PROTOCOLS: Record<string, { value: string; label: string }[]> = {
   openai: [
-    { value: "openai-completions", label: "Chat Completions" },
     { value: "openai-responses", label: "Responses API" },
+    { value: "openai-completions", label: "Chat Completions" },
   ],
   anthropic: [{ value: "anthropic-messages", label: "Messages API" }],
   azure: [{ value: "azure-openai-responses", label: "Azure OpenAI Responses" }],

--- a/frontend/packages/core/src/model-resolver.ts
+++ b/frontend/packages/core/src/model-resolver.ts
@@ -22,8 +22,8 @@ import {
   PROVIDER_PRIORITY,
   ADAPTER_TO_PI_AI,
   ADAPTER_DEFAULT_BASE_URL,
-  ADAPTER_API_PROTOCOL,
   ADAPTER_MODELS,
+  defaultApiProtocol,
 } from "./llm-providers.ts";
 
 /** Workspace BYOK row (decrypted key). Same shape as agent's private ProviderConfig. */
@@ -139,15 +139,11 @@ export function resolvePiModel(
         );
       }
 
-      // Per-model `apiProtocol` overrides — checked in order:
-      //   1. BYOK row's `config.modelProtocols` (user-overridable per workspace)
-      //   2. Catalog's per-model `apiProtocol`, when an entry sets one
-      //   3. Adapter-level default
-      const catalogProtocol = catalog?.find((m) => m.id === fallbackModelId)?.apiProtocol;
+      // The BYOK row's `config.modelProtocols` (user-overridable per workspace)
+      // wins over the catalog/adapter default the provider dialog displays.
       const apiProtocol =
         modelProtocols?.[fallbackModelId] ||
-        catalogProtocol ||
-        ADAPTER_API_PROTOCOL[providerConfig.adapter] ||
+        defaultApiProtocol(providerConfig.adapter, fallbackModelId) ||
         "openai-completions";
       const model = buildFallbackModel(fallbackModelId, apiProtocol, piAIProvider);
       const baseUrl = providerConfig.baseUrl || ADAPTER_DEFAULT_BASE_URL[providerConfig.adapter];

--- a/frontend/packages/core/src/model-resolver.ts
+++ b/frontend/packages/core/src/model-resolver.ts
@@ -35,8 +35,7 @@ export interface ProviderModelConfig {
 }
 
 // Build system model lookup from SYSTEM_MODELS.
-// Per-model apiProtocol overrides the provider-level default
-// (e.g. gpt-5.3-codex → openai-responses).
+// A model's own apiProtocol, when set, overrides the provider-level default.
 const systemModelLookup = new Map<string, { piAIProvider: string; apiProtocol: string }>();
 for (const sys of SYSTEM_MODELS) {
   for (const m of sys.models) {
@@ -142,7 +141,7 @@ export function resolvePiModel(
 
       // Per-model `apiProtocol` overrides — checked in order:
       //   1. BYOK row's `config.modelProtocols` (user-overridable per workspace)
-      //   2. Catalog's per-model `apiProtocol` (e.g. gpt-5.3-codex → openai-responses)
+      //   2. Catalog's per-model `apiProtocol`, when an entry sets one
       //   3. Adapter-level default
       const catalogProtocol = catalog?.find((m) => m.id === fallbackModelId)?.apiProtocol;
       const apiProtocol =

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.test.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.test.tsx
@@ -244,4 +244,49 @@ describe("ModelProvidersTab", () => {
       expect.objectContaining({ baseUrl: "https://example.com/v1testing" }),
     );
   });
+
+  it("shows the catalog protocol for an o-series model and persists an explicit Responses pick", async () => {
+    mocks.getModelProviders.mockResolvedValue({
+      byokEnabled: true,
+      providers: [
+        {
+          id: "provider-1",
+          adapter: "openai",
+          provider: "OpenAI",
+          keyPreview: "sk-...",
+          baseUrl: null,
+          customModels: ["o3"],
+          withDefaultModels: true,
+          config: null, // saved before any override existed
+          enabled: true,
+          createdBy: "user-1",
+          createTime: "2026-06-17T00:00:00.000Z",
+          updateTime: "2026-06-17T00:00:00.000Z",
+        },
+      ],
+    });
+    mocks.updateModelProvider.mockResolvedValue({ id: "provider-1" });
+
+    renderTab();
+    fireEvent.click(await screen.findByRole("button", { name: "Edit" }));
+
+    // The protocol select is the one offering the two OpenAI protocols. With no
+    // override it must show what the resolver will actually use for o3.
+    const protocolSelect = screen
+      .getAllByRole("combobox")
+      .find((el) =>
+        Array.from((el as HTMLSelectElement).options).some((o) => o.value === "openai-completions"),
+      ) as HTMLSelectElement;
+    expect(protocolSelect.value).toBe("openai-completions");
+
+    // Choosing Responses for o3 differs from its effective default, so it is persisted.
+    fireEvent.change(protocolSelect, { target: { value: "openai-responses" } });
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    await waitFor(() => expect(mocks.updateModelProvider).toHaveBeenCalledTimes(1));
+    expect(mocks.updateModelProvider).toHaveBeenCalledWith(
+      "ws-1",
+      "provider-1",
+      expect.objectContaining({ config: { modelProtocols: { o3: "openai-responses" } } }),
+    );
+  });
 });

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -25,10 +25,10 @@ import {
 } from "@/components/ui/select";
 import {
   ADAPTER_CONFIG,
-  ADAPTER_API_PROTOCOL,
   ADAPTER_AVAILABLE_PROTOCOLS,
   ADAPTER_DEFAULT_BASE_URL,
   ADAPTER_MODELS,
+  defaultApiProtocol,
 } from "@traceroot/core";
 import type { LLMAdapter } from "@traceroot/core";
 import {
@@ -178,13 +178,13 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
 
   function handleSave() {
     setSaveError(null);
-    // Build config with per-model protocol overrides (only non-default ones)
-    const defaultProtocol = ADAPTER_API_PROTOCOL[adapter] || "";
+    // Build config with per-model protocol overrides — only picks that differ
+    // from what the resolver would use anyway for that model.
     const trimmedModels = [...new Set(customModels.map((m) => m.trim()).filter(Boolean))];
     const filteredProtocols: Record<string, string> = {};
     for (const modelId of trimmedModels) {
       const proto = modelProtocols[modelId];
-      if (proto && proto !== defaultProtocol) {
+      if (proto && proto !== defaultApiProtocol(adapter, modelId)) {
         filteredProtocols[modelId] = proto;
       }
     }
@@ -255,15 +255,6 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
     setModelProtocols({});
   }
 
-  function seedProtocolFromCatalog(modelId: string) {
-    const catalog = ADAPTER_MODELS[adapter as LLMAdapter];
-    if (!catalog) return;
-    const entry = catalog.find((m) => m.id === modelId);
-    if (entry?.apiProtocol) {
-      setModelProtocols((prev) => ({ ...prev, [modelId]: entry.apiProtocol! }));
-    }
-  }
-
   function addCustomModel() {
     const curatedModels = ADAPTER_MODELS[adapter as LLMAdapter];
     if (curatedModels) {
@@ -271,7 +262,6 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
       const next = curatedModels.find((m) => !used.has(m.id));
       if (!next) return;
       setCustomModels([...customModels, next.id]);
-      seedProtocolFromCatalog(next.id);
     } else {
       setCustomModels([...customModels, ""]);
     }
@@ -285,7 +275,6 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
     const updated = [...customModels];
     updated[index] = value;
     setCustomModels(updated);
-    seedProtocolFromCatalog(value);
   }
 
   if (isLoading) {
@@ -558,7 +547,6 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
                 {(() => {
                   const protocols = ADAPTER_AVAILABLE_PROTOCOLS[adapter];
                   const hasMultipleProtocols = protocols && protocols.length > 1;
-                  const defaultProto = ADAPTER_API_PROTOCOL[adapter] || "";
                   const curatedModels = ADAPTER_MODELS[adapter as LLMAdapter];
 
                   return customModels.map((model, i) => (
@@ -599,7 +587,7 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
                       )}
                       {hasMultipleProtocols && (
                         <Select
-                          value={modelProtocols[model] || defaultProto}
+                          value={modelProtocols[model] || defaultApiProtocol(adapter, model)}
                           onValueChange={(v) =>
                             setModelProtocols((prev) => ({ ...prev, [model]: v }))
                           }


### PR DESCRIPTION
## Summary

System and BYOK OpenAI models defaulted to `openai-completions`, with the Responses API opted into per model (only `gpt-5.3-codex`). Newer OpenAI families (gpt-5.6-*) reject function tools on chat completions unless reasoning is explicitly disabled:

```
400 Function tools with reasoning_effort are not supported for gpt-5.6-sol in /v1/chat/completions.
To use function tools, use /v1/responses or set reasoning_effort to 'none'.
```

The agent sends no `reasoning_effort` (it runs with thinking off), so the model's default effort applies and every request carries tool schemas — plain chat, detector evaluation (`submit_result` tool) and RCA all 400 on those models.

- `SYSTEM_MODELS[OpenAI].apiProtocol` and `ADAPTER_API_PROTOCOL.openai` → `openai-responses`; the per-model codex override is dropped as redundant; Responses listed first in the protocol dropdown.
- `o3` / `o4-mini` pinned to `openai-completions` per model: pi-ai's Responses client sends `reasoning.effort: "none"` when no effort is requested and the o-series rejects that value (verified live), while chat completions sends nothing for them.
- The resolver and the provider dialog now share one source of truth, `defaultApiProtocol(adapter, modelId)` (catalog per-model protocol, else adapter default): the dialog shows it as the per-model fallback and strips saved picks equal to it, so an existing row with `o3`/`o4-mini` displays Chat Completions (what actually runs) and an explicit Responses pick for them is persisted rather than stripped. The dialog no longer seeds protocols from the catalog when a model is added — a catalog pin is followed, not frozen into the row; only user picks that differ are persisted.
- The BYOK `modelProtocols` override is unchanged and remains the escape hatch for OpenAI-compatible proxies that only implement chat completions. Other OpenAI-compatible adapters (DeepSeek, xAI, Moonshot, Z.AI, OpenRouter) are untouched.

**Deploy note:** BYOK rows with `adapter=openai` and no per-model protocol move to `{baseUrl}/responses`. For `api.openai.com` that is the fix; a row whose `baseUrl` is a chat-completions-only proxy needs Chat Completions re-selected per model in the provider dialog. (The dialog strips per-model picks equal to the adapter default on save, so no existing row can carry an explicit `openai-completions`.) To size that population before deploy: `SELECT count(*) FROM model_providers WHERE adapter='openai' AND base_url IS NOT NULL AND base_url NOT LIKE '%api.openai.com%';`

Closes #1978

Split out of #1974 (tool-schema fixes) — independent change, independent risk.

## Test plan

- [x] `pnpm --filter @traceroot-ai/core test` — 129/129 (system + BYOK OpenAI → Responses; o-series → completions; `modelProtocols` override still selects completions; `defaultApiProtocol` pinned/unpinned/unknown cases)
- [x] `ui` settings suite — 22/22 incl. editing an existing OpenAI row with `o3`: select shows Chat Completions, choosing Responses persists `modelProtocols.o3`
- [x] lint / `tsc --noEmit` / prettier clean
- [x] Live against the OpenAI API with pi-ai's exact request shape + a tool: `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.3-codex`, `gpt-5.2` (effort `none`) and `gpt-5`, `gpt-5-mini` (no reasoning param) all succeed on `/v1/responses`; `o3` / `o4-mini` reject `none` (hence the pin)
- [x] Local stack A/B on `gpt-5.6-sol` (BYOK): default (Responses) → 5/5 detector runs completed with findings + 5/5 RCA sessions done, real token usage on the self-trace LLM spans; per-model Chat Completions override → 5/5 runs `failed` with the 400 above, 0 findings, 0 RCA. Agent chat works on `gpt-5.6-sol` under the default.
- [ ] Not live-probed: `gpt-5.5-pro` / `gpt-5.4-pro` (BYOK-only; same request shape as the passing `gpt-5` call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default OpenAI models now use the Responses API by default to restore tool-calling on newer families. The settings dialog and resolver now share the same per-model default so the UI shows what will run and persists non-default picks. `o3` and `o4-mini` remain on Chat Completions because Responses sends `reasoning.effort: "none"`, which those models reject.

- Sets `ADAPTER_API_PROTOCOL.openai` and the OpenAI system provider default to `openai-responses`; removes redundant per-model opt-ins; pins `o3` and `o4-mini` to `openai-completions`.
- Adds `defaultApiProtocol(adapter, modelId)` and uses it in both the resolver and provider dialog. Fixes prior mismatch where the dialog showed Responses for o-series while calls used Chat Completions, and ensures explicit Responses picks for o-series are saved.
- Keeps resolver precedence: per-model `modelProtocols` override > catalog per-model override (when set) > adapter default. Protocol picker shows Responses first. Other adapters mapped to OpenAI (DeepSeek, xAI, Moonshot, Z.AI, OpenRouter) are unchanged.

Bolded Sections:
- Rollout
  - BYOK with `adapter='openai'` and no per-model override will switch to `{baseUrl}/responses`. If `baseUrl` is a chat-completions-only proxy, re-select Chat Completions per model in the provider dialog.
  - Size potentially affected proxies before deploy:
    - `SELECT count(*) FROM model_providers WHERE adapter='openai' AND base_url IS NOT NULL AND base_url NOT LIKE '%api.openai.com%';`

<sup>Written for commit 80502278033557520edd857098b16747750bf6c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

