### PR TITLE
feat: surface producing run_ids on findings (public API) and finding_id in the runs table

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -495,6 +495,14 @@
             "title": "Results",
             "type": "array"
           },
+          "run_ids": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Run Ids",
+            "type": "array"
+          },
           "summary": {
             "title": "Summary",
             "type": "string"
@@ -539,6 +547,14 @@
           "project_id": {
             "title": "Project Id",
             "type": "string"
+          },
+          "run_ids": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Run Ids",
+            "type": "array"
           },
           "summary": {
             "title": "Summary",

--- a/backend/rest/schemas/public.py
+++ b/backend/rest/schemas/public.py
@@ -120,6 +120,12 @@ class FindingSummary(BaseModel):
     summary: str
     timestamp: datetime
     detectors: list[str]
+    # The producing detector runs. A finding is per-trace but a run is
+    # per-(trace, detector), so a finding that fired N detectors has N runs —
+    # this lists all of them (parallel to ``detectors``, but as a set: not
+    # index-aligned). Empty when no run row references the finding (e.g.
+    # legacy/manually-created findings that predate run recording).
+    run_ids: list[str] = []
 
 
 class FindingDetail(FindingSummary):

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -348,8 +348,21 @@ class DetectorReaderService:
     # detail
     # ------------------------------------------------------------------ #
     def get_finding(self, project_id: str, finding_id: str) -> FindingDetail | None:
+        """Get one finding by id.
+
+        Finding ids are dashless 32-hex, but findings written before that
+        format carry a hyphenated uuid shape of the same hash — compare
+        hyphen-insensitively so an id copied from either surface resolves.
+
+        Args:
+            project_id (str): Project that owns the finding.
+            finding_id (str): The finding id, with or without hyphens.
+
+        Returns:
+            FindingDetail | None: The finding, or None when no row matches.
+        """
         row = self._fetch_finding(
-            "finding_id = {finding_id:String}",
+            "replaceAll(finding_id, '-', '') = replaceAll({finding_id:String}, '-', '')",
             {"project_id": project_id, "finding_id": finding_id},
         )
         return self._build_detail(project_id, row) if row else None

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -280,7 +280,50 @@ class DetectorReaderService:
             )
             for row in result.result_rows
         ]
+        run_ids = self._run_ids_for_findings(project_id, [it.finding_id for it in items])
+        for it in items:
+            it.run_ids = run_ids.get(it.finding_id, [])
         return items, total
+
+    def _run_ids_for_findings(
+        self, project_id: str, finding_ids: list[str]
+    ) -> dict[str, list[str]]:
+        """Map finding_id -> its producing run_ids.
+
+        A finding is per-trace but a run is per-(trace, detector), so a finding
+        that fired N detectors has N runs, each referencing it via ``finding_id``;
+        this reverses that for a page of findings in one bounded query. Kept
+        separate from the finding SQL so the delicate dedup/version filtering
+        there stays untouched. ``FINAL`` reads canonical (post-merge) run rows so
+        a run re-evaluated back to non-triggering (its current version drops the
+        ``finding_id``) is not attributed from a stale pre-merge row; sorted for a
+        stable list. ``{}`` on missing/failed lookup — run_ids are a display
+        convenience, never a reason to fail the read.
+
+        Args:
+            project_id (str): Owning project; scopes the lookup.
+            finding_ids (list[str]): The finding ids of the current page.
+
+        Returns:
+            dict[str, list[str]]: ``finding_id -> sorted list of run_ids``, for
+            findings that have at least one run.
+        """
+        ids = [f for f in finding_ids if f]
+        if not ids:
+            return {}
+        try:
+            result = self._client.query(
+                "SELECT finding_id, arraySort(groupUniqArray(run_id)) AS run_ids "
+                "FROM detector_runs FINAL "
+                "WHERE project_id = {project_id:String} "
+                "AND finding_id IN {finding_ids:Array(String)} "
+                "GROUP BY finding_id",
+                parameters={"project_id": project_id, "finding_ids": ids},
+            )
+            return {row[0]: list(row[1]) for row in result.result_rows}
+        except Exception:
+            logger.warning("run_id lookup failed; run_ids will be empty", exc_info=True)
+            return {}
 
     def _resolve_detector_names(self, project_id: str, token: str) -> list[str]:
         """Resolve a `--detector` token to the set of matching detector names.
@@ -355,6 +398,7 @@ class DetectorReaderService:
             detectors=[r.detector_name for r in results],
             results=results,
             rca=self._read_rca(project_id, finding_id),
+            run_ids=self._run_ids_for_findings(project_id, [finding_id]).get(finding_id, []),
         )
 
     def _read_templates(self, project_id: str, detector_ids: list[str]) -> dict[str, str | None]:

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -350,8 +350,8 @@ class DetectorReaderService:
     def get_finding(self, project_id: str, finding_id: str) -> FindingDetail | None:
         """Get one finding by id.
 
