### PR TITLE
feat(examples): add runnable offline-eval examples (Python + TypeScript)

### DIFF
--- a/docs/evals/get-started.mdx
+++ b/docs/evals/get-started.mdx
@@ -149,3 +149,16 @@ TRACEROOT_HOST_URL=https://app.traceroot.ai  # or your self-hosted URL
     Per-metric summaries and per-case results.
   </Card>
 </CardGroup>
+
+## Run the example
+
+Clone the repo and run a complete tool-agent eval end-to-end.
+
+<CardGroup cols={2}>
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/agent-eval">
+    Run the Python example
+  </Card>
+  <Card title="TypeScript" icon="js" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/typescript/agent-eval">
+    Run the TypeScript example
+  </Card>
+</CardGroup>

--- a/examples/python/agent-eval/.env.example
+++ b/examples/python/agent-eval/.env.example
@@ -1,0 +1,10 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# OpenAI — powers the agent (gpt-4o-mini)
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Anthropic — powers the answer_is_grounded LLM judge (claude-haiku-4-5)
+ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/examples/python/agent-eval/.env.example
+++ b/examples/python/agent-eval/.env.example
@@ -3,8 +3,5 @@ TRACEROOT_API_KEY=your_traceroot_api_key_here
 # Override to send traces to a local dev server instead of app.traceroot.ai
 # TRACEROOT_HOST_URL=http://localhost:8000
 
-# OpenAI — powers the agent (gpt-4o-mini)
+# OpenAI
 OPENAI_API_KEY=your_openai_api_key_here
-
-# Anthropic — powers the answer_is_grounded LLM judge (claude-haiku-4-5)
-ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/examples/python/agent-eval/README.md
+++ b/examples/python/agent-eval/README.md
@@ -37,7 +37,7 @@ The dataset (`dataset.py`) has four tool-use cases with exact facts, e.g. NVDA a
 
 By default the run reports to TraceRoot using the same credentials as the tracing SDK (`TRACEROOT_API_KEY`, optional `TRACEROOT_HOST_URL`). `main.py` prints the run's dashboard URL when it's available.
 
-No credentials? `main.py` handles it automatically: when `TRACEROOT_API_KEY` is unset it passes `local=True` to `evaluate()` for you, so the eval runs in full and reports nowhere. This lets you clone and run without an API key (you still need `OPENAI_API_KEY` for the agent and `ANTHROPIC_API_KEY` for the judge).
+No credentials? `main.py` handles it automatically: when `TRACEROOT_API_KEY` is unset it passes `local=True` to `evaluate()` for you, so the eval runs in full and reports nowhere. This lets you clone and run without a TraceRoot API key (you still need `OPENAI_API_KEY` for the agent and `ANTHROPIC_API_KEY` for the judge — `local` only turns off TraceRoot reporting, not the LLM calls).
 
 ## Cross-SDK convergence
 

--- a/examples/python/agent-eval/README.md
+++ b/examples/python/agent-eval/README.md
@@ -37,7 +37,7 @@ The dataset (`dataset.py`) has four tool-use cases with exact facts, e.g. NVDA a
 
 By default the run reports to TraceRoot using the same credentials as the tracing SDK (`TRACEROOT_API_KEY`, optional `TRACEROOT_HOST_URL`). `main.py` prints the run's dashboard URL when it's available.
 
-No credentials? Pass `local=True` to `evaluate()` in `main.py` — it runs the eval in full and reports nowhere, so you can try it without an API key (you still need `OPENAI_API_KEY` for the agent and `ANTHROPIC_API_KEY` for the judge).
+No credentials? `main.py` handles it automatically: when `TRACEROOT_API_KEY` is unset it passes `local=True` to `evaluate()` for you, so the eval runs in full and reports nowhere. This lets you clone and run without an API key (you still need `OPENAI_API_KEY` for the agent and `ANTHROPIC_API_KEY` for the judge).
 
 ## Cross-SDK convergence
 
@@ -45,7 +45,7 @@ No credentials? Pass `local=True` to `evaluate()` in `main.py` — it runs the e
 
 ## Environment
 
-- `TRACEROOT_API_KEY` — reports the run (omit when using `local=True`)
+- `TRACEROOT_API_KEY` — reports the run (omit it and `main.py` runs locally instead)
 - `TRACEROOT_HOST_URL` — optional; self-hosted or local dev server
 - `OPENAI_API_KEY` — the agent's model (`gpt-4o-mini`)
 - `ANTHROPIC_API_KEY` — the `answer_is_grounded` judge (`claude-haiku-4-5`)

--- a/examples/python/agent-eval/README.md
+++ b/examples/python/agent-eval/README.md
@@ -1,6 +1,6 @@
 # Agent Eval (Python)
 
