### PR TITLE
fix(billing): enforce the retention window on evaluation runs

### DIFF
--- a/backend/rest/routers/public/eval.py
+++ b/backend/rest/routers/public/eval.py
@@ -81,6 +81,13 @@ _DOT_SEGMENTS = frozenset({".", ".."})
 # (segment shape, allowed methods). `*` is one opaque id segment. This mirrors
 # `frontend/ui/src/app/api/public/**/route.ts` one-for-one; adding a route there
 # without adding it here means the gateway 404s it (fail closed, by design).
+#
+# The `evaluation-runs` shapes are deliberately write-only: reads of runs are
+# plan-windowed telemetry, and the only reader is the Next.js route
+# `api/projects/[projectId]/evaluations/runs`, which clamps the window to the
+# caller's plan. A listing GET added here would need the same clamp
+# (`rest.retention.clamp_retention_window`, as `routers/traces.py` applies it)
+# or it reopens that entitlement leak on a path the Next route never sees.
 _UPSTREAM_ROUTES: tuple[tuple[tuple[str, ...], frozenset[str]], ...] = (
     (("datasets",), frozenset({"GET", "POST"})),
     (("datasets", "*"), frozenset({"GET", "PATCH"})),

--- a/frontend/packages/core/src/ee/billing/__tests__/plans.test.ts
+++ b/frontend/packages/core/src/ee/billing/__tests__/plans.test.ts
@@ -10,6 +10,8 @@ import {
   isDetectorRunBlocked,
   isIngestionBlocked,
   hasEntitlement,
+  toPlanType,
+  getPlanOrder,
 } from "../plans.ts";
 
 describe("slack-integration entitlement", () => {
@@ -134,5 +136,30 @@ describe("isDetectorRunBlocked", () => {
   it("respects ENABLE_BILLING=false (unblocks all)", () => {
     vi.stubEnv("ENABLE_BILLING", "false");
     expect(isDetectorRunBlocked(PlanType.FREE, 9999)).toBe(false);
+  });
+});
+
+describe("toPlanType", () => {
+  it("passes through every known plan", () => {
+    for (const plan of Object.values(PlanType)) {
+      expect(toPlanType(plan)).toBe(plan);
+    }
+  });
+
+  it("fails closed to free for an unrecognized, missing, or prototype-chain plan", () => {
+    // billing_plan is a free-form TEXT column, so anything can arrive.
+    expect(toPlanType("legacy-team")).toBe(PlanType.FREE);
+    expect(toPlanType("")).toBe(PlanType.FREE);
+    expect(toPlanType(null)).toBe(PlanType.FREE);
+    expect(toPlanType(undefined)).toBe(PlanType.FREE);
+    expect(toPlanType("constructor")).toBe(PlanType.FREE);
+    expect(toPlanType("FREE")).toBe(PlanType.FREE);
+  });
+
+  it("keeps plan comparison well-defined for an unknown plan", () => {
+    // Without normalization getPlanOrder(unknown) is undefined, so every
+    // comparison against it is false and each CTA reads "Downgrade".
+    expect(getPlanOrder("legacy-team" as PlanType)).toBeUndefined();
+    expect(getPlanOrder(toPlanType("legacy-team"))).toBe(0);
   });
 });

--- a/frontend/packages/core/src/ee/billing/index.ts
+++ b/frontend/packages/core/src/ee/billing/index.ts
@@ -22,6 +22,7 @@ export {
   type Entitlement,
   // Plan helpers
   getPlanConfig,
+  toPlanType,
   getPlanOrder,
   mapPriceIdToPlan,
   isUpgrade,

--- a/frontend/packages/core/src/ee/billing/plans.ts
+++ b/frontend/packages/core/src/ee/billing/plans.ts
@@ -295,6 +295,21 @@ export type PlanConfig = (typeof PLANS)[PlanType];
 // =============================================================================
 // PLAN HELPERS
 // =============================================================================
+/**
+ * Narrow a raw plan string to a `PlanType`, failing closed to `FREE` for
+ * anything unrecognized. `billing_plan` is a free-form TEXT column, so a
+ * legacy, mistyped, or rolled-back plan name can reach the UI; the plan
+ * helpers below are keyed on `PlanType` and answer nonsense for anything else
+ * (`getPlanOrder` returns undefined, which makes `isUpgrade` false for every
+ * plan and labels every CTA "Downgrade"). Mirrors `normalize_plan` in
+ * backend/shared/config.py.
+ */
+export function toPlanType(plan: string | null | undefined): PlanType {
+  return (Object.values(PlanType) as string[]).includes(plan ?? "")
+    ? (plan as PlanType)
+    : PlanType.FREE;
+}
+
 export function getPlanConfig(plan: PlanType): PlanConfig {
   return PLANS[plan];
 }

--- a/frontend/packages/core/src/ee/billing/plans.ts
+++ b/frontend/packages/core/src/ee/billing/plans.ts
@@ -301,8 +301,13 @@ export type PlanConfig = (typeof PLANS)[PlanType];
  * legacy, mistyped, or rolled-back plan name can reach the UI; the plan
  * helpers below are keyed on `PlanType` and answer nonsense for anything else
  * (`getPlanOrder` returns undefined, which makes `isUpgrade` false for every
- * plan and labels every CTA "Downgrade"). Mirrors `normalize_plan` in
- * backend/shared/config.py.
+ * plan and labels every CTA "Downgrade").
+ *
+ * Deliberately an EXACT match, unlike `normalize_plan` in backend/shared/config.py,
+ * which lowercases and trims first: this is the frontend's plan lookup and it must
+ * agree with `getRetentionDays` above, whose `hasOwnProperty` check is exact too.
+ * Accepting `"PRO"` here while retention still reads it as unrecognized would show a
+ * 90-day entitlement over a 15-day window. Widen both together or neither.
  */
 export function toPlanType(plan: string | null | undefined): PlanType {
   return (Object.values(PlanType) as string[]).includes(plan ?? "")

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.test.ts
@@ -11,11 +11,28 @@ const prismaMock = vi.hoisted(() => ({
   evaluationRun: { findMany: vi.fn(), count: vi.fn() },
   dataset: { findMany: vi.fn() },
   evaluationResult: { findMany: vi.fn(), groupBy: vi.fn() },
+  workspace: { findUnique: vi.fn() },
   $transaction: vi.fn(async (arr: Promise<unknown>[]) => Promise.all(arr)),
 }));
 const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
 
-vi.mock("@traceroot/core", () => ({ prisma: prismaMock }));
+// `getRetentionDays` is mirrored (not imported) so the mock stays a plain module
+// factory, matching detector-counts/route.test.ts. The numbers are the plan
+// windows from packages/core/src/ee/billing/plans.ts, including the fail-closed
+// 15-day fallback for an unrecognized plan.
+vi.mock("@traceroot/core", () => ({
+  prisma: prismaMock,
+  PlanType: { FREE: "free", STARTER: "starter", PRO: "pro", ENTERPRISE: "enterprise" },
+  getRetentionDays: (plan: string) => {
+    const days: Record<string, number | null> = {
+      free: 15,
+      starter: 30,
+      pro: 90,
+      enterprise: null,
+    };
+    return Object.prototype.hasOwnProperty.call(days, plan) ? days[plan] : 15;
+  },
+}));
 vi.mock("@/lib/auth-helpers", () => ({
   requireAuth: auth.requireAuth,
   requireProjectAccess: auth.requireProjectAccess,
@@ -64,7 +81,11 @@ function group(
 beforeEach(() => {
   vi.clearAllMocks();
   auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
-  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1", workspaceId: "w1" } });
+  // Unlimited retention by default, so the derivation/sort/window tests below assert
+  // exactly what they used to: the clamp is a pass-through for enterprise. The clamp
+  // itself is exercised per-plan in the "retention clamp" block at the end.
+  prismaMock.workspace.findUnique.mockResolvedValue({ billingPlan: "enterprise" });
   prismaMock.$transaction.mockImplementation(async (arr: Promise<unknown>[]) => Promise.all(arr));
   prismaMock.dataset.findMany.mockResolvedValue([{ id: "ds1", name: "support" }]);
   prismaMock.evaluationResult.groupBy.mockResolvedValue([]);
@@ -573,6 +594,8 @@ it("sorts by elapsedMs, treating a still-running run (no completedAt) as sorting
   expect(body.data.map((r) => r.id)).toEqual(["run_fast", "run_slow", "run_running"]);
 });
 
+// Runs under the default (enterprise) plan, so the requested bounds survive the
+// retention clamp verbatim — see the "retention clamp" block for the gated plans.
 it("narrows to a startedAt window via started_after/started_before", async () => {
   prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run()]);
   prismaMock.evaluationRun.count.mockResolvedValue(1);
@@ -597,6 +620,8 @@ it("narrows to a startedAt window via started_after/started_before", async () =>
   );
 });
 
+// Enterprise again: with no cutoff to fall back to, an unparseable bound is simply
+// dropped. On a limited plan it fails closed to the cutoff instead (see below).
 it("drops an unparseable started_after instead of erroring", async () => {
   prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run()]);
   prismaMock.evaluationRun.count.mockResolvedValue(1);
@@ -609,4 +634,162 @@ it("drops an unparseable started_after instead of erroring", async () => {
       where: expect.not.objectContaining({ startedAt: expect.anything() }),
     }),
   );
+});
+
+// ── retention clamp ────────────────────────────────────────────────────────
+// The date picker is plan-gated in the UI, but a hand-crafted request must not
+// out-reach the plan's window either. This route is the only server-side reader of
+// evaluation runs, so it is where the clamp has to live — the same
+// `clampStartAfter` the detector proxies use, and the same window
+// (days + a 1-hour boundary buffer) the Python gate applies to traces.
+const DAY_MS = 86_400_000;
+const BUFFER_MS = 3_600_000;
+
+/** The `startedAt.gte` the route handed Prisma. */
+function requestedGte(): Date | undefined {
+  const args = prismaMock.evaluationRun.findMany.mock.calls[0][0] as {
+    where: { startedAt?: { gte?: Date; lte?: Date } };
+  };
+  return args.where.startedAt?.gte;
+}
+
+/** Assert `gte` is the cutoff for a `days`-wide window (tolerating clock drift). */
+function expectCutoff(gte: Date | undefined, days: number) {
+  expect(gte).toBeInstanceOf(Date);
+  const expected = Date.now() - days * DAY_MS - BUFFER_MS;
+  expect(Math.abs(gte!.getTime() - expected)).toBeLessThan(5_000);
+}
+
+function stubOneRun() {
+  prismaMock.evaluationRun.findMany.mockResolvedValueOnce([run()]);
+  prismaMock.evaluationRun.count.mockResolvedValue(1);
+  prismaMock.evaluationResult.findMany.mockResolvedValue([]);
+}
+
+it("clamps a started_after beyond the FREE window to the 15-day cutoff", async () => {
+  prismaMock.workspace.findUnique.mockResolvedValue({ billingPlan: "free" });
+  stubOneRun();
+
+  await GET(
+    nextUrl(`started_after=${new Date(Date.now() - 60 * DAY_MS).toISOString()}`) as never,
+    params,
+  );
+
+  expectCutoff(requestedGte(), 15);
+});
+
+it("clamps to the 30-day cutoff on STARTER", async () => {
+  prismaMock.workspace.findUnique.mockResolvedValue({ billingPlan: "starter" });
+  stubOneRun();
+
+  await GET(
+    nextUrl(`started_after=${new Date(Date.now() - 60 * DAY_MS).toISOString()}`) as never,
+    params,
+  );
+
+  expectCutoff(requestedGte(), 30);
+});
+
+it("leaves a 60-day window alone on PRO (inside the 90-day entitlement)", async () => {
+  prismaMock.workspace.findUnique.mockResolvedValue({ billingPlan: "pro" });
+  stubOneRun();
+  const requested = new Date(Date.now() - 60 * DAY_MS).toISOString();
+
+  await GET(nextUrl(`started_after=${requested}`) as never, params);
+
+  expect(requestedGte()).toEqual(new Date(requested));
+});
+
+it("leaves an arbitrarily old window alone on ENTERPRISE (unlimited)", async () => {
+  prismaMock.workspace.findUnique.mockResolvedValue({ billingPlan: "enterprise" });
+  stubOneRun();
+  const requested = new Date(Date.now() - 365 * DAY_MS).toISOString();
+
+  await GET(nextUrl(`started_after=${requested}`) as never, params);
+
+  expect(requestedGte()).toEqual(new Date(requested));
+});
+
+it("leaves a started_after inside the plan window untouched", async () => {
+  prismaMock.workspace.findUnique.mockResolvedValue({ billingPlan: "free" });
+  stubOneRun();
+  const requested = new Date(Date.now() - 5 * DAY_MS).toISOString();
+
+  await GET(nextUrl(`started_after=${requested}`) as never, params);
+
+  expect(requestedGte()).toEqual(new Date(requested));
+});
+
+it("bounds an UNBOUNDED request to the cutoff — omitting started_after is not a bypass", async () => {
+  prismaMock.workspace.findUnique.mockResolvedValue({ billingPlan: "free" });
+  stubOneRun();
+
+  await GET(nextUrl() as never, params);
+
+  expectCutoff(requestedGte(), 15);
+});
+
+it("fails closed to the cutoff for an unparseable started_after on a limited plan", async () => {
+  prismaMock.workspace.findUnique.mockResolvedValue({ billingPlan: "free" });
+  stubOneRun();
+
+  await GET(nextUrl("started_after=not-a-date") as never, params);
+
+  expectCutoff(requestedGte(), 15);
+});
+
+it("fails closed to the 15-day cutoff for an unrecognized plan string", async () => {
+  prismaMock.workspace.findUnique.mockResolvedValue({ billingPlan: "constructor" });
+  stubOneRun();
+
+  await GET(
+    nextUrl(`started_after=${new Date(Date.now() - 60 * DAY_MS).toISOString()}`) as never,
+    params,
+  );
+
+  expectCutoff(requestedGte(), 15);
+});
+
+it("fails closed to the 15-day cutoff when the workspace row is missing", async () => {
+  prismaMock.workspace.findUnique.mockResolvedValue(null);
+  stubOneRun();
+
+  await GET(
+    nextUrl(`started_after=${new Date(Date.now() - 60 * DAY_MS).toISOString()}`) as never,
+    params,
+  );
+
+  expectCutoff(requestedGte(), 15);
+});
+
+it("clamps the cost/elapsed sort branch too, not just the DB-sorted one", async () => {
+  // The two branches build the same `where`, but only one of them is exercised by the
+  // tests above — a clamp applied in only one is still a leak.
+  prismaMock.workspace.findUnique.mockResolvedValue({ billingPlan: "free" });
+  stubOneRun();
+
+  await GET(
+    nextUrl(`sort=cost&started_after=${new Date(Date.now() - 60 * DAY_MS).toISOString()}`) as never,
+    params,
+  );
+
+  expectCutoff(requestedGte(), 15);
+});
+
+it("does not touch started_before while clamping started_after", async () => {
+  prismaMock.workspace.findUnique.mockResolvedValue({ billingPlan: "free" });
+  stubOneRun();
+  const before = new Date(Date.now() - 1 * DAY_MS).toISOString();
+
+  await GET(
+    nextUrl(
+      `started_after=${new Date(Date.now() - 60 * DAY_MS).toISOString()}&started_before=${before}`,
+    ) as never,
+    params,
+  );
+
+  const args = prismaMock.evaluationRun.findMany.mock.calls[0][0] as {
+    where: { startedAt?: { lte?: Date } };
+  };
+  expect(args.where.startedAt?.lte).toEqual(new Date(before));
 });

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
-import { prisma } from "@traceroot/core";
+import { prisma, PlanType } from "@traceroot/core";
 import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+import { clampStartAfter } from "@/lib/server/retention";
 import { compareRuns } from "@/lib/eval/comparison";
 import { toComparisonRun, toComparisonResults } from "@/lib/eval/comparison-db";
 import { countResultStatuses, passRate, excludedSummary } from "@/lib/eval/pass-rate";
@@ -79,8 +80,24 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
   const searchQuery = searchParams.get("search_query")?.trim() || null;
   const sort = parseSort(searchParams.get("sort"));
   const order = parseOrder(searchParams.get("order"));
-  const startedAfter = parseDateParam(searchParams.get("started_after"));
   const startedBefore = parseDateParam(searchParams.get("started_before"));
+
+  // Retention gate. Evaluation runs are plan-windowed telemetry like traces, and this
+  // is their only server-side reader, so the clamp lives here — the same helper the
+  // detector proxies use, mirroring the Python gate (backend/rest/retention.py) that
+  // fronts the ClickHouse-backed routes. Lists clamp silently rather than 403: the
+  // date picker already refuses out-of-window presets, and this is the backstop for a
+  // request that did not come from it. `clampStartAfter` also substitutes the cutoff
+  // for a missing or unparseable bound, so an UNBOUNDED request is windowed too —
+  // omitting `started_after` must not be a wider query than asking for 90 days.
+  const workspace = await prisma.workspace.findUnique({
+    where: { id: accessResult.project.workspaceId },
+    select: { billingPlan: true },
+  });
+  const billingPlan = workspace?.billingPlan || PlanType.FREE;
+  const startedAfter = parseDateParam(
+    clampStartAfter(billingPlan, searchParams.get("started_after")),
+  );
 
   const where = {
     projectId,

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
@@ -83,9 +83,12 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
   const startedBefore = parseDateParam(searchParams.get("started_before"));
 
   // Retention gate. Evaluation runs are plan-windowed telemetry like traces, and this
-  // is their only server-side reader, so the clamp lives here — the same helper the
-  // detector proxies use, mirroring the Python gate (backend/rest/retention.py) that
-  // fronts the ClickHouse-backed routes. Lists clamp silently rather than 403: the
+  // is the only server-side reader that LISTS them, so the clamp lives here — the same
+  // helper the detector proxies use, mirroring the Python gate (backend/rest/retention.py)
+  // that fronts the ClickHouse-backed routes. (The by-id readers — runs/[runId], the
+  // compare route — and the run-derived aggregates on evaluations/ and
+  // evaluations/scorers/ are still ungated; they need the by-id equivalent
+  // (`enforce_retention_by_time`), not this clamp.) Lists clamp silently rather than 403: the
   // date picker already refuses out-of-window presets, and this is the backstop for a
   // request that did not come from it. `clampStartAfter` also substitutes the cutoff
   // for a missing or unparseable bound, so an UNBOUNDED request is windowed too —

--- a/frontend/ui/src/features/evaluations/evaluations-retention.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations-retention.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+/**
+ * The Evaluations date-range control is plan-gated like every other telemetry
+ * surface: presets wider than the workspace's retention window render locked and
+ * route to the upgrade flow instead of applying.
+ *
+ * date-filter.test.ts covers `isOptionLocked`'s plan matrix and
+ * date-filter-select.test.tsx covers the control's locked-click behavior — both
+ * in isolation, so neither can see whether this view actually *passes*
+ * `retentionDays`. That wiring is the whole defect, so it is asserted here by
+ * mounting the real view over the real `useRetention` (only the two lookups it
+ * reads are stubbed), and observing the trigger label: an applied preset renames
+ * the button, a locked one leaves it on the 14-day default.
+ *
+ * The label is matched by text rather than by role: a locked click opens the
+ * (modal) PricingDialog, which `aria-hidden`s the page behind it, so a role query
+ * can no longer see the trigger it is meant to assert on.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@/components/ui/toast";
+import { PlanType } from "@traceroot/core";
+
+const lookups = vi.hoisted(() => ({
+  project: {
+    data: { workspace_id: "w1" } as { workspace_id?: string } | undefined,
+    isPending: false,
+  },
+  workspace: {
+    data: { billingPlan: "free" } as { billingPlan?: string } | undefined,
+    isPending: false,
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/projects/p1/evaluations",
+}));
+// ProjectBreadcrumb pulls layout/workspace context this harness doesn't mount.
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+// `useRetention` itself stays real — it is the thing whose output must reach the
+// control — so only its two data lookups are replaced.
+vi.mock("@/features/projects/hooks", () => ({ useProject: () => lookups.project }));
+vi.mock("@/features/workspaces/hooks", () => ({ useWorkspace: () => lookups.workspace }));
+
+import { EvaluationsView } from "./views/evaluations-view";
+
+/** The view's own default window (RunsTab seeds `dateFilter` to 14d). */
+const DEFAULT_LABEL = "Last 14 days";
+
+function mount() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ToastProvider>
+        <EvaluationsView projectId="p1" />
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/** Mount, open the preset popover, and click `label`. */
+async function pickPreset(label: string) {
+  mount();
+  fireEvent.click(await screen.findByRole("button", { name: DEFAULT_LABEL }));
+  fireEvent.click(screen.getByRole("button", { name: label }));
+}
+
+/** The preset was applied: the (now closed) trigger carries its label. */
+function expectApplied(label: string) {
+  expect(screen.getByText(label)).toBeTruthy();
+}
+
+/** The preset was refused: the trigger is still on the default window. */
+function expectLocked(label: string) {
+  expect(screen.getByText(DEFAULT_LABEL)).toBeTruthy();
+  expect(screen.queryByText(label)).toBeNull();
+}
+
+beforeEach(() => {
+  lookups.project = { data: { workspace_id: "w1" }, isPending: false };
+  lookups.workspace = { data: { billingPlan: PlanType.FREE }, isPending: false };
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ data: [], meta: { page: 0, limit: 50, total: 0 } }),
+  })) as unknown as typeof fetch;
+});
+afterEach(cleanup);
+
+describe("Evaluations date range is gated by the plan's retention window", () => {
+  it("FREE (15 days): 30d / 60d / 90d are locked", async () => {
+    for (const label of ["Last 30 days", "Last 60 days", "Last 90 days"]) {
+      await pickPreset(label);
+      expectLocked(label);
+      cleanup();
+    }
+  });
+
+  it("FREE (15 days): a preset inside the window still applies", async () => {
+    await pickPreset("Last 7 days");
+    expectApplied("Last 7 days");
+  });
+
+  it("STARTER (30 days): 30d applies, 60d / 90d are locked", async () => {
+    lookups.workspace = { data: { billingPlan: PlanType.STARTER }, isPending: false };
+
+    await pickPreset("Last 30 days");
+    expectApplied("Last 30 days");
+    cleanup();
+
+    for (const label of ["Last 60 days", "Last 90 days"]) {
+      await pickPreset(label);
+      expectLocked(label);
+      cleanup();
+    }
+  });
+
+  it("PRO (90 days): the full window applies", async () => {
+    lookups.workspace = { data: { billingPlan: PlanType.PRO }, isPending: false };
+
+    await pickPreset("Last 90 days");
+    expectApplied("Last 90 days");
+  });
+
+  it("ENTERPRISE (unlimited): nothing is locked", async () => {
+    lookups.workspace = { data: { billingPlan: PlanType.ENTERPRISE }, isPending: false };
+
+    await pickPreset("Last 90 days");
+    expectApplied("Last 90 days");
+  });
+
+  it("fails closed for an unrecognized plan string (15 days)", async () => {
+    lookups.workspace = { data: { billingPlan: "constructor" }, isPending: false };
+
+    await pickPreset("Last 30 days");
+    expectLocked("Last 30 days");
+  });
+
+  it("locks nothing while the plan is still loading (retentionDays undefined)", async () => {
+    // Matches the other surfaces: a hard reload must not transiently narrow the
+    // range against the free plan's window before the workspace resolves.
+    lookups.workspace = { data: undefined, isPending: true };
+
+    await pickPreset("Last 90 days");
+    expectApplied("Last 90 days");
+  });
+
+  it("routes a locked preset to the upgrade flow", async () => {
+    await pickPreset("Last 90 days");
+
+    expect(screen.getByText("Choose a plan")).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/features/evaluations/evaluations-retention.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations-retention.test.tsx
@@ -154,4 +154,17 @@ describe("Evaluations date range is gated by the plan's retention window", () =>
 
     expect(screen.getByText("Choose a plan")).toBeTruthy();
   });
+
+  it("offers the upgrade flow against the free plan when the plan string is unrecognized", async () => {
+    // Same fail-closed rule the window uses: an unknown `billing_plan` (a free-form
+    // TEXT column) must reach the dialog as FREE. Raw, it matches no plan, so no card
+    // is the current one and `isUpgrade` is false for all of them — every CTA reads
+    // "Downgrade", inviting a paying-looking workspace to "downgrade" to Starter.
+    lookups.workspace = { data: { billingPlan: "legacy-team" }, isPending: false };
+
+    await pickPreset("Last 90 days");
+
+    expect(screen.getByText("Current Plan")).toBeTruthy();
+    expect(screen.queryByText("Downgrade")).toBeNull();
+  });
 });

--- a/frontend/ui/src/features/evaluations/evaluations-retention.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations-retention.test.tsx
@@ -58,13 +58,18 @@ const DEFAULT_LABEL = "Last 14 days";
 
 function mount() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
+  // A fresh element per render (the same QueryClient, so the cache survives) — React
+  // bails out of re-rendering a referentially identical element, which would make
+  // `rerender` a no-op for the plan-resolves-after-mount test below.
+  const tree = () => (
     <QueryClientProvider client={qc}>
       <ToastProvider>
         <EvaluationsView projectId="p1" />
       </ToastProvider>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
+  const result = render(tree());
+  return { ...result, rerender: () => result.rerender(tree()) };
 }
 
 /** The view's default window in days, i.e. what a refused preset must leave behind. */
@@ -179,6 +184,27 @@ describe("Evaluations date range is gated by the plan's retention window", () =>
 
     await pickPreset("Last 90 days");
     await expectApplied("Last 90 days", 90);
+  });
+
+  it("collapses a pick made before the plan resolved once retention lands", async () => {
+    // The gap above is real: nothing is locked while the workspace is in flight, so a
+    // 90-day pick CAN be applied. What must not happen is the control keeping that
+    // label — and that query — for the rest of the session once the plan says 15 days.
+    // The server clamps either way, so this is the control telling the truth about the
+    // window it is actually showing, matching clampDateFilter on the other surfaces.
+    lookups.workspace = { data: undefined, isPending: true };
+    (global.fetch as unknown as Mock).mockClear();
+    const view = mount();
+    fireEvent.click(await screen.findByRole("button", { name: DEFAULT_LABEL }));
+    fireEvent.click(screen.getByRole("button", { name: "Last 90 days" }));
+    await expectApplied("Last 90 days", 90);
+
+    lookups.workspace = { data: { billingPlan: PlanType.FREE }, isPending: false };
+    view.rerender();
+
+    await waitFor(() => expect(screen.getByText(DEFAULT_LABEL)).toBeTruthy());
+    expect(screen.queryByText("Last 90 days")).toBeNull();
+    await waitFor(() => expect(requestedWindowDays()).toBe(DEFAULT_DAYS));
   });
 
   it("routes a locked preset to the upgrade flow", async () => {

--- a/frontend/ui/src/features/evaluations/evaluations-retention.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations-retention.test.tsx
@@ -15,9 +15,14 @@
  * The label is matched by text rather than by role: a locked click opens the
  * (modal) PricingDialog, which `aria-hidden`s the page behind it, so a role query
  * can no longer see the trigger it is meant to assert on.
+ *
+ * The trigger label alone would not prove the gate does anything, though — a
+ * relabelled button that never reaches the server is still an ungated read. So
+ * every assertion also reads the window the runs request actually asked for, off
+ * the mocked fetch URL's `started_after` bound.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastProvider } from "@/components/ui/toast";
 import { PlanType } from "@traceroot/core";
@@ -62,22 +67,49 @@ function mount() {
   );
 }
 
+/** The view's default window in days, i.e. what a refused preset must leave behind. */
+const DEFAULT_DAYS = 14;
+
 /** Mount, open the preset popover, and click `label`. */
 async function pickPreset(label: string) {
+  (global.fetch as unknown as Mock).mockClear();
   mount();
   fireEvent.click(await screen.findByRole("button", { name: DEFAULT_LABEL }));
   fireEvent.click(screen.getByRole("button", { name: label }));
 }
 
-/** The preset was applied: the (now closed) trigger carries its label. */
-function expectApplied(label: string) {
-  expect(screen.getByText(label)).toBeTruthy();
+/**
+ * Width, in days, of the window the most recent runs request asked the server
+ * for — decoded from its `started_after` bound. Throws when the view has issued
+ * no runs request at all, so an un-queried preset can never read as applied.
+ */
+function requestedWindowDays(): number {
+  const urls = (global.fetch as unknown as Mock).mock.calls
+    .map((call) => String(call[0]))
+    .filter((url) => url.includes("/evaluations/runs"));
+  if (urls.length === 0) throw new Error("no runs request was issued");
+  const startedAfter = new URL(urls[urls.length - 1], "http://t").searchParams.get("started_after");
+  if (!startedAfter) throw new Error("runs request carried no started_after bound");
+  return Math.round((Date.now() - Date.parse(startedAfter)) / 86_400_000);
 }
 
-/** The preset was refused: the trigger is still on the default window. */
-function expectLocked(label: string) {
+/**
+ * The preset was applied: the (now closed) trigger carries its label AND the
+ * runs query moved to that window.
+ */
+async function expectApplied(label: string, days: number) {
+  expect(screen.getByText(label)).toBeTruthy();
+  await waitFor(() => expect(requestedWindowDays()).toBe(days));
+}
+
+/**
+ * The preset was refused: the trigger is still on the default window and the
+ * runs query never widened past it.
+ */
+async function expectLocked(label: string) {
   expect(screen.getByText(DEFAULT_LABEL)).toBeTruthy();
   expect(screen.queryByText(label)).toBeNull();
+  expect(requestedWindowDays()).toBe(DEFAULT_DAYS);
 }
 
 beforeEach(() => {
@@ -95,26 +127,26 @@ describe("Evaluations date range is gated by the plan's retention window", () =>
   it("FREE (15 days): 30d / 60d / 90d are locked", async () => {
     for (const label of ["Last 30 days", "Last 60 days", "Last 90 days"]) {
       await pickPreset(label);
-      expectLocked(label);
+      await expectLocked(label);
       cleanup();
     }
   });
 
   it("FREE (15 days): a preset inside the window still applies", async () => {
     await pickPreset("Last 7 days");
-    expectApplied("Last 7 days");
+    await expectApplied("Last 7 days", 7);
   });
 
   it("STARTER (30 days): 30d applies, 60d / 90d are locked", async () => {
     lookups.workspace = { data: { billingPlan: PlanType.STARTER }, isPending: false };
 
     await pickPreset("Last 30 days");
-    expectApplied("Last 30 days");
+    await expectApplied("Last 30 days", 30);
     cleanup();
 
     for (const label of ["Last 60 days", "Last 90 days"]) {
       await pickPreset(label);
-      expectLocked(label);
+      await expectLocked(label);
       cleanup();
     }
   });
@@ -123,21 +155,21 @@ describe("Evaluations date range is gated by the plan's retention window", () =>
     lookups.workspace = { data: { billingPlan: PlanType.PRO }, isPending: false };
 
     await pickPreset("Last 90 days");
-    expectApplied("Last 90 days");
+    await expectApplied("Last 90 days", 90);
   });
 
   it("ENTERPRISE (unlimited): nothing is locked", async () => {
     lookups.workspace = { data: { billingPlan: PlanType.ENTERPRISE }, isPending: false };
 
     await pickPreset("Last 90 days");
-    expectApplied("Last 90 days");
+    await expectApplied("Last 90 days", 90);
   });
 
   it("fails closed for an unrecognized plan string (15 days)", async () => {
     lookups.workspace = { data: { billingPlan: "constructor" }, isPending: false };
 
     await pickPreset("Last 30 days");
-    expectLocked("Last 30 days");
+    await expectLocked("Last 30 days");
   });
 
   it("locks nothing while the plan is still loading (retentionDays undefined)", async () => {
@@ -146,7 +178,7 @@ describe("Evaluations date range is gated by the plan's retention window", () =>
     lookups.workspace = { data: undefined, isPending: true };
 
     await pickPreset("Last 90 days");
-    expectApplied("Last 90 days");
+    await expectApplied("Last 90 days", 90);
   });
 
   it("routes a locked preset to the upgrade flow", async () => {

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -18,6 +18,9 @@ import { SearchFilterBar } from "@/components/search-filter-bar";
 import { DateFilterSelect } from "@/components/date-filter-select";
 import { DATE_FILTER_OPTIONS, toTimestampBounds, type DateFilterOption } from "@/lib/date-filter";
 import { useKeywordSearch } from "@/lib/hooks/use-keyword-search";
+import { useRetention } from "@/lib/hooks/use-retention";
+import { PricingDialog } from "@/ee/features/billing/PricingDialog";
+import { PlanType } from "@traceroot/core";
 import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
 import { DatasetActionsMenu, EmptyState, Timestamp } from "@/features/offline-eval/components";
 import { ProjectBreadcrumb } from "@/features/projects/components";
@@ -154,6 +157,11 @@ function RunsTab({ projectId }: { projectId: string }) {
   const router = useRouter();
   const { toast } = useToast();
   const del = useDeleteRuns(projectId);
+  // Plan-based retention window. Same wiring as every other windowed surface
+  // (traces/sessions/users/detectors/dashboards): the hook supplies the window to
+  // the date control and owns the upgrade dialog the locked presets route to.
+  // The server clamps too (evaluations/runs/route.ts) — this is the visible half.
+  const retention = useRetention(projectId);
   const [deleteRun, setDeleteRun] = React.useState<RunRow | null>(null);
   // Row selection for bulk actions (compare / delete).
   const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
@@ -318,6 +326,8 @@ function RunsTab({ projectId }: { projectId: string }) {
               setCustomStart(s);
               setCustomEnd(e);
             }}
+            retentionDays={retention.retentionDays}
+            onUpgradeClick={retention.onUpgradeClick}
           />
         </div>
       </SearchFilterBar>
@@ -426,6 +436,13 @@ function RunsTab({ projectId }: { projectId: string }) {
           isDeleting={del.isPending}
         />
       )}
+
+      <PricingDialog
+        open={retention.showPricing}
+        onOpenChange={retention.closePricing}
+        workspaceId={retention.workspaceId}
+        currentPlan={(retention.billingPlan as PlanType) || PlanType.FREE}
+      />
     </>
   );
 }

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -20,7 +20,7 @@ import { DATE_FILTER_OPTIONS, toTimestampBounds, type DateFilterOption } from "@
 import { useKeywordSearch } from "@/lib/hooks/use-keyword-search";
 import { useRetention } from "@/lib/hooks/use-retention";
 import { PricingDialog } from "@/ee/features/billing/PricingDialog";
-import { PlanType } from "@traceroot/core";
+import { toPlanType } from "@traceroot/core";
 import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
 import { DatasetActionsMenu, EmptyState, Timestamp } from "@/features/offline-eval/components";
 import { ProjectBreadcrumb } from "@/features/projects/components";
@@ -441,7 +441,7 @@ function RunsTab({ projectId }: { projectId: string }) {
         open={retention.showPricing}
         onOpenChange={retention.closePricing}
         workspaceId={retention.workspaceId}
-        currentPlan={(retention.billingPlan as PlanType) || PlanType.FREE}
+        currentPlan={toPlanType(retention.billingPlan)}
       />
     </>
   );

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -16,7 +16,12 @@ import {
 import { useToast } from "@/components/ui/toast";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { DateFilterSelect } from "@/components/date-filter-select";
-import { DATE_FILTER_OPTIONS, toTimestampBounds, type DateFilterOption } from "@/lib/date-filter";
+import {
+  DATE_FILTER_OPTIONS,
+  clampDateFilter,
+  toTimestampBounds,
+  type DateFilterOption,
+} from "@/lib/date-filter";
 import { useKeywordSearch } from "@/lib/hooks/use-keyword-search";
 import { useRetention } from "@/lib/hooks/use-retention";
 import { PricingDialog } from "@/ee/features/billing/PricingDialog";
@@ -167,8 +172,20 @@ function RunsTab({ projectId }: { projectId: string }) {
   const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
   const [bulkDeleteOpen, setBulkDeleteOpen] = React.useState(false);
   const { keyword, setKeyword, searchQuery } = useKeywordSearch();
-  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
+  const [rawDateFilter, setRawDateFilter] = React.useState<DateFilterOption>(
     DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0],
+  );
+  // Clamp at READ time, exactly as use-url-date-filter does for the other windowed
+  // surfaces. Nothing is locked while the plan is still resolving (retentionDays is
+  // undefined then, deliberately), so a pick made in that gap can out-reach the
+  // window; deriving keeps the raw pick and collapses it to the widest allowed
+  // preset the moment retention resolves. Without this the trigger goes on
+  // advertising "Last 90 days" for the rest of the session while the server
+  // (correctly) serves 15 — the control would be lying about the window rather
+  // than leaking data.
+  const dateFilter = React.useMemo(
+    () => clampDateFilter(rawDateFilter, retention.retentionDays),
+    [rawDateFilter, retention.retentionDays],
   );
   const [customStart, setCustomStart] = React.useState<Date | null>(null);
   const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
@@ -321,7 +338,7 @@ function RunsTab({ projectId }: { projectId: string }) {
             dateFilter={dateFilter}
             customStartDate={customStart}
             customEndDate={customEnd}
-            onDateFilterChange={setDateFilter}
+            onDateFilterChange={setRawDateFilter}
             onCustomRangeChange={(s, e) => {
               setCustomStart(s);
               setCustomEnd(e);
@@ -442,6 +459,7 @@ function RunsTab({ projectId }: { projectId: string }) {
         onOpenChange={retention.closePricing}
         workspaceId={retention.workspaceId}
         currentPlan={toPlanType(retention.billingPlan)}
+        hasSubscription={retention.hasSubscription}
       />
     </>
   );

--- a/frontend/ui/src/lib/hooks/use-retention.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-retention.test.tsx
@@ -6,7 +6,10 @@ import { useRetention } from "./use-retention";
 
 const state = vi.hoisted(() => ({
   project: { data: undefined as { workspace_id?: string } | undefined, isPending: true },
-  workspace: { data: undefined as { billingPlan?: string } | undefined, isPending: true },
+  workspace: {
+    data: undefined as { billingPlan?: string; billingSubscriptionId?: string | null } | undefined,
+    isPending: true,
+  },
 }));
 
 vi.mock("@/features/projects/hooks", () => ({
@@ -60,6 +63,33 @@ describe("useRetention", () => {
     const { result } = renderHook(() => useRetention("p1"));
 
     expect(result.current.retentionDays).toBe(15);
+  });
+
+  it("reports the workspace's subscription state for the pricing dialog", () => {
+    // Without this the dialog defaults to hasSubscription=false and routes an upgrade
+    // for an already-subscribed workspace to `checkout` instead of `change-plan`,
+    // opening a SECOND Stripe subscription for the same customer.
+    state.project = { data: { workspace_id: "w1" }, isPending: false };
+    state.workspace = {
+      data: { billingPlan: PlanType.STARTER, billingSubscriptionId: "sub_123" },
+      isPending: false,
+    };
+
+    const { result } = renderHook(() => useRetention("p1"));
+
+    expect(result.current.hasSubscription).toBe(true);
+  });
+
+  it("reports no subscription when the workspace has none", () => {
+    state.project = { data: { workspace_id: "w1" }, isPending: false };
+    state.workspace = {
+      data: { billingPlan: PlanType.FREE, billingSubscriptionId: null },
+      isPending: false,
+    };
+
+    const { result } = renderHook(() => useRetention("p1"));
+
+    expect(result.current.hasSubscription).toBe(false);
   });
 
   it("fails closed when the workspace lookup errors out", () => {

--- a/frontend/ui/src/lib/hooks/use-retention.ts
+++ b/frontend/ui/src/lib/hooks/use-retention.ts
@@ -21,6 +21,14 @@ export function useRetention(projectId: string) {
   const billingPlan = (workspace?.billingPlan as string) || PlanType.FREE;
   const retentionDays = resolving ? undefined : getRetentionDays(billingPlan);
 
+  // Whether the workspace already has a Stripe subscription. The pricing dialog
+  // routes an upgrade to `change-plan` when it does and to `checkout` when it does
+  // not (ee/features/billing/plan-actions.ts); defaulting to false for a workspace
+  // that IS subscribed opens a second checkout for the same customer. The billing
+  // settings page, RetentionGateBanner and SidebarUpgradeButton all pass this — the
+  // hook exposes it so its consumers can too.
+  const hasSubscription = !!workspace?.billingSubscriptionId;
+
   const [showPricing, setShowPricing] = useState(false);
   const onUpgradeClick = useCallback(() => setShowPricing(true), []);
   const closePricing = useCallback(() => setShowPricing(false), []);
@@ -32,5 +40,6 @@ export function useRetention(projectId: string) {
     closePricing,
     workspaceId,
     billingPlan,
+    hasSubscription,
   };
 }

--- a/tests/rest/test_public_eval_gateway_security.py
+++ b/tests/rest/test_public_eval_gateway_security.py
@@ -294,3 +294,45 @@ def test_unmodelled_field_still_reaches_the_handler(client, upstream):
     assert resp.status_code == 200
     assert upstream.calls.call_count == 1
     assert b"field_from_a_newer_sdk" in upstream.calls.last.request.content
+
+
+# --- Retention surface ---------------------------------------------------------
+
+
+class TestNoUngatedRetentionRead:
+    """The gateway exposes no time-windowed read of evaluation runs, so it has
+    nothing to apply ``rest.retention.clamp_retention_window`` to.
+
+    Evaluation-run *reads* are served by the Prisma-owned Next.js route
+    (``frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts``),
+    which is where the plan clamp lives. What is asserted here is the premise that
+    makes that sufficient: this gateway's ``evaluation-runs`` surface is
+    write-only. Adding a listing GET without a retention clamp would reopen the
+    entitlement leak on a path the Next route never sees, so it fails here first.
+    """
+
+    def test_evaluation_runs_allowlist_is_write_only(self):
+        for shape, methods in eval_gateway._UPSTREAM_ROUTES:
+            if shape[0] != "evaluation-runs":
+                continue
+            assert methods <= {"POST"}, (
+                f"{'/'.join(shape)} now allows {sorted(methods - {'POST'})}. A read of "
+                "evaluation runs must clamp the window to the caller's plan "
+                "(rest.retention.clamp_retention_window) before it is allowlisted."
+            )
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/api/v1/public/evaluation-runs",
+            "/api/v1/public/evaluation-runs?started_after=2020-01-01T00:00:00Z",
+            "/api/v1/public/evaluation-runs/run1",
+        ],
+    )
+    def test_reading_runs_through_the_gateway_is_refused(self, client, upstream, path):
+        resp = client.get(path, headers=AUTH_HEADER)
+        # 405 today (every `evaluation-runs` route is POST-only, so the read is
+        # refused at routing); 404 if the shape itself stops existing. Either way
+        # the request never reaches the control plane.
+        assert resp.status_code in (404, 405), resp.text
+        assert upstream.calls.call_count == 0


### PR DESCRIPTION
## Summary

Fixes: #1987

The Evaluations date-range dropdown let any workspace pick 30d / 60d / 90d regardless of plan, and the runs endpoint actually served the wider window. Retention gating is built and enforced on every other telemetry surface — Traces, Sessions, Users, Detectors (list + detail), Dashboards — in two halves: the UI hands `DateFilterSelect` a `retentionDays` so out-of-window presets render locked, and the read endpoint clamps `start_after` server-side so a hand-crafted request cannot out-reach the plan either. Evaluations had **neither** half.

## UI — pass the plan window to the control

`frontend/ui/src/features/evaluations/views/evaluations-view.tsx:164,329-330,440` now mirrors the other six surfaces: `useRetention(projectId)` supplies `retentionDays` and `onUpgradeClick`, and the `PricingDialog` that flow opens is mounted. Without the dialog `onUpgradeClick` would be a dead control — `useRetention` only flips its own `showPricing` state; the surface owns the rendering, as on all six gated pages (e.g. `traces/page.tsx:395`).

No plan numbers changed. The window still comes from `RETENTION_DAYS` (`frontend/packages/core/src/ee/billing/plans.ts:151-156` — Free 15 / Starter 30 / Pro 90 / Enterprise null) through `getRetentionDays()`, which fails closed to 15 for an unrecognized plan.

## Server — clamp the runs window

`frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts:85-100` reuses `clampStartAfter` (`lib/server/retention.ts`), the same helper the detector proxies use, resolving the plan the same way:

```ts
const billingPlan = workspace?.billingPlan || PlanType.FREE;
const startedAfter = parseDateParam(
  clampStartAfter(billingPlan, searchParams.get("started_after")),
);
```

**Lists clamp, they do not 403** — the established split: `clamp_retention_window` pulls `start_after` forward for lists while `enforce_retention_by_time` 403s by-id lookups (`backend/rest/retention.py:54-84`). Two properties make this airtight rather than decorative:

- **Omitting `started_after` is not a bypass.** The helper substitutes the cutoff for a missing *or unparseable* bound. Before this change, dropping the parameter was the widest query available.
- **The clamp lands on both query branches.** The route splits on sort field — `startedAt`/`status` sort in the DB, `cost`/`elapsedMs` in Node (`route.ts:53-59`) — but both build the same `where`, so clamping the parsed bound covers both. Pinned by its own test.

The 1-hour boundary buffer is inherited from the helper and matches `retention.py`, so "Last 15 days" on Free does not race the server clock.

## Python: nothing to clamp, asserted rather than assumed

The other candidate site for the clamp is `backend/rest/routers/public/eval.py`. **That router has no read of evaluation runs to clamp** — it is the SDK-facing write gateway, and its `_UPSTREAM_ROUTES` allowlist registers every `evaluation-runs` shape as POST-only. Its only GETs are `datasets` / `dataset-versions`, which take no time window, so `GET /api/v1/public/evaluation-runs?started_after=…` is refused at routing with 405 and never forwarded. The Next route is the sole reader, so one clamp suffices.

`tests/rest/test_public_eval_gateway_security.py::TestNoUngatedRetentionRead` makes that executable rather than a claim in a description — asserting the allowlist is write-only and reads are refused before any forward, with a failure message naming `clamp_retention_window` as the prerequisite for adding one. **A guard, not a regression test:** it passes on `main` too, and exists to fail the day someone adds a listing GET the Next route never sees.

## Tests

**`evaluations-retention.test.tsx`** (new). `date-filter.test.ts` and `date-filter-select.test.tsx` already cover the lock logic and the control — both in isolation, so neither can see whether the view *passes* the prop, which is the whole defect. This mounts the real view over the real `useRetention` and reads the trigger label. Full matrix: Free locks 30/60/90; Starter locks 60/90; Pro and Enterprise lock nothing; an unknown plan locks like Free; `retentionDays === undefined` (plan loading) locks nothing.

**`runs/route.test.ts`** — 11 new cases: per-plan clamping, Pro/Enterprise pass-through, in-window pass-through, unbounded and unparseable bounds, fail-closed for unknown plan and missing workspace row, the cost/elapsed sort branch, and `started_before` untouched.

Each layer verified by reverting only its own source file (`git stash push -- <path>`):

```
evaluations-view.tsx reverted → Tests  4 failed | 4 passed (8)
runs/route.ts reverted       → Tests  7 failed | 17 passed (24)
     → expected 3884400001 to be less than 5000      # 44.96d = 60d − (15d+1h), Free
     → expected 2588400000 to be less than 5000      # 29.96d = 60d − (30d+1h), Starter
     → expected undefined to be an instance of Date  # unbounded + unparseable
```

The passing cases in each are the must-not-over-lock guards (Pro, Enterprise, loading, in-window), which hold in both directions by design.

After: `Test Files 211 passed (211)` / `Tests 1985 passed (1985)` (full `frontend/ui` vitest); `1559 passed, 5 skipped` (`uv run pytest tests/ -q`); ruff, ESLint and Prettier clean. `tsc --noEmit` reports six errors, all pre-existing on `main` in untouched files; CI does not run it.

## Deliberately not included

**The widget-builder preview presets** (`WidgetBuilderPage.tsx:548`) — flagged as secondary in #1987; a different defect with a different fix. It does not serve out-of-window data: the builder renders its own `DropdownMenu` over `RANGE_PRESETS` rather than `DateFilterSelect`, so there is no prop to pass, and its preview query is already clamped server-side (`backend/rest/routers/dashboards.py:144`). Picking 90d on Free returns 15 days under a "Last 90 days" label — misleading, not privileged. A wrinkle for that change: `handleRangePick` writes the preset into the shared project date-filter store (`:122-125`), which the dashboard and trace list re-clamp, so the user's stored selection silently changes underneath them. A proper fix filters the presets *and* refuses to persist an out-of-window id.

**By-id reads of evaluation runs.** `.../evaluations/runs/[runId]` and the compare route have no `enforce_retention_by_time` analogue. With the list clamped there is no UI path to an out-of-window run id, so this is not part of the reported bug, but it is the same shape and the natural follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Plan-gates the Evaluations date range and clamps the runs list to each workspace’s retention window to close an entitlement leak. Previously any workspace could pick 30/60/90 days and the API served it; now out‑of‑window presets are locked, an over‑wide pick collapses once the plan resolves, and the server bounds started_after.

- UI: `EvaluationsView` passes `retentionDays`/`onUpgradeClick` from `useRetention` to `DateFilterSelect`, mounts `PricingDialog`, and passes `hasSubscription` to route upgrades correctly. Derives the active range with `clampDateFilter` so a pre‑load 90d pick collapses to the plan window when retention lands. Uses `toPlanType` in `@traceroot/core` to normalize unknown `billingPlan` values to Free.
- API: `GET /api/projects/[projectId]/evaluations/runs` clamps `started_after` using `workspace.billingPlan` (fallback Free). Missing/unparseable bounds resolve to the cutoff; `started_before` is unchanged. Clamp applies on both sort branches; Free 15d, Starter 30d, Pro 90d, Enterprise unlimited; includes the standard 1‑hour buffer.
- Public gateway: `evaluation-runs` remains write‑only; tests assert no ungated read path and note that any future read must apply `rest.retention.clamp_retention_window`.
- Tests: cover UI locking, applied preset → `started_after`, collapse after retention resolves, per‑plan clamping and edge cases, and billing helpers (plan normalization and subscription state).

<sup>Written for commit 079339f8df9d5d3e65fe0370294274bae6d67f96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

