### PR TITLE
fix(api): refuse an evaluation run read outside the plan's retention window

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.readback.test.ts
@@ -61,6 +61,10 @@ vi.mock("@traceroot/core", async (importOriginal) => {
         }),
       },
       dataset: { findFirst: vi.fn(async () => db.dataset) },
+      // The route resolves the workspace's plan for the retention gate. Unlimited
+      // retention keeps these exposure assertions independent of the gate and of the
+      // wall clock; route.retention.test.ts covers the gate itself.
+      workspace: { findUnique: vi.fn(async () => ({ billingPlan: "enterprise" })) },
     },
   };
 });
@@ -74,7 +78,9 @@ const params = (runId: string) => ({
 
 beforeEach(() => {
   auth.requireAuth.mockResolvedValue({ user: { id: "u1", email: "e@x.com" } });
-  auth.requireProjectAccess.mockResolvedValue({ project: { id: PROJECT_ID } });
+  auth.requireProjectAccess.mockResolvedValue({
+    project: { id: PROJECT_ID, workspaceId: "ws1" },
+  });
   db.dataset = { id: "ds1", name: "Billing routing" };
   db.run = {
     id: "run1",

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.retention.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.retention.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Retention gate on the by-id run read.
+ *
+ * A list has a window to pull forward, so it clamps silently; a by-id read has none, so
+ * it refuses with 403 — the split `clamp_retention_window` / `enforce_retention_by_time`
+ * already draws in backend/rest/retention.py. These cases pin that refusal across the
+ * plan table, the fail-closed paths, the one-hour boundary buffer, and the comparison
+ * page (which reads each of its runs through this route).
+ *
+ * Auth + Prisma are mocked; `@traceroot/core` is spread from the real module so the
+ * plan table and `getRetentionDays` are the shipped ones, not a second copy.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  evaluationRun: { findFirst: vi.fn() },
+  dataset: { findFirst: vi.fn() },
+  evaluationResult: { groupBy: vi.fn(), aggregate: vi.fn() },
+  workspace: { findUnique: vi.fn() },
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@traceroot/core")>()),
+  prisma: prismaMock,
+}));
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET } from "./route";
+
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+const agoMs = (ms: number) => new Date(Date.now() - ms);
+const daysAgo = (days: number) => agoMs(days * DAY_MS);
+
+const params = (runId = "run-1") => ({ params: Promise.resolve({ projectId: "p1", runId }) });
+
+/** A minimal, baseline-free run — only `startedAt` matters to the gate. */
+function run(startedAt: Date, id = "run-1") {
+  return {
+    id,
+    projectId: "p1",
+    evaluationId: "eval-1",
+    datasetId: "ds1",
+    datasetVersionId: "dv1",
+    runNumber: 1,
+    candidateVersion: "sonnet",
+    status: "completed",
+    baselineRunId: null,
+    caseCount: 0,
+    taskErrorCount: 0,
+    scorerErrorCount: 0,
+    scorers: [],
+    startedAt,
+    completedAt: startedAt,
+    evaluation: { name: "Billing routing" },
+    datasetVersion: { label: "v1" },
+    baselineRun: null,
+    results: [],
+  };
+}
+
+/** Drive the route for a run started `startedAt` on a workspace holding `plan`. */
+async function read(plan: string | null, startedAt: Date, runId = "run-1") {
+  prismaMock.evaluationRun.findFirst.mockResolvedValue(run(startedAt, runId));
+  prismaMock.workspace.findUnique.mockResolvedValue(plan === null ? null : { billingPlan: plan });
+  return GET({} as never, params(runId));
+}
+
+beforeEach(() => {
+  prismaMock.evaluationRun.findFirst.mockReset();
+  prismaMock.dataset.findFirst.mockReset();
+  prismaMock.evaluationResult.groupBy.mockReset();
+  prismaMock.evaluationResult.aggregate.mockReset();
+  prismaMock.workspace.findUnique.mockReset();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1", workspaceId: "ws1" } });
+  prismaMock.dataset.findFirst.mockResolvedValue({ id: "ds1", name: "Billing routing" });
+  prismaMock.evaluationResult.groupBy.mockResolvedValue([]);
+  prismaMock.evaluationResult.aggregate.mockResolvedValue({
+    _sum: { durationMs: null, cost: null },
+  });
+});
+
+describe("by-id run read, outside the window", () => {
+  it("refuses with 403 rather than returning the run", async () => {
+    const res = await read("free", daysAgo(40));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Data outside retention window" });
+  });
+
+  it("does no further reading once it has refused", async () => {
+    await read("free", daysAgo(40));
+    // The baseline lookup shares evaluationRun.findFirst with the candidate: exactly
+    // one call means the refusal landed before the rest of the detail assembly.
+    expect(prismaMock.evaluationRun.findFirst).toHaveBeenCalledTimes(1);
+    expect(prismaMock.dataset.findFirst).not.toHaveBeenCalled();
+    expect(prismaMock.evaluationResult.groupBy).not.toHaveBeenCalled();
+    expect(prismaMock.evaluationResult.aggregate).not.toHaveBeenCalled();
+  });
+
+  it("resolves the plan from the workspace the project belongs to", async () => {
+    await read("free", daysAgo(40));
+    expect(prismaMock.workspace.findUnique).toHaveBeenCalledWith({
+      where: { id: "ws1" },
+      select: { billingPlan: true },
+    });
+  });
+});
+
+describe("across the plan table", () => {
+  it("returns the run untouched on the free plan", async () => {
+    const res = await read("free", daysAgo(2));
+    expect(res.status).toBe(200);
+    expect((await res.json()).run.id).toBe("run-1");
+  });
+
+  it.each([
+    ["starter", 20],
+    ["pro", 60],
+  ])("returns a run inside the %s window (%i days old)", async (plan, age) => {
+    const res = await read(plan, daysAgo(age));
+    expect(res.status).toBe(200);
+  });
+
+  it.each([
+    ["starter", 40],
+    ["pro", 120],
+  ])("refuses a run outside the %s window (%i days old)", async (plan, age) => {
+    const res = await read(plan, daysAgo(age));
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("unlimited retention", () => {
+  it("returns a five-year-old run on the enterprise plan", async () => {
+    const res = await read("enterprise", daysAgo(5 * 365));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("fail closed", () => {
+  it("treats an unrecognized plan string as the most restrictive window", async () => {
+    // 20 days is inside starter/pro but outside free — so a plan the table does not
+    // know must refuse, not wave the run through.
+    const res = await read("legacy-team-plan", daysAgo(20));
+    expect(res.status).toBe(403);
+  });
+
+  it("treats a missing workspace row as the most restrictive window", async () => {
+    const res = await read(null, daysAgo(40));
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("the boundary buffer", () => {
+  it("keeps a run just past the raw cutoff readable (one-hour buffer)", async () => {
+    const res = await read("free", agoMs(15 * DAY_MS + 30 * 60_000));
+    expect(res.status).toBe(200);
+  });
+
+  it("refuses once the run is past the buffer too", async () => {
+    const res = await read("free", agoMs(15 * DAY_MS + 2 * HOUR_MS));
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("what the gate does not change", () => {
+  it("keeps a missing run a 404, without resolving the plan", async () => {
+    prismaMock.evaluationRun.findFirst.mockResolvedValue(null);
+    const res = await GET({} as never, params("nope"));
+    expect(res.status).toBe(404);
+    expect(prismaMock.workspace.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("leaves auth and project access ahead of it", async () => {
+    auth.requireProjectAccess.mockResolvedValue({ error: { status: 403 } });
+    prismaMock.evaluationRun.findFirst.mockResolvedValue(run(daysAgo(1)));
+    await GET({} as never, params());
+    expect(prismaMock.evaluationRun.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe("the comparison page", () => {
+  // The compare route has no server route of its own: it fetches each selected run
+  // through this handler (see useEvaluationRunDetails). So a comparison mixing an
+  // in-window run with an out-of-window one gets the run for the first and a refusal
+  // for the second — the column cannot be filled by picking an older id by hand.
+  it("refuses the out-of-window member of a comparison and serves the rest", async () => {
+    const fresh = await read("free", daysAgo(3), "run-new");
+    expect(fresh.status).toBe(200);
+
+    const stale = await read("free", daysAgo(200), "run-old");
+    expect(stale.status).toBe(403);
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.retention.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.retention.test.ts
@@ -43,8 +43,13 @@ const daysAgo = (days: number) => agoMs(days * DAY_MS);
 
 const params = (runId = "run-1") => ({ params: Promise.resolve({ projectId: "p1", runId }) });
 
-/** A minimal, baseline-free run — only `startedAt` matters to the gate. */
-function run(startedAt: Date, id = "run-1") {
+/**
+ * A minimal run — only `startedAt` matters to the gate. `baselineRunId` defaults to null
+ * (the common shape), but the route reads the baseline through a second
+ * `evaluationRun.findFirst` only when it is set, so a test counting those calls has to
+ * pass one in or it is asserting against an unreachable branch.
+ */
+function run(startedAt: Date, id = "run-1", baselineRunId: string | null = null) {
   return {
     id,
     projectId: "p1",
@@ -54,7 +59,7 @@ function run(startedAt: Date, id = "run-1") {
     runNumber: 1,
     candidateVersion: "sonnet",
     status: "completed",
-    baselineRunId: null,
+    baselineRunId,
     caseCount: 0,
     taskErrorCount: 0,
     scorerErrorCount: 0,
@@ -69,8 +74,13 @@ function run(startedAt: Date, id = "run-1") {
 }
 
 /** Drive the route for a run started `startedAt` on a workspace holding `plan`. */
-async function read(plan: string | null, startedAt: Date, runId = "run-1") {
-  prismaMock.evaluationRun.findFirst.mockResolvedValue(run(startedAt, runId));
+async function read(
+  plan: string | null,
+  startedAt: Date,
+  runId = "run-1",
+  baselineRunId: string | null = null,
+) {
+  prismaMock.evaluationRun.findFirst.mockResolvedValue(run(startedAt, runId, baselineRunId));
   prismaMock.workspace.findUnique.mockResolvedValue(plan === null ? null : { billingPlan: plan });
   return GET({} as never, params(runId));
 }
@@ -98,7 +108,10 @@ describe("by-id run read, outside the window", () => {
   });
 
   it("does no further reading once it has refused", async () => {
-    await read("free", daysAgo(40));
+    // The run carries a baseline, so the route's second `evaluationRun.findFirst` is
+    // genuinely reachable — the call count below would be 2 if the gate stopped
+    // short-circuiting it. With a baseline-free run that assertion holds either way.
+    await read("free", daysAgo(40), "run-1", "run-0");
     // The baseline lookup shares evaluationRun.findFirst with the candidate: exactly
     // one call means the refusal landed before the rest of the detail assembly.
     expect(prismaMock.evaluationRun.findFirst).toHaveBeenCalledTimes(1);

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.test.ts
@@ -11,10 +11,17 @@ const prismaMock = vi.hoisted(() => ({
   evaluationRun: { findFirst: vi.fn() },
   dataset: { findFirst: vi.fn() },
   evaluationResult: { groupBy: vi.fn(), aggregate: vi.fn() },
+  // The route resolves the workspace's plan for the retention gate.
+  workspace: { findUnique: vi.fn() },
 }));
 const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
 
-vi.mock("@traceroot/core", () => ({ prisma: prismaMock }));
+// Spread the real module so the retention helper's `getRetentionDays`/`PlanType`
+// are the shipped ones, not a second copy of the plan table.
+vi.mock("@traceroot/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@traceroot/core")>()),
+  prisma: prismaMock,
+}));
 vi.mock("@/lib/auth-helpers", () => ({
   requireAuth: auth.requireAuth,
   requireProjectAccess: auth.requireProjectAccess,
@@ -147,8 +154,13 @@ beforeEach(() => {
   prismaMock.dataset.findFirst.mockReset();
   prismaMock.evaluationResult.groupBy.mockReset();
   prismaMock.evaluationResult.aggregate.mockReset();
+  prismaMock.workspace.findUnique.mockReset();
   auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
-  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1", workspaceId: "ws1" } });
+  // Unlimited retention: these cases are about the comparison derivation, so the
+  // gate (and the wall clock the fixture's startedAt is measured against) is kept
+  // out of them. route.retention.test.ts covers the gate itself.
+  prismaMock.workspace.findUnique.mockResolvedValue({ billingPlan: "enterprise" });
   prismaMock.dataset.findFirst.mockResolvedValue({ id: "ds1", name: "Billing routing" });
   // Status counts now come from a grouped aggregate over ALL of a run's results, not the
   // (capped) results page. Default to none; the per-status-counts test supplies its own.

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest } from "next/server";
-import { prisma, Role } from "@traceroot/core";
+import { prisma, PlanType, Role } from "@traceroot/core";
 import {
   requireAuth,
   requireProjectAccess,
   errorResponse,
   successResponse,
 } from "@/lib/auth-helpers";
+import { isOutsideRetention } from "@/lib/server/retention";
 import { compareRuns } from "@/lib/eval/comparison";
 import { toComparisonRun, toComparisonResults } from "@/lib/eval/comparison-db";
 import { countResultStatuses } from "@/lib/eval/result-status-counts";
@@ -54,6 +55,30 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
     },
   });
   if (!run) return errorResponse("Evaluation run not found", 404);
+
+  // Retention gate — the by-id half. A list has a window to pull forward, so it clamps
+  // silently; a by-id read has none, so it refuses. That is the split the telemetry
+  // surfaces already make between clamp_retention_window and enforce_retention_by_time
+  // (backend/rest/retention.py), and `isOutsideRetention` is the second of those for the
+  // Node routes. Plan resolution matches the detector proxies: an unreadable or absent
+  // workspace fails closed to the most restrictive plan.
+  //
+  // This also gates the comparison page, which has no route of its own — it fetches each
+  // selected run through here, so an out-of-window run cannot be smuggled in as a
+  // comparison column either.
+  //
+  // Placed after the 404 so a run that does not exist stays a 404 (and skips the plan
+  // lookup), and before the baseline/dataset/aggregate reads so a refusal does no work.
+  // A run's embedded baseline is not separately gated: it is reachable only as the diff
+  // columns of an in-window run, which is how a run's baseline is surfaced elsewhere too.
+  const workspace = await prisma.workspace.findUnique({
+    where: { id: accessResult.project.workspaceId },
+    select: { billingPlan: true },
+  });
+  const billingPlan = workspace?.billingPlan || PlanType.FREE;
+  if (isOutsideRetention(billingPlan, run.startedAt)) {
+    return errorResponse("Data outside retention window", 403);
+  }
 
   // The baseline's raw results + scores (no per-row N+1), capped the same way.
   const baselineRun = run.baselineRunId

--- a/frontend/ui/src/features/evaluations/compare-runs-route.test.tsx
+++ b/frontend/ui/src/features/evaluations/compare-runs-route.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+/**
+ * The comparison page has no server route of its own — `useEvaluationRunDetails`
+ * fetches each selected run through the by-id run route. That is what puts the
+ * comparison behind that route's retention gate (see
+ * app/api/.../evaluations/runs/[runId]/route.retention.test.ts), so it is pinned
+ * here: a dedicated compare endpoint added later must carry the gate itself.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { useEvaluationRunDetails } from "./hooks";
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+afterEach(() => {
+  cleanup();
+});
+
+describe("useEvaluationRunDetails", () => {
+  it("reads every compared run through the by-id run route", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ run: {}, results: [] }),
+    });
+
+    const { result } = renderHook(() => useEvaluationRunDetails("p1", ["run-a", "run-b"]), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.every((q) => q.isSuccess)).toBe(true));
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "/api/projects/p1/evaluations/runs/run-a",
+      "/api/projects/p1/evaluations/runs/run-b",
+    ]);
+  });
+
+  it("surfaces that route's refusal as an error for that run, never an empty column", async () => {
+    fetchMock.mockImplementation((url: string) =>
+      Promise.resolve(
+        url.endsWith("run-old")
+          ? {
+              ok: false,
+              status: 403,
+              json: async () => ({ error: "Data outside retention window" }),
+            }
+          : { ok: true, status: 200, json: async () => ({ run: {}, results: [] }) },
+      ),
+    );
+
+    const { result } = renderHook(() => useEvaluationRunDetails("p1", ["run-new", "run-old"]), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current[1].isError).toBe(true));
+
+    expect(result.current[0].isSuccess).toBe(true);
+    expect(result.current[1].data).toBeUndefined();
+    expect((result.current[1].error as Error).message).toContain("403");
+  });
+});

--- a/frontend/ui/src/lib/server/retention.ts
+++ b/frontend/ui/src/lib/server/retention.ts
@@ -5,10 +5,16 @@ import { getRetentionDays } from "@traceroot/core";
 // backend gate (backend/rest/retention.py, hours=1).
 const BOUNDARY_BUFFER_MS = 3_600_000;
 
-function getRetentionCutoff(billingPlan: string): string | null {
+/** The plan's cutoff as epoch ms, or null when the plan has unlimited retention. */
+function getRetentionCutoffMs(billingPlan: string): number | null {
   const days = getRetentionDays(billingPlan);
   if (days === null) return null;
-  return new Date(Date.now() - days * 86_400_000 - BOUNDARY_BUFFER_MS).toISOString();
+  return Date.now() - days * 86_400_000 - BOUNDARY_BUFFER_MS;
+}
+
+function getRetentionCutoff(billingPlan: string): string | null {
+  const ms = getRetentionCutoffMs(billingPlan);
+  return ms === null ? null : new Date(ms).toISOString();
 }
 
 /**
@@ -27,4 +33,28 @@ export function clampStartAfter(billingPlan: string, startAfter: string | null):
     return cutoff;
   }
   return startAfter;
+}
+
+/**
+ * The by-id half of the gate: true when a record's own timestamp falls outside
+ * the plan's retention window, so the caller can answer 403.
+ *
+ * A list has a window to pull forward, so it clamps silently (`clampStartAfter`
+ * above). A by-id read has none — the only answers are the record or a refusal —
+ * which is exactly the split the telemetry routes already make between
+ * `clamp_retention_window` and `enforce_retention_by_time` in
+ * backend/rest/retention.py. This is that second helper for the Node routes, on
+ * the same cutoff (and the same one-hour boundary buffer) as the clamp.
+ *
+ * An unlimited-retention plan gates nothing. A missing timestamp gates nothing
+ * either, matching the Python helper's `timestamp is not None` guard: absent is
+ * not evidence of being outside the window.
+ */
+export function isOutsideRetention(
+  billingPlan: string,
+  timestamp: Date | null | undefined,
+): boolean {
+  const cutoffMs = getRetentionCutoffMs(billingPlan);
+  if (cutoffMs === null || timestamp == null) return false;
+  return timestamp.getTime() < cutoffMs;
 }


### PR DESCRIPTION
## Summary

Fixes: #2017

Plan-based retention restricts *query access*, not storage — the data stays, the window moves. The telemetry surfaces enforce that in two shapes, deliberately: a list has a window to pull forward, so it clamps silently (`clamp_retention_window`); a by-id read has none, so it refuses with `403` (`enforce_retention_by_time`). The evaluation-run surface only ever had a place for the first. `GET /api/projects/[projectId]/evaluations/runs/[runId]` did no retention handling at all, so a run older than the workspace's window was returned in full — results, per-case outputs, scores — when asked for by id.

This closes a known hole rather than a live leak. There is no path through the product that hands a caller an out-of-window run id: the evaluations list never surfaces one, so reaching this needs a hand-crafted request or a link kept from before the window moved. The fix is sized to match — one gate, in one route, on the precedent that already exists.

## The fix

`isOutsideRetention(billingPlan, timestamp)` joins `clampStartAfter` in `frontend/ui/src/lib/server/retention.ts`, sharing that module's cutoff and its one-hour boundary buffer. It is the Node counterpart of `enforce_retention_by_time`, down to the `timestamp is not None` guard: an absent timestamp is not evidence of being outside the window, and an unlimited-retention plan gates nothing.

The route resolves the plan the same way the detector proxies do — one keyed lookup of the project's workspace, failing closed to the most restrictive plan for an absent row or an unrecognized plan string — and refuses on `run.startedAt`:

```ts
if (isOutsideRetention(billingPlan, run.startedAt)) {
  return errorResponse("Data outside retention window", 403);
}
```

Placement carries two decisions. It sits **after** the `404`, so a run that does not exist stays a `404` and never pays for the plan lookup; and **before** the baseline, dataset and aggregate reads, so a refusal does no further work.

**The comparison view is covered by the same gate, not a second one.** `/evaluations/compare` has no server route of its own — it fetches each selected run through this handler — so a comparison cannot be filled by naming an older run id by hand. That is now pinned by a test, so a dedicated compare endpoint added later has to carry the gate itself rather than inherit it silently.

## Scope

Deliberately narrow. `DELETE` is left ungated: the Python helper this mirrors is a read gate, and refusing to delete a run because it aged out would be a worse answer than performing it. A run's embedded baseline is not separately gated either — it is reachable only as the diff columns of an in-window run, which is how a baseline is surfaced elsewhere too. The `403` body follows the Node routes' `{ error }` convention rather than inventing a structured detail no client reads yet.

Nothing is enforced against a plan that is still resolving. On this path there is no such state: the plan is a single awaited lookup, and the gate runs only once it has an answer.

## Tests

`route.retention.test.ts` (16 cases) covers the refusal and its message; each plan on both sides of its window (free/starter/pro); a five-year-old run readable on an unlimited plan; failing closed for an unrecognized plan string and for a missing workspace row; both sides of the one-hour boundary buffer; that a refusal issues no further queries; that `404` and the auth/access checks still come first; and the mixed in-window/out-of-window comparison. A second file pins the premise that comparison reads go through this route, and that its refusal surfaces as an error for that run rather than a silently empty column.

Verified:

- Reverting **only** the route (helper and tests intact) fails 9 of the 16 gate cases — every branch that should refuse, and nothing else.
- After: `2020 passed` across `214` files in the UI suite, 18 of those tests new. `eslint` adds no findings; `prettier --check` clean; `tsc --noEmit` reports the same 6 pre-existing errors as `main`, none in the touched files.

Frontend-only, no backend change, no migration, no API contract change beyond the new refusal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2017. `GET /api/projects/[projectId]/evaluations/runs/[runId]` previously returned any run in full regardless of the workspace plan's retention window; it now answers `403` "Data outside retention window" for runs older than the window, the Node counterpart of `enforce_retention_by_time`. The comparison page is gated the same way since it fetches each compared run through this route, so an out-of-window run id can't smuggle a column into a comparison.

**Behavior**
- Fails closed to the most restrictive window for unrecognized plan strings and missing workspace rows.
- Uses the same one-hour boundary buffer as the list's silent clamp (`clampStartAfter`).
- A missing run stays a `404` and skips the plan lookup; a refusal issues no further queries.
- `DELETE` and a run's embedded baseline stay ungated by design.
- Frontend-only; no migration or API contract change beyond the new refusal.

**Tests**
- Adds 16 retention gate cases covering plan windows, fail-closed paths, the boundary buffer, and that a refusal does no further reads (that case now runs with a baseline so its call-count assertion can actually fail).
- Pins that comparison reads go through this route and surface the refusal as an error for that run.

<sup>Written for commit 8b7a633e43bff2d67c7e3b020336a7aa3e89b8e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

