### PR TITLE
fix(agent): render get_finding_by_trace 404 as (#1975)

### DIFF
--- a/frontend/ee/agent/src/tools/__tests__/registry-tools.test.ts
+++ b/frontend/ee/agent/src/tools/__tests__/registry-tools.test.ts
@@ -227,6 +227,49 @@ describe("createRegistryReadTools", () => {
     expect(result.content[0]!.text).toContain("Error calling list_traces");
     expect(result.content[0]!.text).toContain("Forbidden");
   });
+
+  it("renders get_finding_by_trace 404 as 'no finding' instead of a tool error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () => new Response(JSON.stringify({ detail: "Finding not found" }), { status: 404 }),
+      ),
+    );
+    const findingTool = createRegistryReadTools("p1", "u1").find(
+      (t) => t.name === "get_finding_by_trace",
+    )!;
+    const result404 = await findingTool.execute("id", { label: "x", trace_id: "t1" });
+    expect(result404.content[0]!.text).toBe("No detector finding is attached to trace.");
+    expect(result404.content[0]!.text).not.toContain("Error calling");
+
+    // Non-404 status still renders as an error
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ detail: "Internal server error" }), { status: 500 }),
+      ),
+    );
+    const result500 = await findingTool.execute("id", { label: "x", trace_id: "t1" });
+    expect(result500.content[0]!.text).toBe(
+      "Error calling get_finding_by_trace: API error 500: Internal server error",
+    );
+
+    // 404 on other tools (e.g. get_detector) still renders as an error
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () => new Response(JSON.stringify({ detail: "Detector not found" }), { status: 404 }),
+      ),
+    );
+    const detectorTool = createRegistryReadTools("p1", "u1").find(
+      (t) => t.name === "get_detector",
+    )!;
+    const detectorResult = await detectorTool.execute("id", { label: "x", detector_id: "d1" });
+    expect(detectorResult.content[0]!.text).toBe(
+      "Error calling get_detector: API error 404: Detector not found",
+    );
+  });
 });
 
 describe("createTools", () => {

--- a/frontend/ee/agent/src/tools/registry-tools.ts
+++ b/frontend/ee/agent/src/tools/registry-tools.ts
@@ -1,6 +1,7 @@
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import {
   ApiClient,
+  ApiError,
   INTERNAL_BINDINGS,
   REGISTRY,
   internalAuth,
@@ -34,12 +35,17 @@ export function createRegistryReadTools(projectId: string, userId: string): Agen
     baseUrl: process.env.BACKEND_INTERNAL_URL || "http://localhost:8000",
     headers: internalAuth(process.env.INTERNAL_API_SECRET || "", userId),
   });
-  const bind = (name: string, formatResult: (data: unknown) => string) =>
+  const bind = (
+    name: string,
+    formatResult: (data: unknown) => string,
+    formatError?: (error: ApiError) => string | undefined,
+  ) =>
     toPiAgentTool(requireEntry(name), {
       client,
       pathOverride: INTERNAL_BINDINGS[name],
       fixedArgs: { project_id: projectId },
       formatResult,
+      formatError,
     }) as AgentTool<any>;
   return [
     bind("list_traces", formatTraceList),
@@ -49,6 +55,11 @@ export function createRegistryReadTools(projectId: string, userId: string): Agen
     bind("get_detector", formatDetectorDetail),
     bind("list_findings", formatFindingList),
     bind("get_finding", formatFindingDetail),
-    bind("get_finding_by_trace", formatFindingDetail),
+    bind("get_finding_by_trace", formatFindingDetail, (error) => {
+      if (error.status === 404) {
+        return "No detector finding is attached to trace.";
+      }
+      return undefined;
+    }),
   ];
 }

--- a/frontend/packages/tools/src/__tests__/pi.test.ts
+++ b/frontend/packages/tools/src/__tests__/pi.test.ts
@@ -122,6 +122,35 @@ describe("toPiAgentTool", () => {
     expect(result.content[0]!.text).toContain("list_traces");
     expect(result.content[0]!.text).toContain("Forbidden");
   });
