### PR TITLE
chore(terraform): gitignore plan archives

### DIFF
--- a/deploy/terraform/.gitignore
+++ b/deploy/terraform/.gitignore
@@ -4,3 +4,7 @@
 *.tfvars
 !*.tfvars.example
 .terraform.lock.hcl
+
+# Plan output files may contain resolved variable values
+tfplan*
+*.tfplan


### PR DESCRIPTION
Adds `tfplan*` / `*.tfplan` to `deploy/terraform/.gitignore`.

Plan output files can contain resolved variable values, so they belong with the existing `*.tfstate` and `*.tfvars` rules rather than sitting untracked in the working tree.

No functional change.