### PR TITLE
fix(billing): decide AIMessage kind per-request, not per-session

### DIFF
--- a/frontend/ee/agent/src/__tests__/index.test.ts
+++ b/frontend/ee/agent/src/__tests__/index.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// index.ts runs main() (DB check, price sync, HTTP listen) at import time —
+// mock everything it touches so importing `app` in a test is side-effect-free.
+const mocks = vi.hoisted(() => ({
+  appendMessage: vi.fn().mockResolvedValue(undefined),
+  getSession: vi.fn(),
+  updateSessionTitle: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@hono/node-server", () => ({
+  serve: vi.fn(),
+}));
+
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    project: { count: vi.fn().mockResolvedValue(0) },
+    $disconnect: vi.fn().mockResolvedValue(undefined),
+  },
+  calculateCost: vi.fn().mockResolvedValue(0),
+  syncStandardPrices: vi.fn().mockResolvedValue(undefined),
+  ModelSource: { SYSTEM: "system", BYOK: "byok" },
+}));
+
+vi.mock("../session.js", async () => {
+  const actual = await vi.importActual<typeof import("../session.js")>("../session.js");
+  return {
+    ...actual,
+    getSession: mocks.getSession,
+    updateSessionTitle: mocks.updateSessionTitle,
+    createSession: vi.fn(),
+    getSessionMessages: vi.fn(),
+    listSessions: vi.fn(),
+    deleteSession: vi.fn(),
+  };
+});
+
+// runAgent drives handler.onEvent/onDone the way the real pi-agent-core Agent
+// would for a one-turn text reply, so the route's SSE callback runs its full
+// persistence path (both appendMessage call sites) exactly as production does.
+vi.mock("../agent.js", () => ({
+  getOrCreateAgent: vi.fn().mockResolvedValue({
+    agent: {},
+    sessionManager: { appendMessage: mocks.appendMessage },
+  }),
+  runAgent: vi.fn(async (_agent: unknown, _userMessage: string, handler: any) => {
+    handler.onEvent({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "hi there" },
+    });
+    handler.onEvent({
+      type: "message_end",
+      message: {
+        model: "gpt-5",
+        provider: "openai",
+        usage: { input: 10, output: 5, cost: { total: 0.01 } },
+        stopReason: "stop",
+      },
+    });
+    await handler.onDone();
+  }),
+  removeAgent: vi.fn(),
+  invalidateProviderCache: vi.fn(),
+}));
+
+vi.mock("../prompts/system.js", () => ({
+  getSystemPrompt: vi.fn().mockReturnValue("system prompt"),
+}));
+
+vi.mock("../executors/index.js", () => ({
+  createExecutor: vi.fn().mockReturnValue({ destroy: vi.fn().mockResolvedValue(undefined) }),
+}));
+
+vi.mock("../tools/index.js", () => ({
+  createTools: vi.fn().mockReturnValue([]),
+}));
+
+import { app } from "../index.js";
+
+describe("POST /api/v1/projects/:projectId/sessions/:sessionId/messages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue({ workspaceId: "ws-1", title: "existing title" });
+  });
+
+  async function postMessage(headers: Record<string, string>) {
+    const res = await app.request("/api/v1/projects/proj-1/sessions/sess-1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ message: "hello" }),
+    });
+    // Drain the SSE body: appendMessage("assistant", ...) is awaited before the
+    // route writes its final "done" event, so reading to completion guarantees
+    // both appendMessage calls have already landed.
+    await res.text();
+    return res;
+  }
+
+  it("a request without x-user-id (the worker's automatic RCA turn) persists kind='rca' for both messages", async () => {
+    await postMessage({});
+
+    expect(mocks.appendMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.appendMessage.mock.calls[0]).toEqual(["user", "hello", "rca"]);
+    expect(mocks.appendMessage.mock.calls[1][0]).toBe("assistant");
+    expect(mocks.appendMessage.mock.calls[1][2]).toBe("rca");
+  });
+
+  it("a request with x-user-id (a human follow-up) persists kind='chat' for both messages", async () => {
+    await postMessage({ "x-user-id": "user-1" });
+
+    expect(mocks.appendMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.appendMessage.mock.calls[0]).toEqual(["user", "hello", "chat"]);
+    expect(mocks.appendMessage.mock.calls[1][0]).toBe("assistant");
+    expect(mocks.appendMessage.mock.calls[1][2]).toBe("chat");
+  });
+});

