### PR TITLE
fix(pricing): correct gpt-5.6-terra rates and pin them to the published figures

### DIFF
--- a/docs/ai-agent/byok.mdx
+++ b/docs/ai-agent/byok.mdx
@@ -26,4 +26,4 @@ OpenAI, Anthropic, Azure OpenAI, Google (Gemini), Amazon Bedrock, xAI, DeepSeek,
 4. Optionally set a custom base URL for self-hosted or proxied models
 5. Save — keys are encrypted at rest and scoped to your workspace
 
-Once configured, the model selector in the AI chat interface will show both system models and your BYOK models.
+Once configured, the model selector in the AI chat interface will show both system models and your BYOK models — including BYOK-only models such as OpenAI's `gpt-5.6-terra`, which is not part of the system model list above.

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -186,10 +186,10 @@
     "matchPattern": "(?i)^(openai\\/|azure\\/)?(gpt-5\\.6-terra)(-[\\d-]+)?$",
     "provider": "openai",
     "prices": {
-      "input": 0.0000025,
-      "output": 0.000015,
-      "cacheRead": 0.00000025,
-      "cacheWrite": 0.000003125
+      "input": 0.000002,
+      "output": 0.000012,
+      "cacheRead": 0.0000002,
+      "cacheWrite": 0.0000025
     }
   },
   {

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -245,6 +245,19 @@ class TestGpt56CachePricing:
         assert entry["prices"]["cacheRead"] == pytest.approx(entry["prices"]["input"] * 0.10)
 
 
+class TestGpt56TerraPublishedPrices:
+    """Ratio checks alone let a wrong base price stay internally consistent and
+    pass (#2044) — gpt-5.6-terra was billed at $2.50/$15 per 1M tokens against a
+    published $2/$12, with TestGpt56CachePricing green throughout. Assert the
+    absolute, provider-published rate directly.
+    """
+
+    def test_input_and_output_match_published_rate(self, real_cache):
+        entry = next(e for e in real_cache if e["model_name"] == "gpt-5.6-terra")
+        assert entry["prices"]["input"] == pytest.approx(2e-6)  # $2 / 1M tokens
+        assert entry["prices"]["output"] == pytest.approx(1.2e-5)  # $12 / 1M tokens
+
+
 class TestGeminiModelIds:
     @pytest.mark.parametrize("model_id,expected_name", GEMINI_MODEL_CASES)
     def test_matches_expected_model(self, real_cache, model_id, expected_name):

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -246,10 +246,10 @@ class TestGpt56CachePricing:
 
 
 class TestGpt56TerraPublishedPrices:
-    """Ratio checks alone let a wrong base price stay internally consistent and
-    pass (#2044) — gpt-5.6-terra was billed at $2.50/$15 per 1M tokens against a
-    published $2/$12, with TestGpt56CachePricing green throughout. Assert the
-    absolute, provider-published rate directly.
+    """Ratio checks alone let a wrong base price stay internally consistent and pass —
+    gpt-5.6-terra was billed at $2.50/$15 per 1M tokens against a published $2/$12,
+    with TestGpt56CachePricing green throughout. Assert the absolute,
+    provider-published rate directly.
     """
 
     def test_input_and_output_match_published_rate(self, real_cache):


### PR DESCRIPTION
## What

`gpt-5.6-terra` is catalogued at $2.50 / $15 per 1M tokens while the provider publishes **$2 / $12**, so every span on the model is over-billed by 25% on both input and output.

- `standard-model-prices.json`: `input` → `2e-6`, `output` → `1.2e-5`. `cacheRead` and `cacheWrite` are recomputed from the corrected input (`0.10×` / `1.25×`), so the existing ratio assertions in `TestGpt56CachePricing` still hold.
- `tests/worker/tokens/test_pricing.py`: new `TestGpt56TerraPublishedPrices` asserting the **absolute** published rates.
- `docs/ai-agent/byok.mdx`: the model is already offered in the BYOK dropdown but the OpenAI list stopped at `gpt-5.5`; the BYOK page now names it.

## Why the tests didn't catch it

`TestGpt56CachePricing` pins cache prices as *ratios of input* (`cacheWrite` 1.25×, `cacheRead` 0.10×) and never an absolute value, so a wrong base price stays internally consistent and passes. The new test asserts $2 / $12 directly and fails on the old figures — verified by reverting the catalogue entry:

```
FAILED tests/worker/tokens/test_pricing.py::TestGpt56TerraPublishedPrices::test_input_and_output_match_published_rate
E     Obtained: 2.5e-06
E     Expected: 2e-06 ± 2.0e-12
```

## Decisions recorded

- **`SYSTEM_MODELS` is untouched**, as the issue specifies — that list runs on TraceRoot's own keys, so adding a frontier model there is a cost decision, not a bug fix.
- **Already-recorded spans are not repriced.** Cost is materialised at ingest; rewriting historical rows is a migration, not a catalogue fix. The correction applies to spans recorded from here on.

## Validation

`uv run --frozen pytest tests/worker/tokens/test_pricing.py` → 234 passed. `ruff check` / `ruff format --check` clean on the touched file.

No UI change, so no screenshots.

Closes #2044

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects `gpt-5.6-terra` pricing from $2.50/$15 to the published $2/$12 per 1M tokens, so spans are no longer over-billed by 25% on input and output.

- Updates `standard-model-prices.json` rates and recomputes cache read/write from the corrected input.
- Adds a test asserting absolute published rates; the old ratio-only tests couldn't catch the wrong base price.
- Names `gpt-5.6-terra` in the BYOK docs, where the OpenAI list previously stopped at `gpt-5.5`.
- Already-recorded spans are not repriced; the correction applies to new spans only.

<sup>Written for commit 8e0a827ba30c129e418d1113ae43e45d7f22ee1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