-An offline eval of a tool-using [pydantic-ai](https://ai.pydantic.dev) agent, scored with [TraceRoot](https://traceroot.ai). Three scorers — two code checks and an `answer_is_grounded` LLM judge — run over four tool-use cases whose data is fixed, so every question has an exact ground-truth answer (NVDA at `495.20`, a 10% rise to `544.72`). Mirror of [`examples/typescript/agent-eval`](../../typescript/agent-eval), so both runs converge into one history.
+An offline eval of a tool-using [pydantic-ai](https://ai.pydantic.dev) agent, scored with [TraceRoot](https://traceroot.ai) over four tool-use cases whose data is fixed, so every question has an exact ground-truth answer (NVDA at `495.20`, a 10% rise to `544.72`). Mirror of [`examples/typescript/agent-eval`](../../typescript/agent-eval), so both runs converge into one history.
 
 ## Setup
 
@@ -20,3 +20,13 @@ python main.py
 ```
 
 By default the run reports to TraceRoot; with no `TRACEROOT_API_KEY` set, `main.py` runs locally and reports nowhere (you still need `OPENAI_API_KEY` for the agent and judge).
+
+## What it does
+
+Runs four tool-use cases through the agent, then scores each with:
+
+- `calls_expected_tools` (code) — did the agent call the tools the case expects?
+- `reports_expected_facts` (code) — does the answer state the expected numbers?
+- `answer_is_grounded` (LLM judge) — does it give concrete values, not a hedge?
+
+The tools (`get_stock_price`, `calculate`) return fixed data, so every case has an exact answer. `traceroot.initialize()` traces the agent's model and tool calls, and `evaluate()` runs each case as its own trace and reports the run.

--- a/examples/python/agent-eval/README.md
+++ b/examples/python/agent-eval/README.md
@@ -1,0 +1,51 @@
+# Agent Eval (Python)
+
+An offline eval of a tool-using agent, built with [pydantic-ai](https://ai.pydantic.dev) and [TraceRoot](https://traceroot.ai). The agent looks up stock prices and does arithmetic with tools whose data is fixed, so every question has an exact ground-truth answer.
+
+This is the mirror of [`examples/typescript/agent-eval`](../../typescript/agent-eval): the same four questions and expected facts, so the two runs converge into one history.
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in your API keys
+```
+
+With `uv` (recommended):
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+```
+
+Or with pip:
+```bash
+pip install -r requirements.txt
+python main.py
+```
+
+## What it evaluates
+
+The agent (`agent.py`) exposes `run_agent({"question": ...}) -> {"answer", "tools_used", "steps"}`. `main.py` scores each case three ways:
+
+| Scorer | Kind | Checks |
+|--------|------|--------|
+| `calls_expected_tools` | code | The agent called the tools the case expects |
+| `reports_expected_facts` | code | The answer states the exact expected numbers (via `mentions()`) |
+| `answer_is_grounded` | LLM judge (`claude-haiku-4-5`) | The answer gives concrete values rather than hedging |
+
+The dataset (`dataset.py`) has four tool-use cases with exact facts, e.g. NVDA at `495.20` and a 10% rise to `544.72`.
+
+## Reporting
+
+By default the run reports to TraceRoot using the same credentials as the tracing SDK (`TRACEROOT_API_KEY`, optional `TRACEROOT_HOST_URL`). `main.py` prints the run's dashboard URL when it's available.
+
+No credentials? Pass `local=True` to `evaluate()` in `main.py` — it runs the eval in full and reports nowhere, so you can try it without an API key (you still need `OPENAI_API_KEY` for the agent and `ANTHROPIC_API_KEY` for the judge).
+
+## Cross-SDK convergence
+
+`main.py` sets `evaluation_key="agent-tool-eval"` and the dataset uses the same name and key as the TypeScript example. Running both SDKs against that shared identity groups the two runs under one evaluation, so you can diff a Python candidate against a TypeScript one in a single history.
+
+## Environment
+
+- `TRACEROOT_API_KEY` — reports the run (omit when using `local=True`)
+- `TRACEROOT_HOST_URL` — optional; self-hosted or local dev server
+- `OPENAI_API_KEY` — the agent's model (`gpt-4o-mini`)
+- `ANTHROPIC_API_KEY` — the `answer_is_grounded` judge (`claude-haiku-4-5`)

--- a/examples/python/agent-eval/README.md
+++ b/examples/python/agent-eval/README.md
@@ -1,8 +1,6 @@
 # Agent Eval (Python)
 
-An offline eval of a tool-using agent, built with [pydantic-ai](https://ai.pydantic.dev) and [TraceRoot](https://traceroot.ai). The agent looks up stock prices and does arithmetic with tools whose data is fixed, so every question has an exact ground-truth answer.
-
-This is the mirror of [`examples/typescript/agent-eval`](../../typescript/agent-eval): the same four questions and expected facts, so the two runs converge into one history.
+An offline eval of a tool-using [pydantic-ai](https://ai.pydantic.dev) agent, scored with [TraceRoot](https://traceroot.ai). Three scorers — two code checks and an `answer_is_grounded` LLM judge — run over four tool-use cases whose data is fixed, so every question has an exact ground-truth answer (NVDA at `495.20`, a 10% rise to `544.72`). Mirror of [`examples/typescript/agent-eval`](../../typescript/agent-eval), so both runs converge into one history.
 
 ## Setup
 
@@ -21,31 +19,4 @@ pip install -r requirements.txt
 python main.py
 ```
 
-## What it evaluates
-
-The agent (`agent.py`) exposes `run_agent({"question": ...}) -> {"answer", "tools_used", "steps"}`. `main.py` scores each case three ways:
-
-| Scorer | Kind | Checks |
-|--------|------|--------|
-| `calls_expected_tools` | code | The agent called the tools the case expects |
-| `reports_expected_facts` | code | The answer states the exact expected numbers (via `mentions()`) |
-| `answer_is_grounded` | LLM judge (`claude-haiku-4-5`) | The answer gives concrete values rather than hedging |
-
-The dataset (`dataset.py`) has four tool-use cases with exact facts, e.g. NVDA at `495.20` and a 10% rise to `544.72`.
-
-## Reporting
-
-By default the run reports to TraceRoot using the same credentials as the tracing SDK (`TRACEROOT_API_KEY`, optional `TRACEROOT_HOST_URL`). `main.py` prints the run's dashboard URL when it's available.
-
-No credentials? `main.py` handles it automatically: when `TRACEROOT_API_KEY` is unset it passes `local=True` to `evaluate()` for you, so the eval runs in full and reports nowhere. This lets you clone and run without a TraceRoot API key (you still need `OPENAI_API_KEY` for the agent and `ANTHROPIC_API_KEY` for the judge — `local` only turns off TraceRoot reporting, not the LLM calls).
-
-## Cross-SDK convergence
-
-`main.py` sets `evaluation_key="agent-tool-eval"` and the dataset uses the same name and key as the TypeScript example. Running both SDKs against that shared identity groups the two runs under one evaluation, so you can diff a Python candidate against a TypeScript one in a single history.
-
-## Environment
-
-- `TRACEROOT_API_KEY` — reports the run (omit it and `main.py` runs locally instead)
-- `TRACEROOT_HOST_URL` — optional; self-hosted or local dev server
-- `OPENAI_API_KEY` — the agent's model (`gpt-4o-mini`)
-- `ANTHROPIC_API_KEY` — the `answer_is_grounded` judge (`claude-haiku-4-5`)
+By default the run reports to TraceRoot; with no `TRACEROOT_API_KEY` set, `main.py` runs locally and reports nowhere (you still need `OPENAI_API_KEY` for the agent and judge).

--- a/examples/python/agent-eval/agent.py
+++ b/examples/python/agent-eval/agent.py
@@ -1,13 +1,8 @@
 """
 Tool-using research agent (pydantic-ai) — the system under evaluation.
 
-A trimmed, self-contained version of the Pydantic AI tool agent. It exposes a
-single clean callable, `run_agent`, that answers a question by calling tools and
-returns a structured result. The tools use FIXED data, so every question has an
-exact ground-truth answer (e.g. NVDA is 495.20, and a 10% rise is 544.72).
-
-This module knows NOTHING about evaluation. It is a plain agent that could run in
-production unchanged; `main.py` is what points an eval at it.
+Exposes `run_agent`, which answers a question by calling tools over FIXED data, so
+every question has an exact ground-truth answer (NVDA is 495.20, a 10% rise 544.72).
 """
 
 from pydantic_ai import Agent

--- a/examples/python/agent-eval/agent.py
+++ b/examples/python/agent-eval/agent.py
@@ -1,0 +1,123 @@
+"""
+Tool-using research agent (pydantic-ai) — the system under evaluation.
+
+A trimmed, self-contained version of the Pydantic AI tool agent. It exposes a
+single clean callable, `run_agent`, that answers a question by calling tools and
+returns a structured result. The tools use FIXED data, so every question has an
+exact ground-truth answer (e.g. NVDA is 495.20, and a 10% rise is 544.72).
+
+This module knows NOTHING about evaluation. It is a plain agent that could run in
+production unchanged; `main.py` is what points an eval at it.
+"""
+
+from pydantic_ai import Agent
+
+# ---------------------------------------------------------------------------
+# Agent & tools
+# ---------------------------------------------------------------------------
+# Deterministic settings (temperature=0) so the same question yields the same
+# tool calls and answer from run to run.
+
+agent = Agent(
+    "openai-chat:gpt-4o-mini",
+    model_settings={"temperature": 0.0},
+    system_prompt=(
+        "You are a financial research assistant. Use the available tools to look "
+        "up stock prices and to perform any arithmetic. Never compute prices or do "
+        "math from memory — always call the calculate tool. Report concrete numbers "
+        "and keep your answer concise."
+    ),
+)
+
+# Fixed prices — the ground truth the dataset is written against.
+_STOCKS = {
+    "AAPL": {"price": 178.50, "change": +2.30, "percent": "+1.3%"},
+    "GOOGL": {"price": 141.20, "change": -0.80, "percent": "-0.6%"},
+    "MSFT": {"price": 378.90, "change": +4.50, "percent": "+1.2%"},
+    "NVDA": {"price": 495.20, "change": +12.30, "percent": "+2.5%"},
+    "META": {"price": 512.40, "change": +8.10, "percent": "+1.6%"},
+}
+
+
+@agent.tool_plain
+def get_stock_price(symbol: str) -> dict:
+    """Get the current stock price for a ticker symbol."""
+    data = _STOCKS.get(symbol.upper(), {"price": 0.0, "change": 0.0, "percent": "N/A"})
+    return {"symbol": symbol.upper(), **data}
+
+
+@agent.tool_plain
+def calculate(expression: str) -> dict:
+    """Evaluate a mathematical expression safely."""
+    import ast
+    import operator
+
+    ops = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+    }
+
+    def _eval(node):
+        if isinstance(node, ast.Expression):
+            return _eval(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        if isinstance(node, ast.BinOp) and type(node.op) in ops:
+            return ops[type(node.op)](_eval(node.left), _eval(node.right))
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return -_eval(node.operand)
+        raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+    try:
+        result = _eval(ast.parse(expression, mode="eval"))
+        return {"expression": expression, "result": result}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Clean callable for callers (and for the eval task)
+# ---------------------------------------------------------------------------
+
+
+def _inspect_run(result) -> tuple[list[str], int]:
+    """Pull the tools called and the number of model steps from a run result.
+
+    Duck-typed against pydantic-ai's message parts so it survives minor version
+    changes: a tool call is any part whose ``part_kind`` is ``"tool-call"``; a
+    model step is any message that carried a text or tool-call part.
+    """
+    tools_used: list[str] = []
+    steps = 0
+    for message in result.all_messages():
+        produced_output = False
+        for part in getattr(message, "parts", []):
+            kind = getattr(part, "part_kind", "")
+            if kind == "tool-call":
+                name = getattr(part, "tool_name", None)
+                if name and name not in tools_used:
+                    tools_used.append(name)
+                produced_output = True
+            elif kind == "text":
+                produced_output = True
+        if produced_output:
+            steps += 1
+    return tools_used, steps
+
+
+def run_agent(input: dict) -> dict:
+    """Answer a question with the tool agent.
+
+    input:  {"question": "<a question whose answer is an exact value>"}
+    output: {"answer": <str>, "tools_used": <list[str]>, "steps": <int>}
+    """
+    question = input["question"]
+    result = agent.run_sync(question)
+    tools_used, steps = _inspect_run(result)
+    return {
+        "answer": str(result.output),
+        "tools_used": tools_used,
+        "steps": steps,
+    }

--- a/examples/python/agent-eval/dataset.py
+++ b/examples/python/agent-eval/dataset.py
@@ -1,22 +1,24 @@
 """
 Dataset for the tool-agent eval.
 
-A dataset file is a checkable artifact. Each case is content-addressed — its id is
-`tc_` + sha256 over the case's input/expected — so inserting or reordering cases
-never renumbers the others, and the dataset's own id is `ds_` + sha256 over its
-key. Because the ids are derived from content, the same case authored in two SDKs
-produces the same bytes.
+A dataset file is a checkable artifact. Each case here is given an EXPLICIT id
+(`single-stock-lookup`, ...) that is byte-identical to its twin in the TypeScript
+dataset, so the two SDKs' cases pair one-for-one regardless of any content
+differences. (Without an explicit id the SDK content-addresses a case as `tc_` +
+sha256 over the case's INPUT only — not its `expected` — so the snake_case vs
+camelCase tool names below would NOT have split the ids; pinning explicit ids just
+makes that pairing guaranteed and obvious rather than incidental.) The dataset's
+own id is `ds_` + sha256 over its key.
 
 This dataset is deliberately kept PARALLEL with the TypeScript one in
 `examples/typescript/agent-eval/dataset.ts`: the four questions and their expected
 `facts` are identical; only the `tools` names differ, because each SDK names its
 tools idiomatically (`get_stock_price` here, `getStockPrice` there). Running both
-with the same dataset name + key + `evaluation_key` makes the two runs converge
-into ONE diffable history on the platform — here that convergence is real, not
-just a capability we could use.
+with the same dataset name + key + `evaluation_key` — and the shared explicit case
+ids — makes the two runs converge into ONE diffable history on the platform.
 
 (This file is NOT byte-identical to the TypeScript one — different language, and
-tool names differ — but it is its deliberate mirror.)
+tool names differ — but it is its deliberate mirror, and the case ids match.)
 """
 
 import re
@@ -35,6 +37,7 @@ def dataset() -> Dataset:
     ds.add(
         {"question": "What is the current stock price of NVDA?"},
         expected={"tools": ["get_stock_price"], "facts": [495.20]},
+        id="single-stock-lookup",
     )
 
     # 2. Lookup + calculation. 495.20 x 1.1 = 544.72.
@@ -44,18 +47,21 @@ def dataset() -> Dataset:
             "what would the new price be?"
         },
         expected={"tools": ["get_stock_price", "calculate"], "facts": [544.72]},
+        id="stock-rise-percent",
     )
 
     # 3. Two lookups, no math. NVDA 495.20 and MSFT 378.90.
     ds.add(
         {"question": "Compare the current prices of NVDA and MSFT. Give both numbers."},
         expected={"tools": ["get_stock_price"], "facts": [495.20, 378.90]},
+        id="two-stock-compare",
     )
 
     # 4. Lookup + calculation. 3 x 378.90 = 1136.70.
     ds.add(
         {"question": "How much would 3 shares of MSFT cost at the current price?"},
         expected={"tools": ["get_stock_price", "calculate"], "facts": [1136.70]},
+        id="shares-total-cost",
     )
 
     return ds

