### PR TITLE
feat(deploy): rate-limit the auth endpoints with a WAF web ACL on the ALB

### DIFF
--- a/deploy/terraform/aws/outputs.tf
+++ b/deploy/terraform/aws/outputs.tf
@@ -88,3 +88,8 @@ output "helm_release_status" {
   description = "Helm release status"
   value       = helm_release.traceroot.status
 }
+
+output "auth_waf_web_acl_arn" {
+  description = "ARN of the WAF web ACL rate-limiting the auth endpoints (null when disabled)"
+  value       = var.enable_auth_waf ? aws_wafv2_web_acl.auth_rate_limit[0].arn : null
+}

--- a/deploy/terraform/aws/terraform.tfvars.example
+++ b/deploy/terraform/aws/terraform.tfvars.example
@@ -100,6 +100,10 @@ cache_node_type = "cache.t4g.micro"
 # rest_replicas   = 1
 # worker_replicas = 1
 
+# WAF rate limiting for the auth endpoints (see waf.tf)
+# enable_auth_waf     = true
+# auth_waf_rate_limit = 300  # requests per 5 minutes per client IP
+
 # Additional environment variables (escape hatch for anything not covered above)
 # Each entry must have either `value` (plain text) or `valueFrom` (secret reference), not both.
 # additional_env = [

--- a/deploy/terraform/aws/traceroot.tf
+++ b/deploy/terraform/aws/traceroot.tf
@@ -175,6 +175,9 @@ ingress:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/certificate-arn: "${var.domain != "" ? aws_acm_certificate.app[0].arn : ""}"
+%{if var.enable_auth_waf~}
+    alb.ingress.kubernetes.io/wafv2-acl-arn: "${aws_wafv2_web_acl.auth_rate_limit[0].arn}"
+%{endif~}
 EOT
 
   ingress_values_http = <<-EOT
@@ -186,6 +189,9 @@ ingress:
     alb.ingress.kubernetes.io/scheme: ${var.alb_scheme}
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+%{if var.enable_auth_waf~}
+    alb.ingress.kubernetes.io/wafv2-acl-arn: "${aws_wafv2_web_acl.auth_rate_limit[0].arn}"
+%{endif~}
 EOT
 
   ingress_values = var.domain != "" ? local.ingress_values_https : local.ingress_values_http

--- a/deploy/terraform/aws/variables.tf
+++ b/deploy/terraform/aws/variables.tf
@@ -293,6 +293,23 @@ variable "alb_scheme" {
   default     = "internet-facing"
 }
 
+variable "enable_auth_waf" {
+  description = "Attach a WAF rate-based rule for the unauthenticated auth endpoints to the ALB (see waf.tf)"
+  type        = bool
+  default     = true
+}
+
+variable "auth_waf_rate_limit" {
+  description = "WAF rate limit for the auth endpoints: requests per 5 minutes per client IP. Set above legitimate per-user login/refresh volume (the CLI refreshes its token roughly every 10 minutes)."
+  type        = number
+  default     = 300
+
+  validation {
+    condition     = var.auth_waf_rate_limit >= 10
+    error_message = "AWS WAF rate-based rules require a limit of at least 10."
+  }
+}
+
 # --- Additional environment variables ---
 # Catch-all for any env vars not covered above (Google OAuth, SMTP, Stripe, etc.)
 # Each entry has either `value` (plain text) or `valueFrom` (secret ref).

