### PR TITLE
fix(ui): clear a provider's protocol override when it is set back to the default

### DIFF
--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.test.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.test.tsx
@@ -289,4 +289,48 @@ describe("ModelProvidersTab", () => {
       expect.objectContaining({ config: { modelProtocols: { o3: "openai-responses" } } }),
     );
   });
+
+  it("clears a saved override when the pick is changed back to the default", async () => {
+    mocks.getModelProviders.mockResolvedValue({
+      byokEnabled: true,
+      providers: [
+        {
+          id: "provider-1",
+          adapter: "openai",
+          provider: "OpenAI",
+          keyPreview: "sk-...",
+          baseUrl: null,
+          customModels: ["o3"],
+          withDefaultModels: true,
+          config: { modelProtocols: { o3: "openai-responses" } },
+          enabled: true,
+          createdBy: "user-1",
+          createTime: "2026-06-17T00:00:00.000Z",
+          updateTime: "2026-06-17T00:00:00.000Z",
+        },
+      ],
+    });
+    mocks.updateModelProvider.mockResolvedValue({ id: "provider-1" });
+
+    renderTab();
+    fireEvent.click(await screen.findByRole("button", { name: "Edit" }));
+    const protocolSelect = screen
+      .getAllByRole("combobox")
+      .find((el) =>
+        Array.from((el as HTMLSelectElement).options).some((o) => o.value === "openai-completions"),
+      ) as HTMLSelectElement;
+    expect(protocolSelect).toBeDefined();
+    expect(protocolSelect.value).toBe("openai-responses");
+
+    fireEvent.change(protocolSelect, { target: { value: "openai-completions" } });
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+    await waitFor(() => expect(mocks.updateModelProvider).toHaveBeenCalledTimes(1));
+    // The update API merges config, so the override must be sent as cleared,
+    // not omitted — otherwise the stored Responses pick would survive.
+    expect(mocks.updateModelProvider).toHaveBeenCalledWith(
+      "ws-1",
+      "provider-1",
+      expect.objectContaining({ config: { modelProtocols: {} } }),
+    );
+  });
 });

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -188,15 +188,18 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
         filteredProtocols[modelId] = proto;
       }
     }
-    const config: Record<string, unknown> = {};
-    if (Object.keys(filteredProtocols).length > 0) config.modelProtocols = filteredProtocols;
+    // The update API merges `config` into the stored one, so on edit the
+    // overrides are sent even when empty — that is how a pick moved back to
+    // the default clears its stored override. A new provider only needs a
+    // config once there is something to override.
+    const sendConfig = !!editProvider || Object.keys(filteredProtocols).length > 0;
     const base: Record<string, unknown> = {
       adapter,
       provider: providerName,
       ...getBaseUrlPayload(baseUrl, !!editProvider),
       customModels: trimmedModels,
       withDefaultModels: true,
-      ...(Object.keys(config).length > 0 ? { config } : {}),
+      ...(sendConfig ? { config: { modelProtocols: filteredProtocols } } : {}),
     };
 
     if (adapterConfig?.credentialType === "aws") {


### PR DESCRIPTION
## Summary

Follow-up to #1977 (cubic's last review point there). The model-provider update API merges `config` into the stored one (`model-providers/[providerId]/route.ts`: `{...existingConfig, ...config}`), and the provider dialog omitted `config` entirely when no per-model protocol pick differed from the effective default. So a stored override — e.g. `{o3: "openai-responses"}` — switched back to Chat Completions in the dialog survived the save, and the resolver kept using it.

- On edit, always send `config: { modelProtocols: filteredProtocols }` (possibly `{}`) so the shallow merge replaces the overrides map; other config keys (`awsRegion`) are preserved by the merge. A new provider still only sends a config when there is something to override.
- Side effect (desirable): overrides for models removed from the list, or now equal to the default, are dropped on the next save instead of lingering.

## Test plan

- [x] `ModelProvidersTab.test.tsx` — existing OpenAI row with `o3` override `openai-responses` → select shows it → switch to Chat Completions → `updateModelProvider` called with `config: { modelProtocols: {} }` (failed before, passes after); UI settings suite 23/23
- [x] eslint (no new warnings) / prettier clean
- [x] Senior review: update-route merge preserves other keys; create route tolerates an empty map; resolver treats `{}` as no override; Bedrock path still sends `awsRegion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears saved per-model protocol overrides when a selection is set back to the default. Previously the edit dialog omitted `config`, so the server merge kept the old override; edits now send `config: { modelProtocols: ... }` even when empty to replace the stored map.

- Behavior: On edit we always send `modelProtocols`; on create we send it only when overrides exist.
- Side effects: Overrides equal to the default or for removed models are cleared on save; other `config` keys (for example `awsRegion`) are preserved.
- Tests: Adds a test that verifies clearing the override when switching back to the default in `ModelProvidersTab.test.tsx`.

<sup>Written for commit d477e24c583abfcbf9866311a90d49664dc2df38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

