### PR TITLE
fix(worker): ingest the cache_creation spelling of the OpenInference cache-write attribute

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -826,6 +826,10 @@ def transform_otel_to_clickhouse(
                         span_attrs,
                         [
                             "llm.token_count.prompt_details.cache_write",
+                            # traceroot SDKs' Claude Agent SDK instrumentation
+                            # (python + ts) spells the same bucket with
+                            # Anthropic's "cache_creation" word:
+                            "llm.token_count.prompt_details.cache_creation",
                             "gen_ai.usage.cache_creation.input_tokens",
                             "gen_ai.usage.cache_creation_input_tokens",
                             "gen_ai.usage.details.cache_write_tokens",
@@ -837,9 +841,9 @@ def transform_otel_to_clickhouse(
                     )
                     # Optional Anthropic 1-hour cache-write portion (1h write = 2.0x
                     # input, versus 1.25x for the default 5-minute write). A SUBSET of
-                    # cache_write, priced at its own rate when present; absent for every
-                    # emitter today (the split is dropped at the instrumentation layer),
-                    # so this defaults to None -> 0 and leaves pricing unchanged.
+                    # cache_write, priced at its own rate when present; emitters that
+                    # don't distinguish TTLs simply omit it, and this defaults to
+                    # None -> 0, leaving pricing at the combined rate.
                     api_cache_write_1h_tokens = first_present_number(
                         span_attrs,
                         [
@@ -940,12 +944,12 @@ def transform_otel_to_clickhouse(
                         )
                         # Store a GROSS (cache-inclusive) input reconstructed from the
                         # disjoint buckets, so the input column always reconciles with
-                        # its cache breakdown. Net/exclusive emitters (e.g.
-                        # claude-agent-sdk) report only the non-cached tokens in
-                        # llm.token_count.prompt with cache as separate additive
-                        # buckets, so the reported input alone (e.g. 2) understates the
-                        # true total; summing the buckets recovers it. Gross emitters
-                        # are unchanged (cache is already a subset of the input).
+                        # its cache breakdown. Net/exclusive emitters report only the
+                        # non-cached tokens in llm.token_count.prompt with cache as
+                        # separate additive buckets, so the reported input alone
+                        # (e.g. 2) understates the true total; summing the buckets
+                        # recovers it. Gross emitters are unchanged (cache is already
+                        # a subset of the input).
                         gross_input = (
                             buckets.input_uncached + buckets.cache_read + buckets.cache_write
                         )
@@ -964,9 +968,9 @@ def transform_otel_to_clickhouse(
                             ),
                         }
                         # Persist the 1-hour cache-write portion only when an emitter
-                        # actually reports it, so spans with no 1-hour portion (every
-                        # span today) keep an identical usage_details map. The read path
-                        # defaults the missing key to 0.
+                        # actually reports it, so spans with no 1-hour portion keep an
+                        # identical usage_details map. The read path defaults the
+                        # missing key to 0.
                         if buckets.cache_write_1h:
                             span_record["usage_details"]["cache_write_1h_tokens"] = (
                                 buckets.cache_write_1h

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -3,9 +3,9 @@ physical token in exactly one bucket, priced once.
 
 The reported input may be GROSS (cache-inclusive — the common case, e.g.
 OpenInference's ``llm.token_count.prompt``, which already contains the cache
-tokens) or NET (cache-exclusive — e.g. the claude-agent-sdk instrumentor, which
-passes Anthropic's exclusive ``input_tokens`` straight through with cache reported
-as separate additive buckets).
+tokens) or NET (cache-exclusive — an emitter that passes the provider's
+exclusive input count straight through with cache reported as separate additive
+buckets).
 
 A single rule handles both: subtract cache from the input to recover the uncached
 bucket, flooring at zero, and keep the cache buckets UNCAPPED. For gross emitters
@@ -26,7 +26,7 @@ of the ``cache_write`` total, never as a new disjoint bucket::
 
 Keeping ``cache_write`` as the single total means the gross-input reconstruction
 (uncached + cache_read + cache_write) is unchanged, and any emitter that does not
-report the 1-hour portion (every emitter today) is priced exactly as before.
+report the 1-hour portion is priced exactly as before.
 """
 
 from __future__ import annotations
@@ -132,16 +132,16 @@ def normalize_token_usage(
 
     The uncached bucket is ``max(input - cache_read - cache_write, 0)``; cache is
     kept uncapped. This is correct for GROSS emitters (cache is a subset of the
-    input, so it subtracts out) and for NET emitters such as claude-agent-sdk
-    (cache exceeds the input, so the uncached bucket floors to zero while the
-    additive cache is still priced in full). All buckets are clamped non-negative.
+    input, so it subtracts out) and for NET emitters (cache exceeds the input, so
+    the uncached bucket floors to zero while the additive cache is still priced
+    in full). All buckets are clamped non-negative.
 
     ``cache_write_1h_tokens`` is an OPTIONAL 1-hour portion of the cache-write total.
     It is reconciled against ``cache_write`` so the sub-partition invariant always
     holds even for malformed input: clamped non-negative and capped so
     ``cache_write_1h <= cache_write`` (the remainder is priced at the combined
     cache-write rate). Defaults to ``0``, so an emitter that does not report the
-    1-hour portion (every emitter today) is unaffected.
+    1-hour portion is unaffected.
     """
     _warn_once_if_unknown_scope(scope_name)
     cache_read = max(cache_read_tokens, 0)

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -576,6 +576,16 @@ class TestTransformOtelToClickhouse:
                 "gen_ai.usage.details.cache_read_input_tokens",
                 "gen_ai.usage.details.cache_write_tokens",
             ),
+            # traceroot SDKs' Claude Agent SDK instrumentation spells cache-write
+            # with Anthropic's own "cache_creation" word (python and ts both emit
+            # this exact key); both sum input + cache_read + cache_creation into
+            # llm.token_count.prompt, so the prompt arrives GROSS.
+            (
+                "traceroot.claude-agent-sdk",
+                "llm.token_count.prompt",
+                "llm.token_count.prompt_details.cache_read",
+                "llm.token_count.prompt_details.cache_creation",
+            ),
             # Vercel AI SDK: gen_ai totals are emitted natively on doGenerate
             # spans, but cache detail exists only under the raw ai.* namespace.
             (
@@ -958,6 +968,45 @@ class TestTransformOtelToClickhouse:
                 )
             ],
             scope_name="openinference.instrumentation.anthropic",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        ud = spans[0]["usage_details"]
+        assert ud["cache_write_tokens"] == 900
+        assert ud["cache_write_1h_tokens"] == 600
+        expected = 100 * prices["input"] + 300 * prices["cacheWrite"] + 600 * prices["cacheWrite1h"]
+        assert spans[0]["cost"] == pytest.approx(expected)
+
+    def test_cache_write_1h_survives_the_cache_creation_spelling(self):
+        """The 1h sub-bucket is reconciled against the write TOTAL (capped at it),
+        so a missed cache_creation-spelled total would zero the write bucket and
+        clamp the 1h portion away with it — the pair must land together."""
+        from unittest.mock import patch
+
+        prices = {
+            "input": 0.000005,
+            "output": 0.000025,
+            "cacheRead": 0.0000005,
+            "cacheWrite": 0.00000625,
+            "cacheWrite1h": 0.00001,
+        }
+        # gross input 1000 = 100 uncached + 900 write; of the 900: 600 @1h, 300 remainder.
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    attributes=[
+                        make_attr("gen_ai.request.model", "claude-opus-4-7"),
+                        make_attr("llm.token_count.prompt", 1000),
+                        make_attr("llm.token_count.completion", 0),
+                        make_attr("llm.token_count.prompt_details.cache_creation", 900),
+                        make_attr("llm.token_count.prompt_details.cache_write_1h", 600),
+                    ],
+                )
+            ],
+            scope_name="traceroot.claude-agent-sdk",
         )
         with patch("worker.tokens.pricing.get_model_price", return_value=prices):
             _, spans = transform_otel_to_clickhouse(payload, "proj-1")
