### PR TITLE
fix(pricing): strip the PCRE inline flag so the price regex fallback works

### DIFF
--- a/frontend/packages/core/src/__tests__/model-pricing.test.ts
+++ b/frontend/packages/core/src/__tests__/model-pricing.test.ts
@@ -112,3 +112,79 @@ describe("getModelPricing + calculateCost (prisma-backed)", () => {
     expect(cost).toBe(0);
   });
 });
+
+// lookup.ts caches the price table in module scope for the process lifetime, so a
+// fresh catalogue needs a fresh module instance — otherwise these fixtures are
+// shadowed by whichever describe loaded the cache first.
+async function loadWithCatalogue(rows: unknown[]) {
+  vi.resetModules();
+  vi.doMock("../lib/prisma", () => ({
+    prisma: { standardModel: { findMany: vi.fn().mockResolvedValue(rows) } },
+  }));
+  return import("../model-pricing/lookup.ts");
+}
+
+// The catalogue authors matchPattern for the Python worker, so every one of the 92
+// entries in standard-model-prices.json begins with the PCRE inline flag `(?i)`.
+// JavaScript's RegExp rejects that prefix, so these fixtures use the real catalogue
+// shape — an `(?i)`-less fixture passes even when the fallback is entirely dead.
+describe("getModelPricing — regex fallback over catalogue-shaped patterns", () => {
+  const CANONICAL = "claude-opus-4-7";
+  // Verbatim catalogue shape: leading (?i), optional provider prefix, optional
+  // Bedrock region/version decoration.
+  const CATALOGUE_ROW = {
+    modelName: CANONICAL,
+    matchPattern: "(?i)^(anthropic\\/|us\\.anthropic\\.)?claude-opus-4-7(-v\\d+:\\d+)?$",
+    prices: [
+      { usageType: "input", price: 0.000005 },
+      { usageType: "output", price: 0.000025 },
+      { usageType: "cacheRead", price: 0.0000005 },
+      { usageType: "cacheWrite", price: 0.00000625 },
+      { usageType: "cacheWrite1h", price: 0.00001 },
+    ],
+  };
+
+  it("resolves a provider-prefixed alias to the canonical price", async () => {
+    const { getModelPricing: lookup } = await loadWithCatalogue([CATALOGUE_ROW]);
+    const canonical = await lookup(CANONICAL);
+    const aliased = await lookup("anthropic/claude-opus-4-7");
+    expect(aliased).not.toBeNull();
+    expect(aliased).toEqual(canonical);
+  });
+
+  it("resolves a Bedrock-style alias to the canonical price", async () => {
+    const { getModelPricing: lookup } = await loadWithCatalogue([CATALOGUE_ROW]);
+    const canonical = await lookup(CANONICAL);
+    const aliased = await lookup("us.anthropic.claude-opus-4-7-v1:0");
+    expect(aliased).not.toBeNull();
+    expect(aliased).toEqual(canonical);
+  });
+
+  it("matches case-insensitively, the behaviour the inline (?i) intended", async () => {
+    const { getModelPricing: lookup } = await loadWithCatalogue([CATALOGUE_ROW]);
+    expect(await lookup("Anthropic/Claude-Opus-4-7")).not.toBeNull();
+  });
+
+  it("still returns null for a model the pattern genuinely does not cover", async () => {
+    const { getModelPricing: lookup } = await loadWithCatalogue([CATALOGUE_ROW]);
+    expect(await lookup("anthropic/claude-sonnet-9")).toBeNull();
+  });
+});
+
+describe("getModelPricing — uncompilable pattern", () => {
+  it("reports the catalogue defect instead of failing silently", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { getModelPricing: lookup } = await loadWithCatalogue([
+      {
+        modelName: "broken-entry",
+        matchPattern: "^(unclosed", // genuinely invalid in any flavour
+        prices: [{ usageType: "input", price: 0.000005 }],
+      },
+    ]);
+
+    // Does not throw; the bad entry is skipped and the defect is surfaced.
+    expect(await lookup("anything")).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("broken-entry"), expect.anything());
+    warn.mockRestore();
+  });
+});

