### PR TITLE
ci: build custom images via OIDC too

### DIFF
--- a/.github/workflows/_docker-images-custom.yml
+++ b/.github/workflows/_docker-images-custom.yml
@@ -59,8 +59,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # Short-lived credentials minted per run via GitHub OIDC. The role can
+          # push to traceroot-* ECR repositories and nothing else.
+          role-to-assume: arn:aws:iam::965747688757:role/traceroot-build-ecr
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
Follow-up to #2096. This workflow still used the older credential configuration, so it needed the same change to keep both build paths consistent.

It already requested `id-token: write`; only the credentials block changed. It pushes to the same ECR repositories, so no policy change was needed.

Verified: the equivalent change in #2096 built and pushed all six service images successfully.