@@ -1725,8 +1774,8 @@ class TestCacheTokenMetadata:
         assert ud["cache_write_1h_tokens"] == 300
 
     def test_absent_1h_portion_keeps_usage_details_keys_unchanged(self):
-        # No 1-hour portion reported (every span today) -> no extra key is added, so the
-        # stored map is identical to before this change.
+        # No 1-hour portion reported -> no extra key is added, so the stored map
+        # is identical to a pre-split span's.
         payload = make_otel_payload(
             [
                 make_span(


### PR DESCRIPTION
## Summary

The Claude Agent SDK instrumentation in both traceroot SDKs (python and ts) emits its collapsed cache-write total as `llm.token_count.prompt_details.cache_creation` — Anthropic's word for the bucket — but the ingest fallback list only knew the `cache_write` spelling. Those spans' cache-write tokens were silently folded into uncached input and priced at the base input rate instead of the cache-write rate (a 20% undercount on 5m writes, more on 1h). Worse, the 1h sub-bucket is reconciled with `cache_write_1h <= cache_write`, so with the total missed, any SDK-emitted 1h split would have been clamped to zero — making this a prerequisite for the SDK-side 1h emission (traceroot-ts#148, traceroot-py#174).

## Changes

- Add `llm.token_count.prompt_details.cache_creation` to the `api_cache_write_tokens` fallback list (second, after the verified OpenInference `cache_write` key; `first_present_number` short-circuits so an emitter sending both spellings is never double-counted).
- New parametrized row in the cache-attribution test for scope `traceroot.claude-agent-sdk`, and a test pinning that the 1h sub-bucket survives reconciliation when the total arrives under the `cache_creation` spelling.
- De-stale comments: the claim that no emitter reports the 1h portion (the detection worker does, and the SDKs are gaining it), and the claim that claude-agent-sdk is a NET emitter — both SDKs sum `input + cache_read + cache_creation` into `llm.token_count.prompt`, i.e. gross (the bucket math is convention-agnostic either way).

## Testing

579 worker tests green; the new tests were verified to fail against the pre-fix transform.

Advances #1070 (the remaining in-repo gap there is the cost-popup per-TTL breakout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHNU4fYWfcmJXjYPiF2w3i

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ingestion of the `cache_creation` spelling of the OpenInference cache-write attribute so Claude Agent SDK spans are priced correctly: previously their cache-write tokens were silently folded into uncached input at the base input rate, and any 1h sub-bucket was clamped to zero.

**Bug Fixes**
- Adds `llm.token_count.prompt_details.cache_creation` to the cache-write fallback list as the second key after `cache_write`; `first_present_number` short-circuits so an emitter sending both spellings is never double-counted.
- Adds parametrized coverage for the `traceroot.claude-agent-sdk` scope and a test pinning that the 1h sub-bucket survives reconciliation when the total arrives under the `cache_creation` spelling.
- Removes stale comments claiming no emitter reports the 1h portion or that `claude-agent-sdk` is a NET emitter.
- Advances #1070; the remaining gap is the cost-popup per-TTL breakout.

<sup>Written for commit d5a8e2515fe2b15aef4d675058a4e78e0503bd30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