--- a/deploy/terraform/aws/waf.tf
+++ b/deploy/terraform/aws/waf.tf
@@ -1,0 +1,121 @@
+# deploy/terraform/aws/waf.tf
+#
+# Rate-based WAF rule for the unauthenticated auth-layer endpoints.
+#
+# /api/auth/device/code and /api/cli/token ship with the CLI-login work and are
+# handled inside Next.js, never reaching the backend's workspace-keyed limiter.
+# Behind the ALB the app-level limiter cannot trust X-Forwarded-For (the ALB
+# appends to a spoofable header), so it degrades to a single global bucket.
+# This ACL keys on the true client IP the ALB sees natively, which cannot be
+# forged, and is the authoritative per-client limit; the in-process limiters
+# stay as backstops. Until those endpoints deploy, the rule matches nothing and
+# blocks nothing — attaching the ACL ahead of the app change is deliberate, so
+# protection is live the moment the endpoints appear.
+#
+# The ACL is associated with the ALB via the wafv2-acl-arn ingress annotation
+# (see ingress_values in traceroot.tf). An ALB carries at most one web ACL, so
+# any future WAF needs should add rules here rather than create a second ACL —
+# a new association silently replaces the old one. Disabling the flag detaches
+# the annotation and then deletes the ACL; the delete retries while the ALB
+# controller catches up on the disassociation, so a slow controller can make
+# that apply fail once — rerun it.
+
+resource "aws_wafv2_web_acl" "auth_rate_limit" {
+  count = var.enable_auth_waf ? 1 : 0
+
+  name  = "${var.name}-auth-rate-limit"
+  scope = "REGIONAL" # must live in the same region as the ALB
+
+  default_action {
+    allow {} # everything except the matched auth paths passes untouched
+  }
+
+  # Same shape the app-level limiter returns, so the CLI sees one 429 contract
+  # whether the WAF or the in-process backstop throttled it.
+  custom_response_body {
+    key          = "rate-limited"
+    content      = "{\"error\":\"rate limited\"}"
+    content_type = "APPLICATION_JSON"
+  }
+
+  rule {
+    name     = "auth-paths-per-ip"
+    priority = 1
+
+    action {
+      block {
+        # WAF's default block status is 403, which the device-flow CLI treats
+        # as a hard auth failure. 429 keeps throttling retryable per RFC 8628.
+        custom_response {
+          response_code            = 429
+          custom_response_body_key = "rate-limited"
+        }
+      }
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = var.auth_waf_rate_limit # per 5 minutes per IP
+        aggregate_key_type = "IP"
+
+        # The WAF sees the raw path while Next.js routes the decoded one, so
+        # matching without transformations is bypassable via percent-encoding
+        # (e.g. /api/cli/%74oken). Decode then normalize before comparing.
+        # STARTS_WITH is deliberate: it also catches trailing-slash variants
+        # and any future subpaths of these endpoints.
+        scope_down_statement {
+          or_statement {
+            statement {
+              byte_match_statement {
+                search_string         = "/api/auth/device/code"
+                positional_constraint = "STARTS_WITH"
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "URL_DECODE"
+                }
+                text_transformation {
+                  priority = 1
+                  type     = "NORMALIZE_PATH"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                search_string         = "/api/cli/token"
+                positional_constraint = "STARTS_WITH"
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "URL_DECODE"
+                }
+                text_transformation {
+                  priority = 1
+                  type     = "NORMALIZE_PATH"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "auth-paths-per-ip"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "auth-rate-limit-acl"
+    sampled_requests_enabled   = true
+  }
+
+  tags = local.tags
+}

--- a/deploy/terraform/aws/waf.tf
+++ b/deploy/terraform/aws/waf.tf
@@ -155,8 +155,9 @@ resource "aws_cloudwatch_log_group" "waf_auth_rate_limit" {
   count = var.enable_auth_waf ? 1 : 0
 
   # WAF logging requires the destination name to start with "aws-waf-logs-".
-  name              = "aws-waf-logs-${var.name}-auth-rate-limit"
-  retention_in_days = 30
+  name = "aws-waf-logs-${var.name}-auth-rate-limit"
+  # A year costs next to nothing at blocked-only volume.
+  retention_in_days = 365
 
   tags = local.tags
 }

--- a/deploy/terraform/aws/waf.tf
+++ b/deploy/terraform/aws/waf.tf
@@ -63,39 +63,62 @@ resource "aws_wafv2_web_acl" "auth_rate_limit" {
         # (e.g. /api/cli/%74oken). Decode then normalize before comparing.
         # STARTS_WITH is deliberate: it also catches trailing-slash variants
         # and any future subpaths of these endpoints.
+        #
+        # The method match keeps non-POST noise out of the budget. Not a
+        # security boundary — the bucket is per-IP, and an attacker's POSTs
+        # cost them no more than GETs — but scanner sweeps are overwhelmingly
+        # GET, and without it a scanner behind a shared NAT burns that NAT's
+        # login budget for everyone on it. Both endpoints are POST-only.
         scope_down_statement {
-          or_statement {
+          and_statement {
             statement {
               byte_match_statement {
-                search_string         = "/api/auth/device/code"
-                positional_constraint = "STARTS_WITH"
+                search_string         = "POST"
+                positional_constraint = "EXACTLY"
                 field_to_match {
-                  uri_path {}
+                  method {}
                 }
                 text_transformation {
                   priority = 0
-                  type     = "URL_DECODE"
-                }
-                text_transformation {
-                  priority = 1
-                  type     = "NORMALIZE_PATH"
+                  type     = "NONE"
                 }
               }
             }
             statement {
-              byte_match_statement {
-                search_string         = "/api/cli/token"
-                positional_constraint = "STARTS_WITH"
-                field_to_match {
-                  uri_path {}
+              or_statement {
+                statement {
+                  byte_match_statement {
+                    search_string         = "/api/auth/device/code"
+                    positional_constraint = "STARTS_WITH"
+                    field_to_match {
+                      uri_path {}
+                    }
+                    text_transformation {
+                      priority = 0
+                      type     = "URL_DECODE"
+                    }
+                    text_transformation {
+                      priority = 1
+                      type     = "NORMALIZE_PATH"
+                    }
+                  }
                 }
-                text_transformation {
-                  priority = 0
-                  type     = "URL_DECODE"
-                }
-                text_transformation {
-                  priority = 1
-                  type     = "NORMALIZE_PATH"
+                statement {
+                  byte_match_statement {
+                    search_string         = "/api/cli/token"
+                    positional_constraint = "STARTS_WITH"
+                    field_to_match {
+                      uri_path {}
+                    }
+                    text_transformation {
+                      priority = 0
+                      type     = "URL_DECODE"
+                    }
+                    text_transformation {
+                      priority = 1
+                      type     = "NORMALIZE_PATH"
+                    }
+                  }
                 }
               }
             }
@@ -118,4 +141,58 @@ resource "aws_wafv2_web_acl" "auth_rate_limit" {
   }
 
   tags = local.tags
+}
+
+# Durable record of blocked requests. WAF's sampled requests are kept for only
+# a few hours — too short for after-the-fact forensics or spotting a too-low
+# limit throttling legitimate clients (request-volume analysis for tuning the
+# limit down still comes from the rule's CloudWatch metrics, not these logs).
+# Blocked-only via the logging filter: full request logging on this ACL would
+# record every request through the ALB (it evaluates all traffic even though
+# only the auth paths can match the rule), which is enormous volume for a
+# trace-ingestion product and none of it useful here.
+resource "aws_cloudwatch_log_group" "waf_auth_rate_limit" {
+  count = var.enable_auth_waf ? 1 : 0
+
+  # WAF logging requires the destination name to start with "aws-waf-logs-".
+  name              = "aws-waf-logs-${var.name}-auth-rate-limit"
+  retention_in_days = 30
+
+  tags = local.tags
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "auth_rate_limit" {
+  count = var.enable_auth_waf ? 1 : 0
+
+  resource_arn            = aws_wafv2_web_acl.auth_rate_limit[0].arn
+  log_destination_configs = [aws_cloudwatch_log_group.waf_auth_rate_limit[0].arn]
+
+  # Today only the unauthenticated auth paths can be blocked and their secrets
+  # travel in the (unlogged) body, but keep credentials out of the log record
+  # regardless — this ACL is expected to grow rules.
+  redacted_fields {
+    single_header {
+      name = "authorization"
+    }
+  }
+  redacted_fields {
+    single_header {
+      name = "cookie"
+    }
+  }
+
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      behavior    = "KEEP"
+      requirement = "MEETS_ANY"
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What

Adds a regional AWS WAFv2 web ACL to the deploy terraform with a rate-based rule covering the two auth-layer endpoints served by Next.js behind the ALB:

- `POST /api/auth/device/code` — unauthenticated, writes a `device_codes` row per call
- `POST /api/cli/token` — mints the short-lived access JWT

The ACL keys on the true client IP the ALB sees natively (immune to `X-Forwarded-For` spoofing, which the in-process better-auth limiter cannot guarantee behind the ALB — it degrades to a single global bucket). It is associated with the ALB via the `alb.ingress.kubernetes.io/wafv2-acl-arn` ingress annotation injected through `ingress_values` in `traceroot.tf` (both HTTPS and HTTP variants).

Addresses #1909 (WAF is the primary control; the better-auth trusted-proxy config remains a follow-up).

## Design points

- **429, not WAF's 403 default**: the block action sets a custom response code with the same JSON body the app-level limiter returns (`{"error":"rate limited"}`). Verified against the CLI client code: a 403 would be classified as a hard auth failure, while 429 lands in the retryable network class.
- **Percent-encoding hardened**: path matches apply `URL_DECODE` + `NORMALIZE_PATH` before comparing, so encoded requests (e.g. `/api/cli/%74oken`) can't slip past the rule while still reaching the route.
- **Safe sequencing**: the endpoints ship with the CLI-login stack; until they deploy the rule matches nothing and blocks nothing, so attaching the ACL first is deliberate — protection is live the moment they appear.
- **Tunable & gated**: `enable_auth_waf` (default `true`) and `auth_waf_rate_limit` (default 300 req / 5 min / IP, plan-time validated against WAF's minimum of 10). The threshold leaves large headroom over legitimate use (the CLI re-mints roughly every 10 minutes and collapses concurrent mints).
- The app-level limiters stay in place as backstops; an ALB carries at most one web ACL, so future WAF needs should add rules to this ACL (documented in `waf.tf`).

## Verification

- `terraform validate` passes with real providers; `terraform fmt` clean.
- Conditional heredoc rendering tested enabled and disabled — annotation YAML indents correctly in both ingress variants.
- ALB controller IRSA policy already grants `wafv2:AssociateWebACL`/`DisassociateWebACL` (verified in the module source) — no IAM changes needed.
- Endpoint paths verified literal in both the app routes and the CLI client source.
- Quickstart example unaffected; no ALB replacement on apply (WAF association is a mutable attribute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFvXdgU9Qj8yVeX3RjjuhW

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rate-limits the unauthenticated auth endpoints (`POST /api/auth/device/code` and `POST /api/cli/token`) at the ALB with a WAFv2 web ACL, since requests behind the ALB can spoof `X-Forwarded-For` and collapse the in-process limiter to one global bucket. Throttled requests now get a 429 with the same `{"error":"rate limited"}` body the app limiter returns, so the CLI retries instead of hitting WAF's 403 hard failure. Addresses #1909.

- Path matches decode and normalize before comparing, so percent-encoded URLs can't bypass the rule.
- The rule matches POSTs only, so GET scanner noise can't burn a shared IP's budget.
- The rule matches nothing until the endpoints deploy, so attaching the ACL first is safe.
- Config is gated via `enable_auth_waf` (default true) and tunable via `auth_waf_rate_limit` (default 300 per 5 min per IP).
- Blocked requests log to CloudWatch for a year, with authorization and cookie headers redacted; only blocks are logged, since full logging would record all ALB traffic.
- An ALB carries at most one web ACL; future WAF needs should add rules to this ACL.
- Disabling the flag deletes the ACL, which can fail once while the ALB controller disassociates — rerun the apply.

<sup>Written for commit 242f56a905d28cf1c6af8b129156dce95e9ef143. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

