### PR TITLE
feat(ui): add CopyButton for run ID in detector runs table

### DIFF
--- a/frontend/ui/src/features/detectors/components/detector-runs-table.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-runs-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn, formatDate } from "@/lib/utils";
+import { CopyButton } from "@/components/ui/copy-button";
 import { describeRcaStatus, type BackendRun } from "@/features/detectors/hooks/use-findings";
 import { DETECTOR_TH, DETECTOR_TD, IdentifiedBadge, SummaryText } from "./detector-table-cells";
 
@@ -60,23 +61,24 @@ export function DetectorRunsTable({ rows, onTraceClick, onRunClick }: DetectorRu
                 {formatDate(run.timestamp)}
               </td>
               <td className={cn(DETECTOR_TD, "font-mono text-[11px]")}>
-                {run.self_traced ? (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      // Same destination as the row click; stop propagation so
-                      // one click doesn't fire the navigation twice.
-                      e.stopPropagation();
-                      onRunClick(run);
-                    }}
-                    title={run.run_id}
-                    className="block max-w-full truncate text-left text-muted-foreground transition-colors hover:text-foreground hover:underline"
-                  >
-                    {run.run_id}
-                  </button>
-                ) : (
-                  <span className="text-muted-foreground">{run.run_id}</span>
-                )}
+                <div className="flex items-center gap-1">
+                  {run.self_traced ? (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onRunClick(run);
+                      }}
+                      title={run.run_id}
+                      className="block max-w-full truncate text-left text-muted-foreground transition-colors hover:text-foreground hover:underline"
+                    >
+                      {run.run_id}
+                    </button>
+                  ) : (
+                    <span className="truncate text-muted-foreground">{run.run_id}</span>
+                  )}
+                  <CopyButton value={run.run_id} />
+                </div>
               </td>
               <td className={cn(DETECTOR_TD, "font-mono text-[11px]")}>
                 <button


### PR DESCRIPTION
## Summary
Added the `<CopyButton />` component to the `DetectorRunsTable` to allow users to easily copy detector run IDs to their clipboard.

## Type of Change
- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code
- [ ] refactor - A code change that neither fixes a bug nor adds a feature

## Details
- Wrapped the Run ID cell in a `flex items-center gap-1` layout to maintain clean table row alignment.
- Added `<CopyButton value={run.run_id} />` alongside the run ID text/button.
- Added `truncate` to the non-traced ID span to prevent layout breaking on long IDs.

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a copy button next to the run ID in DetectorRunsTable so users can copy run IDs with one click. Previously users had to select the text; now the button copies without affecting navigation.

- Adds a `CopyButton` adjacent to the run ID (`value={run.run_id}`).
- Keeps self-traced run IDs clickable; copy action does not trigger navigation.
- Uses a flex layout for the cell and truncates non-traced IDs to prevent overflow.
- No backend or API changes.

<sup>Written for commit bfacfebb566f5a3a208b8084191f4161e5047051. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

