### PR TITLE
fix(evaluations): follow the published version after deleting a dataset row

### DIFF
--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -69,6 +69,7 @@ const V1 = {
   createTime: "2026-07-16T00:00:00Z",
 };
 const V2 = { ...V1, id: "dv2", versionNumber: 2, label: "v2", createTime: "2026-07-17T00:00:00Z" };
+const V3 = { ...V1, id: "dv3", versionNumber: 3, label: null, createTime: "2026-07-17T12:00:00Z" };
 
 function testCase(over: Partial<Record<string, unknown>> = {}) {
   return {
@@ -376,6 +377,132 @@ describe("Dataset detail — filtering and adding rows", () => {
     expect(requests.some((r) => r.method === "DELETE" && r.url.includes("/test-cases/tc_1"))).toBe(
       true,
     );
+  });
+});
+
+/**
+ * A dataset where DELETE behaves the way the server actually behaves: it
+ * publishes a NEW version (dv3) with the case dropped and repoints
+ * `currentVersionId` at it, leaving dv2 behind as a still-readable snapshot that
+ * keeps the deleted row. Modelling the repoint is what makes a pinned selection
+ * observably stale.
+ */
+function mockDeletePublishesNewVersion() {
+  let currentVersionId = "dv2";
+  const casesOf = (versionId: string) => {
+    if (versionId === "dv1") {
+      return [testCase({ id: "old-1", datasetVersionId: "dv1", input: "seeded ticket" })];
+    }
+    if (versionId === "dv3") return CASES.filter((c) => c.testCaseId !== "tc_1");
+    return CASES;
+  };
+  global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+    const s = String(url);
+    const method = init?.method ?? "GET";
+    requests.push({ url: s, method, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+    if (method === "DELETE") {
+      currentVersionId = "dv3";
+      return { ok: true, status: 201, json: async () => ({ versionId: "dv3", versionNumber: 3 }) };
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => {
+        if (s.includes("/evaluations/runs")) {
+          return { data: [], meta: { page: 0, limit: 50, total: 0 } };
+        }
+        if (s.includes("/test-cases/") && s.endsWith("/runs")) return { data: [] };
+        if (!/\/datasets\/ds1(\?|$)/.test(s)) return {};
+        const versions = currentVersionId === "dv3" ? [V3, V2, V1] : [V2, V1];
+        const requested = new URL(s, "http://x").searchParams.get("version_id");
+        // An unknown or omitted id falls back to the current version — route.ts.
+        const selected =
+          versions.find((v) => v.id === requested) ??
+          versions.find((v) => v.id === currentVersionId)!;
+        return {
+          dataset: { ...DATASET, currentVersionId },
+          currentVersion: versions.find((v) => v.id === currentVersionId),
+          selectedVersion: selected,
+          isCurrentVersion: selected.id === currentVersionId,
+          testCases: casesOf(selected.id),
+          versions,
+        };
+      },
+    };
+  }) as unknown as typeof fetch;
+}
+
+/** The dataset-detail GETs, excluding the nested /test-cases requests. */
+function detailGets() {
+  return requests.filter((r) => r.method === "GET" && /\/datasets\/ds1(\?|$)/.test(r.url));
+}
+
+describe("Dataset detail — deleting a row with a version pinned", () => {
+  it("follows the delete onto the version it published instead of the pinned snapshot", async () => {
+    mockDeletePublishesNewVersion();
+    mountDetail();
+    await screen.findByText(/charged twice/);
+
+    // Pin the selection to a concrete id the way a user reaches that state: pick a
+    // version from the dropdown. Round-tripping back to the current version leaves
+    // the page fully editable but pinned — indistinguishable on screen from the
+    // unpinned default, and the state the regression turns on.
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(await screen.findByRole("option", { name: new RegExp(V1.id) }));
+    await screen.findByText("seeded ticket");
+    // An older snapshot is read-only, so a delete is not even reachable from here.
+    expect(screen.queryByRole("columnheader", { name: "Actions" })).toBeNull();
+    expect(screen.queryAllByLabelText("Row actions")).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(await screen.findByRole("option", { name: new RegExp(V2.id) }));
+    await screen.findByText(/charged twice/);
+    // Pinned, yet still the current version — the Actions column proves it.
+    expect(await screen.findByRole("columnheader", { name: "Actions" })).toBeDefined();
+
+    fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
+    fireEvent.click(await screen.findByText("Delete"));
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete" }).at(-1)!);
+    expect(await screen.findByText("Row deleted")).toBeDefined();
+
+    // The deleted row is gone and the page is still editable. Without the reset the
+    // pinned dv2 snapshot is re-fetched: the row stays and, because dv2 is no longer
+    // current, the Actions column disappears — a silently stale view.
+    await waitFor(() => expect(screen.queryByText(/charged twice/)).toBeNull());
+    expect(screen.getByRole("columnheader", { name: "Actions" })).toBeDefined();
+    // The refetch asked for the current version, not the pinned one.
+    expect(detailGets().at(-1)!.url).not.toContain("version_id");
+  });
+
+  it("add-then-delete still lands on the newest version", async () => {
+    mockDeletePublishesNewVersion();
+    mountDetail();
+    await screen.findByText(/charged twice/);
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(await screen.findByRole("option", { name: new RegExp(V1.id) }));
+    await screen.findByText("seeded ticket");
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(await screen.findByRole("option", { name: new RegExp(V2.id) }));
+    await screen.findByText(/charged twice/);
+
+    // The add un-pins the selection on its own (`onSaved`)...
+    fireEvent.click(screen.getByRole("button", { name: "Row" }));
+    fireEvent.change(await screen.findByLabelText("Input"), {
+      target: { value: "a new question" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await screen.findByText("Row added");
+    expect(detailGets().at(-1)!.url).not.toContain("version_id");
+
+    // ...and the following delete keeps it there.
+    fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
+    fireEvent.click(await screen.findByText("Delete"));
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete" }).at(-1)!);
+    await screen.findByText("Row deleted");
+    await waitFor(() => expect(screen.queryByText(/charged twice/)).toBeNull());
+    expect(screen.getByRole("columnheader", { name: "Actions" })).toBeDefined();
+    expect(detailGets().at(-1)!.url).not.toContain("version_id");
   });
 });
 

--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -69,7 +69,6 @@ const V1 = {
   createTime: "2026-07-16T00:00:00Z",
 };
 const V2 = { ...V1, id: "dv2", versionNumber: 2, label: "v2", createTime: "2026-07-17T00:00:00Z" };
-const V3 = { ...V1, id: "dv3", versionNumber: 3, label: null, createTime: "2026-07-17T12:00:00Z" };
 
 function testCase(over: Partial<Record<string, unknown>> = {}) {
   return {
@@ -381,28 +380,81 @@ describe("Dataset detail — filtering and adding rows", () => {
 });
 
 /**
- * A dataset where DELETE behaves the way the server actually behaves: it
- * publishes a NEW version (dv3) with the case dropped and repoints
- * `currentVersionId` at it, leaving dv2 behind as a still-readable snapshot that
- * keeps the deleted row. Modelling the repoint is what makes a pinned selection
- * observably stale.
+ * A dataset where every write behaves the way the server actually behaves.
+ * `publishDatasetVersion` branches off the CURRENT version, writes a NEW one
+ * with the change applied (fresh per-version row ids and all), and repoints
+ * `currentVersionId` at it — both the add (POST) and the delete (DELETE) routes
+ * go through it. Earlier versions stay readable with their original rows, which
+ * is exactly what makes a pinned selection observably stale after a write.
  */
-function mockDeletePublishesNewVersion() {
+function mockPublishOnWrite() {
+  // Newest first, the order the detail route returns them in. Published versions
+  // carry no label, so widen it off V1's literal type.
+  let versions: (Omit<typeof V1, "label"> & { label: string | null })[] = [V2, V1];
   let currentVersionId = "dv2";
-  const casesOf = (versionId: string) => {
-    if (versionId === "dv1") {
-      return [testCase({ id: "old-1", datasetVersionId: "dv1", input: "seeded ticket" })];
-    }
-    if (versionId === "dv3") return CASES.filter((c) => c.testCaseId !== "tc_1");
-    return CASES;
+  const casesByVersion = new Map<string, ReturnType<typeof testCase>[]>([
+    ["dv1", [testCase({ id: "old-1", datasetVersionId: "dv1", input: "seeded ticket" })]],
+    ["dv2", CASES],
+  ]);
+
+  /** Mirrors publishDatasetVersion: a new version off the current one. */
+  const publish = (
+    transform: (cases: ReturnType<typeof testCase>[]) => ReturnType<typeof testCase>[],
+  ) => {
+    const versionNumber = versions[0].versionNumber + 1;
+    const id = `dv${versionNumber}`;
+    casesByVersion.set(
+      id,
+      // A publish rewrites the rows, so they get fresh row ids; only the
+      // testCaseId lineage carries across versions.
+      transform(casesByVersion.get(currentVersionId)!).map((c) => ({
+        ...c,
+        id: `${c.testCaseId}@${id}`,
+        datasetVersionId: id,
+      })),
+    );
+    versions = [
+      {
+        ...V1,
+        id,
+        versionNumber,
+        label: null,
+        createTime: `2026-07-17T${String(11 + versionNumber).padStart(2, "0")}:00:00Z`,
+      },
+      ...versions,
+    ];
+    currentVersionId = id;
+    return { versionId: id, versionNumber };
   };
+
   global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
     const s = String(url);
     const method = init?.method ?? "GET";
-    requests.push({ url: s, method, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    requests.push({ url: s, method, body });
     if (method === "DELETE") {
-      currentVersionId = "dv3";
-      return { ok: true, status: 201, json: async () => ({ versionId: "dv3", versionNumber: 3 }) };
+      const testCaseId = s.split("/test-cases/")[1];
+      const published = publish((cases) => cases.filter((c) => c.testCaseId !== testCaseId));
+      return { ok: true, status: 201, json: async () => published };
+    }
+    if (method === "POST" && s.includes("/test-cases")) {
+      const testCaseId = `tc_new_${requests.length}`;
+      const added = body as { input: string; expected: string | null; metadata: unknown };
+      const published = publish((cases) => [
+        ...cases,
+        testCase({
+          testCaseId,
+          input: added.input,
+          expected: added.expected ?? null,
+          metadata: added.metadata ?? null,
+          createTime: "2026-07-17T12:00:00Z",
+        }),
+      ]);
+      return {
+        ok: true,
+        status: 201,
+        json: async () => ({ duplicate: false, testCaseId, ...published }),
+      };
     }
     return {
       ok: true,
@@ -413,7 +465,6 @@ function mockDeletePublishesNewVersion() {
         }
         if (s.includes("/test-cases/") && s.endsWith("/runs")) return { data: [] };
         if (!/\/datasets\/ds1(\?|$)/.test(s)) return {};
-        const versions = currentVersionId === "dv3" ? [V3, V2, V1] : [V2, V1];
         const requested = new URL(s, "http://x").searchParams.get("version_id");
         // An unknown or omitted id falls back to the current version — route.ts.
         const selected =
@@ -424,7 +475,7 @@ function mockDeletePublishesNewVersion() {
           currentVersion: versions.find((v) => v.id === currentVersionId),
           selectedVersion: selected,
           isCurrentVersion: selected.id === currentVersionId,
-          testCases: casesOf(selected.id),
+          testCases: casesByVersion.get(selected.id) ?? [],
           versions,
         };
       },
@@ -439,7 +490,7 @@ function detailGets() {
 
 describe("Dataset detail — deleting a row with a version pinned", () => {
   it("follows the delete onto the version it published instead of the pinned snapshot", async () => {
-    mockDeletePublishesNewVersion();
+    mockPublishOnWrite();
     mountDetail();
     await screen.findByText(/charged twice/);
 
@@ -475,7 +526,7 @@ describe("Dataset detail — deleting a row with a version pinned", () => {
   });
 
   it("add-then-delete still lands on the newest version", async () => {
-    mockDeletePublishesNewVersion();
+    mockPublishOnWrite();
     mountDetail();
     await screen.findByText(/charged twice/);
 
@@ -486,21 +537,28 @@ describe("Dataset detail — deleting a row with a version pinned", () => {
     fireEvent.click(await screen.findByRole("option", { name: new RegExp(V2.id) }));
     await screen.findByText(/charged twice/);
 
-    // The add un-pins the selection on its own (`onSaved`)...
+    // The add publishes dv3 and un-pins the selection on its own (`onSaved`)...
     fireEvent.click(screen.getByRole("button", { name: "Row" }));
     fireEvent.change(await screen.findByLabelText("Input"), {
       target: { value: "a new question" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
     await screen.findByText("Row added");
+    // ...so the page is showing dv3, not the dv2 it was pinned to: the row that
+    // only exists in dv3 is on screen, and the page is still editable. Pinned,
+    // the refetch would return dv2 — no new row, no Actions column.
+    expect(await screen.findByText("a new question")).toBeDefined();
+    expect(screen.getByRole("columnheader", { name: "Actions" })).toBeDefined();
     expect(detailGets().at(-1)!.url).not.toContain("version_id");
 
-    // ...and the following delete keeps it there.
+    // ...and the following delete (publishing dv4) keeps it there.
     fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
     fireEvent.click(await screen.findByText("Delete"));
     fireEvent.click(screen.getAllByRole("button", { name: "Delete" }).at(-1)!);
     await screen.findByText("Row deleted");
     await waitFor(() => expect(screen.queryByText(/charged twice/)).toBeNull());
+    // dv4 keeps the row the add introduced and stays editable.
+    expect(screen.getByText("a new question")).toBeDefined();
     expect(screen.getByRole("columnheader", { name: "Actions" })).toBeDefined();
     expect(detailGets().at(-1)!.url).not.toContain("version_id");
   });

--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -380,6 +380,22 @@ describe("Dataset detail — filtering and adding rows", () => {
 });
 
 /**
+ * The detail route's row order — `[createTime desc, testCaseId desc]`, newest
+ * first with the id breaking the tie. Ordering here is not cosmetic: a publish
+ * appends the new case, so served in insertion order the table's TOP row would
+ * be a different case than the one a real user sees there, and a test picking
+ * "the first row" would act on a row the product never puts first.
+ */
+function byNewestFirst(cases: ReturnType<typeof testCase>[]) {
+  return [...cases].sort((a, b) => {
+    const at = String(a.createTime);
+    const bt = String(b.createTime);
+    if (at !== bt) return at < bt ? 1 : -1;
+    return String(a.testCaseId) < String(b.testCaseId) ? 1 : -1;
+  });
+}
+
+/**
  * A dataset where every write behaves the way the server actually behaves.
  * `publishDatasetVersion` branches off the CURRENT version, writes a NEW one
  * with the change applied (fresh per-version row ids and all), and repoints
@@ -388,9 +404,8 @@ describe("Dataset detail — filtering and adding rows", () => {
  * is exactly what makes a pinned selection observably stale after a write.
  */
 function mockPublishOnWrite() {
-  // Newest first, the order the detail route returns them in. Published versions
-  // carry no label, so widen it off V1's literal type.
-  let versions: (Omit<typeof V1, "label"> & { label: string | null })[] = [V2, V1];
+  // Newest first, the order the detail route returns them in.
+  let versions: (typeof V1)[] = [V2, V1];
   let currentVersionId = "dv2";
   const casesByVersion = new Map<string, ReturnType<typeof testCase>[]>([
     ["dv1", [testCase({ id: "old-1", datasetVersionId: "dv1", input: "seeded ticket" })]],
@@ -418,7 +433,8 @@ function mockPublishOnWrite() {
         ...V1,
         id,
         versionNumber,
-        label: null,
+        // publishDatasetVersion labels an unlabelled publish `v<number>`.
+        label: `v${versionNumber}`,
         createTime: `2026-07-17T${String(11 + versionNumber).padStart(2, "0")}:00:00Z`,
       },
       ...versions,
@@ -475,12 +491,22 @@ function mockPublishOnWrite() {
           currentVersion: versions.find((v) => v.id === currentVersionId),
           selectedVersion: selected,
           isCurrentVersion: selected.id === currentVersionId,
-          testCases: casesByVersion.get(selected.id) ?? [],
+          testCases: byNewestFirst(casesByVersion.get(selected.id) ?? []),
           versions,
         };
       },
     };
   }) as unknown as typeof fetch;
+}
+
+/**
+ * Open the action menu of the row whose Input cell matches — addressed by
+ * content, since the table is ordered newest-first and a positional index would
+ * quietly act on a different row than the assertions are written about.
+ */
+async function openRowActions(text: string | RegExp) {
+  const row = (await screen.findAllByText(text))[0].closest("tr")!;
+  fireEvent.click(within(row).getByLabelText("Row actions"));
 }
 
 /** The dataset-detail GETs, excluding the nested /test-cases requests. */
@@ -511,7 +537,7 @@ describe("Dataset detail — deleting a row with a version pinned", () => {
     // Pinned, yet still the current version — the Actions column proves it.
     expect(await screen.findByRole("columnheader", { name: "Actions" })).toBeDefined();
 
-    fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
+    await openRowActions(/charged twice/);
     fireEvent.click(await screen.findByText("Delete"));
     fireEvent.click(screen.getAllByRole("button", { name: "Delete" }).at(-1)!);
     expect(await screen.findByText("Row deleted")).toBeDefined();
@@ -552,7 +578,7 @@ describe("Dataset detail — deleting a row with a version pinned", () => {
     expect(detailGets().at(-1)!.url).not.toContain("version_id");
 
     // ...and the following delete (publishing dv4) keeps it there.
-    fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
+    await openRowActions(/charged twice/);
     fireEvent.click(await screen.findByText("Delete"));
     fireEvent.click(screen.getAllByRole("button", { name: "Delete" }).at(-1)!);
     await screen.findByText("Row deleted");

--- a/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx
@@ -551,6 +551,13 @@ describe("Dataset detail — deleting a row with a version pinned", () => {
     expect(detailGets().at(-1)!.url).not.toContain("version_id");
   });
 
+  /**
+   * The flow that originally MASKED the bug, pinned so a future change cannot
+   * regress it. It passes with AND without the production reset by design, and
+   * is not a second guard on it: the add's `onSaved` un-pins the selection
+   * first, so by the time the delete runs there is no pin left for the delete's
+   * own reset to clear. The pinned delete is guarded by the test above.
+   */
   it("add-then-delete still lands on the newest version", async () => {
     mockPublishOnWrite();
     mountDetail();
@@ -577,7 +584,9 @@ describe("Dataset detail — deleting a row with a version pinned", () => {
     expect(screen.getByRole("columnheader", { name: "Actions" })).toBeDefined();
     expect(detailGets().at(-1)!.url).not.toContain("version_id");
 
-    // ...and the following delete (publishing dv4) keeps it there.
+    // ...and the following delete (publishing dv4) keeps it there. The selection
+    // is already un-pinned here, so this asserts the add's reset still holds
+    // across a second publish — not that the delete resets anything.
     await openRowActions(/charged twice/);
     fireEvent.click(await screen.findByText("Delete"));
     fireEvent.click(screen.getAllByRole("button", { name: "Delete" }).at(-1)!);

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -153,6 +153,12 @@ export function DatasetDetailView({
       onSuccess: () => {
         toast({ title: "Row deleted", tone: "success" });
         setDeleteRow(null);
+        // The delete published a NEW current version with the row dropped, so drop
+        // any pinned selection and follow it — exactly what the editor's `onSaved`
+        // does after an add/edit. Left pinned, the invalidation re-fetches the now
+        // superseded snapshot: the deleted row stays on screen and the Actions
+        // column vanishes with `isCurrentVersion`, reading as a failed delete.
+        setSelectedVersionId(null);
         // Close the slide-in if it was showing the row we just removed.
         if (openCaseId === target.testCaseId) setOpenCaseId(null);
       },


### PR DESCRIPTION
## Summary

Fixes: #1986

Deleting a row on the dataset detail page silently left the view on a stale snapshot. The delete succeeded server-side — a new dataset version was published with the case dropped and `Dataset.currentVersionId` repointed at it — but the page kept showing the deleted row, with the row Actions column gone. Editing or adding a row, by contrast, moved the view onto the version it just published.

The auto-switch was never driven by the mutation; it is driven by resetting local `selectedVersionId` to `null` ("current version"), which only the editor's `onSaved` did. With a concrete version pinned, the delete's cache invalidation re-fetched that same superseded snapshot — so the row stayed, and `isCurrentVersion` flipped false and took the Actions column with it, reading as a failed delete.

Any dropdown interaction pins the selection, including re-picking the version already shown: the `<Select>` binds its `value` to server-derived state but writes to separate local state that is never synced back. Add-then-delete only appeared to work because the add un-pinned the selection as a side effect.

## The fix

One line, in `confirmDelete`'s success handler (`frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx:155-162`):

```tsx
onSuccess: () => {
  toast({ title: "Row deleted", tone: "success" });
  setDeleteRow(null);
  // The delete published a NEW current version with the row dropped, so drop
  // any pinned selection and follow it — exactly what the editor's `onSaved`
  // does after an add/edit.
  setSelectedVersionId(null);
  if (openCaseId === target.testCaseId) setOpenCaseId(null);
},
```

**Delete now uses the same mechanism as add/edit** rather than a parallel one — `setSelectedVersionId(null)` is the single way this page follows a publish, and all three mutations call it. The mutation, query key, DELETE route and `publishDatasetVersion` are untouched, and version immutability is unaffected: the older snapshot still holds the row and is still reachable from the dropdown.

Older non-current versions stay read-only by construction, not by an added guard — `isCurrentVersion` is false there, so the Actions column and its per-row menu never render (`:309`, `:345`) and `confirmDelete` is unreachable. The new reset can only fire from a delete that just published a new current version.

## Tests

Two cases in `frontend/ui/src/features/evaluations/datasets-detail.smoke.test.tsx`. The existing delete test cannot catch this — it never pins a version, and its stub returns a fixed payload, so the current version never advances. The new `mockDeletePublishesNewVersion` fixture models the real server behaviour: DELETE publishes `dv3` without `tc_1` and repoints `currentVersionId`, leaving `dv2` a readable snapshot that keeps the row. Modelling the repoint is what makes the pinned selection observably stale.

- `follows the delete onto the version it published instead of the pinned snapshot` — pins the way a user actually reaches it (dropdown → v1 → back to current v2), deletes, then asserts the row is gone, the Actions column survives, and the last detail GET carries no `version_id`. Also asserts the v1 snapshot exposes neither the Actions column nor any row-action menu.
- `add-then-delete still lands on the newest version` — the flow that previously masked the bug. Passes before and after, pinning behaviour the fix must not regress.

Verified:

- **Before** (`git stash push` of `dataset-detail-view.tsx` alone): `Tests 1 failed | 18 passed (19)`, failing with `expected <td …(1)></td> to be null` — the still-rendered `I was charged twice for my July invoice` cell.
- The Actions-column half discriminates independently: with the fix stashed and that assertion hoisted first, it fails with `Unable to find role="columnheader" and name "Actions"`. Both halves are load-bearing.
- **After**: `Tests 19 passed (19)`; feature suite `Tests 98 passed (98)`.
- `pnpm lint` 0 errors (59 pre-existing warnings, none in touched files); `prettier --check` clean; `tsc --noEmit` shows only the six errors already on `main`.

The `mockPublishOnWrite` fixture serves rows in the detail route's order (`[createTime desc, testCaseId desc]`) and labels published versions `v<n>`, matching `publishDatasetVersion`; both tests address rows by content rather than table position, since a publish appends and the real table is newest-first. `add-then-delete` passes with and without the fix by design — the add's `onSaved` un-pins first, so it guards the flow that masked the bug, not the delete reset.

## What this does not eliminate

The stale view is shortened to one round trip, not removed. `invalidateQueries` in the delete hook runs before the mutate callback's reset, so the pinned key refetches once before the selection flips to `null`; and the `null` key serves its cached snapshot while `isFetching` is true, so for that one RTT the deleted row is still on screen with the Actions column hidden. That transient already happens on the unpinned delete path on `main` (`isCurrentVersion` is `&& !isFetching`) and on add/edit — it is pre-existing and unchanged here, not introduced by this diff. The same ordering also costs one wasted `?version_id=` GET per pinned write, on add/edit exactly as on delete. Both belong with the selector cleanup below, not with this one-liner.

## Scope

Frontend-only, two files: the six-line change in `dataset-detail-view.tsx` and the tests. No API, route, schema, migration, or hook change.

## Follow-up

The `<Select>` reading `value` from server state while writing to unsynced local state is the reason a pinned-but-current state exists at all. Syncing it (or making the selector fully controlled) would remove this class of bug, but changes version-switching behaviour and is out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deleting a dataset row now switches the view to the newly published current version. Previously, with a pinned version, the page re-fetched the superseded snapshot, kept the deleted row visible, and hid the Actions column.

- Resets `selectedVersionId` to current on successful delete, matching add/edit.
- Adds smoke tests that model publish-on-write for add and delete (including with a pinned version), assert refetch follows current (no `version_id`), and that add-then-delete still lands on the newest version; orders mock rows newest-first to match the detail route; documents that the add-then-delete flow unpins selection and is not a second guard on delete.
- Preserves version immutability: older snapshots remain read-only and selectable.
- Frontend-only; no API, route, or schema changes. No rollout or migration actions.

<sup>Written for commit 964b4ae731e0065961b83c132ff609bd4d5f526f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

