### PR TITLE
fix(ui): draw lone buckets on percentile charts and zero-fill additive series

### DIFF
--- a/backend/rest/services/widget_query.py
+++ b/backend/rest/services/widget_query.py
@@ -172,6 +172,12 @@ def compile_widget_query(
         # collapse (a p95 latency line dipping to nothing). Nullable makes the
         # WITH FILL rows below carry NULL, which the chart draws as a gap.
         metric_sql = f"toNullable({metric_sql})"
+    elif is_timeseries:
+        # The zero has to be made explicit: a sum over a Nullable column (cost,
+        # tokens) is itself Nullable, so its WITH FILL rows would carry NULL
+        # too, and the chart would see one real bucket among gaps and draw
+        # nothing for a series that has data.
+        metric_sql = f"ifNull({metric_sql}, 0)"
     # Bound unconditionally: both the bucketing branch and the row-cap branch
     # below key off is_timeseries, and an implicit binding would let them drift.
     gran = _pick_granularity(start_time, end_time)

--- a/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
@@ -179,6 +179,41 @@ describe("QueryWidgetRenderer", () => {
       expect((d.match(/M/g) ?? []).length).toBe(1);
     });
 
+    it("draws a lone real bucket of a non-additive series as a dot", () => {
+      // One day of traffic in a two-week window: every other p95 bucket is a
+      // NULL gap, so there is nothing to connect and a dot-less line renders
+      // nothing at all — the tile looks empty while it has data.
+      const result = makeResult(
+        ["bucket", "value"],
+        [
+          ["2026-06-01T00:00:00", null],
+          ["2026-06-02T00:00:00", 8597],
+          ["2026-06-03T00:00:00", null],
+        ],
+        { granularity: "day" },
+      );
+      const { container } = render(
+        <QueryWidgetRenderer display="line" result={result} agg="p95" />,
+      );
+      expect(container.querySelectorAll(".recharts-line-dot").length).toBe(1);
+    });
+
+    it("draws no dots along a connected series", () => {
+      const result = makeResult(
+        ["bucket", "value"],
+        [
+          ["2026-06-01T00:00:00", 120],
+          ["2026-06-02T00:00:00", 100],
+          ["2026-06-03T00:00:00", 90],
+        ],
+        { granularity: "day" },
+      );
+      const { container } = render(
+        <QueryWidgetRenderer display="line" result={result} agg="p95" />,
+      );
+      expect(container.querySelectorAll(".recharts-line-dot").length).toBe(0);
+    });
+
     it("keeps a non-additive AREA off the zero baseline over gap buckets", () => {
       // Stacked areas are the trap: recharts' stack accessor coerces null to
       // 0 BEFORE connectNulls is consulted, redrawing the false collapse. A

--- a/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
@@ -195,7 +195,25 @@ describe("QueryWidgetRenderer", () => {
       const { container } = render(
         <QueryWidgetRenderer display="line" result={result} agg="p95" />,
       );
-      expect(container.querySelectorAll(".recharts-line-dot").length).toBe(1);
+      expect(container.querySelectorAll(".recharts-isolated-dot").length).toBe(1);
+    });
+
+    it("draws a lone real bucket of a non-additive AREA as a dot too", () => {
+      // recharts hands an area's points a [baseline, value] pair rather than
+      // the bare value, so the isolation check must read through the pair.
+      const result = makeResult(
+        ["bucket", "value"],
+        [
+          ["2026-06-01T00:00:00", null],
+          ["2026-06-02T00:00:00", 8597],
+          ["2026-06-03T00:00:00", null],
+        ],
+        { granularity: "day" },
+      );
+      const { container } = render(
+        <QueryWidgetRenderer display="area" result={result} agg="p95" />,
+      );
+      expect(container.querySelectorAll(".recharts-isolated-dot").length).toBe(1);
     });
 
     it("draws no dots along a connected series", () => {
@@ -211,7 +229,7 @@ describe("QueryWidgetRenderer", () => {
       const { container } = render(
         <QueryWidgetRenderer display="line" result={result} agg="p95" />,
       );
-      expect(container.querySelectorAll(".recharts-line-dot").length).toBe(0);
+      expect(container.querySelectorAll(".recharts-isolated-dot").length).toBe(0);
     });
 
     it("keeps a non-additive AREA off the zero baseline over gap buckets", () => {

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -196,21 +196,16 @@ interface SeriesDotProps {
   stroke?: string;
   points: ReadonlyArray<{ value?: unknown }>;
 }
+// An area's points carry a [baseline, value] pair where a line's carry the
+// bare value; read through the pair so both charts see the same emptiness.
+const rawValue = (value: unknown) => (Array.isArray(value) ? value[1] : value);
 const hasValue = (point: { value?: unknown } | undefined) =>
-  point !== undefined && point.value !== null && point.value !== undefined;
+  point !== undefined && rawValue(point.value) !== null && rawValue(point.value) !== undefined;
 function isolatedDot({ cx, cy, index, value, stroke, points }: SeriesDotProps) {
-  if (cx === undefined || cy === undefined || value === null || value === undefined) return null;
+  if (cx === undefined || cy === undefined || !hasValue({ value })) return null;
   if (hasValue(points[index - 1]) || hasValue(points[index + 1])) return null;
   return (
-    <circle
-      key={index}
-      className="recharts-line-dot"
-      cx={cx}
-      cy={cy}
-      r={2.5}
-      fill={stroke}
-      stroke="none"
-    />
+    <circle className="recharts-isolated-dot" cx={cx} cy={cy} r={2.5} fill={stroke} stroke="none" />
   );
 }
 
@@ -476,7 +471,7 @@ function Bars({
   const data = useColoredRows(result);
   return (
     <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
-      <BarChart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+      <BarChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
         <CartesianGrid strokeOpacity={0.15} vertical={false} />
         <XAxis dataKey="name" tick={{ fontSize: 10 }} />
         <YAxis
@@ -618,12 +613,12 @@ function HistogramView({
   }));
   return (
     <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
-      <BarChart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+      <BarChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
         <XAxis dataKey="name" tick={{ fontSize: 9 }} interval="preserveStartEnd" />
         {/* The y-axis counts rows per bin (no unit), but large counts clip in
             the fixed gutter just like the other charts — compact them too. */}
         <YAxis
-          tick={{ fontSize: 10 }}
+          tick={Y_AXIS_TICK}
           width={Y_AXIS_WIDTH}
           tickFormatter={(v: unknown) => fmtAxisTick(v)}
         />

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -169,11 +169,50 @@ export const fmtValueWithUnit = (v: unknown, unit?: FieldUnit) => {
 // "100K", "$1.2M"), so the gutter widths below hold for every tick.
 const Y_AXIS_WIDTH = 42;
 const Y_AXIS_WIDTH_WITH_UNIT = 58;
+// Recharts wraps a tick label to the axis width by default, so "10,000 ms"
+// breaks into two lines in the unit gutter and the top one runs off the
+// chart. Labels are bounded by the compact formatter above, so give the
+// text a width no label reaches and let the gutter alone decide the fit.
+const Y_AXIS_TICK = { fontSize: 10, width: 160 };
 export const fmtAxisTick = (v: unknown, unit?: FieldUnit) => {
   const text = fmtStatNumber(v);
   if (!unit || text === "—") return text;
   return `${unit.prefix ?? ""}${text}${unit.suffix ? ` ${unit.suffix}` : ""}`;
 };
+
+/**
+ * A dot for a real bucket with gap buckets on both sides. A non-additive
+ * series draws its NULL gaps as breaks, so a lone bucket — one day of traffic
+ * in a two-week window — has nothing to connect to and a dot-less line renders
+ * nothing: the tile looks empty while it has data. Everywhere else the line
+ * itself is the mark, so no dot is drawn. Returned as a function so recharts
+ * hands each point its neighbours; a null return draws nothing.
+ */
+interface SeriesDotProps {
+  cx?: number;
+  cy?: number;
+  index: number;
+  value?: unknown;
+  stroke?: string;
+  points: ReadonlyArray<{ value?: unknown }>;
+}
+const hasValue = (point: { value?: unknown } | undefined) =>
+  point !== undefined && point.value !== null && point.value !== undefined;
+function isolatedDot({ cx, cy, index, value, stroke, points }: SeriesDotProps) {
+  if (cx === undefined || cy === undefined || value === null || value === undefined) return null;
+  if (hasValue(points[index - 1]) || hasValue(points[index + 1])) return null;
+  return (
+    <circle
+      key={index}
+      className="recharts-line-dot"
+      cx={cx}
+      cy={cy}
+      r={2.5}
+      fill={stroke}
+      stroke="none"
+    />
+  );
+}
 
 // Bucket keys come back ISO-ish ("2026-06-01T00:00:00"); a space reads better
 // in the tooltip header than the "T" separator.
@@ -357,11 +396,13 @@ function TimeSeries({
 
   return (
     <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
-      <Chart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+      {/* Top margin clears the topmost tick label, which is centred on the
+          axis line and would otherwise lose its upper half to the SVG edge. */}
+      <Chart data={data} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
         <CartesianGrid strokeOpacity={0.15} vertical={false} />
         <XAxis dataKey="bucket" tick={{ fontSize: 10 }} tickFormatter={tickFormatter} />
         <YAxis
-          tick={{ fontSize: 10 }}
+          tick={Y_AXIS_TICK}
           width={unit ? Y_AXIS_WIDTH_WITH_UNIT : Y_AXIS_WIDTH}
           tickFormatter={(v: unknown) => fmtAxisTick(v, unit)}
         />
@@ -401,6 +442,7 @@ function TimeSeries({
               fillOpacity={seriesOpacity(hovered, k, 0.35)}
               isAnimationActive={false}
               connectNulls={!additive}
+              dot={additive ? false : isolatedDot}
             />
           ) : (
             <Line
@@ -408,7 +450,7 @@ function TimeSeries({
               dataKey={k}
               stroke={seriesColor(i)}
               strokeOpacity={seriesOpacity(hovered, k)}
-              dot={false}
+              dot={additive ? false : isolatedDot}
               strokeWidth={1.5}
               isAnimationActive={false}
               connectNulls={!additive}
@@ -438,7 +480,7 @@ function Bars({
         <CartesianGrid strokeOpacity={0.15} vertical={false} />
         <XAxis dataKey="name" tick={{ fontSize: 10 }} />
         <YAxis
-          tick={{ fontSize: 10 }}
+          tick={Y_AXIS_TICK}
           width={unit ? Y_AXIS_WIDTH_WITH_UNIT : Y_AXIS_WIDTH}
           tickFormatter={(v: unknown) => fmtAxisTick(v, unit)}
         />

--- a/tests/rest/test_widget_query.py
+++ b/tests/rest/test_widget_query.py
@@ -497,3 +497,32 @@ def test_run_widget_query_sets_execution_guards(monkeypatch):
     assert settings["readonly"] == 1
     assert settings["max_execution_time"] == QUERY_TIMEOUT_S
     assert settings["max_bytes_before_external_group_by"] == GROUP_BY_SPILL_BYTES
+
+
+def test_additive_timeseries_metric_coalesces_fill_rows_to_zero():
+    """A sum over a Nullable column is Nullable, so its WITH FILL rows carry NULL —
+    the chart would then see one real bucket among gaps and draw nothing. The
+    stated contract is that a count or sum of nothing IS zero, so additive
+    timeseries metrics coalesce to 0; non-additive ones keep their NULL gaps.
+    """
+    sql, _ = compile_(
+        make_spec(
+            metric={"measure": "cost", "agg": "sum"}, display={"type": "line"}, breakdown=None
+        )
+    )
+    assert "ifNull(sum(cost), 0) AS value" in sql
+    assert "toNullable" not in sql
+
+    sql, _ = compile_(
+        make_spec(
+            metric={"measure": "duration_ms", "agg": "p95"},
+            display={"type": "line"},
+            breakdown=None,
+        )
+    )
+    assert "toNullable(quantile(0.95)(duration_ms)) AS value" in sql
+    assert "ifNull(quantile" not in sql
+
+    # Not a timeseries: no fill rows exist, so there is nothing to coalesce.
+    sql, _ = compile_(make_spec(metric={"measure": "cost", "agg": "sum"}, display={"type": "bar"}))
+    assert "ifNull(sum(cost), 0)" not in sql


### PR DESCRIPTION
Part 1 of 14 of the agent UI stack; independent of the rest and mergeable first. Base: `main`.

Three dashboard chart fixes visible on today's default dashboard: a lone real bucket on a percentile line or area chart draws as a dot instead of nothing; the y-axis tick label no longer wraps and clips at the top; and a sum over a nullable column (cost, tokens) fills empty buckets with zero instead of NULL so the series keeps its baseline.

### Commits
- fix(ui): show a lone bucket on percentile charts and keep the top tick label on the chart
- fix(ui): dot a lone bucket on area charts too, and align the bar charts' chrome
- fix(api): fill an additive time series' empty buckets with zero, not NULL

4 files changed, 132 insertions(+), 7 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JddAMkfJ7P4HbtVZpkkTj9


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three dashboard chart issues visible on the default dashboard: percentile charts with a lone real bucket now draw a dot instead of rendering nothing, y-axis tick labels no longer wrap and clip at the top, and additive series over nullable columns fill empty buckets with zero instead of NULL.

- Percentile line and area charts draw a dot for a real bucket whose neighbors are both gaps; the line stays the mark everywhere else.
- Y-axis tick labels get a wider text width and the charts a larger top margin, so labels like "10,000 ms" no longer wrap or clip on time series, bar, and histogram charts.
- Additive time-series metrics (`sum` over nullable columns like `cost` and `tokens`) now coalesce `WITH FILL` rows to zero in the query, keeping the series baseline; non-additive metrics keep NULL gaps.

<sup>Written for commit b9720675a2b0b514a972caddb89583c34783f7a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

