### PR TITLE
feat(byok): add Grok 4.6 to xAI catalog

### DIFF
--- a/frontend/packages/core/src/__tests__/llm-providers.test.ts
+++ b/frontend/packages/core/src/__tests__/llm-providers.test.ts
@@ -37,6 +37,15 @@ describe("ADAPTER_MODELS", () => {
     }
   });
 
+  it("places grok-4.6 at index 0 in the xAI model catalog", () => {
+    const xaiModels = ADAPTER_MODELS[LLMAdapter.XAI];
+    expect(xaiModels).toBeDefined();
+    expect(xaiModels![0]).toEqual({
+      id: "grok-4.6",
+      label: "grok-4.6",
+    });
+  });
+
   it("label equals id for every model", () => {
     for (const [adapter, models] of Object.entries(ADAPTER_MODELS)) {
       if (!models) continue;

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -199,6 +199,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "deepseek-chat", label: "deepseek-chat" },
   ],
   xai: [
+    { id: "grok-4.6", label: "grok-4.6" },
     { id: "grok-4.5", label: "grok-4.5" },
     { id: "grok-4.20", label: "grok-4.20" },
     { id: "grok-4", label: "grok-4" },

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -1095,5 +1095,18 @@
       "cacheRead": 0.0000003,
       "cacheWrite": null
     }
+  },
+
+  {
+    "id": "tr-grok-4-6",
+    "modelName": "grok-4.6",
+    "matchPattern": "(?i)^(xai\\/)?grok-4\\.6(-[\\d-]+)?$",
+    "provider": "xai",
+    "prices": {
+      "input": 0.000002,
+      "output": 0.000006,
+      "cacheRead": 0.0000005,
+      "cacheWrite": null
+    }
   }
 ]


### PR DESCRIPTION
Fix <#1873>

## Summary

- added `grok-4.6` to the curated xAI BYOK model catalog
- added Grok 4.6 pricing metadata
- added a regression test ensuring `grok-4.6` is the first model in the xAI catalog

## Testing

- 15 tests passed
- checked locally that `grok-4.6` appears in the xAI provider model dropdown without the unsupported-model warning
- checked that the xAI provider can be configured and saved locally

## E2E Testing

- The grok-4.6 version appears in the model catalog and UI behavior were verified locally. 
- And when i added my api key and click on the `Test connection` it says `API lacks permission` and the problem is from my side that i don't have enough credits.
- then after that once i clicked on the `Update Button` its given me a green signal as it says `enabled`

<img width="1710" height="1107" alt="Screenshot 2026-08-22 at 7 15 19 PM" src="https://github.com/user-attachments/assets/6aaddb80-a6cd-4a37-b226-73a3e31f4f9b" />

<img width="1709" height="993" alt="Screenshot 2026-08-22 at 7 19 39 PM" src="https://github.com/user-attachments/assets/79efffe7-428f-4b19-84cc-ba266b8afabd" />

<img width="1708" height="993" alt="Screenshot 2026-08-22 at 7 37 45 PM" src="https://github.com/user-attachments/assets/a78b9258-6e06-4045-bb75-b536178fdba7" />

<img width="1710" height="992" alt="Screenshot 2026-08-22 at 7 38 14 PM" src="https://github.com/user-attachments/assets/2b911596-76a6-487a-8398-17f82f147b4b" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `grok-4.6` to the curated xAI BYOK model catalog and makes it the first-listed model. Previously `grok-4.6` was absent and could show as unsupported; now it appears with pricing metadata to enable accurate cost calculations.

- Ensures `grok-4.6` is index 0 in the xAI catalog (regression test added). Verify any UI or defaults that pick the first model now select `grok-4.6`.
- Adds pricing entry `tr-grok-4-6` with match pattern for `xai/grok-4.6`; confirm metering/quotas read the new entry.
- No migration steps required.

<sup>Written for commit 1d31e43542425a3914491026b0fc8161a094bbb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