--- a/examples/python/agent-eval/dataset.py
+++ b/examples/python/agent-eval/dataset.py
@@ -1,24 +1,11 @@
 """
-Dataset for the tool-agent eval.
+Dataset for the tool-agent eval — four tool-use cases with exact expected facts.
 
-A dataset file is a checkable artifact. Each case here is given an EXPLICIT id
-(`single-stock-lookup`, ...) that is byte-identical to its twin in the TypeScript
-dataset, so the two SDKs' cases pair one-for-one regardless of any content
-differences. (Without an explicit id the SDK content-addresses a case as `tc_` +
-sha256 over the case's INPUT only — not its `expected` — so the snake_case vs
-camelCase tool names below would NOT have split the ids; pinning explicit ids just
-makes that pairing guaranteed and obvious rather than incidental.) The dataset's
-own id is `ds_` + sha256 over its key.
-
-This dataset is deliberately kept PARALLEL with the TypeScript one in
-`examples/typescript/agent-eval/dataset.ts`: the four questions and their expected
-`facts` are identical; only the `tools` names differ, because each SDK names its
-tools idiomatically (`get_stock_price` here, `getStockPrice` there). Running both
-with the same dataset name + key + `evaluation_key` — and the shared explicit case
-ids — makes the two runs converge into ONE diffable history on the platform.
-
-(This file is NOT byte-identical to the TypeScript one — different language, and
-tool names differ — but it is its deliberate mirror, and the case ids match.)
+Kept PARALLEL with the TypeScript dataset in
+`examples/typescript/agent-eval/dataset.ts`: same questions and `facts`, only the
+tool names differ per SDK idiom (`get_stock_price` here, `getStockPrice` there).
+Each case has an EXPLICIT id matching its twin one-for-one, so running both under
+the same name + key + `evaluation_key` converges into ONE diffable history.
 """
 
 import re

--- a/examples/python/agent-eval/dataset.py
+++ b/examples/python/agent-eval/dataset.py
@@ -1,0 +1,77 @@
+"""
+Dataset for the tool-agent eval.
+
+A dataset file is a checkable artifact. Each case is content-addressed — its id is
+`tc_` + sha256 over the case's input/expected — so inserting or reordering cases
+never renumbers the others, and the dataset's own id is `ds_` + sha256 over its
+key. Because the ids are derived from content, the same case authored in two SDKs
+produces the same bytes.
+
+This dataset is deliberately kept PARALLEL with the TypeScript one in
+`examples/typescript/agent-eval/dataset.ts`: the four questions and their expected
+`facts` are identical; only the `tools` names differ, because each SDK names its
+tools idiomatically (`get_stock_price` here, `getStockPrice` there). Running both
+with the same dataset name + key + `evaluation_key` makes the two runs converge
+into ONE diffable history on the platform — here that convergence is real, not
+just a capability we could use.
+
+(This file is NOT byte-identical to the TypeScript one — different language, and
+tool names differ — but it is its deliberate mirror.)
+"""
+
+import re
+
+from traceroot import Dataset
+
+DATASET_NAME = "Agent tool eval"
+DATASET_KEY = "agent-tool-eval"
+
+
+def dataset() -> Dataset:
+    """Build the tool-use dataset with four cases and exact expected facts."""
+    ds = Dataset(DATASET_NAME, key=DATASET_KEY)
+
+    # 1. Single stock lookup. NVDA is fixed at 495.20.
+    ds.add(
+        {"question": "What is the current stock price of NVDA?"},
+        expected={"tools": ["get_stock_price"], "facts": [495.20]},
+    )
+
+    # 2. Lookup + calculation. 495.20 x 1.1 = 544.72.
+    ds.add(
+        {
+            "question": "NVDA is climbing. If it rises 10% from its current price, "
+            "what would the new price be?"
+        },
+        expected={"tools": ["get_stock_price", "calculate"], "facts": [544.72]},
+    )
+
+    # 3. Two lookups, no math. NVDA 495.20 and MSFT 378.90.
+    ds.add(
+        {"question": "Compare the current prices of NVDA and MSFT. Give both numbers."},
+        expected={"tools": ["get_stock_price"], "facts": [495.20, 378.90]},
+    )
+
+    # 4. Lookup + calculation. 3 x 378.90 = 1136.70.
+    ds.add(
+        {"question": "How much would 3 shares of MSFT cost at the current price?"},
+        expected={"tools": ["get_stock_price", "calculate"], "facts": [1136.70]},
+    )
+
+    return ds
+
+
+def mentions(text, value) -> bool:
+    """True if `text` contains the number `value`.
+
+    Tolerates formatting: thousands separators are stripped, and trailing-zero
+    differences match (1136.7, 1136.70, "$1,136.70" all match 1136.70).
+    """
+    cleaned = str(text).replace(",", "")
+    for token in re.findall(r"-?\d+\.?\d*", cleaned):
+        try:
+            if abs(float(token) - float(value)) < 1e-6:
+                return True
+        except ValueError:
+            continue
+    return False

--- a/examples/python/agent-eval/main.py
+++ b/examples/python/agent-eval/main.py
@@ -14,6 +14,7 @@ passes local=True to evaluate() so the eval runs in full and reports nowhere.
 """
 
 import os
+import sys
 
 from dotenv import find_dotenv, load_dotenv
 
@@ -106,4 +107,11 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        # A failed eval run must exit non-zero so CI / shell callers can detect it.
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)

--- a/examples/python/agent-eval/main.py
+++ b/examples/python/agent-eval/main.py
@@ -1,16 +1,8 @@
 """
-Offline eval for the tool agent.
+Offline eval for the tool agent: three scorers over the dataset, one run.
 
