### PR TITLE
feat(evaluations): reveal the dataset row a publish just touched

### DIFF
--- a/frontend/ui/src/app/globals.css
+++ b/frontend/ui/src/app/globals.css
@@ -82,3 +82,21 @@
 .animate-slide-in-left {
   animation: slideInFromLeft 0.3s ease-out;
 }
+
+/* One-shot highlight for a table row the page has just scrolled to (a dataset
+   case that was added or edited). It FADES rather than sticking, so it reads as
+   "here it is", not as a selection the user now has to clear. Not gated on
+   prefers-reduced-motion: a colour fade carries no motion, and it is the only
+   signal that says which row changed. */
+@keyframes rowFlash {
+  from {
+    background-color: hsl(var(--muted));
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+.animate-row-flash {
+  animation: rowFlash 2s ease-out;
+}

--- a/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
+++ b/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
@@ -41,8 +41,10 @@ export function TestCaseEditorModal({
   datasetId: string;
   mode: TestCaseEditorMode;
   onClose: () => void;
-  /** Called with the row the publish wants revealed (the server's `focusTestCaseId`). */
-  onSaved: (focusTestCaseId: string | null) => void;
+  /** Called with the row the publish wants revealed (the server's `focusTestCaseId`)
+   *  and the version number it published, so the caller can wait for that snapshot
+   *  to load before revealing the row (null when no new version was published). */
+  onSaved: (focusTestCaseId: string | null, versionNumber: number | null) => void;
 }) {
   const { toast } = useToast();
   const save = useSaveTestCase(projectId, datasetId);
@@ -96,12 +98,16 @@ export function TestCaseEditorModal({
     // The row to reveal comes from the publish response, never re-derived here —
     // the server decides where a case lands, and a duplicate POST short-circuits
     // to an existing case rather than publishing a new one at all.
-    const onSuccess = (res: { focusTestCaseId?: string; testCaseId?: string }) => {
+    const onSuccess = (res: {
+      focusTestCaseId?: string;
+      testCaseId?: string;
+      versionNumber?: number;
+    }) => {
       toast({
         title: isEdit ? "Row saved — new version published" : "Row added",
         tone: "success",
       });
-      onSaved(res.focusTestCaseId || res.testCaseId || null);
+      onSaved(res.focusTestCaseId || res.testCaseId || null, res.versionNumber ?? null);
       onClose();
     };
     const onError = (e: unknown) =>

--- a/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
+++ b/frontend/ui/src/features/evaluations/components/test-case-editor-modal.tsx
@@ -41,7 +41,8 @@ export function TestCaseEditorModal({
   datasetId: string;
   mode: TestCaseEditorMode;
   onClose: () => void;
-  onSaved: () => void;
+  /** Called with the row the publish wants revealed (the server's `focusTestCaseId`). */
+  onSaved: (focusTestCaseId: string | null) => void;
 }) {
   const { toast } = useToast();
   const save = useSaveTestCase(projectId, datasetId);
@@ -92,12 +93,15 @@ export function TestCaseEditorModal({
     const metadataObj: Record<string, unknown> | null = metadata.trim()
       ? (JSON.parse(metadata) as Record<string, unknown>)
       : null;
-    const onSuccess = () => {
+    // The row to reveal comes from the publish response, never re-derived here —
+    // the server decides where a case lands, and a duplicate POST short-circuits
+    // to an existing case rather than publishing a new one at all.
+    const onSuccess = (res: { focusTestCaseId?: string; testCaseId?: string }) => {
       toast({
         title: isEdit ? "Row saved — new version published" : "Row added",
         tone: "success",
       });
-      onSaved();
+      onSaved(res.focusTestCaseId || res.testCaseId || null);
       onClose();
     };
     const onError = (e: unknown) =>

--- a/frontend/ui/src/features/evaluations/dataset-focus-case.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/dataset-focus-case.smoke.test.tsx
@@ -1,0 +1,262 @@
+// @vitest-environment jsdom
+/**
+ * Adding or editing a dataset row must SHOW the user the row it touched. The
+ * publish response already carries `focusTestCaseId` (the POST sets it to the
+ * new case, the PATCH to the edited one); these tests pin that the view
+ * consumes it — scrolling that row into view and flashing it — instead of
+ * leaving the change invisible below the fold.
+ *
+ * jsdom has no layout, so nothing here proves a row was actually off-screen or
+ * that the browser scrolled. What it does prove: the right element is asked to
+ * scroll, with `block: "nearest"` (the option that leaves an already-visible row
+ * alone), and that the row carries the one-shot highlight class.
+ */
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, afterEach, beforeAll, beforeEach } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@/components/ui/toast";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1", datasetId: "ds1" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/projects/p1/datasets/ds1",
+}));
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => null,
+}));
+vi.mock("@/features/ai-assistant/components/ai-assistant-panel", () => ({
+  AiAssistantPanel: () => <div data-testid="ai-assistant" />,
+}));
+
+import { DatasetDetailView } from "./views/dataset-detail-view";
+
+// ---------------------------------------------------------------------------
+// Server-shaped fixtures
+// ---------------------------------------------------------------------------
+
+const DATASET = {
+  id: "ds1",
+  projectId: "p1",
+  name: "Billing routing",
+  description: null,
+  currentVersionId: "dv2",
+  createTime: "2026-08-20T00:00:00Z",
+  updateTime: "2026-08-21T00:00:00Z",
+  caseCount: 3,
+  versionCount: 2,
+};
+const V2 = {
+  id: "dv2",
+  datasetId: "ds1",
+  projectId: "p1",
+  versionNumber: 2,
+  label: "v2",
+  note: null,
+  createdBy: null,
+  createTime: "2026-08-21T00:00:00Z",
+};
+
+function testCase(id: string, input: string, over: Record<string, unknown> = {}) {
+  return {
+    id: `row-${id}`,
+    testCaseId: id,
+    datasetVersionId: "dv2",
+    datasetId: "ds1",
+    projectId: "p1",
+    input,
+    expected: null,
+    metadata: null,
+    review: "needs_review",
+    captureReason: "manual",
+    sourceTraceId: null,
+    sourceSpanId: null,
+    sourceSpanName: null,
+    sourceSpanKind: null,
+    addedBy: null,
+    createTime: "2026-08-21T10:00:00Z",
+    ...over,
+  };
+}
+
+const SEED = [
+  testCase("tc_1", "I was charged twice"),
+  testCase("tc_2", "Reset my password please"),
+  testCase("tc_3", "Where is my refund"),
+];
+
+/** Rows the dataset GET currently serves; a POST/PATCH mutates this. */
+let cases: ReturnType<typeof testCase>[] = [];
+/** What the publish response reports as the row to reveal. */
+let focusTestCaseId = "";
+
+/** Every `scrollIntoView` call, with the element that received it. */
+let scrolled: Array<{ el: HTMLElement; opts: ScrollIntoViewOptions | undefined }> = [];
+
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = function (
+    this: HTMLElement,
+    opts?: boolean | ScrollIntoViewOptions,
+  ) {
+    scrolled.push({ el: this, opts: typeof opts === "object" ? opts : undefined });
+  };
+  window.HTMLElement.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+  Object.assign(navigator, { clipboard: { writeText: vi.fn(async () => {}) } });
+});
+
+beforeEach(() => {
+  cases = [...SEED];
+  focusTestCaseId = "";
+  scrolled = [];
+  global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+    const s = String(url);
+    const method = init?.method ?? "GET";
+    if (method === "POST" && s.includes("/test-cases")) {
+      cases = [...cases, testCase("tc_new", "a brand new question")];
+      return { ok: true, status: 201, json: async () => ({ duplicate: false, ...published() }) };
+    }
+    if (method === "PATCH" && s.includes("/test-cases/")) {
+      return { ok: true, status: 201, json: async () => published() };
+    }
+    return { ok: true, status: 200, json: async () => payloadFor(s) };
+  }) as unknown as typeof fetch;
+});
+afterEach(() => cleanup());
+
+function published() {
+  return { versionId: "dv3", versionNumber: 3, focusTestCaseId, caseCount: cases.length };
+}
+
+function payloadFor(url: string): unknown {
+  if (url.includes("/test-cases/") && url.endsWith("/runs")) return { data: [] };
+  if (url.includes("/evaluations/runs"))
+    return { data: [], meta: { page: 0, limit: 50, total: 0 } };
+  return {
+    dataset: DATASET,
+    currentVersion: V2,
+    selectedVersion: V2,
+    isCurrentVersion: true,
+    testCases: cases,
+    versions: [V2],
+  };
+}
+
+function mountDetail() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <ToastProvider>
+        <DatasetDetailView projectId="p1" datasetId="ds1" />
+      </ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/** The rendered row for a stable testCaseId, or null when it isn't on the page. */
+function row(testCaseId: string): HTMLElement | null {
+  return document.querySelector<HTMLElement>(`tr[data-test-case-id="${testCaseId}"]`);
+}
+
+/** Only the scroll calls aimed at a table row (Radix and the panel scroll too). */
+function scrolledRowIds(): string[] {
+  return scrolled.map((s) => s.el.dataset.testCaseId).filter((id): id is string => !!id);
+}
+
+async function addRow(input = "a brand new question") {
+  fireEvent.click(screen.getByRole("button", { name: "Row" }));
+  await screen.findByText("New Row");
+  fireEvent.change(screen.getByLabelText("Input"), { target: { value: input } });
+  fireEvent.click(screen.getByRole("button", { name: "Save" }));
+  await screen.findByText("Row added");
+}
+
+describe("Dataset detail — revealing the row a publish touched", () => {
+  it("scrolls the added row into view and flashes it", async () => {
+    focusTestCaseId = "tc_new";
+    mountDetail();
+    await screen.findByText("I was charged twice");
+    await addRow();
+
+    await waitFor(() => expect(row("tc_new")).not.toBeNull());
+    await waitFor(() => expect(scrolledRowIds()).toContain("tc_new"));
+    expect(row("tc_new")!.className).toContain("animate-row-flash");
+    // Never a persistent selection — the panel stays shut and nothing is marked open.
+    expect(row("tc_new")!.getAttribute("data-selected")).toBeNull();
+  });
+
+  it("asks for `block: nearest`, which leaves an already-visible row where it is", async () => {
+    focusTestCaseId = "tc_new";
+    mountDetail();
+    await screen.findByText("I was charged twice");
+    await addRow();
+
+    await waitFor(() => expect(scrolledRowIds()).toContain("tc_new"));
+    const call = scrolled.find((s) => s.el.dataset.testCaseId === "tc_new")!;
+    expect(call.opts?.block).toBe("nearest");
+  });
+
+  it("follows the server's focusTestCaseId rather than assuming the last row", async () => {
+    // The server says to reveal an EXISTING row while the refetched version still
+    // appends the new case last. Deriving the target client-side ("the new row is
+    // the last one") would scroll to tc_new and fail here.
+    focusTestCaseId = "tc_2";
+    mountDetail();
+    await screen.findByText("I was charged twice");
+    await addRow();
+
+    await waitFor(() => expect(scrolledRowIds()).toContain("tc_2"));
+    expect(scrolledRowIds()).not.toContain("tc_new");
+    expect(row("tc_2")!.className).toContain("animate-row-flash");
+    expect(row("tc_new")!.className).not.toContain("animate-row-flash");
+  });
+
+  it("leaves the order alone — the added row is still last", async () => {
+    focusTestCaseId = "tc_new";
+    mountDetail();
+    await screen.findByText("I was charged twice");
+    await addRow();
+
+    await waitFor(() => expect(row("tc_new")).not.toBeNull());
+    const ids = Array.from(document.querySelectorAll<HTMLElement>("tr[data-test-case-id]")).map(
+      (el) => el.dataset.testCaseId,
+    );
+    expect(ids).toEqual(["tc_1", "tc_2", "tc_3", "tc_new"]);
+  });
+
+  it("flashes the edited row on the PATCH path too", async () => {
+    focusTestCaseId = "tc_1";
+    mountDetail();
+    await screen.findByText("I was charged twice");
+    fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
+    fireEvent.click(await screen.findByText("Edit"));
+    await screen.findByText("Edit Row");
+    fireEvent.change(screen.getByLabelText("Input"), { target: { value: "edited question" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await screen.findByText(/Row saved/);
+
+    await waitFor(() => expect(scrolledRowIds()).toContain("tc_1"));
+    expect(row("tc_1")!.className).toContain("animate-row-flash");
+  });
+
+  it("clears an active search that would have hidden the row", async () => {
+    // The table renders every case of the version (no pagination), so the one way
+    // a just-published row can be missing from the DOM is the keyword filter.
+    focusTestCaseId = "tc_new";
+    mountDetail();
+    await screen.findByText("I was charged twice");
+    const search = screen.getByPlaceholderText("Search...") as HTMLInputElement;
+    fireEvent.change(search, { target: { value: "charged" } });
+    expect(row("tc_2")).toBeNull();
+
+    await addRow();
+
+    await waitFor(() => expect(row("tc_new")).not.toBeNull());
+    expect(search.value).toBe("");
+    await waitFor(() => expect(scrolledRowIds()).toContain("tc_new"));
+  });
+});

--- a/frontend/ui/src/features/evaluations/dataset-focus-case.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/dataset-focus-case.smoke.test.tsx
@@ -60,6 +60,9 @@ const V2 = {
   createdBy: null,
   createTime: "2026-08-21T00:00:00Z",
 };
+/** What every publish here creates: datasets are immutable, so a save never edits
+ *  a version in place — it publishes the next one. */
+const V3 = { ...V2, id: "dv3", versionNumber: 3, label: "v3", createTime: "2026-08-21T12:00:00Z" };
 
 function testCase(id: string, input: string, over: Record<string, unknown> = {}) {
   return {
@@ -91,6 +94,8 @@ const SEED = [
 
 /** Rows the dataset GET currently serves; a POST/PATCH mutates this. */
 let cases: ReturnType<typeof testCase>[] = [];
+/** The version the dataset GET currently serves; a POST/PATCH moves it to V3. */
+let currentVersion = V2;
 /** What the publish response reports as the row to reveal. */
 let focusTestCaseId = "";
 
@@ -98,6 +103,8 @@ let focusTestCaseId = "";
 let scrolled: Array<{ el: HTMLElement; opts: ScrollIntoViewOptions | undefined }> = [];
 /** Delay applied to the dataset GET that follows a publish (0 = answer at once). */
 let refetchDelayMs = 0;
+/** When set, the first dataset GET after a publish rejects (a transient failure). */
+let failNextRefetch = false;
 let publishSeen = false;
 
 beforeAll(() => {
@@ -114,24 +121,43 @@ beforeAll(() => {
 
 beforeEach(() => {
   cases = [...SEED];
+  currentVersion = V2;
   focusTestCaseId = "";
   scrolled = [];
   refetchDelayMs = 0;
+  failNextRefetch = false;
   publishSeen = false;
   global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
     const s = String(url);
     const method = init?.method ?? "GET";
     if (method === "POST" && s.includes("/test-cases")) {
-      cases = [...cases, testCase("tc_new", "a brand new question")];
+      cases = [...cases, testCase("tc_new", "a brand new question", { datasetVersionId: V3.id })];
+      currentVersion = V3;
       publishSeen = true;
       return { ok: true, status: 201, json: async () => ({ duplicate: false, ...published() }) };
     }
     if (method === "PATCH" && s.includes("/test-cases/")) {
+      // The edited case keeps its stable `testCaseId` but lands in a new version
+      // as a NEW row — a fresh per-version row id, carrying the edited input.
+      // Nothing about the pre-edit row is rewritten; the server never mutates a
+      // published snapshot.
+      const edited = decodeURIComponent(s.split("/test-cases/")[1]);
+      const patch = JSON.parse(String(init?.body ?? "{}")) as { input?: string };
+      cases = cases.map((c) =>
+        c.testCaseId === edited
+          ? { ...c, id: `${c.id}-v3`, datasetVersionId: V3.id, input: patch.input ?? c.input }
+          : c,
+      );
+      currentVersion = V3;
       publishSeen = true;
       return { ok: true, status: 201, json: async () => published() };
     }
     if (publishSeen && refetchDelayMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, refetchDelayMs));
+    }
+    if (publishSeen && failNextRefetch && !s.endsWith("/runs")) {
+      failNextRefetch = false;
+      throw new Error("network");
     }
     return { ok: true, status: 200, json: async () => payloadFor(s) };
   }) as unknown as typeof fetch;
@@ -139,7 +165,12 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 function published() {
-  return { versionId: "dv3", versionNumber: 3, focusTestCaseId, caseCount: cases.length };
+  return {
+    versionId: V3.id,
+    versionNumber: V3.versionNumber,
+    focusTestCaseId,
+    caseCount: cases.length,
+  };
 }
 
 function payloadFor(url: string): unknown {
@@ -147,12 +178,12 @@ function payloadFor(url: string): unknown {
   if (url.includes("/evaluations/runs"))
     return { data: [], meta: { page: 0, limit: 50, total: 0 } };
   return {
-    dataset: DATASET,
-    currentVersion: V2,
-    selectedVersion: V2,
+    dataset: { ...DATASET, currentVersionId: currentVersion.id },
+    currentVersion,
+    selectedVersion: currentVersion,
     isCurrentVersion: true,
     testCases: cases,
-    versions: [V2],
+    versions: currentVersion === V3 ? [V3, V2] : [V2],
   };
 }
 
@@ -172,6 +203,12 @@ function row(testCaseId: string): HTMLElement | null {
   return document.querySelector<HTMLElement>(`tr[data-test-case-id="${testCaseId}"]`);
 }
 
+/** The elements scrollIntoView was called on, for identity (not id) comparisons —
+ *  a publish replaces a row's element, and only identity tells the two apart. */
+function scrolledElements(): HTMLElement[] {
+  return scrolled.map((s) => s.el);
+}
+
 /** Only the scroll calls aimed at a table row (Radix and the panel scroll too). */
 function scrolledRowIds(): string[] {
   return scrolled.map((s) => s.el.dataset.testCaseId).filter((id): id is string => !!id);
@@ -183,6 +220,16 @@ async function addRow(input = "a brand new question") {
   fireEvent.change(screen.getByLabelText("Input"), { target: { value: input } });
   fireEvent.click(screen.getByRole("button", { name: "Save" }));
   await screen.findByText("Row added");
+}
+
+/** Edit the first row's input via the row action menu (the PATCH path). */
+async function editFirstRow(input = "edited question") {
+  fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
+  fireEvent.click(await screen.findByText("Edit"));
+  await screen.findByText("Edit Row");
+  fireEvent.change(screen.getByLabelText("Input"), { target: { value: input } });
+  fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+  await screen.findByText(/Row saved/);
 }
 
 describe("Dataset detail — revealing the row a publish touched", () => {
@@ -242,16 +289,65 @@ describe("Dataset detail — revealing the row a publish touched", () => {
     focusTestCaseId = "tc_1";
     mountDetail();
     await screen.findByText("I was charged twice");
-    fireEvent.click((await screen.findAllByLabelText("Row actions"))[0]);
-    fireEvent.click(await screen.findByText("Edit"));
-    await screen.findByText("Edit Row");
-    fireEvent.change(screen.getByLabelText("Input"), { target: { value: "edited question" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
-    await screen.findByText(/Row saved/);
+    await editFirstRow();
 
     await waitFor(() => expect(scrolledRowIds()).toContain("tc_1"));
     expect(row("tc_1")!.className).toContain("animate-row-flash");
   });
+
+  it("waits for the edited row's own version when the refetch outlives the flash", async () => {
+    // An edit KEEPS the case's testCaseId, so a row carrying that id is already on
+    // screen from the PRE-edit version — unlike an add, whose row does not exist
+    // until the refetch lands. Targeting whatever row currently holds the id would
+    // scroll and flash pre-edit content and start the expiry against a row about to
+    // be replaced: past the flash duration, the edited row arrives unmarked and the
+    // save reads as the no-op this whole change exists to fix.
+    focusTestCaseId = "tc_1";
+    refetchDelayMs = 2500; // > ROW_FLASH_MS (2000)
+    mountDetail();
+    await screen.findByText("I was charged twice");
+    const preEditRow = row("tc_1")!;
+
+    await editFirstRow();
+
+    // The edited row only exists once the slow refetch delivers the new version,
+    // and it is a NEW element — the publish minted a fresh per-version row id.
+    await screen.findByText("edited question", undefined, { timeout: 8000 });
+    const editedRow = row("tc_1")!;
+    expect(editedRow).not.toBe(preEditRow);
+
+    await waitFor(() => expect(scrolledElements()).toContain(editedRow), { timeout: 8000 });
+    expect(editedRow.className).toContain("animate-row-flash");
+    // ...and the superseded row was never the one revealed.
+    expect(scrolledElements()).not.toContain(preEditRow);
+  }, 20000);
+
+  it("retains the target when the post-edit refetch fails, revealing it on recovery", async () => {
+    // A failed refetch leaves the pre-edit snapshot on screen. Dropping the target
+    // there would spend the reveal on content the user did not just author and
+    // leave the edit permanently unannounced; it is held until a version that
+    // actually contains the edit loads.
+    focusTestCaseId = "tc_1";
+    failNextRefetch = true;
+    mountDetail();
+    await screen.findByText("I was charged twice");
+    const preEditRow = row("tc_1")!;
+
+    await editFirstRow();
+
+    // The refetch failed, so the page still shows the pre-edit row — untouched.
+    await waitFor(() => expect(failNextRefetch).toBe(false));
+    expect(row("tc_1")).toBe(preEditRow);
+    expect(scrolledElements()).not.toContain(preEditRow);
+    expect(preEditRow.className).not.toContain("animate-row-flash");
+
+    // The next successful fetch still reveals it: the target was retained.
+    window.dispatchEvent(new Event("visibilitychange"));
+    await screen.findByText("edited question", undefined, { timeout: 8000 });
+    const editedRow = row("tc_1")!;
+    await waitFor(() => expect(scrolledElements()).toContain(editedRow), { timeout: 8000 });
+    expect(editedRow.className).toContain("animate-row-flash");
+  }, 20000);
 
   it("still reveals the row when the refetch outlives the flash", async () => {
     // The row does not exist until the refetch of the new version lands. Starting

--- a/frontend/ui/src/features/evaluations/dataset-focus-case.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/dataset-focus-case.smoke.test.tsx
@@ -96,6 +96,9 @@ let focusTestCaseId = "";
 
 /** Every `scrollIntoView` call, with the element that received it. */
 let scrolled: Array<{ el: HTMLElement; opts: ScrollIntoViewOptions | undefined }> = [];
+/** Delay applied to the dataset GET that follows a publish (0 = answer at once). */
+let refetchDelayMs = 0;
+let publishSeen = false;
 
 beforeAll(() => {
   window.HTMLElement.prototype.scrollIntoView = function (
@@ -113,15 +116,22 @@ beforeEach(() => {
   cases = [...SEED];
   focusTestCaseId = "";
   scrolled = [];
+  refetchDelayMs = 0;
+  publishSeen = false;
   global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
     const s = String(url);
     const method = init?.method ?? "GET";
     if (method === "POST" && s.includes("/test-cases")) {
       cases = [...cases, testCase("tc_new", "a brand new question")];
+      publishSeen = true;
       return { ok: true, status: 201, json: async () => ({ duplicate: false, ...published() }) };
     }
     if (method === "PATCH" && s.includes("/test-cases/")) {
+      publishSeen = true;
       return { ok: true, status: 201, json: async () => published() };
+    }
+    if (publishSeen && refetchDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, refetchDelayMs));
     }
     return { ok: true, status: 200, json: async () => payloadFor(s) };
   }) as unknown as typeof fetch;
@@ -242,6 +252,23 @@ describe("Dataset detail — revealing the row a publish touched", () => {
     await waitFor(() => expect(scrolledRowIds()).toContain("tc_1"));
     expect(row("tc_1")!.className).toContain("animate-row-flash");
   });
+
+  it("still reveals the row when the refetch outlives the flash", async () => {
+    // The row does not exist until the refetch of the new version lands. Starting
+    // the highlight's expiry at publish time instead would let a refetch slower
+    // than the flash (a big dataset — precisely when the row lands off-screen)
+    // clear the target before its row ever rendered, and the add would read as
+    // the no-op this whole change exists to fix.
+    focusTestCaseId = "tc_new";
+    refetchDelayMs = 2500; // > ROW_FLASH_MS (2000)
+    mountDetail();
+    await screen.findByText("I was charged twice");
+    await addRow();
+
+    await waitFor(() => expect(row("tc_new")).not.toBeNull(), { timeout: 8000 });
+    await waitFor(() => expect(scrolledRowIds()).toContain("tc_new"), { timeout: 8000 });
+    expect(row("tc_new")!.className).toContain("animate-row-flash");
+  }, 20000);
 
   it("clears an active search that would have hidden the row", async () => {
     // The table renders every case of the version (no pagination), so the one way

--- a/frontend/ui/src/features/evaluations/hooks.ts
+++ b/frontend/ui/src/features/evaluations/hooks.ts
@@ -136,11 +136,14 @@ export function useSaveTestCase(projectId: string, datasetId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (input: SaveTestCaseInput) =>
-      sendJson<{ duplicate: boolean; testCaseId?: string; versionId?: string }>(
-        `/api/projects/${projectId}/datasets/${datasetId}/test-cases`,
-        "POST",
-        input,
-      ),
+      // `focusTestCaseId` is the published version's row to reveal; on the duplicate
+      // short-circuit the server returns the existing case as `testCaseId` instead.
+      sendJson<{
+        duplicate: boolean;
+        testCaseId?: string;
+        versionId?: string;
+        focusTestCaseId?: string;
+      }>(`/api/projects/${projectId}/datasets/${datasetId}/test-cases`, "POST", input),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ["datasets"] });
       // Refresh the trace's span→dataset chips so a just-saved span is marked.

--- a/frontend/ui/src/features/evaluations/hooks.ts
+++ b/frontend/ui/src/features/evaluations/hooks.ts
@@ -142,6 +142,7 @@ export function useSaveTestCase(projectId: string, datasetId: string) {
         duplicate: boolean;
         testCaseId?: string;
         versionId?: string;
+        versionNumber?: number;
         focusTestCaseId?: string;
       }>(`/api/projects/${projectId}/datasets/${datasetId}/test-cases`, "POST", input),
     onSuccess: () => {

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -42,6 +42,10 @@ import { TestCaseEditorModal, type TestCaseEditorMode } from "../components/test
 import { DeleteTestCaseDialog } from "../components/delete-test-case-dialog";
 import type { TestCaseRow } from "../types";
 
+/** How long a just-published row stays highlighted. Matches the `.animate-row-flash`
+ *  duration in globals.css — the class is removed when this elapses. */
+const ROW_FLASH_MS = 2000;
+
 /** A dash for the list; empty reads as a placeholder, not a blank cell. */
 function orDash(value: string | null): React.ReactNode {
   return value && value.trim() !== "" ? value : <span className="text-muted-foreground">-</span>;
@@ -146,6 +150,41 @@ export function DatasetDetailView({
   // stable testCaseId — otherwise typing in the search box, or a save publishing
   // a new version's row ids, would silently unmount the open panel.
   const openCase = openCaseId ? (allCases.find((c) => c.testCaseId === openCaseId) ?? null) : null;
+
+  // The row a publish just touched. Adding a case appends it, so on any dataset
+  // past one screenful the change happens off-screen and the page reads as a
+  // no-op. The id is the server's `focusTestCaseId` from the publish response,
+  // not re-derived here: where a case lands is the server's call.
+  const [focusCaseId, setFocusCaseId] = React.useState<string | null>(null);
+  const tableRef = React.useRef<HTMLDivElement>(null);
+
+  // A search left running while a row is added filters that row straight back
+  // out, leaving nothing to reveal. Drop the keyword instead — the whole point
+  // of the publish is to show what it wrote. (The table renders every case of
+  // the version, so the filter is the only thing that can hide one.)
+  React.useEffect(() => {
+    if (!focusCaseId) return;
+    if (!allCases.some((c) => c.testCaseId === focusCaseId)) return;
+    if (!cases.some((c) => c.testCaseId === focusCaseId)) setKeyword("");
+  }, [focusCaseId, allCases, cases]);
+
+  // Bring the row on screen, then drop the highlight. `block: "nearest"` is a
+  // no-op for a row already in view, so editing a visible row never yanks the
+  // table out from under the pointer. Re-runs as `cases` settles, because the
+  // row only exists once the refetch of the new version lands; the timer is
+  // reset with it, so a slow refetch can't expire the highlight before the row
+  // it belongs to renders.
+  React.useEffect(() => {
+    if (!focusCaseId) return;
+    const row = Array.from(
+      tableRef.current?.querySelectorAll<HTMLElement>("tr[data-test-case-id]") ?? [],
+    ).find((el) => el.dataset.testCaseId === focusCaseId);
+    const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
+    row?.scrollIntoView({ block: "nearest", behavior: reduceMotion ? "auto" : "smooth" });
+    const timer = window.setTimeout(() => setFocusCaseId(null), ROW_FLASH_MS);
+    return () => window.clearTimeout(timer);
+  }, [focusCaseId, cases]);
+
   const confirmDelete = () => {
     if (!deleteRow) return;
     const target = deleteRow;
@@ -291,7 +330,7 @@ export function DatasetDetailView({
           </SearchFilterBar>
 
           {/* Table + focused-case slide-in panel */}
-          <div className="min-h-0 flex-1 overflow-auto">
+          <div ref={tableRef} className="min-h-0 flex-1 overflow-auto">
             {cases.length === 0 ? (
               <EmptyState>
                 {keyword
@@ -323,6 +362,11 @@ export function DatasetDetailView({
                     return (
                       <TR
                         key={tc.id}
+                        // Keyed on the STABLE testCaseId, not the per-version row
+                        // id: a publish mints fresh row ids, and the id the server
+                        // hands back to focus is the stable one.
+                        data-test-case-id={tc.testCaseId}
+                        className={cn(tc.testCaseId === focusCaseId && "animate-row-flash")}
                         interactive
                         selected={tc.testCaseId === openCaseId}
                         tabIndex={0}
@@ -397,7 +441,10 @@ export function DatasetDetailView({
           datasetId={datasetId}
           mode={editorMode}
           onClose={() => setEditorMode(null)}
-          onSaved={() => setSelectedVersionId(null)}
+          onSaved={(focusTestCaseId) => {
+            setSelectedVersionId(null);
+            setFocusCaseId(focusTestCaseId);
+          }}
         />
       )}
 

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -171,16 +171,20 @@ export function DatasetDetailView({
   // Bring the row on screen, then drop the highlight. `block: "nearest"` is a
   // no-op for a row already in view, so editing a visible row never yanks the
   // table out from under the pointer. Re-runs as `cases` settles, because the
-  // row only exists once the refetch of the new version lands; the timer is
-  // reset with it, so a slow refetch can't expire the highlight before the row
-  // it belongs to renders.
+  // row only exists once the refetch of the new version lands.
   React.useEffect(() => {
     if (!focusCaseId) return;
     const row = Array.from(
       tableRef.current?.querySelectorAll<HTMLElement>("tr[data-test-case-id]") ?? [],
     ).find((el) => el.dataset.testCaseId === focusCaseId);
+    // Until that refetch delivers the row there is nothing on screen and nothing
+    // flashing, so its expiry doesn't start either. Armed on the publish instead,
+    // a refetch slower than the flash would clear the highlight before the row it
+    // belongs to ever rendered — and a slow refetch means a big dataset, the exact
+    // case where the row lands off-screen and this reveal is the only signal.
+    if (!row) return;
     const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
-    row?.scrollIntoView({ block: "nearest", behavior: reduceMotion ? "auto" : "smooth" });
+    row.scrollIntoView({ block: "nearest", behavior: reduceMotion ? "auto" : "smooth" });
     const timer = window.setTimeout(() => setFocusCaseId(null), ROW_FLASH_MS);
     return () => window.clearTimeout(timer);
   }, [focusCaseId, cases]);

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -151,12 +151,29 @@ export function DatasetDetailView({
   // a new version's row ids, would silently unmount the open panel.
   const openCase = openCaseId ? (allCases.find((c) => c.testCaseId === openCaseId) ?? null) : null;
 
-  // The row a publish just touched. Adding a case appends it, so on any dataset
-  // past one screenful the change happens off-screen and the page reads as a
-  // no-op. The id is the server's `focusTestCaseId` from the publish response,
-  // not re-derived here: where a case lands is the server's call.
-  const [focusCaseId, setFocusCaseId] = React.useState<string | null>(null);
+  // The row a publish just touched, held with the version that publish created.
+  // Adding a case appends it, so on any dataset past one screenful the change
+  // happens off-screen and the page reads as a no-op. The id is the server's
+  // `focusTestCaseId` from the publish response, not re-derived here: where a
+  // case lands is the server's call.
+  const [focus, setFocus] = React.useState<{ caseId: string; version: number | null } | null>(null);
   const tableRef = React.useRef<HTMLDivElement>(null);
+
+  // An edit keeps the case's stable testCaseId, so a row carrying that id is
+  // ALREADY on screen — from the pre-edit snapshot — while the refetch is still
+  // in flight. Matching it there would flash the old content and start the
+  // highlight's expiry against a row about to be replaced, so a refetch slower
+  // than the flash would leave the edited row arriving unmarked: the same
+  // failure the add path avoids by having no such row yet. Hold the target until
+  // the snapshot on screen is at least the version the publish created (`>=`, so
+  // a publish that raced ahead of ours still satisfies it). A failed refetch
+  // leaves the older snapshot in place, which retains the target rather than
+  // dropping it — the next successful fetch reveals it.
+  const focusCaseId =
+    focus &&
+    (focus.version === null || (data?.selectedVersion?.versionNumber ?? -1) >= focus.version)
+      ? focus.caseId
+      : null;
 
   // A search left running while a row is added filters that row straight back
   // out, leaving nothing to reveal. Drop the keyword instead — the whole point
@@ -177,15 +194,13 @@ export function DatasetDetailView({
     const row = Array.from(
       tableRef.current?.querySelectorAll<HTMLElement>("tr[data-test-case-id]") ?? [],
     ).find((el) => el.dataset.testCaseId === focusCaseId);
-    // Until that refetch delivers the row there is nothing on screen and nothing
-    // flashing, so its expiry doesn't start either. Armed on the publish instead,
-    // a refetch slower than the flash would clear the highlight before the row it
-    // belongs to ever rendered — and a slow refetch means a big dataset, the exact
-    // case where the row lands off-screen and this reveal is the only signal.
+    // The keyword filter can still hold the row out of the DOM for a render (the
+    // effect above drops the keyword on the same pass). Nothing is on screen and
+    // nothing is flashing, so its expiry doesn't start either.
     if (!row) return;
     const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
     row.scrollIntoView({ block: "nearest", behavior: reduceMotion ? "auto" : "smooth" });
-    const timer = window.setTimeout(() => setFocusCaseId(null), ROW_FLASH_MS);
+    const timer = window.setTimeout(() => setFocus(null), ROW_FLASH_MS);
     return () => window.clearTimeout(timer);
   }, [focusCaseId, cases]);
 
@@ -303,7 +318,13 @@ export function DatasetDetailView({
                   <span className="text-[12px] text-muted-foreground">Version</span>
                   <Select
                     value={selectedVersion?.id ?? ""}
-                    onValueChange={(v) => setSelectedVersionId(v)}
+                    onValueChange={(v) => {
+                      // Deliberately navigating to another snapshot supersedes a
+                      // pending reveal; left armed, it would fire on whatever
+                      // version the user lands on next.
+                      setFocus(null);
+                      setSelectedVersionId(v);
+                    }}
                   >
                     {/* The version id IS the time-sortable snowflake (`v.id`); the
                           dropdown pairs each version NUMBER with that id so both the
@@ -445,9 +466,9 @@ export function DatasetDetailView({
           datasetId={datasetId}
           mode={editorMode}
           onClose={() => setEditorMode(null)}
-          onSaved={(focusTestCaseId) => {
+          onSaved={(focusTestCaseId, versionNumber) => {
             setSelectedVersionId(null);
-            setFocusCaseId(focusTestCaseId);
+            setFocus(focusTestCaseId ? { caseId: focusTestCaseId, version: versionNumber } : null);
           }}
         />
       )}


### PR DESCRIPTION
## Summary

Fixes: #2019

Adding a row on a dataset detail page appended it correctly and then showed the user nothing. `position` is insertion order, so a new case lands last; past one screenful that is below the fold, the table is otherwise unchanged, and the only signal is a toast. The user could not tell which row they had just created, or whether the value they typed was stored as they meant it. Editing had the same gap.

The plumbing already existed and was simply not consumed. `publishDatasetVersion` returns `focusTestCaseId` — the POST sets it to the new case, the PATCH to the edited one — and nothing on the client read it. The add mutation did not even type the field, so it was dropped before a view could reach it.

## The change

- `useSaveTestCase` types `focusTestCaseId` on the POST response (the edit mutation already did).
- The editor modal passes the value through on save: `onSaved(res.focusTestCaseId || res.testCaseId || null)`. Falling through on an empty string is deliberate — the publish helper returns `""` for "no row to reveal".
- Dataset detail holds that id in `focusCaseId`, tags each row with `data-test-case-id` (the **stable** case id, not the per-version row id, which a publish re-mints), scrolls the matching row into view, and flashes it with a one-shot `animate-row-flash` that fades out after 2s. Never a persistent selection the user then has to clear.
- `block: "nearest"` means a row already on screen is left exactly where it is, so editing a visible row does not yank the table out from under the pointer. Under `prefers-reduced-motion` the scroll is not animated; the colour fade stays, as it carries no motion and is the only mark of which row changed.
- A keyword search left running would filter the new row straight back out, so the reveal clears it. The table renders every case of the version — there is no pagination — so the filter is the only thing that can keep a just-published row out of the DOM.

The target is always the server's id, never re-derived client-side, so it stays correct if the server ever changes where a new case lands.

**Ordering is untouched.** No sort, insert, or `position` logic is changed on either side; a new case is still last and existing rows do not shift. A test pins the rendered order as `tc_1, tc_2, tc_3, tc_new`.

## Timing

The row does not exist until the refetch of the new version lands, so the highlight's expiry is armed when the row renders, not when the publish returns. Armed at publish time, a refetch slower than the flash would clear the target before its row ever appeared — and a slow refetch means a large dataset, exactly the case where the row is off-screen and this reveal is the only signal. The timer is cleared on unmount.

## Tests

Seven cases in `dataset-focus-case.smoke.test.tsx`, driving the real view against a server-shaped fetch mock: the add path scrolls and flashes; `block: "nearest"` is the option asked for; the server's `focusTestCaseId` wins over "the new row is the last one" (the fixture points it at an existing row and the test fails if the target is guessed); order is unchanged; the PATCH path flashes the edited row; an active search is cleared; and a refetch that outlives the flash still reveals the row.

Verified: 7/7 pass; 0/7 with only the view file reverted, so the tests discriminate. Frontend suite `2012 passed` (213 files), ESLint clean on the touched files, Prettier clean, `tsc --noEmit` adds no error.

**What the tests do not establish.** jsdom has no layout engine. Nothing here proves a row was genuinely off-screen or that a browser scrolled — `scrollIntoView` is stubbed and recorded. They prove the right element is asked to scroll, with the option that leaves an already-visible row alone, and that the row carries the highlight class. The visual result needs an eye on a real browser.

## Scope

Frontend only, four files plus one new test file. No API, schema, or migration change — the server already returned everything this needs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2019. Reveals the dataset row a publish just touched: after adding or editing a case, the table scrolls that row into view and flashes it for 2s instead of leaving the change invisible below the fold.

- The publish response already carried `focusTestCaseId`; nothing on the client read it, and the add mutation didn't even type the field.
- The editor modal now passes the server's id and the published version number through on save, falling back to `testCaseId` for the duplicate short-circuit.
- The reveal waits for the loaded snapshot to be at least the version the publish created, so an edit never flashes the pre-edit row and a failed refetch keeps the target for the next successful load.
- `block: "nearest"` leaves an already-visible row exactly where it is.
- An active keyword search is cleared so it can't hide the just-published row.
- The 2s highlight's expiry starts when the row renders, not at publish time, so a refetch slower than the flash can't clear it before the row exists.
- Row ordering is untouched: a new case is still last.
- Frontend-only, no API, schema, or migration change.
- Nine jsdom smoke tests pin the reveal logic; jsdom has no layout, so they verify the right element is asked to scroll and carries the highlight, not that a browser scrolled.

<sup>Written for commit ad38ee1bb9ba66f3d7985f72d98de7fbe9b1e3ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