--- a/frontend/ee/agent/src/__tests__/session.test.ts
+++ b/frontend/ee/agent/src/__tests__/session.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    aISession: { findUnique: vi.fn() },
+    aIMessage: { create: vi.fn() },
+  },
+}));
+
+import { prisma } from "@traceroot/core";
+import { SessionManager, resolveMessageKind } from "../session.js";
+
+describe("resolveMessageKind", () => {
+  it('empty userId (no x-user-id header — the worker\'s automatic RCA turn) resolves to "rca"', () => {
+    expect(resolveMessageKind("")).toBe("rca");
+  });
+
+  it('non-empty userId (an authenticated request — a human follow-up) resolves to "chat"', () => {
+    expect(resolveMessageKind("user-123")).toBe("chat");
+  });
+
+  it('documents current truthy-based semantics: whitespace-only userId resolves to "chat"', () => {
+    // Not a real-world input (the header is either the proxy's authenticated
+    // user.id or omitted entirely) — this pins today's behavior explicitly
+    // so a future `.trim()` "cleanup" here is a conscious decision, not a
+    // silent flip of RCA-session billing.
+    expect(resolveMessageKind("   ")).toBe("chat");
+  });
+});
+
+describe("SessionManager.appendMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("persists kind='chat' for a follow-up in a system-owned RCA session (userId: null)", async () => {
+    (prisma.aISession.findUnique as any).mockResolvedValue({
+      workspaceId: "ws-1",
+      userId: null,
+    });
+
+    const manager = new SessionManager("sess-rca");
+    await manager.appendMessage("user", "what caused this?", "chat");
+
+    expect(prisma.aIMessage.create).toHaveBeenCalledTimes(1);
+    const data = (prisma.aIMessage.create as any).mock.calls[0][0].data;
+    expect(data.kind).toBe("chat");
+  });
+
+  it("persists kind='rca' for the automatic first turn in a user-owned session (userId set)", async () => {
+    (prisma.aISession.findUnique as any).mockResolvedValue({
+      workspaceId: "ws-1",
+      userId: "u1",
+    });
+
+    const manager = new SessionManager("sess-user");
+    await manager.appendMessage("assistant", "here's the analysis", "rca");
+
+    expect(prisma.aIMessage.create).toHaveBeenCalledTimes(1);
+    const data = (prisma.aIMessage.create as any).mock.calls[0][0].data;
+    expect(data.kind).toBe("rca");
+  });
+
+  it("still pulls workspaceId from the session row", async () => {
+    (prisma.aISession.findUnique as any).mockResolvedValue({
+      workspaceId: "ws-42",
+      userId: null,
+    });
+
+    const manager = new SessionManager("sess-1");
+    await manager.appendMessage("user", "hi", "rca");
+
+    const data = (prisma.aIMessage.create as any).mock.calls[0][0].data;
+    expect(data.workspaceId).toBe("ws-42");
+  });
+
+  it("still merges tokenUsage fields onto the created row when passed", async () => {
+    (prisma.aISession.findUnique as any).mockResolvedValue({
+      workspaceId: "ws-1",
+      userId: "u1",
+    });
+
+    const manager = new SessionManager("sess-1");
+    await manager.appendMessage("assistant", "reply", "chat", undefined, {
+      model: "gpt-5",
+      provider: "openai",
+      isByok: false,
+      inputTokens: 10,
+      outputTokens: 20,
+      cost: 0.01,
+    });
+
+    const data = (prisma.aIMessage.create as any).mock.calls[0][0].data;
+    expect(data.model).toBe("gpt-5");
+    expect(data.provider).toBe("openai");
+    expect(data.inputTokens).toBe(10);
+    expect(data.outputTokens).toBe(20);
+    expect(data.cost).toBe(0.01);
+  });
+
+  it("throws when the session isn't found", async () => {
+    (prisma.aISession.findUnique as any).mockResolvedValue(null);
+
+    const manager = new SessionManager("missing-session");
+    await expect(manager.appendMessage("user", "hi", "chat")).rejects.toThrow(
+      "AISession not found: missing-session",
+    );
+  });
+
+  it("does not confuse metadata with kind now that kind is a new positional argument", async () => {
+    (prisma.aISession.findUnique as any).mockResolvedValue({
+      workspaceId: "ws-1",
+      userId: null,
+    });
+
+    const manager = new SessionManager("sess-1");
+    await manager.appendMessage("user", "hi", "chat", { traceId: "t1", toolCalls: 2 });
+
+    const data = (prisma.aIMessage.create as any).mock.calls[0][0].data;
+    expect(data.kind).toBe("chat");
+    expect(data.metadata).toEqual({ traceId: "t1", toolCalls: 2 });
+  });
+
+  it("leaves token/cost fields absent on the row when tokenUsage isn't passed", async () => {
+    (prisma.aISession.findUnique as any).mockResolvedValue({
+      workspaceId: "ws-1",
+      userId: "u1",
+    });
+
+    const manager = new SessionManager("sess-1");
+    await manager.appendMessage("user", "hi", "chat");
+
+    const data = (prisma.aIMessage.create as any).mock.calls[0][0].data;
+    expect(data.model).toBeUndefined();
+    expect(data.provider).toBeUndefined();
+    expect(data.cost).toBeUndefined();
+  });
+
+  it("looks up the specific session this instance was constructed with, not a fixed id", async () => {
+    (prisma.aISession.findUnique as any)
+      .mockResolvedValueOnce({ workspaceId: "ws-a", userId: null })
+      .mockResolvedValueOnce({ workspaceId: "ws-b", userId: null });
+
+    await new SessionManager("session-aaa").appendMessage("user", "hi", "rca");
+    await new SessionManager("session-bbb").appendMessage("user", "hi", "rca");
+
+    const findUniqueCalls = (prisma.aISession.findUnique as any).mock.calls;
+    expect(findUniqueCalls[0][0].where).toEqual({ id: "session-aaa" });
+    expect(findUniqueCalls[1][0].where).toEqual({ id: "session-bbb" });
+
+    const createCalls = (prisma.aIMessage.create as any).mock.calls;
+    expect(createCalls[0][0].data.sessionId).toBe("session-aaa");
+    expect(createCalls[0][0].data.workspaceId).toBe("ws-a");
+    expect(createCalls[1][0].data.sessionId).toBe("session-bbb");
+    expect(createCalls[1][0].data.workspaceId).toBe("ws-b");
+  });
+});

