### PR TITLE
ci: push images to ECR via OIDC instead of a stored AWS key

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -24,6 +24,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write      # mint the OIDC token used to assume the ECR push role
 
 env:
   AWS_REGION: us-east-1
@@ -63,8 +64,10 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # Short-lived credentials minted per run via GitHub OIDC. The role can
+          # push to traceroot-* ECR repositories and nothing else; there is no
+          # stored AWS key to leak.
+          role-to-assume: arn:aws:iam::965747688757:role/traceroot-build-ecr
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
Switches the image build to short-lived credentials issued per run, replacing the previous static configuration.

The role used is scoped to pushing this project's container images and nothing else.

Rollout was staged so the previous path stayed available until the new one was confirmed working.