--- a/frontend/packages/core/src/model-pricing/lookup.ts
+++ b/frontend/packages/core/src/model-pricing/lookup.ts
@@ -15,8 +15,35 @@ export interface ModelPricing {
 
 interface CachedModel {
   modelName: string;
-  matchPattern: string;
+  // Compiled at cache-load time, or null when the catalogue pattern cannot compile.
+  matcher: RegExp | null;
   prices: ModelPricing;
+}
+
+// `matchPattern` values are authored for the Python worker, which accepts the PCRE
+// inline flag `(?i)`. JavaScript's RegExp does not — it throws "Invalid group" — and
+// every catalogue pattern carries that prefix. Case-insensitivity is already supplied
+// by the "i" flag below, so the inline flag is redundant here and is stripped.
+const INLINE_IGNORECASE_PREFIX = /^\(\?i\)/;
+
+/**
+ * Compile a catalogue match pattern for the JS path, or null if it cannot compile.
+ *
+ * Called once per cache load rather than per lookup, so an uncompilable pattern is
+ * reported once instead of on every pricing call.
+ */
+function compileMatchPattern(matchPattern: string, modelName: string): RegExp | null {
+  try {
+    return new RegExp(matchPattern.replace(INLINE_IGNORECASE_PREFIX, ""), "i");
+  } catch (err) {
+    // A pattern that cannot compile is a catalogue defect. Swallowing it silently is
+    // what hid the fallback being dead: pricing just returned null and looked free.
+    console.warn(
+      `[model-pricing] Ignoring uncompilable matchPattern for "${modelName}": ${matchPattern}`,
+      err,
+    );
+    return null;
+  }
 }
 
 let cache: CachedModel[] | null = null;
@@ -42,7 +69,7 @@ async function loadCache(): Promise<CachedModel[]> {
     }
     return {
       modelName: m.modelName,
-      matchPattern: m.matchPattern,
+      matcher: compileMatchPattern(m.matchPattern, m.modelName),
       prices: {
         input: priceMap["input"] ?? 0,
         output: priceMap["output"] ?? 0,
@@ -68,14 +95,10 @@ export async function getModelPricing(modelId: string): Promise<ModelPricing | n
   const exact = models.find((m) => m.modelName === modelId);
   if (exact) return exact.prices;
 
-  // Regex fallback
+  // Regex fallback — catches provider-prefixed and Bedrock/Vertex-style aliases
+  // (e.g. "anthropic/claude-opus-5", "us.anthropic.claude-opus-5-v1:0").
   for (const m of models) {
-    try {
-      const re = new RegExp(m.matchPattern, "i");
-      if (re.test(modelId)) return m.prices;
-    } catch {
-      // Invalid regex — skip
-    }
+    if (m.matcher?.test(modelId)) return m.prices;
   }
 
   return null;


### PR DESCRIPTION
Fixes #2015

## Summary

`getModelPricing`'s regex fallback was dead code. All 92 `matchPattern` values in
`standard-model-prices.json` begin with the PCRE inline flag `(?i)`, which
JavaScript's `RegExp` rejects as "Invalid group" — and the bare `catch {}`
swallowed the failure. Aliased model ids therefore priced as `null`, rendering as
absent rather than wrong, so a model read as free.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

**The fix.** Strip a leading `(?i)` before constructing the RegExp. The `"i"` flag
is already passed, so the inline flag was redundant on this path.

**Why not edit the catalogue.** The Python worker applies the same patterns with
`re.IGNORECASE`, where `(?i)` is valid, so it matches correctly today — the two
pricing paths currently disagree about the same model. Leaving the catalogue
untouched means the Python path is unaffected by this change, and avoids a DB
re-sync of all 92 entries.

**Compilation moved to cache load.** Previously each pattern was compiled on every
lookup. Compiling once per cache load is what keeps the new warning to once per
load rather than once per pattern per pricing call.

**The `catch` now warns instead of discarding.** An uncompilable pattern is still
skipped, but reported — the silence is what hid this.

**Validation:**

- 5 new tests, verified load-bearing by stashing the fix and re-running: they fail
  without it. They cover a provider-prefixed alias, a Bedrock-style alias,
  case-insensitive matching, a genuine non-match, and the uncompilable-pattern
  warning.
- The fixtures use the real catalogue shape **including** the leading `(?i)`. The
  existing fixture omitted it, which is why the dead fallback went unnoticed.
- Checked against the real catalogue: all 92 patterns compile after the strip, and
  the three aliases named in the issue now resolve — `anthropic/claude-opus-5`,
  `us.anthropic.claude-opus-5-v1:0`, and `claude-opus-5[1m]` all map to
  `claude-opus-5`.
- `packages/core`: 122 → 127 passing, no new failures. Three files fail on clean
  `main` as well, from an ungenerated local Prisma client — unrelated to this change.
- Pre-commit passed, including `frontend lint-staged`.

## Screenshots / Recordings (if applicable)

N/A — no UI change.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable) — N/A, no UI change
- [ ] I have updated documentation where necessary — N/A, no user-facing behaviour change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2015: the model price regex fallback was dead code, so aliased model IDs priced as `null` and read as free. All 92 catalogue `matchPattern` values start with the PCRE inline flag `(?i)`, which JavaScript's `RegExp` rejects, and the bare `catch {}` swallowed the failure.

- Strips a leading `(?i)` before compiling (case-insensitivity is already supplied by the `i` flag), leaving the catalogue untouched so the Python pricing path is unaffected.
- Compiles patterns once per cache load instead of per lookup, and warns on uncompilable patterns instead of silently skipping them.
- Adds tests using the real catalogue shape including the `(?i)` prefix; the old fixture omitted it, which hid the dead fallback.

<sup>Written for commit 05446fbc856a5608301886ad01ac2ee691c1d8cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