-Points three scorers at the agent from `agent.py` over the dataset in
-`dataset.py`, runs every case, and reports the run to TraceRoot.
-
-Run:
-    cp .env.example .env   # fill in your keys
-    uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
-    # or:  pip install -r requirements.txt && python main.py
-
-No creds? This runs locally on its own: with no TRACEROOT_API_KEY set, `main()`
-passes local=True to evaluate() so the eval runs in full and reports nowhere.
+Run `cp .env.example .env`, then `python main.py` (or the `uv run` line in the
+README). With no TRACEROOT_API_KEY set the run stays local and reports nowhere.
 """
 
 import os
@@ -64,7 +56,7 @@ def reports_expected_facts(ctx):
 
 answer_is_grounded = Scorer.llm_judge(
     name="answer_is_grounded",
-    model="claude-haiku-4-5",
+    model="gpt-4o-mini",
     messages=[
         {
             "role": "system",

--- a/examples/python/agent-eval/main.py
+++ b/examples/python/agent-eval/main.py
@@ -1,0 +1,103 @@
+"""
+Offline eval for the tool agent.
+
+Points three scorers at the agent from `agent.py` over the dataset in
+`dataset.py`, runs every case, and reports the run to TraceRoot.
+
+Run:
+    cp .env.example .env   # fill in your keys
+    uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+    # or:  pip install -r requirements.txt && python main.py
+
+No creds? Pass local=True to evaluate() (see README) to run in full and report
+nowhere.
+"""
+
+from dotenv import find_dotenv, load_dotenv
+
+load_dotenv(find_dotenv())
+
+# Initialize TraceRoot BEFORE importing the agent so pydantic-ai is instrumented.
+import traceroot
+from traceroot import Integration, Scorer, evaluate
+
+traceroot.initialize(integrations=[Integration.PYDANTIC_AI])
+
+from agent import run_agent
+from dataset import dataset, mentions
+
+# ── Scorers ─────────────────────────────────────────────────────────────────
+
+
+@Scorer.code(
+    key="calls_expected_tools",
+    value_type="numeric",
+    direction="higher_is_better",
+    threshold=1.0,
+)
+def calls_expected_tools(ctx):
+    """Fraction of the expected tools the agent actually called."""
+    expected = ctx.expected["tools"]
+    used = set(ctx.output.get("tools_used", []))
+    if not expected:
+        return 1.0
+    return sum(tool in used for tool in expected) / len(expected)
+
+
+@Scorer.code(
+    key="reports_expected_facts",
+    value_type="numeric",
+    direction="higher_is_better",
+    threshold=1.0,
+)
+def reports_expected_facts(ctx):
+    """Fraction of the expected facts the answer states (number-matched)."""
+    facts = ctx.expected["facts"]
+    answer = ctx.output.get("answer", "")
+    if not facts:
+        return 1.0
+    return sum(mentions(answer, fact) for fact in facts) / len(facts)
+
+
+answer_is_grounded = Scorer.llm_judge(
+    name="answer_is_grounded",
+    model="claude-haiku-4-5",
+    messages=[
+        {
+            "role": "system",
+            "content": (
+                "You grade whether an ANSWER gives concrete, specific values for "
+                "the TASK. Reply with exactly 1.0 if the answer states concrete "
+                "numbers that address the task, or 0.0 if it is empty, hedged, or "
+                "refuses. Reply with only the number."
+            ),
+        },
+        {"role": "user", "content": "TASK:\n{{input}}\n\nANSWER:\n{{output}}"},
+    ],
+    value_type="numeric",
+    threshold=1.0,
+)
+
+
+# ── Run ─────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    result = evaluate(
+        name="Agent tool eval",
+        dataset=dataset(),
+        task=run_agent,
+        scorers=[calls_expected_tools, reports_expected_facts, answer_is_grounded],
+        candidate_version="gpt-4o-mini",
+        evaluation_key="agent-tool-eval",
+    )
+    print(result.summary())
+
+    upload = getattr(result, "upload_state", None)
+    url = getattr(upload, "dashboard_url", None)
+    if url:
+        print(f"\nView the run: {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/agent-eval/main.py
+++ b/examples/python/agent-eval/main.py
@@ -9,9 +9,11 @@ Run:
     uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
     # or:  pip install -r requirements.txt && python main.py
 
-No creds? Pass local=True to evaluate() (see README) to run in full and report
-nowhere.
+No creds? This runs locally on its own: with no TRACEROOT_API_KEY set, `main()`
+passes local=True to evaluate() so the eval runs in full and reports nowhere.
 """
+
+import os
 
 from dotenv import find_dotenv, load_dotenv
 