-        Finding ids are dashless 32-hex, but findings written before that
-        format carry a hyphenated uuid shape of the same hash — compare
+        Stored finding ids are uuid-hyphenated, but display surfaces render
+        them dashless to match run/trace id shape — compare
         hyphen-insensitively so an id copied from either surface resolves.
 
         Args:

--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.test.tsx
@@ -174,8 +174,10 @@ describe("DetectorDetailPage", () => {
     mocks.useRuns.mockImplementation(defaultUseRuns);
     render(<DetectorDetailPage />);
 
-    // The finding id is an opaque internal correlation id — never displayed.
-    expect(screen.queryByText("f1")).toBeNull();
+    // The finding id is shown in its own column (correlates a finding to its
+    // trace/runs across surfaces).
+    expect(screen.getByRole("columnheader", { name: "Finding ID" })).toBeTruthy();
+    expect(screen.getByText("f1")).toBeTruthy();
     expect(screen.getByText("Something went wrong")).toBeTruthy();
     expect(screen.getAllByText("Done").length).toBeGreaterThan(0);
     expect(screen.getByRole("columnheader", { name: "Agent analysis" })).toBeTruthy();

--- a/frontend/ui/src/features/detectors/components/detector-runs-table.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-runs-table.test.tsx
@@ -9,7 +9,7 @@ const triggeredRun: BackendRun = {
   detector_id: "det-1",
   project_id: "proj-1",
   trace_id: "trace-triggered",
-  finding_id: "finding-1",
+  finding_id: "finding1",
   status: "completed",
   timestamp: "2026-05-01T12:00:00Z",
   summary: "Something went wrong",
@@ -64,11 +64,23 @@ describe("DetectorRunsTable", () => {
   it("renders the finding_id in the Finding ID cell for a triggered run", () => {
     render(<DetectorRunsTable rows={[triggeredRun]} onTraceClick={vi.fn()} onRunClick={vi.fn()} />);
     // The finding id shows as plain (non-clickable) muted mono text.
-    const cell = screen.getByText("finding-1");
+    const cell = screen.getByText("finding1");
     expect(cell).toBeTruthy();
-    expect(cell.getAttribute("title")).toBe("finding-1");
+    expect(cell.getAttribute("title")).toBe("finding1");
     // Unlike trace/run ids, the finding id is not a click target.
-    expect(screen.queryByRole("button", { name: "finding-1" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "finding1" })).toBeNull();
+  });
+
+  it("renders a legacy hyphenated finding_id dashless, matching run/trace id shape", () => {
+    const legacyRun: BackendRun = {
+      ...triggeredRun,
+      finding_id: "b3977f86-c96d-f250-b7b5-dd9062a94dfd",
+    };
+    render(<DetectorRunsTable rows={[legacyRun]} onTraceClick={vi.fn()} onRunClick={vi.fn()} />);
+    const cell = screen.getByText("b3977f86c96df250b7b5dd9062a94dfd");
+    expect(cell).toBeTruthy();
+    expect(cell.getAttribute("title")).toBe("b3977f86c96df250b7b5dd9062a94dfd");
+    expect(screen.queryByText("b3977f86-c96d-f250-b7b5-dd9062a94dfd")).toBeNull();
   });
 
   it("renders an em dash in the Finding ID cell for a findingless run", () => {
@@ -78,7 +90,7 @@ describe("DetectorRunsTable", () => {
     const row = screen.getByText("run-clean").closest("tr")!;
     const findingCell = row.querySelectorAll("td")[3];
     expect(findingCell.textContent).toBe("—");
-    expect(screen.queryByText("finding-1")).toBeNull();
+    expect(screen.queryByText("finding1")).toBeNull();
   });
 
   it("fires onTraceClick with the run when its trace_id cell is clicked", () => {

--- a/frontend/ui/src/features/detectors/components/detector-runs-table.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-runs-table.test.tsx
@@ -36,6 +36,7 @@ describe("DetectorRunsTable", () => {
       "Timestamp",
       "Run ID",
       "Trace ID",
+      "Finding ID",
       "Identified",
       "Summary",
       "Status",
@@ -43,9 +44,6 @@ describe("DetectorRunsTable", () => {
     ]) {
       expect(screen.getByRole("columnheader", { name: header })).toBeTruthy();
     }
-    // The finding id is an opaque internal correlation id — never displayed
-    // (its hyphenated uuid also line-wrapped and doubled the row height).
-    expect(screen.queryByRole("columnheader", { name: "Finding ID" })).toBeNull();
   });
 
   it("shows N/A in the Agent analysis cell for a findingless run", () => {
@@ -57,12 +55,30 @@ describe("DetectorRunsTable", () => {
 
   it("shows the RCA label in the Agent analysis cell for a triggered run", () => {
     render(<DetectorRunsTable rows={[triggeredRun]} onTraceClick={vi.fn()} onRunClick={vi.fn()} />);
-    // describeRcaStatus("done") -> "Done"; Yes surfaces, the raw finding id
-    // itself is never rendered (it only keys the Identified/RCA cells).
+    // describeRcaStatus("done") -> "Done"; Yes surfaces.
     expect(screen.getByText("Done")).toBeTruthy();
-    expect(screen.queryByText("finding-1")).toBeNull();
     expect(screen.getByText("Yes")).toBeTruthy();
     expect(screen.queryByText("N/A")).toBeNull();
+  });
+
+  it("renders the finding_id in the Finding ID cell for a triggered run", () => {
+    render(<DetectorRunsTable rows={[triggeredRun]} onTraceClick={vi.fn()} onRunClick={vi.fn()} />);
+    // The finding id shows as plain (non-clickable) muted mono text.
+    const cell = screen.getByText("finding-1");
+    expect(cell).toBeTruthy();
+    expect(cell.getAttribute("title")).toBe("finding-1");
+    // Unlike trace/run ids, the finding id is not a click target.
+    expect(screen.queryByRole("button", { name: "finding-1" })).toBeNull();
+  });
+
+  it("renders an em dash in the Finding ID cell for a findingless run", () => {
+    render(<DetectorRunsTable rows={[cleanRun]} onTraceClick={vi.fn()} onRunClick={vi.fn()} />);
+    // No finding -> muted em dash in the Finding ID cell (column index 3:
+    // Timestamp, Run ID, Trace ID, Finding ID), and no finding id text.
+    const row = screen.getByText("run-clean").closest("tr")!;
+    const findingCell = row.querySelectorAll("td")[3];
+    expect(findingCell.textContent).toBe("—");
+    expect(screen.queryByText("finding-1")).toBeNull();
   });
 
   it("fires onTraceClick with the run when its trace_id cell is clicked", () => {

--- a/frontend/ui/src/features/detectors/components/detector-runs-table.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-runs-table.test.tsx
@@ -71,12 +71,14 @@ describe("DetectorRunsTable", () => {
     expect(screen.queryByRole("button", { name: "finding1" })).toBeNull();
   });
 
-  it("renders a legacy hyphenated finding_id dashless, matching run/trace id shape", () => {
-    const legacyRun: BackendRun = {
+  it("renders a stored hyphenated finding_id dashless, matching run/trace id shape", () => {
+    const hyphenatedRun: BackendRun = {
       ...triggeredRun,
       finding_id: "b3977f86-c96d-f250-b7b5-dd9062a94dfd",
     };
-    render(<DetectorRunsTable rows={[legacyRun]} onTraceClick={vi.fn()} onRunClick={vi.fn()} />);
+    render(
+      <DetectorRunsTable rows={[hyphenatedRun]} onTraceClick={vi.fn()} onRunClick={vi.fn()} />,
+    );
     const cell = screen.getByText("b3977f86c96df250b7b5dd9062a94dfd");
     expect(cell).toBeTruthy();
     expect(cell.getAttribute("title")).toBe("b3977f86c96df250b7b5dd9062a94dfd");

--- a/frontend/ui/src/features/detectors/components/detector-runs-table.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-runs-table.tsx
@@ -42,10 +42,10 @@ export function DetectorRunsTable({ rows, onTraceClick, onRunClick }: DetectorRu
       <tbody>
         {rows.map((run) => {
           const rca = describeRcaStatus(run.rca_status);
-          // Findings written before the dashless id format carry a hyphenated
-          // uuid shape; render both shapes dashless so the Finding ID column
-          // matches the run and trace id columns. The finding-detail API
-          // accepts either shape, so a copied display id still resolves.
+          // Stored finding ids are uuid-hyphenated while run and trace ids are
+          // dashless 32-hex; strip at render so the three id columns share one
+          // shape. The finding-detail API compares ids hyphen-insensitively,
+          // so a copied display id still resolves.
           const findingId = run.finding_id?.replaceAll("-", "") ?? null;
           return (
             <tr

--- a/frontend/ui/src/features/detectors/components/detector-runs-table.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-runs-table.tsx
@@ -32,6 +32,7 @@ export function DetectorRunsTable({ rows, onTraceClick, onRunClick }: DetectorRu
           <th className={cn(DETECTOR_TH, "w-[160px]")}>Timestamp</th>
           <th className={cn(DETECTOR_TH, "w-[280px]")}>Run ID</th>
           <th className={DETECTOR_TH}>Trace ID</th>
+          <th className={DETECTOR_TH}>Finding ID</th>
           <th className={cn(DETECTOR_TH, "w-[80px]")}>Identified</th>
           <th className={DETECTOR_TH}>Summary</th>
           <th className={cn(DETECTOR_TH, "w-[90px]")}>Status</th>
@@ -84,6 +85,18 @@ export function DetectorRunsTable({ rows, onTraceClick, onRunClick }: DetectorRu
                 >
                   {run.trace_id}
                 </button>
+              </td>
+              <td className={cn(DETECTOR_TD, "font-mono text-[11px]")}>
+                {run.finding_id == null ? (
+                  <span className="text-muted-foreground">—</span>
+                ) : (
+                  <span
+                    title={run.finding_id}
+                    className="block max-w-full truncate text-muted-foreground"
+                  >
+                    {run.finding_id}
+                  </span>
+                )}
               </td>
               <td className={DETECTOR_TD}>
                 <IdentifiedBadge identified={run.finding_id != null} />

--- a/frontend/ui/src/features/detectors/components/detector-runs-table.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-runs-table.tsx
@@ -42,6 +42,11 @@ export function DetectorRunsTable({ rows, onTraceClick, onRunClick }: DetectorRu
       <tbody>
         {rows.map((run) => {
           const rca = describeRcaStatus(run.rca_status);
+          // Findings written before the dashless id format carry a hyphenated
+          // uuid shape; render both shapes dashless so the Finding ID column
+          // matches the run and trace id columns. The finding-detail API
+          // accepts either shape, so a copied display id still resolves.
+          const findingId = run.finding_id?.replaceAll("-", "") ?? null;
           return (
             <tr
               key={run.run_id}
@@ -87,14 +92,14 @@ export function DetectorRunsTable({ rows, onTraceClick, onRunClick }: DetectorRu
                 </button>
               </td>
               <td className={cn(DETECTOR_TD, "font-mono text-[11px]")}>
-                {run.finding_id == null ? (
+                {findingId == null ? (
                   <span className="text-muted-foreground">—</span>
                 ) : (
                   <span
-                    title={run.finding_id}
+                    title={findingId}
                     className="block max-w-full truncate text-muted-foreground"
                   >
-                    {run.finding_id}
+                    {findingId}
                   </span>
                 )}
               </td>

--- a/frontend/worker/src/processors/__tests__/rca-gating.test.ts
+++ b/frontend/worker/src/processors/__tests__/rca-gating.test.ts
@@ -141,19 +141,16 @@ describe("traceFindingId: one finding (and one RCA job) per trace", () => {
     expect(traceFindingId("projA", "trace")).not.toBe(traceFindingId("projB", "trace"));
   });
 
-  it("is formatted as a uuid-shaped string", () => {
-    expect(traceFindingId("proj", "trace")).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+  it("is dashless 32-hex, the same shape as run and trace ids", () => {
+    expect(traceFindingId("proj", "trace")).toMatch(/^[0-9a-f]{32}$/);
   });
 
   it("is order-sensitive: swapping project and trace yields a different id", () => {
     expect(traceFindingId("a", "b")).not.toBe(traceFindingId("b", "a"));
   });
 
-  it("stays uuid-shaped and deterministic even for empty inputs", () => {
-    const uuidShape = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-    expect(traceFindingId("", "")).toMatch(uuidShape);
+  it("stays 32-hex and deterministic even for empty inputs", () => {
+    expect(traceFindingId("", "")).toMatch(/^[0-9a-f]{32}$/);
     expect(traceFindingId("", "")).toBe(traceFindingId("", ""));
   });
 });

--- a/frontend/worker/src/processors/__tests__/rca-gating.test.ts
+++ b/frontend/worker/src/processors/__tests__/rca-gating.test.ts
@@ -141,16 +141,19 @@ describe("traceFindingId: one finding (and one RCA job) per trace", () => {
     expect(traceFindingId("projA", "trace")).not.toBe(traceFindingId("projB", "trace"));
   });
 
-  it("is dashless 32-hex, the same shape as run and trace ids", () => {
-    expect(traceFindingId("proj", "trace")).toMatch(/^[0-9a-f]{32}$/);
+  it("is formatted as a uuid-shaped string", () => {
+    expect(traceFindingId("proj", "trace")).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
   });
 
   it("is order-sensitive: swapping project and trace yields a different id", () => {
     expect(traceFindingId("a", "b")).not.toBe(traceFindingId("b", "a"));
   });
 
-  it("stays 32-hex and deterministic even for empty inputs", () => {
-    expect(traceFindingId("", "")).toMatch(/^[0-9a-f]{32}$/);
+  it("stays uuid-shaped and deterministic even for empty inputs", () => {
+    const uuidShape = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+    expect(traceFindingId("", "")).toMatch(uuidShape);
     expect(traceFindingId("", "")).toBe(traceFindingId("", ""));
   });
 });

--- a/frontend/worker/src/processors/detector-run-processor.ts
+++ b/frontend/worker/src/processors/detector-run-processor.ts
@@ -46,11 +46,6 @@ function hash32(input: string): string {
   return createHash("sha256").update(input).digest("hex").slice(0, 32);
 }
 
-/** Hash a string to a uuid-shaped id (first 128 bits of sha256, 8-4-4-4-12). */
-function hashToUuid(input: string): string {
-  return hash32(input).replace(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, "$1-$2-$3-$4-$5");
-}
-
 /**
  * Deterministic run id keyed on (projectId, traceId, detectorId).
  * On a BullMQ retry, the same triple lands on the same runId — so re-writes
@@ -84,9 +79,14 @@ export function shouldRunRca(
  * triggers on the same trace maps to the SAME finding, and therefore the SAME
  * RCA job (`rca-${findingId}`): exactly one RCA per trace, and a BullMQ retry
  * lands on the same row instead of duplicating it.
+ *
+ * Dashless 32-hex, the same shape as run and trace ids. Findings written
+ * before this format carry a hyphenated uuid shape of the same hash and are
+ * not backfilled; id lookups compare hyphen-insensitively so both shapes
+ * resolve.
  */
 export function traceFindingId(projectId: string, traceId: string): string {
-  return hashToUuid(`${projectId}:${traceId}`);
+  return hash32(`${projectId}:${traceId}`);
 }
 
 /**

--- a/frontend/worker/src/processors/detector-run-processor.ts
+++ b/frontend/worker/src/processors/detector-run-processor.ts
@@ -46,6 +46,11 @@ function hash32(input: string): string {
   return createHash("sha256").update(input).digest("hex").slice(0, 32);
 }
 
+/** Hash a string to a uuid-shaped id (first 128 bits of sha256, 8-4-4-4-12). */
+function hashToUuid(input: string): string {
+  return hash32(input).replace(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, "$1-$2-$3-$4-$5");
+}
+
 /**
  * Deterministic run id keyed on (projectId, traceId, detectorId).
  * On a BullMQ retry, the same triple lands on the same runId — so re-writes
@@ -80,13 +85,15 @@ export function shouldRunRca(
  * RCA job (`rca-${findingId}`): exactly one RCA per trace, and a BullMQ retry
  * lands on the same row instead of duplicating it.
  *
- * Dashless 32-hex, the same shape as run and trace ids. Findings written
- * before this format carry a hyphenated uuid shape of the same hash and are
- * not backfilled; id lookups compare hyphen-insensitively so both shapes
- * resolve.
+ * The stored shape is uuid-hyphenated and must stay stable: a re-evaluation
+ * of a trace at any later time must land on the id its finding and RCA rows
+ * were written under, or it would duplicate both. Surfaces that want the
+ * dashless run/trace-id shape normalize at render, and the finding-detail
+ * lookup compares hyphen-insensitively, so display and copy-paste don't
+ * depend on the stored shape.
  */
 export function traceFindingId(projectId: string, traceId: string): string {
-  return hash32(`${projectId}:${traceId}`);
+  return hashToUuid(`${projectId}:${traceId}`);
 }
 
 /**

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -18,15 +18,20 @@ def _ch_result(rows):
 
 
 class FakeCH:
-    """Fake ClickHouse client: count queries get count_rows, others get rows."""
+    """Fake ClickHouse client, dispatching by SQL content: the run_id lookup
+    (``FROM detector_runs``) gets run_rows, count queries get count_rows, and the
+    finding queries get rows."""
 
     def __init__(self):
         self.calls: list[tuple] = []
         self.count_rows = [(0,)]
         self.rows: list[tuple] = []
+        self.run_rows: list[tuple] = []  # (finding_id, [run_id, ...])
 
     def query(self, query, parameters=None):
         self.calls.append((query, parameters))
+        if "from detector_runs" in query.lower():
+            return _ch_result(self.run_rows)
         if "count(" in query.lower():
             return _ch_result(self.count_rows)
         return _ch_result(self.rows)
@@ -56,6 +61,8 @@ def test_list_findings_parses_payload_into_summaries(reader):
     )
     reader._client.rows = [("f1", "p1", "t1", "combined", payload, datetime(2026, 6, 29, 10, 42))]
     reader._client.count_rows = [(1,)]
+    # A finding is per-trace; the two detectors above each produced a run.
+    reader._client.run_rows = [("f1", ["run-1", "run-2"])]  # finding_id -> [run_id, ...]
 
     items, total = reader.list_findings(
         project_id="p1", limit=50, start_after=None, end_before=None, detector=None, trace_id=None
@@ -65,8 +72,46 @@ def test_list_findings_parses_payload_into_summaries(reader):
     assert len(items) == 1
     assert items[0].finding_id == "f1"
     assert items[0].detectors == ["hallucination", "logic"]
+    # All producing runs are joined back onto the finding for display.
+    assert items[0].run_ids == ["run-1", "run-2"]
     # every query is project-scoped
     assert all(p and p.get("project_id") == "p1" for _, p in reader._client.calls)
+
+
+def test_list_findings_run_ids_empty_when_no_run_references_the_finding(reader):
+    payload = json.dumps([{"detectorId": "d1", "detectorName": "x", "summary": "s", "data": None}])
+    reader._client.rows = [("f1", "p1", "t1", "sum", payload, datetime(2026, 6, 29))]
+    reader._client.count_rows = [(1,)]
+    reader._client.run_rows = []  # no run row references f1
+
+    items, _ = reader.list_findings(
+        project_id="p1", limit=50, start_after=None, end_before=None, detector=None, trace_id=None
+    )
+
+    assert items[0].run_ids == []
+
+
+def test_list_findings_run_ids_empty_when_lookup_raises(reader):
+    """The run_id lookup is a display convenience: if it throws, the finding
+    still reads back with empty run_ids rather than failing the whole request."""
+    payload = json.dumps([{"detectorId": "d1", "detectorName": "x", "summary": "s", "data": None}])
+    reader._client.rows = [("f1", "p1", "t1", "sum", payload, datetime(2026, 6, 29))]
+    reader._client.count_rows = [(1,)]
+
+    real_query = reader._client.query
+
+    def boom(query, parameters=None):
+        if "from detector_runs" in query.lower():
+            raise RuntimeError("clickhouse unavailable")
+        return real_query(query, parameters)
+
+    reader._client.query = boom
+
+    items, _ = reader.list_findings(
+        project_id="p1", limit=50, start_after=None, end_before=None, detector=None, trace_id=None
+    )
+
+    assert items[0].run_ids == []
 
 
 def test_list_findings_detector_filter_includes_token_and_resolved_names(reader, monkeypatch):
@@ -159,6 +204,7 @@ def test_get_finding_normalizes_results_and_attaches_rca(reader, monkeypatch):
         [{"detectorId": "d1", "detectorName": "hallucination", "summary": "s", "data": {"x": 1}}]
     )
     reader._client.rows = [("f1", "p1", "t1", "sum", payload, datetime(2026, 6, 29))]
+    reader._client.run_rows = [("f1", ["run-9"])]
 
     def fake_pg(sql, params):
         s = sql.lower()
@@ -181,6 +227,7 @@ def test_get_finding_normalizes_results_and_attaches_rca(reader, monkeypatch):
     assert detail.detectors == ["hallucination"]
     assert detail.rca.status == "done"
     assert detail.rca.result == "root cause text"
+    assert detail.run_ids == ["run-9"]
 
 
 def test_get_finding_returns_none_when_missing(reader):
@@ -223,7 +270,9 @@ def test_get_finding_by_trace_is_project_and_trace_scoped(reader, monkeypatch):
     detail = reader.get_finding_by_trace("p1", "t9")
 
     assert detail.trace_id == "t9"
-    _, params = reader._client.calls[-1]
+    # The finding-fetch query (the one carrying trace_id) is project- and
+    # trace-scoped — the trailing run_id lookup is a separate call.
+    _, params = next((q, p) for q, p in reader._client.calls if p and "trace_id" in p)
     assert params["project_id"] == "p1"
     assert params["trace_id"] == "t9"
 

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -235,6 +235,26 @@ def test_get_finding_returns_none_when_missing(reader):
     assert reader.get_finding("p1", "missing") is None
 
 
+def test_get_finding_compares_ids_hyphen_insensitively(reader, monkeypatch):
+    """Ids are dashless 32-hex, but pre-format findings carry a hyphenated uuid
+    shape — the lookup predicate must strip hyphens from BOTH sides so either
+    shape of the id resolves either shape of the stored row."""
+    payload = json.dumps([{"detectorId": "d1", "detectorName": "x", "summary": "s", "data": None}])
+    reader._client.rows = [("f1", "p1", "t1", "sum", payload, datetime(2026, 6, 29))]
+    monkeypatch.setattr(reader, "_pg_rows", lambda sql, params: [])
+
+    reader.get_finding("p1", "b3977f86-c96d-f250-b7b5-dd9062a94dfd")
+
+    finding_queries = [
+        (q, p) for q, p in reader._client.calls if "from detector_findings" in q.lower()
+    ]
+    assert finding_queries, "expected a detector_findings lookup"
+    query, params = finding_queries[0]
+    assert "replaceAll(finding_id, '-', '')" in query
+    assert "replaceAll({finding_id:String}, '-', '')" in query
+    assert params["finding_id"] == "b3977f86-c96d-f250-b7b5-dd9062a94dfd"
+
+
 def test_get_finding_absent_rca_yields_none(reader, monkeypatch):
     payload = json.dumps([{"detectorId": "d1", "detectorName": "x", "summary": "s", "data": None}])
     reader._client.rows = [("f1", "p1", "t1", "sum", payload, datetime(2026, 6, 29))]

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -236,9 +236,9 @@ def test_get_finding_returns_none_when_missing(reader):
 
 
 def test_get_finding_compares_ids_hyphen_insensitively(reader, monkeypatch):
-    """Ids are dashless 32-hex, but pre-format findings carry a hyphenated uuid
-    shape — the lookup predicate must strip hyphens from BOTH sides so either
-    shape of the id resolves either shape of the stored row."""
+    """Stored ids are uuid-hyphenated but display surfaces render them dashless
+    — the lookup predicate must strip hyphens from BOTH sides so either shape
+    of the id resolves either shape of the stored row."""
     payload = json.dumps([{"detectorId": "d1", "detectorName": "x", "summary": "s", "data": None}])
     stored_id = "b3977f86-c96d-f250-b7b5-dd9062a94dfd"
     reader._client.rows = [(stored_id, "p1", "t1", "sum", payload, datetime(2026, 6, 29))]

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -240,10 +240,16 @@ def test_get_finding_compares_ids_hyphen_insensitively(reader, monkeypatch):
     shape — the lookup predicate must strip hyphens from BOTH sides so either
     shape of the id resolves either shape of the stored row."""
     payload = json.dumps([{"detectorId": "d1", "detectorName": "x", "summary": "s", "data": None}])
-    reader._client.rows = [("f1", "p1", "t1", "sum", payload, datetime(2026, 6, 29))]
+    stored_id = "b3977f86-c96d-f250-b7b5-dd9062a94dfd"
+    reader._client.rows = [(stored_id, "p1", "t1", "sum", payload, datetime(2026, 6, 29))]
     monkeypatch.setattr(reader, "_pg_rows", lambda sql, params: [])
 
-    reader.get_finding("p1", "b3977f86-c96d-f250-b7b5-dd9062a94dfd")
+    detail = reader.get_finding("p1", "b3977f86c96df250b7b5dd9062a94dfd")
+
+    # The matched row is returned with its stored id untouched. The fake client
+    # cannot evaluate the predicate, so the SQL itself is asserted below.
+    assert detail is not None
+    assert detail.finding_id == stored_id
 
     finding_queries = [
         (q, p) for q, p in reader._client.calls if "from detector_findings" in q.lower()
@@ -252,7 +258,7 @@ def test_get_finding_compares_ids_hyphen_insensitively(reader, monkeypatch):
     query, params = finding_queries[0]
     assert "replaceAll(finding_id, '-', '')" in query
     assert "replaceAll({finding_id:String}, '-', '')" in query
-    assert params["finding_id"] == "b3977f86-c96d-f250-b7b5-dd9062a94dfd"
+    assert params["finding_id"] == "b3977f86c96df250b7b5dd9062a94dfd"
 
 
 def test_get_finding_absent_rca_yields_none(reader, monkeypatch):


### PR DESCRIPTION
## What

Surface all three ids that identify detector output, in both places that were only showing two:
- **Public API** — add `run_ids` to `FindingSummary`/`FindingDetail`.
- **UI** — add a **Finding ID** column to the detector runs table (`Run ID → Trace ID → Finding ID`).

## Why `run_ids` is plural

A **finding is per trace**, but a **run is per (trace, detector)**. When N detectors trigger on one trace there is one finding and **N runs**, all sharing that finding's `finding_id` *and* timestamp. A single scalar `run_id` (e.g. `argMax(run_id, timestamp)`) would tie across the N runs and return one arbitrarily — nondeterministic on a public contract, silently dropping N−1. So `run_ids` is a list, parallel to the existing plural `detectors` field.

## How

- `detector_findings` has no run column, so the reader reverses the `finding_id → run_ids` link from `detector_runs`: `SELECT finding_id, arraySort(groupUniqArray(run_id)) FROM detector_runs FINAL WHERE project_id = … AND finding_id IN (…) GROUP BY finding_id`. One bounded query per findings page (batched, not N+1), kept **separate** from the finding SQL so its dedup/version filtering stays untouched. `FINAL` reads canonical post-merge rows (a run re-evaluated back to non-triggering drops its `finding_id`, so a stale pre-merge row can't wrongly attribute it); `groupUniqArray` dedups; `arraySort` gives a stable order. Empty list when no run references the finding. It's a display convenience — the lookup is wrapped so it can never fail the read.
- Regenerated `public.json` (`run_ids` as a string array on both schemas). **Registry unchanged** — `run_ids` is a response field, not a tool input, so `@traceroot-ai/tools` needs no republish (verified: regenerating produces no diff).
- UI: the internal route already returns `finding_id` per run, so the new column is display-only (muted mono, em dash when the run produced no finding).

## Notes for the CLI (separate repo)

`traceroot findings list` can show `run_ids` with **zero registry change**. It's an additive, nullable-defaulting response field — backward compatible.

## Tests
- `test_detector_reader`: `run_ids` populated (list), empty when no run, on both list and detail paths.
- `detector-runs-table.test.tsx`: the Finding ID cell renders the id, em dash when null, non-clickable.
- OpenAPI drift + registry parity pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces producing run_ids on findings (public API) and shows a Finding ID column in the runs table. Previously run_ids were omitted and finding_id was hidden; now run_ids are returned, the table shows Finding ID, and stored finding_ids remain UUID-hyphenated while displays are dashless and lookups accept both shapes.

- Public API: adds run_ids: string[] (default []) to FindingSummary/FindingDetail. Populated via one bounded query to detector_runs FINAL (deduped, sorted); on error, returns []. Regenerated public.json; registry unchanged — `@traceroot-ai/tools` needs no republish.
- Backend: attaches run_ids on list/detail; get_finding compares ids hyphen-insensitively so either shape resolves.
- UI: detector runs table adds a Finding ID column. Renders dashless (strips hyphens), muted mono, truncated with title; em dash when no finding; not clickable.
- Worker/storage: stored finding_id stays UUID-hyphenated for stability; dashless is display-only. This avoids deploy-window duplicates.
- Tests/rollout: adds coverage for run_ids population, empty/error cases, dashless rendering, and hyphen-insensitive lookup. Backward compatible; no migrations.

<sup>Written for commit 8c983bad09da84613f2f2377f12eb7375336f3e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

## Update: dashless finding-id display (685b86b0, 8c983bad)

Finding ids are stored uuid-hyphenated while run and trace ids are dashless 32-hex, so the three id columns this PR correlates rendered in two shapes.

- The runs-table Finding ID cell strips hyphens at render, so all three id columns display in the same dashless shape.
- `get_finding` compares ids hyphen-insensitively, so an id copied from the dashless display (or the CLI, which also renders dashless) resolves the hyphenated stored row.
- The stored id format is unchanged: `traceFindingId` stays uuid-hyphenated so a re-evaluation of a trace at any later time lands on the id its finding and RCA rows were written under, never duplicating them. (An intermediate commit generated dashless ids; reverted per review since display + lookup already deliver the UX and a stable stored id avoids the deploy-window duplicate.)

