### PR TITLE
fix(billing): exclude failed detector runs from usage

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -226,7 +226,7 @@ async def get_usage_details(
     traces = int(traces_result.result_rows[0][0]) if traces_result.result_rows else 0
     spans = int(spans_result.result_rows[0][0]) if spans_result.result_rows else 0
 
-    # Detector runs: count every scan attempt recorded by the detector worker
+    # Detector runs: count every completed scan recorded by the detector worker
     # (BYOK + system source both count toward Free-plan hard cap).
     # uniqExact on run_id dedups pre-merge duplicates in the ReplacingMergeTree —
     # same pattern as the traces / spans queries above.
@@ -235,6 +235,7 @@ async def get_usage_details(
         SELECT uniqExact(run_id) as total
         FROM detector_runs
         WHERE project_id IN {project_ids:Array(String)}
+                    AND status = 'completed'
           AND timestamp >= {start:String}
           AND timestamp < {end:String}
         """,

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -1083,8 +1083,9 @@ class TestUsageBillsEveryStoredRow:
         # would silently stop billing self-traces again.
         assert "source" not in traces_sql
         assert "source" not in spans_sql
-        # detector_runs was never filtered — it is the per-evaluation result record.
+        # detector_runs is not source-filtered — it is the per-evaluation result record.
         assert "source" not in runs_sql
+        assert "status = 'completed'" in runs_sql
 
     def test_usage_total_counts_rows_from_every_source(self, client, mock_ch, secret):
         mock_ch.query.side_effect = [_make_query_result([(12,)], ["total"])]


### PR DESCRIPTION
Closes #2033

## Summary

- Count only completed detector runs in billing usage details.
- Continue counting completed runs from both BYOK and system sources.

## Type of Change

- [x] fix - A bug fix

## Details

Failed detector judge runs were included in the detector-scan usage count, consuming free-plan quota and affecting overage calculations. The usage query now filters detector runs to `status = 'completed'` while preserving its existing source-agnostic behavior.

## Screenshots / Recordings (if applicable)

Not applicable; this is a backend-only billing query change.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] Screenshots or recordings are not applicable to this backend-only change
- [x] Documentation updates are not necessary for this internal behavior fix

## Validation

- `uv run pytest tests/rest/test_detector_endpoints.py -q` (64 passed)
- `uv run ruff check backend/rest/routers/internal.py tests/rest/test_detector_endpoints.py`
- `uv run ruff format --check backend/rest/routers/internal.py tests/rest/test_detector_endpoints.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes billing usage details so failed detector runs no longer consume the free-plan quota or affect overage calculations. The detector-scan usage query now only counts runs with `status = 'completed'`, preserving its existing source-agnostic counting for BYOK and system runs.

<sup>Written for commit 0b81008ad01b808a4e2845632df67895f4ef92b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

