### PR TITLE
fix(billing): narrow `billingPlan` instead of casting it at twelve call sites

### DIFF
--- a/frontend/packages/core/src/ee/billing/__tests__/plans.test.ts
+++ b/frontend/packages/core/src/ee/billing/__tests__/plans.test.ts
@@ -10,6 +10,10 @@ import {
   isDetectorRunBlocked,
   isIngestionBlocked,
   hasEntitlement,
+  isUpgrade,
+  getPlanOrder,
+  toPlanType,
+  ENTITLEMENTS,
 } from "../plans.ts";
 
 describe("slack-integration entitlement", () => {
@@ -134,5 +138,69 @@ describe("isDetectorRunBlocked", () => {
   it("respects ENABLE_BILLING=false (unblocks all)", () => {
     vi.stubEnv("ENABLE_BILLING", "false");
     expect(isDetectorRunBlocked(PlanType.FREE, 9999)).toBe(false);
+  });
+});
+
+describe("toPlanType", () => {
+  beforeEach(() => {
+    vi.stubEnv("ENABLE_BILLING", "true");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns every recognized plan unchanged", () => {
+    for (const plan of Object.values(PlanType)) {
+      expect(toPlanType(plan)).toBe(plan);
+    }
+  });
+
+  it("fails closed to FREE for anything unrecognized", () => {
+    // billingPlan is free-form TEXT with no CHECK constraint, so these are all
+    // values a workspace row can actually hold.
+    expect(toPlanType("legacy-team")).toBe(PlanType.FREE);
+    expect(toPlanType("Pro")).toBe(PlanType.FREE); // matching is exact
+    expect(toPlanType("pro ")).toBe(PlanType.FREE); // trailing whitespace
+    expect(toPlanType("")).toBe(PlanType.FREE);
+    expect(toPlanType(null)).toBe(PlanType.FREE);
+    expect(toPlanType(undefined)).toBe(PlanType.FREE);
+  });
+
+  it("does not resolve prototype-chain keys to a plan", () => {
+    expect(toPlanType("constructor")).toBe(PlanType.FREE);
+    expect(toPlanType("toString")).toBe(PlanType.FREE);
+    expect(toPlanType("__proto__")).toBe(PlanType.FREE);
+  });
+
+  it("gives an unrecognized plan the same entitlements as an explicit FREE", () => {
+    // The failure mode this closes: an unrecognized plan is absent from the
+    // entitlement table, so every entitlement check answered false for it —
+    // byok included, which is granted on every plan including Free.
+    expect(hasEntitlement("legacy-team" as PlanType, "byok")).toBe(false);
+
+    expect(hasEntitlement(toPlanType("legacy-team"), "byok")).toBe(
+      hasEntitlement(PlanType.FREE, "byok"),
+    );
+    for (const entitlement of ENTITLEMENTS) {
+      expect(hasEntitlement(toPlanType("legacy-team"), entitlement)).toBe(
+        hasEntitlement(PlanType.FREE, entitlement),
+      );
+    }
+  });
+
+  it("restores plan ordering, which an unrecognized plan left undefined", () => {
+    expect(getPlanOrder("legacy-team" as PlanType)).toBeUndefined();
+    expect(isUpgrade("legacy-team" as PlanType, PlanType.PRO)).toBe(false);
+
+    expect(getPlanOrder(toPlanType("legacy-team"))).toBe(getPlanOrder(PlanType.FREE));
+    expect(isUpgrade(toPlanType("legacy-team"), PlanType.PRO)).toBe(true);
+  });
+
+  it("leaves a recognized plan's ordering and entitlements untouched", () => {
+    expect(isUpgrade(toPlanType("pro"), PlanType.ENTERPRISE)).toBe(true);
+    expect(isUpgrade(toPlanType("pro"), PlanType.STARTER)).toBe(false);
+    expect(hasEntitlement(toPlanType("pro"), "github-integration")).toBe(true);
+    expect(hasEntitlement(toPlanType("starter"), "github-integration")).toBe(false);
   });
 });

--- a/frontend/packages/core/src/ee/billing/index.ts
+++ b/frontend/packages/core/src/ee/billing/index.ts
@@ -17,6 +17,7 @@ export {
   FAIL_CLOSED_RETENTION_DAYS,
   getRetentionDays,
   PlanType,
+  toPlanType,
   // Types
   type PlanConfig,
   type Entitlement,

--- a/frontend/packages/core/src/ee/billing/plans.ts
+++ b/frontend/packages/core/src/ee/billing/plans.ts
@@ -12,6 +12,31 @@ export const PlanType = {
 } as const;
 export type PlanType = (typeof PlanType)[keyof typeof PlanType];
 
+// `workspace.billingPlan` is a free-form TEXT column with no CHECK constraint,
+// so a legacy, mistyped or rolled-back plan name can reach code that is typed
+// on PlanType. Casting with `as` asserts at compile time and validates nothing
+// at runtime, which leaves the plan helpers answering nonsense: getPlanOrder
+// returns undefined, isUpgrade is false for every plan, and an unrecognized
+// plan is absent from the entitlement table rather than resolving to a known
+// one. Narrow through toPlanType instead.
+const PLAN_TYPE_VALUES: ReadonlySet<string> = new Set(Object.values(PlanType));
+
+/**
+ * Narrow an untyped billing-plan string to PlanType, failing closed to FREE.
+ *
+ * Matching is exact: a recognized plan is returned unchanged, and anything
+ * else — unknown name, wrong case, stray whitespace, empty, null, undefined —
+ * resolves to FREE. Deliberately no trimming or case-folding: inferring a paid
+ * plan from a malformed string would grant entitlements the stored value does
+ * not actually name. Set membership (rather than an object lookup) also keeps
+ * prototype-chain keys such as "constructor" from resolving to a plan.
+ */
+export function toPlanType(plan: string | null | undefined): PlanType {
+  return typeof plan === "string" && PLAN_TYPE_VALUES.has(plan)
+    ? (plan as PlanType)
+    : PlanType.FREE;
+}
+
 // =============================================================================
 // USAGE QUOTAS
 // =============================================================================

--- a/frontend/ui/src/app/api/billing/change-plan/__tests__/route.test.ts
+++ b/frontend/ui/src/app/api/billing/change-plan/__tests__/route.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import path from "path";
+import { pathToFileURL } from "url";
+
+const mockGetSession = vi.fn();
+const mockWorkspaceFindFirst = vi.fn();
+const mockWorkspaceUpdate = vi.fn();
+
+const stripe = {
+  subscriptions: { retrieve: vi.fn(), update: vi.fn() },
+  subscriptionSchedules: { release: vi.fn(), create: vi.fn(), update: vi.fn() },
+};
+
+vi.mock("next/headers", () => ({ headers: async () => new Headers() }));
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: (...a: unknown[]) => mockGetSession(...a) } },
+}));
+
+vi.mock("@traceroot/core", async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>);
+  return {
+    ...actual,
+    prisma: {
+      workspace: {
+        findFirst: (...a: unknown[]) => mockWorkspaceFindFirst(...a),
+        update: (...a: unknown[]) => mockWorkspaceUpdate(...a),
+      },
+    },
+    getStripeOrThrow: () => stripe,
+  };
+});
+
+const routePath = path.join(__dirname, "..", "route.ts");
+const PERIOD_END = 1_800_000_000;
+
+function subscription(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "sub_1",
+    schedule: null,
+    cancel_at_period_end: false,
+    current_period_end: PERIOD_END,
+    items: { data: [{ id: "si_plan", price: { id: "price_plan" }, quantity: 1 }] },
+    ...overrides,
+  };
+}
+
+async function changePlan(billingPlan: string, newPlan: string, billingSubscriptionId = "sub_1") {
+  mockWorkspaceFindFirst.mockResolvedValue({ id: "ws-1", billingPlan, billingSubscriptionId });
+  const mod = await import(pathToFileURL(routePath).href);
+  const res = await mod.POST({ json: async () => ({ workspaceId: "ws-1", newPlan }) });
+  return { status: res.status, body: await res.json() };
+}
+
+describe("change-plan route", () => {
+  beforeEach(() => {
+    vi.stubEnv("ENABLE_BILLING", "true");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockGetSession.mockResolvedValue({ user: { id: "u-1" } });
+    stripe.subscriptions.retrieve.mockResolvedValue(subscription());
+    stripe.subscriptions.update.mockResolvedValue({
+      id: "sub_1",
+      status: "active",
+      items: { data: [{ price: { id: "price_new" } }] },
+    });
+    stripe.subscriptionSchedules.create.mockResolvedValue({
+      id: "sched_1",
+      phases: [{ start_date: 1 }],
+    });
+    mockWorkspaceUpdate.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  describe("recognized plans behave exactly as before", () => {
+    it("moving to a higher plan changes the subscription immediately", async () => {
+      const { body } = await changePlan("starter", "pro");
+      expect(body.message).toBe("Upgraded immediately");
+      expect(stripe.subscriptions.update).toHaveBeenCalledWith(
+        "sub_1",
+        expect.objectContaining({ proration_behavior: "always_invoice" }),
+      );
+      expect(stripe.subscriptionSchedules.create).not.toHaveBeenCalled();
+    });
+
+    it("moving to a lower paid plan schedules the change for period end", async () => {
+      const { body } = await changePlan("pro", "starter");
+      expect(body.message).toBe("Downgrade scheduled for next billing period");
+      expect(stripe.subscriptionSchedules.create).toHaveBeenCalled();
+      expect(stripe.subscriptions.update).not.toHaveBeenCalledWith(
+        "sub_1",
+        expect.objectContaining({ proration_behavior: "always_invoice" }),
+      );
+    });
+
+    it("moving to free cancels at period end", async () => {
+      const { body } = await changePlan("pro", "free");
+      expect(body.message).toBe("Subscription will be canceled at period end");
+      expect(stripe.subscriptions.update).toHaveBeenCalledWith("sub_1", {
+        cancel_at_period_end: true,
+      });
+    });
+
+    it("re-requesting the plan already stored is a no-op", async () => {
+      const { body } = await changePlan("pro", "pro");
+      expect(body.message).toBe("Already on this plan");
+      expect(stripe.subscriptions.retrieve).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("unrecognized stored plan", () => {
+    // billingPlan is free-form TEXT. Casting it left getPlanOrder undefined, so
+    // isUpgrade was false for every target and a move up landed in the
+    // downgrade branch — scheduled for period end instead of applied now.
+    it("is ordered as free, so a paid target is applied immediately", async () => {
+      const { body } = await changePlan("legacy-team", "pro");
+      expect(body.message).toBe("Upgraded immediately");
+      expect(stripe.subscriptions.update).toHaveBeenCalledWith(
+        "sub_1",
+        expect.objectContaining({ proration_behavior: "always_invoice" }),
+      );
+      expect(stripe.subscriptionSchedules.create).not.toHaveBeenCalled();
+    });
+
+    // The same-plan short-circuit compares the *stored* value, not the narrowed
+    // one. A workspace with an unrecognized plan can still hold a live paid
+    // subscription; narrowing it to free here would answer "already on this
+    // plan" and silently leave that subscription running.
+    it("can still cancel a live subscription by moving to free", async () => {
+      const { body } = await changePlan("legacy-team", "free");
+      expect(body.message).toBe("Subscription will be canceled at period end");
+      expect(stripe.subscriptions.update).toHaveBeenCalledWith("sub_1", {
+        cancel_at_period_end: true,
+      });
+    });
+  });
+});

--- a/frontend/ui/src/app/api/billing/change-plan/route.ts
+++ b/frontend/ui/src/app/api/billing/change-plan/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
-import { prisma, getStripeOrThrow, getPlanConfig, isUpgrade, PlanType } from "@traceroot/core";
+import {
+  prisma,
+  getStripeOrThrow,
+  getPlanConfig,
+  isUpgrade,
+  toPlanType,
+  PlanType,
+} from "@traceroot/core";
 
 export async function POST(req: NextRequest) {
   try {
@@ -25,18 +32,27 @@ export async function POST(req: NextRequest) {
     }
 
     const stripe = getStripeOrThrow();
-    const currentPlan = workspace.billingPlan as PlanType;
+    // Narrowed rather than cast: billingPlan is free-form TEXT, and an
+    // unrecognized value left getPlanOrder undefined, which made isUpgrade
+    // false and sent every change down the downgrade branch below. A
+    // recognized plan is returned unchanged, so nothing moves for valid data.
+    const currentPlan = toPlanType(workspace.billingPlan);
 
     console.log("Change plan request:", {
       currentPlan,
+      storedPlan: workspace.billingPlan,
       newPlan,
       isUpgradeResult: isUpgrade(currentPlan, newPlan as PlanType),
       subscriptionId: workspace.billingSubscriptionId,
       newPriceId: newPlanConfig.billingPriceId,
     });
 
-    // Case 0: Same plan, nothing to do
-    if (currentPlan === newPlan) {
+    // Case 0: Same plan, nothing to do. Compared against the stored value, not
+    // the narrowed one — for a recognized plan the two are identical, but a
+    // workspace whose stored plan is unrecognized may still hold a live paid
+    // subscription, and answering "already on this plan" to its downgrade-to-
+    // free request would leave that subscription running.
+    if (workspace.billingPlan === newPlan) {
       return NextResponse.json({ success: true, message: "Already on this plan" });
     }
 

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/__tests__/route.byok-entitlement.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/__tests__/route.byok-entitlement.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import path from "path";
+import { pathToFileURL } from "url";
+
+const mockRequireAuth = vi.fn();
+const mockRequireWorkspaceMembership = vi.fn();
+const mockWorkspaceFindUnique = vi.fn();
+const mockProviderFindMany = vi.fn();
+const mockProviderUpsert = vi.fn();
+
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...a: unknown[]) => mockRequireAuth(...a),
+  requireWorkspaceMembership: (...a: unknown[]) => mockRequireWorkspaceMembership(...a),
+  errorResponse: (msg: string, s: number) =>
+    new Response(JSON.stringify({ error: msg }), { status: s }),
+  successResponse: (d: unknown, s = 200) => new Response(JSON.stringify(d), { status: s }),
+}));
+
+vi.mock("@traceroot/core", async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>);
+  return {
+    ...actual,
+    prisma: {
+      workspace: { findUnique: (...a: unknown[]) => mockWorkspaceFindUnique(...a) },
+      modelProvider: {
+        findMany: (...a: unknown[]) => mockProviderFindMany(...a),
+        upsert: (...a: unknown[]) => mockProviderUpsert(...a),
+      },
+    },
+    Role: { ADMIN: "ADMIN" },
+    encryptKey: (v: string) => `cipher:${v}`,
+    maskKey: (v: string) => `sk-...${v.slice(-4)}`,
+  };
+});
+
+const routePath = path.join(__dirname, "..", "route.ts");
+const params = { params: Promise.resolve({ workspaceId: "ws-1" }) };
+
+const validBody = {
+  adapter: "openai",
+  provider: "my-openai",
+  apiKey: "sk-test-abcd",
+};
+
+async function getByokEnabled(billingPlan: string): Promise<boolean> {
+  mockWorkspaceFindUnique.mockResolvedValue({ billingPlan });
+  mockProviderFindMany.mockResolvedValue([]);
+  const mod = await import(pathToFileURL(routePath).href);
+  const res = await mod.GET(new Request("http://localhost/"), params);
+  return (await res.json()).byokEnabled;
+}
+
+async function postStatus(billingPlan: string): Promise<number> {
+  mockWorkspaceFindUnique.mockResolvedValue({ billingPlan });
+  mockProviderUpsert.mockResolvedValue({ id: "mp-1", provider: "my-openai" });
+  const mod = await import(pathToFileURL(routePath).href);
+  const res = await mod.POST(
+    new Request("http://localhost/", { method: "POST", body: JSON.stringify(validBody) }),
+    params,
+  );
+  return res.status;
+}
+
+// `workspace.billingPlan` is free-form TEXT, so a legacy, rolled-back or
+// mistyped plan name reaches hasEntitlement. Casting it to PlanType asserts at
+// compile time and validates nothing, and an unrecognized plan is absent from
+// the entitlement table — so BYOK, which every plan including Free grants, was
+// refused outright. Narrowing fails closed to FREE, making the worst case a
+// known plan rather than no plan at all.
+describe("model-providers BYOK entitlement", () => {
+  beforeEach(() => {
+    vi.stubEnv("ENABLE_BILLING", "true");
+    mockRequireAuth.mockResolvedValue({ user: { id: "u-1" }, error: null });
+    mockRequireWorkspaceMembership.mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("GET: an unrecognized plan resolves BYOK exactly like an explicit free", async () => {
+    const free = await getByokEnabled("free");
+    expect(free).toBe(true);
+
+    for (const plan of ["legacy-team", "Pro", "pro ", ""]) {
+      expect(await getByokEnabled(plan)).toBe(free);
+    }
+  });
+
+  it("GET: recognized plans are unaffected", async () => {
+    for (const plan of ["free", "starter", "pro", "enterprise"]) {
+      expect(await getByokEnabled(plan)).toBe(true);
+    }
+  });
+
+  it("POST: an unrecognized plan is not refused, and matches explicit free", async () => {
+    const free = await postStatus("free");
+    expect(free).toBe(201);
+
+    for (const plan of ["legacy-team", "Pro"]) {
+      const status = await postStatus(plan);
+      expect(status).not.toBe(403);
+      expect(status).toBe(free);
+    }
+  });
+
+  it("POST: a recognized paid plan still creates the provider", async () => {
+    expect(await postStatus("pro")).toBe(201);
+    expect(mockProviderUpsert).toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.ts
@@ -6,7 +6,7 @@ import {
   encryptKey,
   maskKey,
   hasEntitlement,
-  type PlanType,
+  toPlanType,
   LLMAdapter,
   BEDROCK_USE_DEFAULT_CREDENTIALS,
 } from "@traceroot/core";
@@ -63,7 +63,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     select: { billingPlan: true },
   });
 
-  const byokEnabled = workspace ? hasEntitlement(workspace.billingPlan as PlanType, "byok") : false;
+  const byokEnabled = workspace ? hasEntitlement(toPlanType(workspace.billingPlan), "byok") : false;
 
   const providers = await prisma.modelProvider.findMany({
     where: { workspaceId },
@@ -102,7 +102,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     where: { id: workspaceId },
     select: { billingPlan: true },
   });
-  if (!workspace || !hasEntitlement(workspace.billingPlan as PlanType, "byok")) {
+  if (!workspace || !hasEntitlement(toPlanType(workspace.billingPlan), "byok")) {
     return errorResponse("BYOK is not available on your current plan", 403);
   }
 

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -16,7 +16,7 @@ import { DateFilterSelect } from "@/components/date-filter-select";
 import { useUrlDateFilter } from "@/lib/hooks/use-url-date-filter";
 import { useRetention } from "@/lib/hooks/use-retention";
 import { PricingDialog } from "@/ee/features/billing/PricingDialog";
-import { PlanType } from "@traceroot/core";
+import { toPlanType } from "@traceroot/core";
 import { Button } from "@/components/ui/button";
 
 export default function DashboardDetailPage() {
@@ -198,7 +198,7 @@ export default function DashboardDetailPage() {
         open={retention.showPricing}
         onOpenChange={retention.closePricing}
         workspaceId={retention.workspaceId}
-        currentPlan={(retention.billingPlan as PlanType) || PlanType.FREE}
+        currentPlan={toPlanType(retention.billingPlan)}
       />
     </div>
   );

--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
@@ -16,7 +16,7 @@ import { DETECTORS_DEFAULT_DATE_FILTER_ID } from "@/lib/date-filter";
 import { TraceViewerPanel } from "@/features/traces/components/TraceViewerPanel";
 import { useRetention } from "@/lib/hooks/use-retention";
 import { PricingDialog } from "@/ee/features/billing/PricingDialog";
-import { PlanType } from "@traceroot/core";
+import { toPlanType } from "@traceroot/core";
 
 /**
  * Which trace the consolidated panel shows. `kind` selects RCA auto-open:
@@ -315,7 +315,7 @@ export default function DetectorDetailPage() {
         open={retention.showPricing}
         onOpenChange={retention.closePricing}
         workspaceId={retention.workspaceId}
-        currentPlan={(retention.billingPlan as PlanType) || PlanType.FREE}
+        currentPlan={toPlanType(retention.billingPlan)}
       />
     </div>
   );

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -22,7 +22,7 @@ import { DETECTORS_DEFAULT_DATE_FILTER_ID } from "@/lib/date-filter";
 import { useProject } from "@/features/projects/hooks";
 import { useRetention } from "@/lib/hooks/use-retention";
 import { PricingDialog } from "@/ee/features/billing/PricingDialog";
-import { PlanType } from "@traceroot/core";
+import { toPlanType } from "@traceroot/core";
 import { DeleteDetectorDialog } from "@/features/detectors/components/delete-detector-dialog";
 import { DetectorPanel } from "@/features/detectors/components/detector-panel";
 import { getTemplate } from "@/features/detectors/templates";
@@ -362,7 +362,7 @@ export default function DetectorsPage() {
         open={retention.showPricing}
         onOpenChange={retention.closePricing}
         workspaceId={retention.workspaceId}
-        currentPlan={(retention.billingPlan as PlanType) || PlanType.FREE}
+        currentPlan={toPlanType(retention.billingPlan)}
       />
     </div>
   );

--- a/frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
@@ -13,7 +13,7 @@ import { SessionDetailPanel } from "@/features/traces/components/SessionDetailPa
 import { useSessions } from "@/features/traces/hooks";
 import { useRetention } from "@/lib/hooks/use-retention";
 import { PricingDialog } from "@/ee/features/billing/PricingDialog";
-import { PlanType } from "@traceroot/core";
+import { toPlanType } from "@traceroot/core";
 import { useListPageState } from "@/lib/hooks/use-list-page-state";
 import { useSession as useAuthSession } from "@/lib/auth-client";
 import {
@@ -275,7 +275,7 @@ export default function SessionsPage() {
         open={retention.showPricing}
         onOpenChange={retention.closePricing}
         workspaceId={retention.workspaceId}
-        currentPlan={(retention.billingPlan as PlanType) || PlanType.FREE}
+        currentPlan={toPlanType(retention.billingPlan)}
       />
     </div>
   );

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -16,7 +16,7 @@ import type { TraceListItem } from "@/types/api";
 import { useTraces, usePrefetchTraces, useTracesExist } from "@/features/traces/hooks";
 import { useRetention } from "@/lib/hooks/use-retention";
 import { PricingDialog } from "@/ee/features/billing/PricingDialog";
-import { PlanType } from "@traceroot/core";
+import { toPlanType } from "@traceroot/core";
 import { useListPageState } from "@/lib/hooks/use-list-page-state";
 import { useLocalStorage } from "@/lib/hooks/use-local-storage";
 import { TraceViewerPanel, GettingStarted } from "@/features/traces/components";
@@ -396,7 +396,7 @@ export default function TracesPage() {
         open={retention.showPricing}
         onOpenChange={retention.closePricing}
         workspaceId={retention.workspaceId}
-        currentPlan={(retention.billingPlan as PlanType) || PlanType.FREE}
+        currentPlan={toPlanType(retention.billingPlan)}
       />
     </div>
   );

--- a/frontend/ui/src/app/projects/[projectId]/users/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/users/page.tsx
@@ -24,7 +24,7 @@ import type { UserListItem } from "@/lib/api/users";
 import type { UserQueryOptions } from "@/lib/api/users";
 import { useRetention } from "@/lib/hooks/use-retention";
 import { PricingDialog } from "@/ee/features/billing/PricingDialog";
-import { PlanType } from "@traceroot/core";
+import { toPlanType } from "@traceroot/core";
 
 const tabs = [
   { id: "traces", label: "Traces", icon: DOMAIN_ICONS.trace, href: "traces" },
@@ -231,7 +231,7 @@ export default function UsersPage() {
         open={retention.showPricing}
         onOpenChange={retention.closePricing}
         workspaceId={retention.workspaceId}
-        currentPlan={(retention.billingPlan as PlanType) || PlanType.FREE}
+        currentPlan={toPlanType(retention.billingPlan)}
       />
     </div>
   );

--- a/frontend/ui/src/app/workspaces/[workspaceId]/settings/billing/page.tsx
+++ b/frontend/ui/src/app/workspaces/[workspaceId]/settings/billing/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
-import { PlanType } from "@traceroot/core";
+import { toPlanType } from "@traceroot/core";
 import { WorkspaceBreadcrumb } from "@/features/workspaces/components";
 import { BillingTab } from "@/ee/features/billing/BillingTab";
 import { getWorkspace } from "@/lib/api";
@@ -31,7 +31,7 @@ export default function WorkspaceSettingsBillingPage() {
         ) : (
           <BillingTab
             workspaceId={workspaceId}
-            currentPlan={(workspace?.billingPlan as PlanType) || PlanType.FREE}
+            currentPlan={toPlanType(workspace?.billingPlan)}
             hasSubscription={!!workspace?.billingSubscriptionId}
             currentUsage={workspace?.currentUsage}
           />

--- a/frontend/ui/src/components/RetentionGateBanner.test.tsx
+++ b/frontend/ui/src/components/RetentionGateBanner.test.tsx
@@ -1,9 +1,13 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+
+type MockWorkspace = { billingPlan?: string | null; billingSubscriptionId: string | null };
 
 const mocks = vi.hoisted(() => ({
   showPricing: false,
+  workspace: { billingPlan: "free", billingSubscriptionId: null } as MockWorkspace,
+  currentPlan: undefined as string | undefined,
 }));
 
 vi.mock("@/features/projects/hooks", () => ({
@@ -11,14 +15,14 @@ vi.mock("@/features/projects/hooks", () => ({
 }));
 
 vi.mock("@/features/workspaces/hooks", () => ({
-  useWorkspace: () => ({
-    data: { billingPlan: "free", billingSubscriptionId: null },
-  }),
+  useWorkspace: () => ({ data: mocks.workspace }),
 }));
 
 vi.mock("@/ee/features/billing/PricingDialog", () => ({
-  PricingDialog: ({ open }: { open: boolean }) =>
-    open ? <div data-testid="pricing-dialog">Pricing</div> : null,
+  PricingDialog: ({ open, currentPlan }: { open: boolean; currentPlan: string }) => {
+    mocks.currentPlan = currentPlan;
+    return open ? <div data-testid="pricing-dialog">Pricing</div> : null;
+  },
 }));
 
 import { RetentionGateBanner } from "./RetentionGateBanner";
@@ -30,7 +34,20 @@ const detail = {
   plan: "free",
 };
 
+beforeEach(() => {
+  mocks.workspace = { billingPlan: "free", billingSubscriptionId: null };
+  mocks.currentPlan = undefined;
+});
+
 afterEach(cleanup);
+
+/** Mount the banner with a given stored billingPlan and read the plan the
+ *  pricing dialog was handed. */
+function currentPlanFor(billingPlan: string | null | undefined): string | undefined {
+  mocks.workspace = { billingPlan, billingSubscriptionId: null };
+  render(<RetentionGateBanner projectId="proj-1" detail={detail} />);
+  return mocks.currentPlan;
+}
 
 describe("RetentionGateBanner", () => {
   it("renders trace-specific messaging with plan and retention days", () => {
@@ -51,5 +68,25 @@ describe("RetentionGateBanner", () => {
   it("renders unknown plan names as-is", () => {
     render(<RetentionGateBanner projectId="proj-1" detail={{ ...detail, plan: "custom_plan" }} />);
     expect(screen.getByText(/custom_plan plan retains the last/)).toBeTruthy();
+  });
+});
+
+// billingPlan is free-form TEXT, and PricingDialog's CTA labelling is driven by
+// getPlanOrder, which returns undefined for anything outside the enum: isUpgrade
+// then reads false for every plan, so every card said "Downgrade" and none was
+// marked current. The banner narrows the stored value instead of casting it.
+describe("RetentionGateBanner plan narrowing", () => {
+  it("passes a recognized plan through unchanged", () => {
+    for (const plan of ["free", "starter", "pro", "enterprise"]) {
+      cleanup();
+      expect(currentPlanFor(plan)).toBe(plan);
+    }
+  });
+
+  it("resolves an unrecognized plan to free", () => {
+    for (const plan of ["legacy-team", "Pro", "pro ", "", null, undefined]) {
+      cleanup();
+      expect(currentPlanFor(plan)).toBe("free");
+    }
   });
 });

--- a/frontend/ui/src/components/RetentionGateBanner.tsx
+++ b/frontend/ui/src/components/RetentionGateBanner.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Lock } from "lucide-react";
-import { PLANS, PlanType } from "@traceroot/core";
+import { PLANS, toPlanType } from "@traceroot/core";
 import { Button } from "@/components/ui/button";
 import { useProject } from "@/features/projects/hooks";
 import { useWorkspace } from "@/features/workspaces/hooks";
@@ -53,7 +53,7 @@ export function RetentionGateBanner({ projectId, detail }: RetentionGateBannerPr
         open={showPricing}
         onOpenChange={setShowPricing}
         workspaceId={workspaceId}
-        currentPlan={(workspace?.billingPlan as PlanType) || PlanType.FREE}
+        currentPlan={toPlanType(workspace?.billingPlan)}
         hasSubscription={!!workspace?.billingSubscriptionId}
       />
     </>

--- a/frontend/ui/src/components/layout/SidebarUpgradeButton.tsx
+++ b/frontend/ui/src/components/layout/SidebarUpgradeButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Sparkles } from "lucide-react";
-import { PlanType } from "@traceroot/core";
+import { toPlanType } from "@traceroot/core";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useProject } from "@/features/projects/hooks";
@@ -57,7 +57,7 @@ export function SidebarUpgradeButton({
         open={showPricingDialog}
         onOpenChange={setShowPricingDialog}
         workspaceId={workspaceId}
-        currentPlan={(workspace?.billingPlan as PlanType) || PlanType.FREE}
+        currentPlan={toPlanType(workspace?.billingPlan)}
         hasSubscription={!!workspace?.billingSubscriptionId}
       />
     </>


### PR DESCRIPTION
## Summary

Fixes: #2016

`workspace.billingPlan` is a free-form `TEXT` column with no `CHECK` constraint, so a legacy, rolled-back or mistyped plan name can reach code that is typed on `PlanType`. Twelve call sites cast it with `as PlanType` — a compile-time assertion that validates nothing at runtime — and the plan helpers answer nonsense for anything outside the enum. Matching is exact, so `'Pro'` with a capital P or a trailing space is enough.

**Two of the twelve are entitlement paths, not cosmetics.** `hasEntitlement` tests membership in a per-entitlement plan list, and an unrecognized plan is in no list at all — so it resolves `false` for everything, including `byok`, which *every* plan grants, Free included. A workspace could lose BYOK to a plan-string typo with nothing logged and nothing thrown:

- `model-providers` GET reported `byokEnabled: false`, hiding the feature.
- `model-providers` POST returned `403 BYOK is not available on your current plan`.

The third non-presentation site is the plan-change route, where the unvalidated value was the starting state for the upgrade/downgrade decision: `getPlanOrder` returned `undefined`, `isUpgrade` was therefore false for every target, and a move *up* from an unrecognized plan took the downgrade branch — scheduled for period end instead of applied immediately with proration.

The remaining nine are presentation: the raw cast was passed to `PricingDialog`, where the same `undefined` ordering made every CTA read "Downgrade" and left no card marked as current.

## The fix

A new `toPlanType(plan: string | null | undefined): PlanType` in `packages/core/src/ee/billing/plans.ts` narrows through set membership over the enum's own values and fails closed to `FREE`. All twelve sites call it.

Matching stays exact, deliberately: no trimming, no case-folding. Inferring a paid plan from a malformed string would grant entitlements the stored value does not name — the opposite of failing closed. Set membership (rather than an object lookup) also keeps `"constructor"` and friends from resolving to a plan.

**Every recognized plan is returned unchanged, so no valid workspace moves.** No quota, retention window or entitlement list is touched.

One place needs the un-narrowed value. The plan-change route's "already on this plan" short-circuit now compares the **stored** string, not the narrowed one — for a recognized plan the two are identical, but a workspace whose stored plan is unrecognized may still hold a live paid subscription, and normalising it to `free` there would answer "already on this plan" to a cancellation request and quietly leave that subscription running.

## Tests

- `plans.test.ts`: recognized plans pass through; unknown names, wrong case, stray whitespace, empty, `null`, `undefined` and prototype keys all resolve to `FREE`; and an unrecognized plan now matches an explicit `FREE` across **every** entitlement, with the old `false`-for-`byok` behaviour asserted alongside so the regression is documented, not just fixed.
- `model-providers/__tests__/route.byok-entitlement.test.ts`: GET and POST both resolve an unrecognized plan exactly as they resolve `free`, and all four recognized plans are unaffected.
- `change-plan/__tests__/route.test.ts`: the four recognized-plan outcomes (immediate change, scheduled downgrade, cancel-at-period-end, no-op) are pinned unchanged, plus the two unrecognized-plan cases above.
- `RetentionGateBanner.test.tsx`: asserts the plan handed to `PricingDialog` — identity for recognized plans, `free` otherwise.

Each new test was checked against a revert of its source file alone: 2 fail on the entitlement route, 1 on the plan-change route, 1 on the banner, and every recognized-plan assertion keeps passing throughout — so the discriminating tests are the unrecognized-plan ones, and the recognized-plan ones genuinely pin unchanged behaviour.

`2014 passed` (UI, 214 files), `135 passed` (core, 12 files), `pnpm lint` 0 errors with no new warnings, prettier clean, and `tsc --noEmit` unchanged at its pre-existing 6 errors.

## Scope

Frontend only. No migration, no schema change, no API contract change. Sites that read `billingPlan` through paths already tolerant of a raw string (`getRetentionDays`, the worker's metering and detector processors) are untouched.

> **Merge-order note:** open PR #1991 also adds `toPlanType` to `frontend/packages/core/src/ee/billing/plans.ts` and exports it. Whichever lands second will conflict on that file. Either merge #1991 first and rebase this onto it, or drop the helper from one of the two.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2016. `workspace.billingPlan` is free-form `TEXT`, so a legacy or mistyped plan string could reach code typed on `PlanType`. This replaces twelve `as PlanType` casts with `toPlanType()`, which narrows through set membership and fails closed to `FREE` — an unrecognized plan now behaves as `free` instead of silently breaking entitlements and plan ordering.

**Bug Fixes**
- Unrecognized plans now resolve BYOK like explicit `free`; previously every entitlement check answered `false`, so GET hid BYOK and POST returned 403.
- Upgrades from an unrecognized plan now apply immediately; previously `isUpgrade` was false for every target, so they were scheduled for period end like downgrades.
- `PricingDialog` now labels CTAs and marks the current plan correctly instead of showing "Downgrade" everywhere.

The "already on this plan" check now compares the stored string, not the narrowed plan, so a workspace with a malformed stored plan can still cancel a live paid subscription.

Open PR #1991 also adds `toPlanType` to the same file and exports it; if both land, the second needs a small rebase on that file.

<sup>Written for commit 9e8a6ac98156f2c06ebe23cef05fb5308437388a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