+
+  it("customizes error rendering with formatError when defined", async () => {
+    const client = new ApiClient({
+      baseUrl: "http://x",
+      headers: {},
+      fetchImpl: fakeFetch(404, { detail: "Not found" }),
+    });
+    const tool = toPiAgentTool(listTracesEntry, {
+      client,
+      formatError: (error) => (error.status === 404 ? "Custom 404 message" : undefined),
+    });
+
+    const result404 = await tool.execute("call-1", { label: "x" });
+    expect(result404.content[0]!.text).toBe("Custom 404 message");
+
+    const client500 = new ApiClient({
+      baseUrl: "http://x",
+      headers: {},
+      fetchImpl: fakeFetch(500, { detail: "Server error" }),
+    });
+    const tool500 = toPiAgentTool(listTracesEntry, {
+      client: client500,
+      formatError: (error) => (error.status === 404 ? "Custom 404 message" : undefined),
+    });
+    const result500 = await tool500.execute("call-1", { label: "x" });
+    expect(result500.content[0]!.text).toBe(
+      "Error calling list_traces: API error 500: Server error",
+    );
+  });
 });
 
 describe("INTERNAL_BINDINGS", () => {

--- a/frontend/packages/tools/src/pi.ts
+++ b/frontend/packages/tools/src/pi.ts
@@ -1,4 +1,4 @@
-import type { ApiClient } from "./client.js";
+import { ApiError, type ApiClient } from "./client.js";
 import { dispatch } from "./dispatch.js";
 import type { ParamSchema, RegistryEntry } from "./types.js";
 
@@ -41,6 +41,8 @@ export interface ToPiAgentToolOptions {
   fixedArgs?: Record<string, unknown>;
   /** Renders the API result for the model; defaults to pretty-printed JSON. */
   formatResult?: (result: unknown) => string;
+  /** Custom handler for API errors; return a string to override error rendering as a plain result. */
+  formatError?: (error: ApiError) => string | undefined;
 }
 
 /** "list_traces" -> "List traces" for the tool's human-readable label. */
@@ -55,7 +57,7 @@ function humanizeName(name: string): string {
  * results and errors as text content.
  */
 export function toPiAgentTool(entry: RegistryEntry, options: ToPiAgentToolOptions): PiAgentTool {
-  const { client, pathOverride, fixedArgs = {}, formatResult } = options;
+  const { client, pathOverride, fixedArgs = {}, formatResult, formatError } = options;
 
   const properties: Record<string, ParamSchema> = {
     label: {
@@ -84,6 +86,12 @@ export function toPiAgentTool(entry: RegistryEntry, options: ToPiAgentToolOption
         const text = formatResult ? formatResult(result) : JSON.stringify(result, null, 2);
         return { content: [{ type: "text", text }], details: undefined };
       } catch (error) {
+        if (error instanceof ApiError && formatError) {
+          const customText = formatError(error);
+          if (customText !== undefined) {
+            return { content: [{ type: "text", text: customText }], details: undefined };
+          }
+        }
         // Deliberate divergence from the runtime's throw-on-failure contract:
         // errors are returned as tool-result text so the model can read the
         // failure (status, detail) and adapt — matching how the in-app agent's


### PR DESCRIPTION
## Problem
When no detector finding is attached to a trace, `GET /api/v1/public/detectors/traces/{trace_id}/finding` returns HTTP 404 (`Finding not found`), which is the expected outcome for a trace with no findings. 

Previously, `toPiAgentTool` (`frontend/packages/tools/src/pi.ts`) rendered all non-2xx responses as error strings:
`Error calling get_finding_by_trace: API error 404: Finding not found`

This led the LLM agent to perceive an informative response as a tool failure, causing unnecessary retries or errors.

## Solution
1. **Added `formatError` option in `ToPiAgentToolOptions`**:
   - Updated `toPiAgentTool` in `@traceroot-ai/tools` (`pi.ts`) to accept `formatError?: (error: ApiError) => string | undefined`.
   - If `formatError` returns a custom string, `toPiAgentTool` renders it as a plain, successful tool result text instead of an error message.
2. **Mapped 404 for `get_finding_by_trace`**:
   - In `frontend/ee/agent/src/tools/registry-tools.ts`, bound `get_finding_by_trace` with a custom `formatError` handler that maps HTTP 404 to `"No detector finding is attached to trace."`.
   - Non-404 status codes (e.g., 401/403/500) and 404s on other tools (e.g., `get_detector`) remain formatted as error messages.
3. **Unit Tests**:
   - Added tests in `pi.test.ts` for the `formatError` option.
   - Added tests in `registry-tools.test.ts` for `get_finding_by_trace` 404 mapping.

## Verification
- Ran unit tests in `frontend/packages/tools`: `4 passed (28 tests)`.
- Ran unit tests in `frontend/ee/agent`: `5 passed (62 tests)`.

Closes #1975


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the agent from treating “no finding” as a failure. Previously all non-2xx responses were rendered as tool errors; now a 404 from get_finding_by_trace is rendered as plain text “No detector finding is attached to trace.” This reduces unnecessary retries while keeping other errors unchanged.

- Add `formatError?: (error) => string | undefined` to `toPiAgentTool` in `@traceroot-ai/tools`; when it returns a string, the tool outputs that as a normal result.
- Bind get_finding_by_trace in the agent registry with a `formatError` that maps 404 to “No detector finding is attached to trace.” Non-404 statuses and 404s from other tools still render as errors.
- Add unit tests in tools and agent packages to cover the new behavior.
- No migration required.

<sup>Written for commit 9dfafa9eea4d9a8e3a07eae7f4c995b3ba0a8c66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

