### PR TITLE
fix(alerts): clear lastError and lastNotify* fields on alert rule reset (#2027)

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/alerts/rule-state.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/alerts/rule-state.test.ts
@@ -205,6 +205,11 @@ describe("alertStateReset", () => {
       lastEvaluatedAt: null,
       nextRunAt: RESET_AT,
       lastClaimedAt: null,
+      lastError: null,
+      lastErrorAt: null,
+      lastNotifyStatus: null,
+      lastNotifyError: null,
+      lastNotifyAt: null,
     });
   });
 

--- a/frontend/ui/src/app/api/projects/[projectId]/alerts/rule-state.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/alerts/rule-state.ts
@@ -32,6 +32,11 @@ export function alertStateReset() {
     lastEvaluatedAt: null,
     nextRunAt: new Date(),
     lastClaimedAt: null,
+    lastError: null,
+    lastErrorAt: null,
+    lastNotifyStatus: null,
+    lastNotifyError: null,
+    lastNotifyAt: null,
   };
 }
 


### PR DESCRIPTION
Fixes #2027

### Summary
When an alert rule is edited or resumed, `alertStateReset()` resets severity, evaluation clocks, and claim tokens to cold start defaults. However, it previously left `lastError`, `lastErrorAt`, and the `lastNotify*` columns untouched.

This resulted in:
1. **Stale Error Labels**: A rule that was failing and subsequently edited/fixed continued to render `"Failing: <old error>"` until the next successful evaluation cycle.
2. **Stale Delivery Warnings**: A failed delivery status (`lastNotifyStatus = FAILED`) persisted indefinitely on reset rules since delivery columns are only updated by the delivery worker.

### Fix
- Folded the 5 error and notification delivery history columns into `alertStateReset()` by setting them to `null`:
  - `lastError: null`
  - `lastErrorAt: null`
  - `lastNotifyStatus: null`
  - `lastNotifyError: null`
  - `lastNotifyAt: null`

### Testing
- Updated `rule-state.test.ts` to verify that `alertStateReset()` returns all 11 reset fields set to `null`/cold start defaults.
- Ran `pnpm --filter traceroot-ui test rule-state.test.ts` (17 tests passed).
- Ran full package test suite `pnpm --filter traceroot-ui test` (236 test files / 2,278 tests passed).

Before

<img width="1160" height="534" alt="Image" src="https://github.com/user-attachments/assets/eb60407a-63f7-4520-af60-67f1e823da1c" />

<img width="1102" height="396" alt="Image" src="https://github.com/user-attachments/assets/c89ef4fc-7bf9-48df-9527-391a8e5f51a4" />

After 

<img width="1010" height="680" alt="Image" src="https://github.com/user-attachments/assets/17b13ef2-6901-454b-afd0-4230a641a8b4" />


<img width="816" height="562" alt="Image" src="https://github.com/user-attachments/assets/a4bcf6de-dd03-4f73-998f-bfe4dd717cba" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the alerts feature end-to-end and stops edited or resumed rules from showing stale failure state: `alertStateReset()` now also clears the `lastError` and `lastNotify*` columns, so a rule that was failing and then fixed no longer renders `"Failing: <old error>"` or a failed-delivery badge until its next run.

**Alerts**
- Projects define rules over a widget measure with a threshold, window, and a no-data mode (`HOLD`, `ZERO`, or `NOTIFY`).
- The Node worker claims due rules once a minute and evaluates them through the widget query engine, so the value a threshold compares against is the same number the preview drew.
- Slack notifications retry on their own budget; paused or deleted rules don't page, and permanent delivery failures record the cause without re-emitting every minute.
- Editing any part of a rule other than its name voids its evaluation state, so a changed rule restarts from never-evaluated.
- Dashboard widgets gain `p75`/`p90`/`uniq` aggregations, keyed metadata filters, and explicit bucket widths; `uniq` series are no longer summed in the legend.

**Migration**
- The `alerts` table ships as one squashed migration; dev databases that applied any earlier alert migration must reset or mark `20260827000000_add_alerts` applied by hand.
- The scheduler ships disabled under Helm and enabled in `docker-compose.prod.yml`; flip `alertsSchedulerEnabled` to turn it on.
- Internal endpoints moved behind an `INTERNAL_API_SECRET` that now fails closed; an unset secret rejects all requests instead of allowing anonymous writes.

<sup>Written for commit e31822dc91b488ac4fbf4f71cacce3a6bb35775f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