@@ -83,6 +85,9 @@ answer_is_grounded = Scorer.llm_judge(
 
 
 def main() -> None:
+    # No TraceRoot key? Run locally — execute every case in full but report
+    # nowhere — so a fresh clone works without a TraceRoot credential.
+    local = not os.getenv("TRACEROOT_API_KEY")
     result = evaluate(
         name="Agent tool eval",
         dataset=dataset(),
@@ -90,6 +95,7 @@ def main() -> None:
         scorers=[calls_expected_tools, reports_expected_facts, answer_is_grounded],
         candidate_version="gpt-4o-mini",
         evaluation_key="agent-tool-eval",
+        local=local,
     )
     print(result.summary())
 

--- a/examples/python/agent-eval/main.py
+++ b/examples/python/agent-eval/main.py
@@ -87,8 +87,10 @@ answer_is_grounded = Scorer.llm_judge(
 
 def main() -> None:
     # No TraceRoot key? Run locally — execute every case in full but report
-    # nowhere — so a fresh clone works without a TraceRoot credential.
-    local = not os.getenv("TRACEROOT_API_KEY")
+    # nowhere — so a fresh clone works without a TraceRoot credential. The
+    # unedited .env.example placeholder counts as "no key" too.
+    api_key = (os.getenv("TRACEROOT_API_KEY") or "").strip()
+    local = api_key in ("", "your_traceroot_api_key_here")
     result = evaluate(
         name="Agent tool eval",
         dataset=dataset(),

--- a/examples/python/agent-eval/requirements.txt
+++ b/examples/python/agent-eval/requirements.txt
@@ -1,0 +1,5 @@
+pydantic-ai>=0.2.0
+openai>=1.0.0
+python-dotenv>=1.0.0
+
+traceroot>=0.2.0

--- a/examples/typescript/agent-eval/.env.example
+++ b/examples/typescript/agent-eval/.env.example
@@ -1,0 +1,10 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# OpenAI — powers the agent (gpt-4o-mini)
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Anthropic — powers the answer_is_grounded LLM judge (claude-haiku-4-5)
+ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/examples/typescript/agent-eval/.env.example
+++ b/examples/typescript/agent-eval/.env.example
@@ -3,8 +3,5 @@ TRACEROOT_API_KEY=your_traceroot_api_key_here
 # Override to send traces to a local dev server instead of app.traceroot.ai
 # TRACEROOT_HOST_URL=http://localhost:8000
 
-# OpenAI — powers the agent (gpt-4o-mini)
+# OpenAI
 OPENAI_API_KEY=your_openai_api_key_here
-
-# Anthropic — powers the answer_is_grounded LLM judge (claude-haiku-4-5)
-ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/examples/typescript/agent-eval/README.md
+++ b/examples/typescript/agent-eval/README.md
@@ -34,7 +34,7 @@ The dataset (`dataset.ts`) has four tool-use cases with exact facts, e.g. NVDA a
 
 By default the run reports to TraceRoot using the same credentials as the tracing SDK (`TRACEROOT_API_KEY`, optional `TRACEROOT_HOST_URL`). `main.ts` prints the run's dashboard URL when it's available.
 
-No credentials? `main.ts` handles it automatically: when `TRACEROOT_API_KEY` is unset it sets `local: true` on the `evaluate()` call for you, so the eval runs in full and reports nowhere. This lets you clone and run without an API key (you still need `OPENAI_API_KEY` for the agent and `ANTHROPIC_API_KEY` for the judge).
+No credentials? `main.ts` handles it automatically: when `TRACEROOT_API_KEY` is unset it sets `local: true` on the `evaluate()` call for you, so the eval runs in full and reports nowhere. This lets you clone and run without a TraceRoot API key (you still need `OPENAI_API_KEY` for the agent and `ANTHROPIC_API_KEY` for the judge — `local` only turns off TraceRoot reporting, not the LLM calls).
 
 ## Cross-SDK convergence
 

--- a/examples/typescript/agent-eval/README.md
+++ b/examples/typescript/agent-eval/README.md
@@ -34,7 +34,7 @@ The dataset (`dataset.ts`) has four tool-use cases with exact facts, e.g. NVDA a
 
 By default the run reports to TraceRoot using the same credentials as the tracing SDK (`TRACEROOT_API_KEY`, optional `TRACEROOT_HOST_URL`). `main.ts` prints the run's dashboard URL when it's available.
 
-No credentials? Set `local: true` on the `evaluate()` call in `main.ts` — it runs the eval in full and reports nowhere, so you can try it without an API key (you still need `OPENAI_API_KEY` for the agent and `ANTHROPIC_API_KEY` for the judge).
+No credentials? `main.ts` handles it automatically: when `TRACEROOT_API_KEY` is unset it sets `local: true` on the `evaluate()` call for you, so the eval runs in full and reports nowhere. This lets you clone and run without an API key (you still need `OPENAI_API_KEY` for the agent and `ANTHROPIC_API_KEY` for the judge).
 
 ## Cross-SDK convergence
 
@@ -42,7 +42,7 @@ No credentials? Set `local: true` on the `evaluate()` call in `main.ts` — it r
 
 ## Environment
 
-- `TRACEROOT_API_KEY` — reports the run (omit when using `local: true`)
+- `TRACEROOT_API_KEY` — reports the run (omit it and `main.ts` runs locally instead)
 - `TRACEROOT_HOST_URL` — optional; self-hosted or local dev server
 - `OPENAI_API_KEY` — the agent's model (`gpt-4o-mini`)
 - `ANTHROPIC_API_KEY` — the `answer_is_grounded` judge (`claude-haiku-4-5`)

--- a/examples/typescript/agent-eval/README.md
+++ b/examples/typescript/agent-eval/README.md
@@ -1,8 +1,6 @@
 # Agent Eval (TypeScript)
 
-An offline eval of a tool-using agent, built with the [Vercel AI SDK](https://sdk.vercel.ai/) and [TraceRoot](https://traceroot.ai). The agent looks up stock prices and does arithmetic with tools whose data is fixed, so every question has an exact ground-truth answer.
-
-This is the mirror of [`examples/python/agent-eval`](../../python/agent-eval): the same four questions and expected facts, so the two runs converge into one history.
+An offline eval of a tool-using [Vercel AI SDK](https://sdk.vercel.ai/) agent, scored with [TraceRoot](https://traceroot.ai). Three scorers — two code checks and an `answer_is_grounded` LLM judge — run over four tool-use cases whose data is fixed, so every question has an exact ground-truth answer (NVDA at `495.20`, a 10% rise to `544.72`). Mirror of [`examples/python/agent-eval`](../../python/agent-eval), so both runs converge into one history.
 
 ## Setup
 
@@ -18,31 +16,4 @@ pnpm start   # main.ts — run the eval
 pnpm agent   # agent.ts — the system under evaluation, on its own
 ```
 
-## What it evaluates
-
-The agent (`agent.ts`) exposes `runAgent({ question }) -> { answer, toolsUsed, steps }`. `main.ts` scores each case three ways:
-
-| Scorer | Kind | Checks |
-|--------|------|--------|
-| `calls_expected_tools` | code | The agent called the tools the case expects |
-| `reports_expected_facts` | code | The answer states the exact expected numbers (via `mentions()`) |
-| `answer_is_grounded` | LLM judge (`claude-haiku-4-5`) | The answer gives concrete values rather than hedging |
-
-The dataset (`dataset.ts`) has four tool-use cases with exact facts, e.g. NVDA at `495.20` and a 10% rise to `544.72`.
-
-## Reporting
-
-By default the run reports to TraceRoot using the same credentials as the tracing SDK (`TRACEROOT_API_KEY`, optional `TRACEROOT_HOST_URL`). `main.ts` prints the run's dashboard URL when it's available.
-
-No credentials? `main.ts` handles it automatically: when `TRACEROOT_API_KEY` is unset it sets `local: true` on the `evaluate()` call for you, so the eval runs in full and reports nowhere. This lets you clone and run without a TraceRoot API key (you still need `OPENAI_API_KEY` for the agent and `ANTHROPIC_API_KEY` for the judge — `local` only turns off TraceRoot reporting, not the LLM calls).
-
-## Cross-SDK convergence
-
-`main.ts` sets `evaluationKey: "agent-tool-eval"` and the dataset uses the same name and key as the Python example. Running both SDKs against that shared identity groups the two runs under one evaluation, so you can diff a TypeScript candidate against a Python one in a single history.
-
-## Environment
-
-- `TRACEROOT_API_KEY` — reports the run (omit it and `main.ts` runs locally instead)
-- `TRACEROOT_HOST_URL` — optional; self-hosted or local dev server
-- `OPENAI_API_KEY` — the agent's model (`gpt-4o-mini`)
-- `ANTHROPIC_API_KEY` — the `answer_is_grounded` judge (`claude-haiku-4-5`)
+By default the run reports to TraceRoot; with no `TRACEROOT_API_KEY` set, `main.ts` runs locally and reports nowhere (you still need `OPENAI_API_KEY` for the agent and judge).

--- a/examples/typescript/agent-eval/README.md
+++ b/examples/typescript/agent-eval/README.md
@@ -1,0 +1,48 @@
+# Agent Eval (TypeScript)
+
+An offline eval of a tool-using agent, built with the [Vercel AI SDK](https://sdk.vercel.ai/) and [TraceRoot](https://traceroot.ai). The agent looks up stock prices and does arithmetic with tools whose data is fixed, so every question has an exact ground-truth answer.
+
+This is the mirror of [`examples/python/agent-eval`](../../python/agent-eval): the same four questions and expected facts, so the two runs converge into one history.
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in your API keys
+pnpm install
+```
+
+## Usage
+
+```bash
+pnpm start   # main.ts — run the eval
+pnpm agent   # agent.ts — the system under evaluation, on its own
+```
+
+## What it evaluates
+
+The agent (`agent.ts`) exposes `runAgent({ question }) -> { answer, toolsUsed, steps }`. `main.ts` scores each case three ways:
+
+| Scorer | Kind | Checks |
+|--------|------|--------|
+| `calls_expected_tools` | code | The agent called the tools the case expects |
+| `reports_expected_facts` | code | The answer states the exact expected numbers (via `mentions()`) |
+| `answer_is_grounded` | LLM judge (`claude-haiku-4-5`) | The answer gives concrete values rather than hedging |
+
+The dataset (`dataset.ts`) has four tool-use cases with exact facts, e.g. NVDA at `495.20` and a 10% rise to `544.72`.
+
+## Reporting
+
+By default the run reports to TraceRoot using the same credentials as the tracing SDK (`TRACEROOT_API_KEY`, optional `TRACEROOT_HOST_URL`). `main.ts` prints the run's dashboard URL when it's available.
+
+No credentials? Set `local: true` on the `evaluate()` call in `main.ts` — it runs the eval in full and reports nowhere, so you can try it without an API key (you still need `OPENAI_API_KEY` for the agent and `ANTHROPIC_API_KEY` for the judge).
+
+## Cross-SDK convergence
+
+`main.ts` sets `evaluationKey: "agent-tool-eval"` and the dataset uses the same name and key as the Python example. Running both SDKs against that shared identity groups the two runs under one evaluation, so you can diff a TypeScript candidate against a Python one in a single history.
+
+## Environment
+
+- `TRACEROOT_API_KEY` — reports the run (omit when using `local: true`)
+- `TRACEROOT_HOST_URL` — optional; self-hosted or local dev server
+- `OPENAI_API_KEY` — the agent's model (`gpt-4o-mini`)
+- `ANTHROPIC_API_KEY` — the `answer_is_grounded` judge (`claude-haiku-4-5`)

--- a/examples/typescript/agent-eval/README.md
+++ b/examples/typescript/agent-eval/README.md
@@ -1,6 +1,6 @@
 # Agent Eval (TypeScript)
 
-An offline eval of a tool-using [Vercel AI SDK](https://sdk.vercel.ai/) agent, scored with [TraceRoot](https://traceroot.ai). Three scorers — two code checks and an `answer_is_grounded` LLM judge — run over four tool-use cases whose data is fixed, so every question has an exact ground-truth answer (NVDA at `495.20`, a 10% rise to `544.72`). Mirror of [`examples/python/agent-eval`](../../python/agent-eval), so both runs converge into one history.
+An offline eval of a tool-using [Vercel AI SDK](https://sdk.vercel.ai/) agent, scored with [TraceRoot](https://traceroot.ai) over four tool-use cases whose data is fixed, so every question has an exact ground-truth answer (NVDA at `495.20`, a 10% rise to `544.72`). Mirror of [`examples/python/agent-eval`](../../python/agent-eval), so both runs converge into one history.
 
 ## Setup
 
@@ -17,3 +17,13 @@ pnpm agent   # agent.ts — the system under evaluation, on its own
 ```
 
 By default the run reports to TraceRoot; with no `TRACEROOT_API_KEY` set, `main.ts` runs locally and reports nowhere (you still need `OPENAI_API_KEY` for the agent and judge).
+
+## What it does
+
+Runs four tool-use cases through the agent, then scores each with:
+
+- `callsExpectedTools` (code) — did the agent call the tools the case expects?
+- `reportsExpectedFacts` (code) — does the answer state the expected numbers?
+- `answerIsGrounded` (LLM judge) — does it give concrete values, not a hedge?
+
+The tools (`getStockPrice`, `calculate`) return fixed data, so every case has an exact answer. `TraceRoot.initialize()` traces the agent's model and tool calls, and `evaluate()` runs each case as its own trace and reports the run.

--- a/examples/typescript/agent-eval/agent.ts
+++ b/examples/typescript/agent-eval/agent.ts
@@ -1,0 +1,91 @@
+/**
+ * Tool-using research agent (Vercel AI SDK) — the system under evaluation.
+ *
+ * A trimmed, self-contained multi-step tool agent. It exposes a single clean
+ * callable, `runAgent`, that answers a question by calling tools and returns a
+ * structured result. The tools use FIXED data, so every question has an exact
+ * ground-truth answer (e.g. NVDA is 495.20, and a 10% rise is 544.72).
+ *
+ * This module knows NOTHING about evaluation. It is a plain agent that could run
+ * in production unchanged; `main.ts` is what points an eval at it.
+ */
+
+import { generateText, tool, stepCountIs } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { z } from 'zod';
+
+// Fixed prices — the ground truth the dataset is written against.
+const STOCKS: Record<string, { price: number; change: number; percent: string }> = {
+  AAPL: { price: 178.5, change: 2.3, percent: '+1.3%' },
+  GOOGL: { price: 141.2, change: -0.8, percent: '-0.6%' },
+  MSFT: { price: 378.9, change: 4.5, percent: '+1.2%' },
+  NVDA: { price: 495.2, change: 12.3, percent: '+2.5%' },
+  META: { price: 512.4, change: 8.1, percent: '+1.6%' },
+};
+
+const SYSTEM_PROMPT =
+  'You are a financial research assistant. Use the available tools to look up ' +
+  'stock prices and to perform any arithmetic. Never compute prices or do math ' +
+  'from memory — always call the calculate tool. Report concrete numbers and keep ' +
+  'your answer concise.';
+
+export interface AgentResult {
+  answer: string;
+  toolsUsed: string[];
+  steps: number;
+}
+
+export async function runAgent(input: { question: string }): Promise<AgentResult> {
+  const result = await generateText({
+    // openai.chat → Chat Completions API (matches the sibling tracing examples).
+    model: openai.chat('gpt-4o-mini'),
+    // temperature 0 → the same question yields the same tool calls and answer.
+    temperature: 0,
+    stopWhen: stepCountIs(5),
+    system: SYSTEM_PROMPT,
+    prompt: input.question,
+    tools: {
+      getStockPrice: tool({
+        description: 'Get the current stock price for a ticker symbol',
+        inputSchema: z.object({
+          symbol: z.string().describe('Stock ticker symbol e.g. NVDA'),
+        }),
+        execute: async ({ symbol }) => {
+          const upper = symbol.toUpperCase();
+          const data = STOCKS[upper] ?? { price: 0, change: 0, percent: 'N/A' };
+          return { symbol: upper, ...data };
+        },
+      }),
+      calculate: tool({
+        description: 'Evaluate a mathematical expression',
+        inputSchema: z.object({
+          expression: z.string().describe("Math expression e.g. '495.20 * 1.1'"),
+        }),
+        execute: async ({ expression }) => {
+          if (!/^[\d\s+\-*/().]+$/.test(expression)) {
+            return { error: `Unsupported expression: ${expression}` };
+          }
+          try {
+            // eslint-disable-next-line no-new-func
+            const value = Function(`"use strict"; return (${expression})`)() as number;
+            return { expression, result: value };
+          } catch {
+            return { error: `Invalid expression: ${expression}` };
+          }
+        },
+      }),
+    },
+  });
+
+  // Collect the tools called across every step, de-duplicated in call order.
+  const toolsUsed: string[] = [];
+  for (const step of result.steps) {
+    for (const call of step.toolCalls) {
+      if (!toolsUsed.includes(call.toolName)) {
+        toolsUsed.push(call.toolName);
+      }
+    }
+  }
+
+  return { answer: result.text, toolsUsed, steps: result.steps.length };
+}

--- a/examples/typescript/agent-eval/agent.ts
+++ b/examples/typescript/agent-eval/agent.ts
@@ -1,13 +1,8 @@
 /**
  * Tool-using research agent (Vercel AI SDK) — the system under evaluation.
  *
- * A trimmed, self-contained multi-step tool agent. It exposes a single clean
- * callable, `runAgent`, that answers a question by calling tools and returns a
- * structured result. The tools use FIXED data, so every question has an exact
- * ground-truth answer (e.g. NVDA is 495.20, and a 10% rise is 544.72).
- *
- * This module knows NOTHING about evaluation. It is a plain agent that could run
- * in production unchanged; `main.ts` is what points an eval at it.
+ * Exposes `runAgent`, which answers a question by calling tools over FIXED data, so
+ * every question has an exact ground-truth answer (NVDA is 495.20, a 10% rise 544.72).
  */
 
 import { generateText, tool, stepCountIs } from 'ai';

--- a/examples/typescript/agent-eval/agent.ts
+++ b/examples/typescript/agent-eval/agent.ts
@@ -41,6 +41,9 @@ export async function runAgent(input: { question: string }): Promise<AgentResult
     model: openai.chat('gpt-4o-mini'),
     // temperature 0 → the same question yields the same tool calls and answer.
     temperature: 0,
+    // Emit OpenTelemetry model/tool spans so TraceRoot captures the agent's
+    // execution (matches the sibling `examples/typescript/vercel-ai` example).
+    experimental_telemetry: { isEnabled: true },
     stopWhen: stepCountIs(5),
     system: SYSTEM_PROMPT,
     prompt: input.question,

--- a/examples/typescript/agent-eval/agent.ts
+++ b/examples/typescript/agent-eval/agent.ts
@@ -89,3 +89,20 @@ export async function runAgent(input: { question: string }): Promise<AgentResult
 
   return { answer: result.text, toolsUsed, steps: result.steps.length };
 }
+
+// ---------------------------------------------------------------------------
+// Standalone entrypoint — `pnpm agent`
+// ---------------------------------------------------------------------------
+// Runs the agent on a sample question and prints the structured result. Guarded
+// so importing this module (as `main.ts` does) never triggers a run — only
+// executing the file directly does.
+if (require.main === module) {
+  // Load OPENAI_API_KEY (and friends) from .env for the standalone run.
+  require('dotenv/config');
+  runAgent({ question: 'What is the current stock price of NVDA?' })
+    .then((result) => console.log(JSON.stringify(result, null, 2)))
+    .catch((err) => {
+      console.error(err);
+      process.exitCode = 1;
+    });
+}

--- a/examples/typescript/agent-eval/dataset.ts
+++ b/examples/typescript/agent-eval/dataset.ts
@@ -1,0 +1,70 @@
+/**
+ * Dataset for the tool-agent eval.
+ *
+ * A dataset file is a checkable artifact. Each case is content-addressed — its id
+ * is `tc_` + sha256 over the case's input/expected — so inserting or reordering
+ * cases never renumbers the others, and the dataset's own id is `ds_` + sha256
+ * over its key. Because the ids are derived from content, the same case authored
+ * in two SDKs produces the same bytes.
+ *
+ * This dataset is deliberately kept PARALLEL with the Python one in
+ * `examples/python/agent-eval/dataset.py`: the four questions and their expected
+ * `facts` are identical; only the `tools` names differ, because each SDK names
+ * its tools idiomatically (`getStockPrice` here, `get_stock_price` there).
+ * Running both with the same dataset name + key + `evaluationKey` makes the two
+ * runs converge into ONE diffable history on the platform — here that
+ * convergence is real, not just a capability we could use.
+ *
+ * (This file is NOT byte-identical to the Python one — different language, and
+ * tool names differ — but it is its deliberate mirror.)
+ */
+
+import { Dataset } from '@traceroot-ai/traceroot';
+
+export const DATASET_NAME = 'Agent tool eval';
+export const DATASET_KEY = 'agent-tool-eval';
+
+export function dataset(): Dataset {
+  const ds = new Dataset(DATASET_NAME, null, { key: DATASET_KEY });
+
+  // 1. Single stock lookup. NVDA is fixed at 495.20.
+  ds.add(
+    { question: 'What is the current stock price of NVDA?' },
+    { expected: { tools: ['getStockPrice'], facts: [495.2] } },
+  );
+
+  // 2. Lookup + calculation. 495.20 x 1.1 = 544.72.
+  ds.add(
+    {
+      question:
+        'NVDA is climbing. If it rises 10% from its current price, what would the new price be?',
+    },
+    { expected: { tools: ['getStockPrice', 'calculate'], facts: [544.72] } },
+  );
+
+  // 3. Two lookups, no math. NVDA 495.20 and MSFT 378.90.
+  ds.add(
+    { question: 'Compare the current prices of NVDA and MSFT. Give both numbers.' },
+    { expected: { tools: ['getStockPrice'], facts: [495.2, 378.9] } },
+  );
+
+  // 4. Lookup + calculation. 3 x 378.90 = 1136.70.
+  ds.add(
+    { question: 'How much would 3 shares of MSFT cost at the current price?' },
+    { expected: { tools: ['getStockPrice', 'calculate'], facts: [1136.7] } },
+  );
+
+  return ds;
+}
+
+/**
+ * True if `text` contains the number `value`.
+ *
+ * Tolerates formatting: thousands separators are stripped, and trailing-zero
+ * differences match (1136.7, 1136.70, "$1,136.70" all match 1136.70).
+ */
+export function mentions(text: string, value: number): boolean {
+  const cleaned = String(text).replace(/,/g, '');
+  const tokens = cleaned.match(/-?\d+\.?\d*/g) ?? [];
+  return tokens.some((token) => Math.abs(parseFloat(token) - value) < 1e-6);
+}

--- a/examples/typescript/agent-eval/dataset.ts
+++ b/examples/typescript/agent-eval/dataset.ts
@@ -1,22 +1,24 @@
 /**
  * Dataset for the tool-agent eval.
  *
- * A dataset file is a checkable artifact. Each case is content-addressed — its id
- * is `tc_` + sha256 over the case's input/expected — so inserting or reordering
- * cases never renumbers the others, and the dataset's own id is `ds_` + sha256
- * over its key. Because the ids are derived from content, the same case authored
- * in two SDKs produces the same bytes.
+ * A dataset file is a checkable artifact. Each case here is given an EXPLICIT id
+ * (`single-stock-lookup`, ...) that is byte-identical to its twin in the Python
+ * dataset, so the two SDKs' cases pair one-for-one regardless of any content
+ * differences. (Without an explicit id the SDK content-addresses a case as `tc_` +
+ * sha256 over the case's INPUT only — not its `expected` — so the camelCase vs
+ * snake_case tool names below would NOT have split the ids; pinning explicit ids
+ * just makes that pairing guaranteed and obvious rather than incidental.) The
+ * dataset's own id is `ds_` + sha256 over its key.
  *
  * This dataset is deliberately kept PARALLEL with the Python one in
  * `examples/python/agent-eval/dataset.py`: the four questions and their expected
  * `facts` are identical; only the `tools` names differ, because each SDK names
  * its tools idiomatically (`getStockPrice` here, `get_stock_price` there).
- * Running both with the same dataset name + key + `evaluationKey` makes the two
- * runs converge into ONE diffable history on the platform — here that
- * convergence is real, not just a capability we could use.
+ * Running both with the same dataset name + key + `evaluationKey` — and the shared
+ * explicit case ids — makes the two runs converge into ONE diffable history.
  *
  * (This file is NOT byte-identical to the Python one — different language, and
- * tool names differ — but it is its deliberate mirror.)
+ * tool names differ — but it is its deliberate mirror, and the case ids match.)
  */
 
 import { Dataset } from '@traceroot-ai/traceroot';
@@ -30,7 +32,7 @@ export function dataset(): Dataset {
   // 1. Single stock lookup. NVDA is fixed at 495.20.
   ds.add(
     { question: 'What is the current stock price of NVDA?' },
-    { expected: { tools: ['getStockPrice'], facts: [495.2] } },
+    { expected: { tools: ['getStockPrice'], facts: [495.2] }, id: 'single-stock-lookup' },
   );
 
   // 2. Lookup + calculation. 495.20 x 1.1 = 544.72.
@@ -39,19 +41,19 @@ export function dataset(): Dataset {
       question:
         'NVDA is climbing. If it rises 10% from its current price, what would the new price be?',
     },
-    { expected: { tools: ['getStockPrice', 'calculate'], facts: [544.72] } },
+    { expected: { tools: ['getStockPrice', 'calculate'], facts: [544.72] }, id: 'stock-rise-percent' },
   );
 
   // 3. Two lookups, no math. NVDA 495.20 and MSFT 378.90.
   ds.add(
     { question: 'Compare the current prices of NVDA and MSFT. Give both numbers.' },
-    { expected: { tools: ['getStockPrice'], facts: [495.2, 378.9] } },
+    { expected: { tools: ['getStockPrice'], facts: [495.2, 378.9] }, id: 'two-stock-compare' },
   );
 
   // 4. Lookup + calculation. 3 x 378.90 = 1136.70.
   ds.add(
     { question: 'How much would 3 shares of MSFT cost at the current price?' },
-    { expected: { tools: ['getStockPrice', 'calculate'], facts: [1136.7] } },
+    { expected: { tools: ['getStockPrice', 'calculate'], facts: [1136.7] }, id: 'shares-total-cost' },
   );
 
   return ds;

--- a/examples/typescript/agent-eval/dataset.ts
+++ b/examples/typescript/agent-eval/dataset.ts
@@ -1,24 +1,11 @@
 /**
- * Dataset for the tool-agent eval.
+ * Dataset for the tool-agent eval — four tool-use cases with exact expected facts.
  *
- * A dataset file is a checkable artifact. Each case here is given an EXPLICIT id
- * (`single-stock-lookup`, ...) that is byte-identical to its twin in the Python
- * dataset, so the two SDKs' cases pair one-for-one regardless of any content
- * differences. (Without an explicit id the SDK content-addresses a case as `tc_` +
- * sha256 over the case's INPUT only — not its `expected` — so the camelCase vs
- * snake_case tool names below would NOT have split the ids; pinning explicit ids
- * just makes that pairing guaranteed and obvious rather than incidental.) The
- * dataset's own id is `ds_` + sha256 over its key.
- *
- * This dataset is deliberately kept PARALLEL with the Python one in
- * `examples/python/agent-eval/dataset.py`: the four questions and their expected
- * `facts` are identical; only the `tools` names differ, because each SDK names
- * its tools idiomatically (`getStockPrice` here, `get_stock_price` there).
- * Running both with the same dataset name + key + `evaluationKey` — and the shared
- * explicit case ids — makes the two runs converge into ONE diffable history.
- *
- * (This file is NOT byte-identical to the Python one — different language, and
- * tool names differ — but it is its deliberate mirror, and the case ids match.)
+ * Kept PARALLEL with the Python dataset in
+ * `examples/python/agent-eval/dataset.py`: same questions and `facts`, only the
+ * tool names differ per SDK idiom (`getStockPrice` here, `get_stock_price` there).
+ * Each case has an EXPLICIT id matching its twin one-for-one, so running both under
+ * the same name + key + `evaluationKey` converges into ONE diffable history.
  */
 
 import { Dataset } from '@traceroot-ai/traceroot';

--- a/examples/typescript/agent-eval/main.ts
+++ b/examples/typescript/agent-eval/main.ts
@@ -82,7 +82,10 @@ const answerIsGrounded = Scorer.llmJudge({
 async function main() {
   try {
     // No TraceRoot key? Run locally — execute every case in full but report
-    // nowhere — so a fresh clone works without a TraceRoot credential.
+    // nowhere — so a fresh clone works without a TraceRoot credential. The
+    // unedited .env.example placeholder counts as "no key" too.
+    const apiKey = (process.env.TRACEROOT_API_KEY ?? '').trim();
+    const local = apiKey === '' || apiKey === 'your_traceroot_api_key_here';
     const result = await evaluate({
       name: 'Agent tool eval',
       dataset: dataset(),
@@ -90,7 +93,7 @@ async function main() {
       scorers: [callsExpectedTools, reportsExpectedFacts, answerIsGrounded],
       candidateVersion: 'gpt-4o-mini',
       evaluationKey: 'agent-tool-eval',
-      local: !process.env.TRACEROOT_API_KEY,
+      local,
     });
     console.log(result.summary());
 

--- a/examples/typescript/agent-eval/main.ts
+++ b/examples/typescript/agent-eval/main.ts
@@ -1,0 +1,103 @@
+/**
+ * Offline eval for the tool agent.
+ *
+ * Points three scorers at the agent from `agent.ts` over the dataset in
+ * `dataset.ts`, runs every case, and reports the run to TraceRoot.
+ *
+ * Run:
+ *   cp .env.example .env   # fill in your keys
+ *   pnpm install
+ *   pnpm start
+ *
+ * No creds? Set `local: true` on evaluate() (see README) to run in full and
+ * report nowhere.
+ */
+
+import 'dotenv/config';
+
+import { TraceRoot, Dataset, evaluate, Scorer, type ScorerContext } from '@traceroot-ai/traceroot';
+
+import { runAgent, type AgentResult } from './agent';
+import { dataset, mentions } from './dataset';
+
+// Initialize TraceRoot so the agent's AI SDK calls are traced and the run reports.
+TraceRoot.initialize();
+
+interface Expected {
+  tools: string[];
+  facts: number[];
+}
+
+// ── Scorers ─────────────────────────────────────────────────────────────────
+
+const callsExpectedTools = Scorer.code(
+  {
+    key: 'calls_expected_tools',
+    valueType: 'numeric',
+    direction: 'higher_is_better',
+    threshold: 1.0,
+  },
+  (ctx: ScorerContext) => {
+    const expected = (ctx.expected as Expected).tools;
+    const used = new Set((ctx.output as AgentResult).toolsUsed ?? []);
+    if (expected.length === 0) return 1.0;
+    return expected.filter((t) => used.has(t)).length / expected.length;
+  },
+);
+
+const reportsExpectedFacts = Scorer.code(
+  {
+    key: 'reports_expected_facts',
+    valueType: 'numeric',
+    direction: 'higher_is_better',
+    threshold: 1.0,
+  },
+  (ctx: ScorerContext) => {
+    const facts = (ctx.expected as Expected).facts;
+    const answer = (ctx.output as AgentResult).answer ?? '';
+    if (facts.length === 0) return 1.0;
+    return facts.filter((f) => mentions(answer, f)).length / facts.length;
+  },
+);
+
+const answerIsGrounded = Scorer.llmJudge({
+  name: 'answer_is_grounded',
+  model: 'claude-haiku-4-5',
+  messages: [
+    {
+      role: 'system',
+      content:
+        'You grade whether an ANSWER gives concrete, specific values for the TASK. ' +
+        'Reply with exactly 1.0 if the answer states concrete numbers that address ' +
+        'the task, or 0.0 if it is empty, hedged, or refuses. Reply with only the number.',
+    },
+    { role: 'user', content: 'TASK:\n{{input}}\n\nANSWER:\n{{output}}' },
+  ],
+  valueType: 'numeric',
+  threshold: 1.0,
+});
+
+// ── Run ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  try {
+    const result = await evaluate({
+      name: 'Agent tool eval',
+      dataset: dataset(),
+      task: (input) => runAgent(input as { question: string }),
+      scorers: [callsExpectedTools, reportsExpectedFacts, answerIsGrounded],
+      candidateVersion: 'gpt-4o-mini',
+      evaluationKey: 'agent-tool-eval',
+    });
+    console.log(result.summary());
+
+    const url = result.uploadState?.dashboardUrl;
+    if (url) {
+      console.log(`\nView the run: ${url}`);
+    }
+  } finally {
+    await TraceRoot.shutdown();
+  }
+}
+
+main().catch(console.error);

--- a/examples/typescript/agent-eval/main.ts
+++ b/examples/typescript/agent-eval/main.ts
@@ -103,4 +103,7 @@ async function main() {
   }
 }
 
-main().catch(console.error);
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/typescript/agent-eval/main.ts
+++ b/examples/typescript/agent-eval/main.ts
@@ -1,16 +1,8 @@
 /**
- * Offline eval for the tool agent.
+ * Offline eval for the tool agent: three scorers over the dataset, one run.
  *
- * Points three scorers at the agent from `agent.ts` over the dataset in
- * `dataset.ts`, runs every case, and reports the run to TraceRoot.
- *
- * Run:
- *   cp .env.example .env   # fill in your keys
- *   pnpm install
- *   pnpm start
- *
- * No creds? This runs locally on its own: with no TRACEROOT_API_KEY set, `main()`
- * passes `local: true` to evaluate() so the eval runs in full and reports nowhere.
+ * Run: `cp .env.example .env`, `pnpm install`, `pnpm start`.
+ * With no TRACEROOT_API_KEY set the run stays local and reports nowhere.
  */
 
 import 'dotenv/config';
@@ -20,8 +12,13 @@ import { TraceRoot, Dataset, evaluate, Scorer, type ScorerContext } from '@trace
 import { runAgent, type AgentResult } from './agent';
 import { dataset, mentions } from './dataset';
 
-// Initialize TraceRoot so the agent's AI SDK calls are traced and the run reports.
-TraceRoot.initialize();
+// No TraceRoot key (or the unedited .env.example placeholder)? Run fully local.
+const apiKey = (process.env.TRACEROOT_API_KEY ?? '').trim();
+const LOCAL = apiKey === '' || apiKey === 'your_traceroot_api_key_here';
+
+// Initialize TraceRoot (traces the agent's AI SDK calls + reports the run) only when a
+// real key is present; in local mode it stays off so a keyless clone emits/exports nothing.
+if (!LOCAL) TraceRoot.initialize();
 
 interface Expected {
   tools: string[];
@@ -32,6 +29,7 @@ interface Expected {
 
 const callsExpectedTools = Scorer.code(
   {
+    name: 'calls_expected_tools',
     key: 'calls_expected_tools',
     valueType: 'numeric',
     direction: 'higher_is_better',
@@ -47,6 +45,7 @@ const callsExpectedTools = Scorer.code(
 
 const reportsExpectedFacts = Scorer.code(
   {
+    name: 'reports_expected_facts',
     key: 'reports_expected_facts',
     valueType: 'numeric',
     direction: 'higher_is_better',
@@ -62,7 +61,7 @@ const reportsExpectedFacts = Scorer.code(
 
 const answerIsGrounded = Scorer.llmJudge({
   name: 'answer_is_grounded',
-  model: 'claude-haiku-4-5',
+  model: 'gpt-4o-mini',
   messages: [
     {
       role: 'system',
@@ -81,11 +80,6 @@ const answerIsGrounded = Scorer.llmJudge({
 
 async function main() {
   try {
-    // No TraceRoot key? Run locally — execute every case in full but report
-    // nowhere — so a fresh clone works without a TraceRoot credential. The
-    // unedited .env.example placeholder counts as "no key" too.
-    const apiKey = (process.env.TRACEROOT_API_KEY ?? '').trim();
-    const local = apiKey === '' || apiKey === 'your_traceroot_api_key_here';
     const result = await evaluate({
       name: 'Agent tool eval',
       dataset: dataset(),
@@ -93,7 +87,7 @@ async function main() {
       scorers: [callsExpectedTools, reportsExpectedFacts, answerIsGrounded],
       candidateVersion: 'gpt-4o-mini',
       evaluationKey: 'agent-tool-eval',
-      local,
+      local: LOCAL,
     });
     console.log(result.summary());
 

--- a/examples/typescript/agent-eval/main.ts
+++ b/examples/typescript/agent-eval/main.ts
@@ -9,8 +9,8 @@
  *   pnpm install
  *   pnpm start
  *
- * No creds? Set `local: true` on evaluate() (see README) to run in full and
- * report nowhere.
+ * No creds? This runs locally on its own: with no TRACEROOT_API_KEY set, `main()`
+ * passes `local: true` to evaluate() so the eval runs in full and reports nowhere.
  */
 
 import 'dotenv/config';
@@ -81,6 +81,8 @@ const answerIsGrounded = Scorer.llmJudge({
 
 async function main() {
   try {
+    // No TraceRoot key? Run locally — execute every case in full but report
+    // nowhere — so a fresh clone works without a TraceRoot credential.
     const result = await evaluate({
       name: 'Agent tool eval',
       dataset: dataset(),
@@ -88,6 +90,7 @@ async function main() {
       scorers: [callsExpectedTools, reportsExpectedFacts, answerIsGrounded],
       candidateVersion: 'gpt-4o-mini',
       evaluationKey: 'agent-tool-eval',
+      local: !process.env.TRACEROOT_API_KEY,
     });
     console.log(result.summary());
 

--- a/examples/typescript/agent-eval/package.json
+++ b/examples/typescript/agent-eval/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "traceroot-example-agent-eval",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "tsx main.ts",
+    "agent": "tsx agent.ts"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^3.0.0",
+    "@traceroot-ai/traceroot": "^0.3.0",
+    "ai": "^6.0.0",
+    "dotenv": "^16.0.0",
+    "zod": "^4.1.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/typescript/agent-eval/package.json
+++ b/examples/typescript/agent-eval/package.json
@@ -11,6 +11,7 @@
     "@traceroot-ai/traceroot": "^0.3.0",
     "ai": "^6.0.0",
     "dotenv": "^16.0.0",
+    "openai": "^6.0.0",
     "zod": "^4.1.8"
   },
   "devDependencies": {

--- a/examples/typescript/agent-eval/tsconfig.json
+++ b/examples/typescript/agent-eval/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Summary

Fixes: #1992

The eval docs (`docs/evals/*.mdx`) shipped snippets but no linked, runnable project — while every framework-integration doc ends with a `## Run the example` card group pointing at a clone-and-run folder. This adds two self-contained offline-eval examples (Python + TypeScript) and links both from `docs/evals/get-started.mdx` with the same `CardGroup`/`Card` pattern.

Each wraps an existing tool agent, points three scorers at it, and reports the run with a single `evaluate()`. Both subjects are tool agents, so the two examples ship **parallel** datasets — the same four questions and expected `{tools, facts}` under a shared dataset name/key — so the Python and TypeScript runs converge into one diffable history.

## What's included

- **`examples/python/agent-eval/`** — a Pydantic AI tool agent with fixed tool data (exact ground truth). `agent.py`, `dataset.py`, `main.py`, `requirements.txt` (pins `traceroot>=0.2.0`), `README.md`, `.env.example`.
- **`examples/typescript/agent-eval/`** — a Vercel AI SDK tool agent; parallel structure. `agent.ts`, `dataset.ts`, `main.ts`, `package.json` (pins `@traceroot-ai/traceroot ^0.3.0`), `tsconfig.json`, `README.md`, `.env.example`.
- **Scorers (both):** `calls_expected_tools` + `reports_expected_facts` (code, formatting-tolerant numeric matcher) and `answer_is_grounded` (LLM judge, `claude-haiku-4-5`).
- **Docs:** a `## Run the example` `CardGroup` in `docs/evals/get-started.mdx` with GitHub `tree/main/examples/...` hrefs.

Folders are named for the subject (`agent-eval`), not the technique. No existing example's SDK pin is touched.

## How to run

```bash
# Python
cd examples/python/agent-eval && cp .env.example .env
pip install -r requirements.txt && python main.py

# TypeScript
cd examples/typescript/agent-eval && cp .env.example .env
pnpm install && pnpm start
```

Each run prints a per-metric summary and, when reporting, the dashboard URL. The live run needs `OPENAI_API_KEY` (agent, `gpt-4o-mini`) and `ANTHROPIC_API_KEY` (judge, `claude-haiku-4-5`); `local: true` runs in full and reports nowhere.

## Test plan

- [x] TypeScript: `pnpm install` + `tsc --noEmit` clean against the real SDK types.
- [x] Python: `py_compile` clean; tool extraction + numeric matcher confirmed via an offline agent run.
- [ ] End-to-end run against a real project with keys — summary + run URL confirmed by hand.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runnable offline evaluation examples for tool agents in Python and TypeScript and links them from the evals get-started page. Previously we shipped snippets; now users can clone and run a complete eval that converges both SDKs into one diffable history via a shared dataset and explicit case ids.

- Adds `examples/python/agent-eval/` (Pydantic AI) and `examples/typescript/agent-eval/` (Vercel AI SDK) with fixed-data tools and three scorers: `calls_expected_tools`, `reports_expected_facts`, and `answer_is_grounded` (LLM judge). Uses a shared dataset name/key and `evaluation_key="agent-tool-eval"` with pinned case ids.
- Runtime: requires `OPENAI_API_KEY` (agent) and `ANTHROPIC_API_KEY` (judge). `TRACEROOT_API_KEY` is optional; when unset or left as the `.env.example` placeholder, examples auto-run in local mode; failures exit non-zero.
- Pins SDKs only within these examples: Python `traceroot>=0.2.0`; TypeScript `@traceroot-ai/traceroot ^0.3.0` plus `ai` and `@ai-sdk/openai`.
- TypeScript example enables Vercel AI SDK telemetry so agent spans are captured and adds `pnpm agent` to run the agent standalone.
- Updates `docs/evals/get-started.mdx` with “Run the example” cards linking to both folders.

<sup>Written for commit 8c449de70d6036be0f800d6f9981b6c718d62e33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