--- a/frontend/ee/agent/src/index.ts
+++ b/frontend/ee/agent/src/index.ts
@@ -9,6 +9,7 @@ import {
   listSessions,
   deleteSession,
   updateSessionTitle,
+  resolveMessageKind,
 } from "./session.js";
 import { getOrCreateAgent, runAgent, removeAgent, invalidateProviderCache } from "./agent.js";
 import { getSystemPrompt } from "./prompts/system.js";
@@ -111,6 +112,7 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
   const sessionId = c.req.param("sessionId");
   const userId = c.req.header("x-user-id") || "";
   const workspaceId = c.req.header("x-workspace-id") || "";
+  const kind = resolveMessageKind(userId);
   const body = await c.req.json<{
     message: string;
     model?: string;
@@ -170,7 +172,7 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
   console.log(`[Agent] Agent ready, running prompt: "${body.message.slice(0, 50)}"`);
 
   // Persist user message to DB via SessionManager
-  await sessionManager.appendMessage("user", body.message);
+  await sessionManager.appendMessage("user", body.message, kind);
 
   // Auto-generate session title from first user message (we already have
   // the session loaded above for the auth check — reuse it).
@@ -287,7 +289,13 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
                   cost,
                 }
               : undefined;
-            await sessionManager.appendMessage("assistant", assistantText, undefined, tokenUsage);
+            await sessionManager.appendMessage(
+              "assistant",
+              assistantText,
+              kind,
+              undefined,
+              tokenUsage,
+            );
           }
           stream.writeSSE({ event: "done", data: "{}" });
           resolve();

--- a/frontend/ee/agent/src/session.ts
+++ b/frontend/ee/agent/src/session.ts
@@ -17,6 +17,16 @@ export interface TokenUsageData {
   cost: number;
 }
 
