### PR TITLE
feat(helm): keep service-to-service routes off the public load balancer

### DIFF
--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -6,6 +6,16 @@ metadata:
   labels:
     {{- include "traceroot.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.ingress.blockInternalRoutes }}
+    # Service-to-service routes are reached in-cluster via BACKEND_INTERNAL_URL
+    # (http://<release>-rest:8000), never through this load balancer, so they do
+    # not need to be routable from outside. Answer 404 rather than 403 so the
+    # response says nothing about what is mounted there.
+    alb.ingress.kubernetes.io/actions.block-internal: >-
+      {"type":"fixed-response","fixedResponseConfig":
+      {"contentType":"application/json","statusCode":"404",
+      "messageBody":"{\"detail\":\"Not Found\"}"}}
+    {{- end }}
     {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -17,6 +27,19 @@ spec:
       {{- end }}
       http:
         paths:
+          {{- if .Values.ingress.blockInternalRoutes }}
+          # Listed before /api/v1 so the longer prefix wins. The service name
+          # must match the actions.* annotation suffix and the port name must be
+          # use-annotation -- that pairing is how the AWS Load Balancer
+          # Controller substitutes the fixed response for a real backend.
+          - path: {{ .Values.ingress.internalRoutePrefix }}
+            pathType: Prefix
+            backend:
+              service:
+                name: block-internal
+                port:
+                  name: use-annotation
+          {{- end }}
           - path: /api/v1
             pathType: Prefix
             backend:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -109,6 +109,11 @@ ingress:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+  # Stop the load balancer routing the service-to-service API. Callers reach it
+  # over cluster DNS, so this is also correct for a single-cluster self-host.
+  # Set false to restore the previous behaviour without rebuilding an image.
+  blockInternalRoutes: true
+  internalRoutePrefix: /api/v1/internal
 
 # --- External services (injected by Terraform) ---
 postgresql:

--- a/tests/deploy/test_ingress_internal_block.py
+++ b/tests/deploy/test_ingress_internal_block.py
@@ -1,0 +1,126 @@
+"""Deploy-artifact guard: the service-to-service API stays off the load balancer.
+
+/api/v1/internal/* is reached in-cluster over BACKEND_INTERNAL_URL, so it has no
+reason to be routable from outside. The chart drops it with an ALB fixed
+response, which depends on two pairings that are easy to break silently:
+
+* the path must be listed *before* /api/v1, so the longer prefix wins;
+* the backend service name must equal the ``actions.*`` annotation suffix and
+  the port name must be ``use-annotation``, or the controller looks for a real
+  Service called "block-internal" and the rule quietly fails to sync.
+
+Neither mistake shows up until traffic is live, and CI has no Helm, so the
+structural checks below run unconditionally against the template source and the
+full render runs whenever Helm happens to be installed.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+import yaml
+
+_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+_CHART = os.path.join(_ROOT, "deploy", "helm")
+_TEMPLATE = os.path.join(_CHART, "templates", "ingress.yaml")
+_VALUES = os.path.join(_CHART, "values.yaml")
+
+
+def _template_text() -> str:
+    with open(_TEMPLATE) as f:
+        return f.read()
+
+
+def _values() -> dict:
+    with open(_VALUES) as f:
+        return yaml.safe_load(f)
+
+
+def test_blocking_is_on_by_default():
+    ingress = _values()["ingress"]
+    assert ingress["blockInternalRoutes"] is True
+    assert ingress["internalRoutePrefix"] == "/api/v1/internal"
+
+
+def test_internal_prefix_is_longer_than_the_public_one():
+    """A prefix that does not extend /api/v1 would block real API traffic."""
+    prefix = _values()["ingress"]["internalRoutePrefix"]
+    assert prefix.startswith("/api/v1/") and len(prefix) > len("/api/v1")
+
+
+def test_internal_path_precedes_the_public_api_path():
+    text = _template_text()
+    assert text.index("internalRoutePrefix") < text.index("- path: /api/v1\n")
+
+
+def test_action_name_matches_the_annotation_suffix():
+    """`actions.<name>` and the backend service name have to be the same word."""
+    text = _template_text()
+    assert "alb.ingress.kubernetes.io/actions.block-internal:" in text
+    assert "name: block-internal" in text
+    assert "name: use-annotation" in text
+
+
+def test_rule_is_removable_without_an_image_rebuild():
+    """Rollback lever: the whole thing hangs off one value."""
+    text = _template_text()
+    assert text.count("{{- if .Values.ingress.blockInternalRoutes }}") == 2
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
+class TestRendered:
+    @staticmethod
+    def _render(*extra: str) -> dict:
+        out = subprocess.run(
+            ["helm", "template", "traceroot", _CHART, "--set", "ingress.host=example.com", *extra],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        for doc in yaml.safe_load_all(out):
+            if doc and doc.get("kind") == "Ingress":
+                return doc
+        raise AssertionError("chart rendered no Ingress")
+
+    def test_paths_are_ordered_most_specific_first(self):
+        paths = [p["path"] for p in self._render()["spec"]["rules"][0]["http"]["paths"]]
+        assert paths == ["/api/v1/internal", "/api/v1", "/"]
+
+    def test_action_is_valid_json_the_controller_can_read(self):
+        annotations = self._render()["metadata"]["annotations"]
+        action = json.loads(annotations["alb.ingress.kubernetes.io/actions.block-internal"])
+        assert action["type"] == "fixed-response"
+        assert action["fixedResponseConfig"]["statusCode"] == "404"
+        assert json.loads(action["fixedResponseConfig"]["messageBody"]) == {"detail": "Not Found"}
+
+    def test_404_not_403_so_the_response_reveals_nothing(self):
+        annotations = self._render()["metadata"]["annotations"]
+        action = json.loads(annotations["alb.ingress.kubernetes.io/actions.block-internal"])
+        assert action["fixedResponseConfig"]["statusCode"] != "403"
+
+    def test_disabling_restores_the_previous_ingress(self):
+        doc = self._render("--set", "ingress.blockInternalRoutes=false")
+        paths = [p["path"] for p in doc["spec"]["rules"][0]["http"]["paths"]]
+        assert paths == ["/api/v1", "/"]
+        assert not any("block-internal" in k for k in doc["metadata"]["annotations"])
+
+    def test_internal_callers_bypass_the_load_balancer(self):
+        """The premise of the whole change: they use cluster DNS, not the host."""
+        out = subprocess.run(
+            ["helm", "template", "traceroot", _CHART, "--set", "ingress.host=example.com"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        urls = set()
+        for doc in yaml.safe_load_all(out):
+            if not doc or doc.get("kind") != "Deployment":
+                continue
+            for container in doc["spec"]["template"]["spec"]["containers"]:
+                for env in container.get("env") or []:
+                    if env.get("name") == "BACKEND_INTERNAL_URL":
+                        urls.add(env.get("value"))
+        assert urls, "no service declares BACKEND_INTERNAL_URL"
+        assert urls == {"http://traceroot-rest:8000"}, urls


### PR DESCRIPTION
The `/api/v1/internal` prefix is service-to-service only, but the ingress forwards it like any other path, so the load balancer routes traffic that has no reason to arrive there.

Every internal caller already reaches the REST service over cluster DNS — `BACKEND_INTERNAL_URL` renders to `http://traceroot-rest:8000` for web, agent, detector and billing — so nothing legitimate travels through the ingress to reach it. The chart now answers that prefix with an ALB fixed response instead of forwarding it.

## Details

- The path is listed **before** `/api/v1` so the longer prefix wins.
- The backend service name matches the `actions.*` annotation suffix and the port name is `use-annotation`; that pairing is how the AWS Load Balancer Controller substitutes a fixed response for a real backend. Get either wrong and the rule silently fails to sync.
- Gated on `ingress.blockInternalRoutes` (default `true`), so it can be turned off with a Helm value rather than an image rebuild.
- Responds `404`, not `403` — the response says nothing about what is mounted there.

Correct for single-cluster self-hosting too, for the same reason: callers use cluster DNS.

## Tests

Ten tests. The structural ones always run and cover the two pairings that fail silently — path ordering and the service-name/`use-annotation` pairing. The rendering ones shell out to `helm template` and skip where Helm is absent (CI has no Helm step today); they assert the rendered path order, that the annotation is JSON the controller can parse, that disabling restores the previous ingress exactly, and that every `BACKEND_INTERNAL_URL` resolves to cluster DNS.

## Rollout

Ships via `helm upgrade`, not an image build. Staging first, then production:

```
# after upgrade, ALB rules take ~30-60s to propagate
curl -o /dev/null -w %{http_code} https://<host>/api/v1/internal/usage/total   # 404
kubectl exec deploy/traceroot-web -- curl -o /dev/null -w %{http_code} \
  http://traceroot-rest:8000/api/v1/internal/usage/total                        # 403
curl -o /dev/null -w %{http_code} https://<host>/api/v1/public/traces/recent    # unaffected
# then confirm detector counts and trace findings still render
```

Rollback is `--set ingress.blockInternalRoutes=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps service-to-service routes off the public load balancer by answering `/api/v1/internal` with a 404 fixed response instead of forwarding it. Internal callers already reach the REST service over cluster DNS (`BACKEND_INTERNAL_URL`), so the prefix never legitimately arrives at the ingress.

**Details**
- Gated on `ingress.blockInternalRoutes` (default `true`); set it to `false` in Helm to restore the previous ingress.
- Path is listed before `/api/v1` so the longer prefix wins.
- The rule silently fails to sync if the backend service name `block-internal` doesn't match the `actions.*` annotation suffix, or if the port name isn't `use-annotation`.
- Returns 404 rather than 403 so the response reveals nothing about what's mounted there.
- Ships via `helm upgrade`; ALB rules take about 30–60 seconds to propagate after upgrade.
- New tests cover path ordering and the service-name/`use-annotation` pairing; rendering tests run only where Helm is installed.

<sup>Written for commit 6d9bf7e65e129c7135c4c8b117c70acc2882f1d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

