### PR TITLE
terraform(aws): pin ClickHouse to 16Gi + add RDS CloudWatch alarms

### DIFF
--- a/deploy/terraform/aws/rds_alarms.tf
+++ b/deploy/terraform/aws/rds_alarms.tf
@@ -1,0 +1,59 @@
+# deploy/terraform/aws/rds_alarms.tf
+# RDS CloudWatch alarms + notification topic (SOC 2 monitoring).
+#
+# These were applied out-of-band earlier (present in state, absent from committed
+# config), so a plain `terraform apply` wanted to delete them. Re-added here to
+# match existing state exactly — same resource addresses, env-agnostic via
+# var.name and the RDS instance — so the alarms are preserved, not dropped.
+
+resource "aws_sns_topic" "postgres_alarms" {
+  name = "${var.name}-postgres-alarms"
+}
+
+resource "aws_cloudwatch_metric_alarm" "postgres_cpu" {
+  alarm_name          = "${var.name}-postgres-cpu-high"
+  alarm_description   = "RDS ${aws_rds_cluster_instance.postgres.identifier} CPU utilization above 90% for 15 minutes."
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 90
+  evaluation_periods  = 3
+  dimensions          = { DBInstanceIdentifier = aws_rds_cluster_instance.postgres.identifier }
+  alarm_actions       = [aws_sns_topic.postgres_alarms.arn]
+  ok_actions          = [aws_sns_topic.postgres_alarms.arn]
+  treat_missing_data  = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "postgres_freeable_memory" {
+  alarm_name          = "${var.name}-postgres-freeable-memory-low"
+  alarm_description   = "RDS ${aws_rds_cluster_instance.postgres.identifier} freeable memory below 256 MB for 15 minutes."
+  comparison_operator = "LessThanThreshold"
+  metric_name         = "FreeableMemory"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 268435456
+  evaluation_periods  = 3
+  dimensions          = { DBInstanceIdentifier = aws_rds_cluster_instance.postgres.identifier }
+  alarm_actions       = [aws_sns_topic.postgres_alarms.arn]
+  ok_actions          = [aws_sns_topic.postgres_alarms.arn]
+  treat_missing_data  = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "postgres_disk_queue_depth" {
+  alarm_name          = "${var.name}-postgres-disk-queue-depth-high"
+  alarm_description   = "RDS ${aws_rds_cluster_instance.postgres.identifier} disk queue depth above 15 (I/O saturation) for 15 minutes."
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "DiskQueueDepth"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 15
+  evaluation_periods  = 3
+  dimensions          = { DBInstanceIdentifier = aws_rds_cluster_instance.postgres.identifier }
+  alarm_actions       = [aws_sns_topic.postgres_alarms.arn]
+  ok_actions          = [aws_sns_topic.postgres_alarms.arn]
+  treat_missing_data  = "notBreaching"
+}

--- a/deploy/terraform/aws/traceroot.tf
+++ b/deploy/terraform/aws/traceroot.tf
@@ -147,10 +147,10 @@ clickhouse:
   resources:
     requests:
       cpu: "2"
-      memory: "8Gi"
+      memory: "16Gi"
     limits:
       cpu: "2"
-      memory: "8Gi"
+      memory: "16Gi"
   extraEnvVars:
     - name: MALLOC_CONF
       value: "background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000"


### PR DESCRIPTION
## What

Two infra changes that were applied to the live clusters out-of-band and existed **only in Terraform state**, so a plain `terraform apply` proposed reverting them. This commits the config so state and code agree and future plans stay clean.

- **ClickHouse memory `8Gi` → `16Gi`** (requests + limits): headroom for background merges; prevents OOM under large-trace read load.
- **`rds_alarms.tf`** — three CloudWatch alarms (CPU utilization, freeable memory, disk queue depth) + an SNS topic for database monitoring. Env-agnostic via `var.name` and the RDS instance identifier, so it applies to every environment.

## Why

Without this, a routine `terraform apply` silently proposes downsizing ClickHouse back to 8Gi and deleting the alarms — an OOM/monitoring-loss risk. This makes the committed config match what's already running.

## Safety

- **No secrets** and no environment-specific values are added — all inputs remain in gitignored `tfvars` and local state.
- Purely additive/idempotent against current state: applying this proposes **no infrastructure changes** (state already matches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Commits two out-of-band infra changes that existed only in Terraform state, so a plain `terraform apply` no longer proposes reverting ClickHouse to 8Gi or deleting RDS alarms.

- Raises ClickHouse memory requests and limits from 8Gi to 16Gi to prevent OOMs and give headroom for background merges.
- Adds three RDS CloudWatch alarms (CPU utilization, freeable memory, disk queue depth) and an SNS topic in `rds_alarms.tf`.
- No environment-specific values are added; names derive from `var.name` and the RDS instance identifier.
- Applying this proposes no infrastructure changes since the live state already matches, so no migration steps are needed.

<sup>Written for commit a9b40bddb5d79ff4ce5ab2f2a8d28e1117098844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