+/**
+ * Decide the billing `kind` for a message from the *request* that carries
+ * it, not from the session it lands in. A request with an authenticated
+ * `x-user-id` is a human-initiated turn (chat); one without it is the
+ * worker's automatic RCA prompt (rca). See appendMessage below.
+ */
+export function resolveMessageKind(userId: string): "chat" | "rca" {
+  return userId ? "chat" : "rca";
+}
+
 export class SessionManager {
   constructor(private sessionId: string) {}
 
@@ -57,13 +67,15 @@ export class SessionManager {
    * Like Mom's sessionManager.appendMessage() — persists to DB.
    *
    * `workspaceId` and `kind` are required on every AIMessage row (see schema).
-   * We derive both from the parent AISession: `kind = "chat"` for user sessions
-   * (userId set), `kind = "rca"` for system sessions (userId null). This
-   * mirrors the existing convention in createSession.
+   * `workspaceId` comes from the parent AISession. `kind` is decided by the
+   * caller (see resolveMessageKind) from the request that triggered this
+   * turn — NOT from the session's ownership, since a human follow-up can
+   * land in a system-owned RCA session and must still bill as "chat".
    */
   async appendMessage(
     role: string,
     content: string,
+    kind: "chat" | "rca",
     metadata?: Record<string, unknown>,
     tokenUsage?: TokenUsageData,
   ): Promise<void> {
@@ -74,7 +86,6 @@ export class SessionManager {
     if (!session) {
       throw new Error(`AISession not found: ${this.sessionId}`);
     }
-    const kind = session.userId === null ? "rca" : "chat";
 
     await prisma.aIMessage.create({
       data: {


### PR DESCRIPTION
## Summary

RCA sessions are owned by the system (`userId: null`). `SessionManager.appendMessage` derived the `AIMessage.kind` field from that session ownership, so every message appended to an RCA session was billed as `kind="rca"` forever — including a human's follow-up question typed into the Alert panel afterward. Those follow-ups never counted toward the `chat`/AI-run quota, since `usageMetering.ts` aggregates strictly by the stored `kind`.

Traced both ways a message reaches `POST /api/v1/projects/:projectId/sessions/:sessionId/messages`:
- The worker's automatic RCA turn (`detector-rca-processor.ts`) posts without an `x-user-id` header.
- A human follow-up, proxied through `frontend/ui/.../ai/sessions/[sessionId]/messages/route.ts`, always sets `x-user-id: user.id` since it requires an authenticated user.

So `x-user-id`'s presence on the request — not the session's ownership — is what should decide `kind`.

## Fix

- Added `resolveMessageKind(userId)` in `session.ts`: empty userId → `"rca"`, non-empty → `"chat"`.
- `appendMessage` now takes `kind` as an explicit parameter instead of deriving it from `session.userId`.
- The message route computes `kind` once from the `x-user-id` header and passes it into both `appendMessage` calls (the user message and the assistant reply).

## Type of Change

- [x] fix - A bug fix

## Test plan

New `frontend/ee/agent/src/__tests__/session.test.ts` (11 tests) — no test file existed yet for this package's `session.ts`/`index.ts`:

- `resolveMessageKind`: empty / whitespace-only / non-empty userId cases
- `appendMessage` persists the passed-in `kind` regardless of the session's own `userId`, in both directions — the core regression test for this bug
- Regression guards for behavior the refactor must preserve: `workspaceId` still sourced from the session row, `tokenUsage` fields present/absent correctly, session-not-found still throws, `metadata` doesn't collide with the new `kind` positional argument, and lookups stay scoped to the correct `sessionId`

Verified the tests are meaningful by reverting just the source fix (keeping the tests) and confirming 7 of 11 fail with the exact wrong `kind` values described above; restored the fix and confirmed all 11 pass. Also ran `tsc --noEmit` and `eslint` clean on the changed files.

Fixes #2031

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AI-message billing so human follow-ups in RCA sessions count toward the chat quota instead of being metered as `rca`. `appendMessage` now takes an explicit `kind` resolved from the `x-user-id` header instead of deriving it from session ownership, with unit and route-level regression tests covering the change. Fixes #2031.

<sup>Written for commit c62a2113f3272ad384992606089d227089b197c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

