### PR TITLE
perf(db): drop the unused `ix_test_case_project_id` index

### DIFF
--- a/frontend/packages/core/prisma/migrations/20260826000000_drop_test_case_project_id_index/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260826000000_drop_test_case_project_id_index/migration.sql
@@ -1,0 +1,23 @@
+-- `test_cases` carried a btree on `project_id` alone that no read selects. Every query
+-- against the table filters by `dataset_version_id` (dataset detail, version detail,
+-- publish, the per-version case counts) except one — the trace-to-case lookup, which
+-- filters `(project_id, source_trace_id)` and is resolved by the far more selective
+-- `ix_test_case_source_trace_id`. `project_id` also carries no foreign key on this model,
+-- so no constraint check reads it either. The index only cost write throughput and storage
+-- on the fastest-growing table in the schema: a dataset publish writes one row per case,
+-- so its maintenance scaled with cases x versions.
+
+-- Dropped NON-concurrently on purpose. `DROP INDEX CONCURRENTLY` cannot run inside a
+-- transaction block, and Prisma Migrate (`migrate deploy`, run from the Helm pre-upgrade
+-- hook) wraps every migration file in a transaction on PostgreSQL — so a CONCURRENTLY drop
+-- here would abort the whole migration and block the upgrade. A plain DROP INDEX only has
+-- to unlink the index and takes its ACCESS EXCLUSIVE lock on `test_cases` briefly; it does
+-- not rewrite the table. The lock_timeout is a safety bound: rather than queue behind a
+-- long-running reader or writer and stall the table indefinitely, fail fast (the migrate
+-- Job retries per its backoffLimit). SET LOCAL scopes the timeout to this migration's own
+-- transaction, so it does not leak into later pending migrations `migrate deploy` runs on
+-- the same connection.
+SET LOCAL lock_timeout = '5s';
+
+-- DropIndex
+DROP INDEX IF EXISTS "ix_test_case_project_id";

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -550,7 +550,6 @@ model TestCase {
   // comparison alignment, and the TEST_CASE_ORDER tiebreak).
   @@unique([datasetVersionId, testCaseId], map: "uq_test_case_version_test_case_id")
   @@index([datasetVersionId], map: "ix_test_case_version_id")
-  @@index([projectId], map: "ix_test_case_project_id")
   @@index([sourceTraceId], map: "ix_test_case_source_trace_id")
   @@map("test_cases")
 }


### PR DESCRIPTION
## Summary

Fixes: #2018

`test_cases` carried a btree on `project_id` alone that no read selects. It cost write throughput and storage on the fastest-growing table in the schema — a dataset publish writes one row per case, so index maintenance scaled with cases x versions — and returned nothing.

## Every read of `test_cases`, and what resolves it

Thirteen Prisma call sites plus four relation traversals. There is no raw SQL against this table anywhere (`$queryRaw`/`$executeRaw` appear nowhere in the frontend) and the backend never touches it — its only `test_case_id` references are on `evaluation_results`.

Twelve of the thirteen filter by `dataset_version_id` and are served by `ix_test_case_version_id` or `uq_test_case_version_test_case_id`: the dataset-detail read, the version-detail and public version reads, the per-version case counts (two `groupBy` aggregates keyed `datasetVersionId: { in: [...] }`, plus three `count`s), the duplicate-source-span check, the edit/delete existence guards, the publish read-and-copy, and the save-result-to-dataset liveness check. None of them mentions `project_id`, so no plan could reach for it.

The thirteenth is the trace-to-case lookup (`GET /api/projects/[projectId]/traces/[traceId]/test-cases`), the one site that filters `project_id` at all — and it filters `{ projectId, sourceTraceId }` together. `source_trace_id` is near-unique here (a handful of cases per trace) while `project_id` matches a large fraction of the table, so `ix_test_case_source_trace_id` returns the rows and `project_id` is a cheap heap recheck. A `BitmapAnd` across both would add a wide index scan to save at most a few heap fetches, which costs more than it saves.

`project_id` also carries no foreign key on this model — `TestCase`'s only relation is `version` — so no constraint check or cascade reads the column either. The cascade path is `datasets` -> `dataset_versions` -> `test_cases` on `dataset_version_id`.

## Plan evidence

No live Postgres was available in this environment, so **no `EXPLAIN` output is included** — the case above is static rather than measured. Reviewers with a populated database should confirm the dataset-detail and version-detail plans are unchanged and that the trace-to-case lookup still resolves through `ix_test_case_source_trace_id`.

What is measured: `prisma generate` produces a byte-identical `index.d.ts` before and after. The generated client's only delta is the embedded schema text — one removed line — and its hash. No type or query surface changes, so no read path can behave differently.

## Scope

One schema line and one migration. The migration drops the index non-concurrently and under `SET LOCAL lock_timeout = '5s'`, matching the reasoning in `20260818000000_test_case_unique_version_case_id`: Prisma Migrate wraps each file in a transaction, where `CONCURRENTLY` cannot run. A plain `DROP INDEX` only unlinks the index and holds its lock briefly; it does not rewrite the table. No table data changes, no read-path changes, no other schema edits — additive and independent of the `position` column in #1998.

## Verify

`pnpm vitest run` in `ui`: 212 files, 2002 tests passed. `@traceroot/core`: 12 files, 129 tests passed. `pnpm lint`: 0 errors (187 pre-existing warnings). `tsc --noEmit` on `ui`: 6 pre-existing errors in unrelated test files, unchanged — the client's `index.d.ts` is byte-identical, so this change cannot affect typechecking. Prettier has no parser for `.prisma`/`.sql`; both files match the existing migrations' style.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the unused `ix_test_case_project_id` index on `test_cases`, fixing #2018. No read query filters `project_id` alone — the trace-to-case lookup filters `(project_id, source_trace_id)` and resolves via `ix_test_case_source_trace_id` — so the index only cost write throughput and storage on the fastest-growing table, with no read side effects.

**Migration**
- Drops the index non-concurrently; Prisma Migrate wraps each migration file in a transaction, where `CONCURRENTLY` cannot run.
- Sets a 5-second local `lock_timeout` to fail fast instead of queueing behind a long-running statement; the migrate job retries on failure.

<sup>Written for commit 76772465243cfed992212f6fc10325ee40cf9bf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

