### PR TITLE
fix(agent): reclaim sandbox containers instead of leaking them

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,6 +143,11 @@ SANDBOX_PROVIDER=docker
 # Daytona settings (when SANDBOX_PROVIDER=daytona)
 # DAYTONA_API_KEY=your-api-key
 
+# How long a docker sandbox may sit unused before the agent tears it down.
+# Nothing else ends a session's sandbox in practice, so this is what bounds the
+# containers a long-running agent holds. Set to 0 to disable the sweep.
+# SANDBOX_IDLE_TTL_MINUTES=30
+
 # --- Analytics (PostHog) -------------------------------------------------------
 # Get these from https://us.posthog.com → Project Settings → Project API Key
 # Leave blank to disable analytics (safe for local dev)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -355,6 +355,10 @@ services:
       dockerfile: docker/Dockerfile.agent
     ports:
       - "8100:8100"
+    # Shutdown tears down every sandbox container this instance owns. The 10s
+    # default can expire mid-teardown, and anything still alive when SIGKILL
+    # lands is leaked until the next start reconciles it.
+    stop_grace_period: 60s
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:

--- a/frontend/ee/agent/package.json
+++ b/frontend/ee/agent/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "dev": "dotenv -e ../../../.env -- vite-node --watch src/index.ts",
+    "dev": "dotenv -e ../../../.env -- tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "clean": "rm -rf dist",

--- a/frontend/ee/agent/src/executors/__tests__/docker.test.ts
+++ b/frontend/ee/agent/src/executors/__tests__/docker.test.ts
@@ -9,7 +9,8 @@ vi.mock("child_process", () => ({
   execFile: (...args: unknown[]) => execFileMock(...args),
 }));
 
-const { DockerExecutor } = await import("../docker.js");
+const { DockerExecutor, reclaimOrphanedSandboxes, SANDBOX_LABEL, SESSION_LABEL, OWNER_LABEL } =
+  await import("../docker.js");
 
 const TOKEN = "ghs_supersecrettoken000000000000000000";
 
@@ -150,5 +151,79 @@ describe("DockerExecutor.cloneRepo", () => {
   it("reports native git support", async () => {
     const executor = await readyExecutor();
     expect(executor.hasNativeGit()).toBe(true);
+  });
+});
+
+describe("DockerExecutor sandbox ownership labels", () => {
+  it("labels the container with the sandbox marker, session and owner", async () => {
+    stubSpawn();
+    stubExecFile();
+    const executor = new DockerExecutor({ sessionId: "session-abc", ownerId: "instance-1" });
+    await executor.init();
+
+    const runArgs = execFileMock.mock.calls.find((c) => (c[1] as string[])[0] === "run")![1] as
+      | string[]
+      | undefined;
+    expect(runArgs).toBeDefined();
+    const labels = runArgs!.filter((_, i) => runArgs![i - 1] === "--label");
+    expect(labels).toEqual([
+      `${SANDBOX_LABEL}=1`,
+      `${SESSION_LABEL}=session-abc`,
+      `${OWNER_LABEL}=instance-1`,
+    ]);
+  });
+});
+
+describe("reclaimOrphanedSandboxes", () => {
+  /** `docker ps` stdout: one "<id> <owner label>" line per container. */
+  function stubPsThenRm(psStdout: string) {
+    const calls: string[][] = [];
+    execFileMock.mockImplementation((_cmd: string, args: string[], cb: unknown) => {
+      calls.push(args);
+      const stdout = args[0] === "ps" ? psStdout : "";
+      (cb as (e: null, r: { stdout: string; stderr: string }) => void)(null, {
+        stdout,
+        stderr: "",
+      });
+    });
+    return calls;
+  }
+
+  it("removes sandboxes owned by an earlier instance and spares the current one's", async () => {
+    const calls = stubPsThenRm(
+      ["dead1 instance-old", "mine1 instance-2", "dead2 instance-old", "mine2 instance-2"].join(
+        "\n",
+      ) + "\n",
+    );
+
+    const reclaimed = await reclaimOrphanedSandboxes("instance-2");
+
+    expect(reclaimed).toEqual(["dead1", "dead2"]);
+    const rm = calls.find((args) => args[0] === "rm")!;
+    // One batched removal, not one call per container.
+    expect(rm).toEqual(["rm", "-f", "dead1", "dead2"]);
+    expect(calls.filter((args) => args[0] === "rm")).toHaveLength(1);
+  });
+
+  it("reclaims unlabelled sandboxes left by versions that predate the labels", async () => {
+    const calls = stubPsThenRm("legacy1 \nlegacy2 \n");
+
+    expect(await reclaimOrphanedSandboxes("instance-2")).toEqual(["legacy1", "legacy2"]);
+    expect(calls.find((args) => args[0] === "rm")).toEqual(["rm", "-f", "legacy1", "legacy2"]);
+  });
+
+  it("removes nothing when every sandbox belongs to this instance", async () => {
+    const calls = stubPsThenRm("mine1 instance-2\n");
+
+    expect(await reclaimOrphanedSandboxes("instance-2")).toEqual([]);
+    expect(calls.some((args) => args[0] === "rm")).toBe(false);
+  });
+
+  it("does not fail startup when docker is unavailable", async () => {
+    execFileMock.mockImplementation((_cmd: string, _args: string[], cb: unknown) => {
+      (cb as (e: Error) => void)(new Error("Cannot connect to the Docker daemon"));
+    });
+
+    await expect(reclaimOrphanedSandboxes("instance-2")).resolves.toEqual([]);
   });
 });

--- a/frontend/ee/agent/src/executors/__tests__/docker.test.ts
+++ b/frontend/ee/agent/src/executors/__tests__/docker.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.fn();
 const execFileMock = vi.fn();
@@ -11,6 +11,7 @@ vi.mock("child_process", () => ({
 
 const { DockerExecutor, reclaimOrphanedSandboxes, SANDBOX_LABEL, SESSION_LABEL, OWNER_LABEL } =
   await import("../docker.js");
+const { createExecutor } = await import("../index.js");
 
 const TOKEN = "ghs_supersecrettoken000000000000000000";
 
@@ -175,7 +176,7 @@ describe("DockerExecutor sandbox ownership labels", () => {
 });
 
 describe("reclaimOrphanedSandboxes", () => {
-  /** `docker ps` stdout: one "<id> <owner label>" line per container. */
+  /** `docker ps` stdout: one "<id> <names> <owner label>" line per container. */
   function stubPsThenRm(psStdout: string) {
     const calls: string[][] = [];
     execFileMock.mockImplementation((_cmd: string, args: string[], cb: unknown) => {
@@ -191,9 +192,12 @@ describe("reclaimOrphanedSandboxes", () => {
 
   it("removes sandboxes owned by an earlier instance and spares the current one's", async () => {
     const calls = stubPsThenRm(
-      ["dead1 instance-old", "mine1 instance-2", "dead2 instance-old", "mine2 instance-2"].join(
-        "\n",
-      ) + "\n",
+      [
+        "dead1 traceroot-sandbox-1 instance-old",
+        "mine1 traceroot-sandbox-2 instance-2",
+        "dead2 traceroot-sandbox-3 instance-old",
+        "mine2 traceroot-sandbox-4 instance-2",
+      ].join("\n") + "\n",
     );
 
     const reclaimed = await reclaimOrphanedSandboxes("instance-2");
@@ -206,17 +210,37 @@ describe("reclaimOrphanedSandboxes", () => {
   });
 
   it("reclaims unlabelled sandboxes left by versions that predate the labels", async () => {
-    const calls = stubPsThenRm("legacy1 \nlegacy2 \n");
+    const calls = stubPsThenRm("legacy1 traceroot-sandbox-9 \nlegacy2 traceroot-sandbox-8 \n");
 
     expect(await reclaimOrphanedSandboxes("instance-2")).toEqual(["legacy1", "legacy2"]);
     expect(calls.find((args) => args[0] === "rm")).toEqual(["rm", "-f", "legacy1", "legacy2"]);
   });
 
   it("removes nothing when every sandbox belongs to this instance", async () => {
-    const calls = stubPsThenRm("mine1 instance-2\n");
+    const calls = stubPsThenRm("mine1 traceroot-sandbox-5 instance-2\n");
 
     expect(await reclaimOrphanedSandboxes("instance-2")).toEqual([]);
     expect(calls.some((args) => args[0] === "rm")).toBe(false);
+  });
+
+  it("ignores a container that merely contains the prefix in its name", async () => {
+    // `docker ps --filter name=` matches a substring, so someone else's
+    // "my-traceroot-sandbox-notes" is listed and, carrying no owner label, would
+    // read as an orphan. Force-removing a container we did not create is not an
+    // acceptable cost for a sweep.
+    const calls = stubPsThenRm(
+      "ours1 traceroot-sandbox-1 instance-old\ntheirs my-traceroot-sandbox-notes \n",
+    );
+
+    expect(await reclaimOrphanedSandboxes("instance-2")).toEqual(["ours1"]);
+    expect(calls.find((args) => args[0] === "rm")).toEqual(["rm", "-f", "ours1"]);
+  });
+
+  it("keeps a container whose second name carries the prefix", async () => {
+    const calls = stubPsThenRm("multi alias,traceroot-sandbox-7 instance-old\n");
+
+    expect(await reclaimOrphanedSandboxes("instance-2")).toEqual(["multi"]);
+    expect(calls.find((args) => args[0] === "rm")).toEqual(["rm", "-f", "multi"]);
   });
 
   it("does not fail startup when docker is unavailable", async () => {
@@ -225,5 +249,52 @@ describe("reclaimOrphanedSandboxes", () => {
     });
 
     await expect(reclaimOrphanedSandboxes("instance-2")).resolves.toEqual([]);
+  });
+
+  it("reports a failed removal instead of throwing at startup", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    execFileMock.mockImplementation((_cmd: string, args: string[], cb: unknown) => {
+      if (args[0] === "ps") {
+        (cb as (e: null, r: { stdout: string; stderr: string }) => void)(null, {
+          stdout: "gone traceroot-sandbox-1 instance-old\n",
+          stderr: "",
+        });
+        return;
+      }
+      // Removed by someone else between the list and the remove.
+      (cb as (e: Error) => void)(new Error("No such container: gone"));
+    });
+
+    await expect(reclaimOrphanedSandboxes("instance-2")).resolves.toEqual(["gone"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Failed to remove"));
+    warn.mockRestore();
+  });
+});
+
+describe("createExecutor", () => {
+  const previous = process.env.SANDBOX_PROVIDER;
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.SANDBOX_PROVIDER;
+    else process.env.SANDBOX_PROVIDER = previous;
+  });
+
+  it("defaults to docker and passes the sandbox identity through", async () => {
+    delete process.env.SANDBOX_PROVIDER;
+    stubSpawn();
+    stubExecFile();
+    const executor = createExecutor({ sessionId: "s1", ownerId: "o1" });
+    await executor.init();
+
+    const runArgs = execFileMock.mock.calls.find(
+      (c) => (c[1] as string[])[0] === "run",
+    )![1] as string[];
+    expect(runArgs).toContain(`${SESSION_LABEL}=s1`);
+    expect(runArgs).toContain(`${OWNER_LABEL}=o1`);
+  });
+
+  it("rejects an unknown provider by name", () => {
+    process.env.SANDBOX_PROVIDER = "not-a-provider";
+    expect(() => createExecutor()).toThrow(/not-a-provider/);
   });
 });

--- a/frontend/ee/agent/src/executors/__tests__/registry.test.ts
+++ b/frontend/ee/agent/src/executors/__tests__/registry.test.ts
@@ -94,6 +94,50 @@ describe("SandboxRegistry.sweepIdle", () => {
   });
 });
 
+describe("SandboxRegistry.retain", () => {
+  it("keeps a sandbox off the sweep for as long as the request holds it", async () => {
+    const { registry, created } = makeRegistry(30 * 60_000);
+    const release = registry.retain("long-run");
+
+    // A tool loop far longer than the TTL: acquire() alone recorded only when the
+    // turn started, so a purely time-based sweep would have killed it mid-request.
+    clock += 90 * 60_000;
+    expect(await registry.sweepIdle()).toEqual([]);
+    expect(created[0].executor.destroyed).toBe(0);
+
+    release();
+    expect(await registry.sweepIdle()).toEqual([]); // clock restarts on release
+    clock += 31 * 60_000;
+    expect(await registry.sweepIdle()).toEqual(["long-run"]);
+  });
+
+  it("counts concurrent holds, so one finishing does not expose the other", async () => {
+    const { registry } = makeRegistry(30 * 60_000);
+    const releaseFirst = registry.retain("shared");
+    const releaseSecond = registry.retain("shared");
+
+    clock += 90 * 60_000;
+    releaseFirst();
+    expect(await registry.sweepIdle()).toEqual([]);
+
+    releaseSecond();
+    clock += 31 * 60_000;
+    expect(await registry.sweepIdle()).toEqual(["shared"]);
+  });
+
+  it("is idempotent, so a finally that runs twice cannot free another hold", async () => {
+    const { registry } = makeRegistry(30 * 60_000);
+    const releaseFirst = registry.retain("shared");
+    registry.retain("shared");
+
+    releaseFirst();
+    releaseFirst();
+
+    clock += 90 * 60_000;
+    expect(await registry.sweepIdle()).toEqual([]);
+  });
+});
+
 describe("SandboxRegistry.destroyAll", () => {
   it("destroys every sandbox even when one teardown rejects", async () => {
     const failing = stubExecutor({
@@ -145,6 +189,90 @@ describe("SandboxRegistry.destroyAll", () => {
     // Sequential teardown can outlast compose's stop grace period, after which
     // SIGKILL leaks whatever is left (#2101).
     expect(peak).toBe(4);
+  });
+});
+
+describe("SandboxRegistry shutdown admission", () => {
+  it("refuses new sandboxes once teardown has begun", async () => {
+    const { registry, created } = makeRegistry();
+    registry.acquire("before");
+
+    await registry.destroyAll();
+
+    // Snapshotting the map without closing admission left a window where a
+    // request created a container the teardown had already walked past.
+    expect(() => registry.acquire("during")).toThrow(/shutting down/);
+    expect(() => registry.retain("during")).toThrow(/shutting down/);
+    expect(created).toHaveLength(1);
+    expect(registry.size).toBe(0);
+  });
+
+  it("drains a sandbox created while teardown was in flight", async () => {
+    const created: Array<Executor & { destroyed: number }> = [];
+    // Slip an acquire in while the first destroy is awaiting, the exact race the
+    // snapshot-then-destroy version could not see. `racing` closes over
+    // `registry` below; the closure only runs during destroyAll, long after it
+    // is initialised.
+    const racing = stubExecutor({
+      destroy: vi.fn(async () => {
+        try {
+          registry.acquire("late");
+        } catch {
+          // Expected once admission closes — the assertion is on what got destroyed.
+        }
+        racing.destroyed += 1;
+      }),
+    });
+    const registry = new SandboxRegistry({
+      create: (sessionId) => {
+        if (sessionId === "first") return racing;
+        const executor = stubExecutor();
+        created.push(executor);
+        return executor;
+      },
+      idleTtlMs: 30 * 60_000,
+      now,
+    });
+    registry.acquire("first");
+
+    await registry.destroyAll();
+
+    expect(registry.size).toBe(0);
+    expect(created.every((e) => e.destroyed === 1)).toBe(true);
+  });
+});
+
+describe("SandboxRegistry.startSweeping", () => {
+  it("sweeps on the interval and stops when told to", async () => {
+    vi.useFakeTimers();
+    try {
+      const { registry, created } = makeRegistry(30 * 60_000);
+      registry.acquire("idle");
+      clock += 31 * 60_000;
+
+      registry.startSweeping(1_000);
+      registry.startSweeping(1_000); // second call must not add a second timer
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(created[0].executor.destroyed).toBe(1);
+      expect(registry.size).toBe(0);
+
+      registry.stopSweeping();
+      registry.stopSweeping(); // idempotent
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not arm a timer when the TTL is disabled", () => {
+    vi.useFakeTimers();
+    try {
+      const { registry } = makeRegistry(0);
+      registry.startSweeping(1_000);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/frontend/ee/agent/src/executors/__tests__/registry.test.ts
+++ b/frontend/ee/agent/src/executors/__tests__/registry.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SandboxRegistry, idleTtlMsFromEnv } from "../registry.js";
+import type { Executor } from "../interface.js";
+
+/** A stand-in executor that only records whether it was destroyed. */
+function stubExecutor(overrides: Partial<Executor> = {}): Executor & { destroyed: number } {
+  const executor = {
+    destroyed: 0,
+    init: vi.fn(),
+    exec: vi.fn(),
+    getWorkspacePath: () => "/workspace",
+    writeFile: vi.fn(),
+    readFile: vi.fn(),
+    isReady: () => true,
+    cloneRepo: vi.fn(),
+    destroy: vi.fn(async () => {
+      executor.destroyed += 1;
+    }),
+    ...overrides,
+  } as Executor & { destroyed: number };
+  return executor;
+}
+
+let clock = 0;
+const now = () => clock;
+
+function makeRegistry(idleTtlMs = 30 * 60_000) {
+  const created: Array<{ sessionId: string; executor: Executor & { destroyed: number } }> = [];
+  const registry = new SandboxRegistry({
+    create: (sessionId) => {
+      const executor = stubExecutor();
+      created.push({ sessionId, executor });
+      return executor;
+    },
+    idleTtlMs,
+    now,
+  });
+  return { registry, created };
+}
+
+beforeEach(() => {
+  clock = 1_000_000;
+});
+
+describe("SandboxRegistry.acquire", () => {
+  it("creates one executor per session and reuses it", () => {
+    const { registry, created } = makeRegistry();
+
+    const first = registry.acquire("session-a");
+    const second = registry.acquire("session-a");
+
+    expect(second).toBe(first);
+    expect(created).toHaveLength(1);
+    expect(created[0].sessionId).toBe("session-a");
+  });
+});
+
+describe("SandboxRegistry.sweepIdle", () => {
+  it("destroys sandboxes past the idle TTL and keeps the rest", async () => {
+    const { registry, created } = makeRegistry(30 * 60_000);
+    registry.acquire("idle");
+    clock += 25 * 60_000;
+    registry.acquire("active");
+
+    clock += 20 * 60_000; // idle: 45m since last use, active: 20m
+    const swept = await registry.sweepIdle();
+
+    expect(swept).toEqual(["idle"]);
+    expect(created.find((c) => c.sessionId === "idle")!.executor.destroyed).toBe(1);
+    expect(created.find((c) => c.sessionId === "active")!.executor.destroyed).toBe(0);
+    expect(registry.size).toBe(1);
+  });
+
+  it("treats renewed use as activity, so a busy session is never swept", async () => {
+    const { registry } = makeRegistry(30 * 60_000);
+    registry.acquire("busy");
+
+    for (let i = 0; i < 5; i++) {
+      clock += 29 * 60_000;
+      registry.acquire("busy");
+      expect(await registry.sweepIdle()).toEqual([]);
+    }
+
+    expect(registry.size).toBe(1);
+  });
+
+  it("does not sweep when the TTL is disabled", async () => {
+    const { registry, created } = makeRegistry(0);
+    registry.acquire("forever");
+    clock += 365 * 24 * 60 * 60_000;
+
+    expect(await registry.sweepIdle()).toEqual([]);
+    expect(created[0].executor.destroyed).toBe(0);
+  });
+});
+
+describe("SandboxRegistry.destroyAll", () => {
+  it("destroys every sandbox even when one teardown rejects", async () => {
+    const failing = stubExecutor({
+      destroy: vi.fn(async () => {
+        throw new Error("docker daemon unreachable");
+      }),
+    });
+    const survivors: Array<Executor & { destroyed: number }> = [];
+    const registry = new SandboxRegistry({
+      create: (sessionId) => {
+        if (sessionId === "broken") return failing;
+        const executor = stubExecutor();
+        survivors.push(executor);
+        return executor;
+      },
+      idleTtlMs: 30 * 60_000,
+      now,
+    });
+
+    registry.acquire("broken");
+    registry.acquire("ok-1");
+    registry.acquire("ok-2");
+
+    await expect(registry.destroyAll()).resolves.toBeUndefined();
+    expect(survivors.every((e) => e.destroyed === 1)).toBe(true);
+    expect(registry.size).toBe(0);
+  });
+
+  it("tears sandboxes down concurrently rather than one after another", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const registry = new SandboxRegistry({
+      create: () =>
+        stubExecutor({
+          destroy: vi.fn(async () => {
+            inFlight += 1;
+            peak = Math.max(peak, inFlight);
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            inFlight -= 1;
+          }),
+        }),
+      idleTtlMs: 30 * 60_000,
+      now,
+    });
+
+    for (let i = 0; i < 4; i++) registry.acquire(`session-${i}`);
+    await registry.destroyAll();
+
+    // Sequential teardown can outlast compose's stop grace period, after which
+    // SIGKILL leaks whatever is left (#2101).
+    expect(peak).toBe(4);
+  });
+});
+
+describe("SandboxRegistry.release", () => {
+  it("destroys the session's sandbox and forgets it", async () => {
+    const { registry, created } = makeRegistry();
+    registry.acquire("session-a");
+
+    await registry.release("session-a");
+
+    expect(created[0].executor.destroyed).toBe(1);
+    expect(registry.size).toBe(0);
+    await expect(registry.release("session-a")).resolves.toBeUndefined();
+  });
+});
+
+describe("idleTtlMsFromEnv", () => {
+  it("defaults to 30 minutes when unset or unparseable", () => {
+    expect(idleTtlMsFromEnv({})).toBe(30 * 60_000);
+    expect(idleTtlMsFromEnv({ SANDBOX_IDLE_TTL_MINUTES: "" })).toBe(30 * 60_000);
+    expect(idleTtlMsFromEnv({ SANDBOX_IDLE_TTL_MINUTES: "soon" })).toBe(30 * 60_000);
+    expect(idleTtlMsFromEnv({ SANDBOX_IDLE_TTL_MINUTES: "-5" })).toBe(30 * 60_000);
+  });
+
+  it("honours an explicit value, including 0 to disable", () => {
+    expect(idleTtlMsFromEnv({ SANDBOX_IDLE_TTL_MINUTES: "5" })).toBe(5 * 60_000);
+    expect(idleTtlMsFromEnv({ SANDBOX_IDLE_TTL_MINUTES: "0" })).toBe(0);
+  });
+});

--- a/frontend/ee/agent/src/executors/docker.ts
+++ b/frontend/ee/agent/src/executors/docker.ts
@@ -7,18 +7,54 @@ const execFileAsync = promisify(execFile);
 
 const DOCKER_IMAGE = "ubuntu:24.04";
 const WORKSPACE_DIR = "/workspace";
+const CONTAINER_NAME_PREFIX = "traceroot-sandbox-";
+
+/** Marks a container as an agent sandbox. Set on every container we create. */
+export const SANDBOX_LABEL = "traceroot.sandbox";
+/** The session a sandbox belongs to. */
+export const SESSION_LABEL = "traceroot.session";
+/** The agent instance that created a sandbox — the basis for reconciliation. */
+export const OWNER_LABEL = "traceroot.owner";
+
+export interface DockerExecutorOptions {
+  /** Session this sandbox serves, recorded as a label for out-of-process lookup. */
+  sessionId?: string;
+  /**
+   * Identifier of the agent instance that owns the sandbox. Startup
+   * reconciliation removes every sandbox NOT carrying the current owner id, so
+   * this must be unique per process (see reclaimOrphanedSandboxes).
+   */
+  ownerId?: string;
+}
 
 export class DockerExecutor implements Executor {
   private containerId: string | null = null;
+  private readonly sessionId: string;
+  private readonly ownerId: string;
+
+  constructor(options: DockerExecutorOptions = {}) {
+    this.sessionId = options.sessionId ?? "unknown";
+    this.ownerId = options.ownerId ?? "unknown";
+  }
 
   async init(): Promise<void> {
     console.log("[DockerExecutor] Creating container...");
 
+    // Ownership also lives in labels, not just in the caller's in-memory map: a
+    // crash, an OOM kill or a SIGKILL past the stop grace period leaves the
+    // container running with no one holding a reference to it. Labels are what
+    // let the next process find and reclaim it.
     const { stdout } = await execFileAsync("docker", [
       "run",
       "-d",
       "--name",
-      `traceroot-sandbox-${Date.now()}`,
+      `${CONTAINER_NAME_PREFIX}${Date.now()}`,
+      "--label",
+      `${SANDBOX_LABEL}=1`,
+      "--label",
+      `${SESSION_LABEL}=${this.sessionId}`,
+      "--label",
+      `${OWNER_LABEL}=${this.ownerId}`,
       // Network enabled — required for git clone and gh CLI (per design doc)
       // Token-based auth is ephemeral (1hr) and container is disposable
       "-w",
@@ -184,6 +220,63 @@ export class DockerExecutor implements Executor {
     }
     this.containerId = null;
   }
+}
+
+/**
+ * Remove every agent sandbox on this Docker host that the current instance does
+ * not own.
+ *
+ * Ownership used to live only in the agent's in-memory map, so any exit short of
+ * a fully completed graceful shutdown — a crash, an OOM kill, a SIGKILL after
+ * the stop grace period — orphaned every container the process had created, and
+ * the next process had no way to name them. Reconciling at startup makes a
+ * restart the reliable sweeper.
+ *
+ * Matching is by name prefix rather than by label so that sandboxes created
+ * before labels existed are reclaimed too; a container is spared only when it
+ * carries the current owner id, which no other process can have.
+ */
+export async function reclaimOrphanedSandboxes(ownerId: string): Promise<string[]> {
+  let listed: string;
+  try {
+    const { stdout } = await execFileAsync("docker", [
+      "ps",
+      "-a",
+      "--filter",
+      `name=${CONTAINER_NAME_PREFIX}`,
+      "--format",
+      `{{.ID}} {{.Label "${OWNER_LABEL}"}}`,
+    ]);
+    listed = stdout;
+  } catch (error) {
+    // No docker socket (Daytona deployments, CI) is not a failure — there is
+    // simply nothing to reclaim, and startup must not depend on it.
+    console.warn(`[DockerExecutor] Could not list sandbox containers: ${String(error)}`);
+    return [];
+  }
+
+  const orphaned = listed
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [id, owner] = line.split(/\s+/, 2);
+      return { id, owner };
+    })
+    .filter(({ owner }) => owner !== ownerId)
+    .map(({ id }) => id);
+
+  if (orphaned.length === 0) return [];
+
+  console.log(`[DockerExecutor] Reclaiming ${orphaned.length} orphaned sandbox container(s)`);
+  try {
+    await execFileAsync("docker", ["rm", "-f", ...orphaned]);
+  } catch (error) {
+    // A container removed by someone else between the list and the remove fails
+    // the whole batch; the next restart retries.
+    console.warn(`[DockerExecutor] Failed to remove orphaned sandboxes: ${String(error)}`);
+  }
+  return orphaned;
 }
 
 /**

--- a/frontend/ee/agent/src/executors/docker.ts
+++ b/frontend/ee/agent/src/executors/docker.ts
@@ -245,7 +245,7 @@ export async function reclaimOrphanedSandboxes(ownerId: string): Promise<string[
       "--filter",
       `name=${CONTAINER_NAME_PREFIX}`,
       "--format",
-      `{{.ID}} {{.Label "${OWNER_LABEL}"}}`,
+      `{{.ID}} {{.Names}} {{.Label "${OWNER_LABEL}"}}`,
     ]);
     listed = stdout;
   } catch (error) {
@@ -260,9 +260,16 @@ export async function reclaimOrphanedSandboxes(ownerId: string): Promise<string[
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      const [id, owner] = line.split(/\s+/, 2);
-      return { id, owner };
+      const [id, names, owner] = line.split(/\s+/);
+      return { id, names: (names ?? "").split(","), owner };
     })
+    // `docker ps --filter name=` matches a substring, not a prefix, so a
+    // container someone else called "my-traceroot-sandbox-notes" is listed here
+    // and — carrying no owner label — would read as an orphan. Force-removing a
+    // container we did not create is not a risk worth taking for a sweep, so the
+    // name is re-checked exactly. A container can carry several names; ours is
+    // created with one, and any name matching the prefix identifies it.
+    .filter(({ names }) => names.some((name) => name.startsWith(CONTAINER_NAME_PREFIX)))
     .filter(({ owner }) => owner !== ownerId)
     .map(({ id }) => id);
 

--- a/frontend/ee/agent/src/executors/index.ts
+++ b/frontend/ee/agent/src/executors/index.ts
@@ -1,16 +1,20 @@
 import type { Executor } from "./interface.js";
-import { DockerExecutor } from "./docker.js";
+import { DockerExecutor, type DockerExecutorOptions } from "./docker.js";
 import { DaytonaExecutor } from "./daytona.js";
 
 export type { Executor, ExecResult, ExecOptions } from "./interface.js";
+export { SandboxRegistry, idleTtlMsFromEnv } from "./registry.js";
+export { reclaimOrphanedSandboxes } from "./docker.js";
 
-export function createExecutor(): Executor {
+export function createExecutor(options: DockerExecutorOptions = {}): Executor {
   const provider = process.env.SANDBOX_PROVIDER || "docker";
 
   switch (provider) {
     case "docker":
-      return new DockerExecutor();
+      return new DockerExecutor(options);
     case "daytona":
+      // Daytona sandboxes are created ephemeral with an autoStopInterval, so
+      // they reclaim themselves and need no ownership labels from us.
       return new DaytonaExecutor();
     default:
       throw new Error(`Unknown sandbox provider: ${provider}`);

--- a/frontend/ee/agent/src/executors/registry.ts
+++ b/frontend/ee/agent/src/executors/registry.ts
@@ -14,6 +14,14 @@ export function idleTtlMsFromEnv(env: NodeJS.ProcessEnv = process.env): number {
 interface Entry {
   executor: Executor;
   lastUsedAt: number;
+  /**
+   * Requests currently holding this sandbox. A turn can run far longer than the
+   * TTL — tool loops, a long RCA — and `lastUsedAt` alone only records when the
+   * turn *started*, so a purely time-based sweep would `docker rm -f` a container
+   * out from under a live request. An entry with a lease outstanding is never
+   * idle, whatever the clock says.
+   */
+  leases: number;
 }
 
 /**
@@ -32,6 +40,7 @@ export class SandboxRegistry {
   private readonly idleTtlMs: number;
   private readonly now: () => number;
   private sweepTimer: NodeJS.Timeout | null = null;
+  private closed = false;
 
   constructor(options: {
     create: (sessionId: string) => Executor;
@@ -49,14 +58,43 @@ export class SandboxRegistry {
 
   /** The session's executor, created on first use. Marks the session as active. */
   acquire(sessionId: string): Executor {
+    // Admission closes before teardown starts. Without this, a request arriving
+    // during shutdown could create a container after destroyAll() had taken its
+    // snapshot, and nothing would ever destroy it.
+    if (this.closed) {
+      throw new Error("Sandbox registry is shutting down");
+    }
     const existing = this.entries.get(sessionId);
     if (existing) {
       existing.lastUsedAt = this.now();
       return existing.executor;
     }
     const executor = this.create(sessionId);
-    this.entries.set(sessionId, { executor, lastUsedAt: this.now() });
+    this.entries.set(sessionId, { executor, lastUsedAt: this.now(), leases: 0 });
     return executor;
+  }
+
+  /**
+   * Hold the session's sandbox for the length of one request, returning the
+   * function that gives it back.
+   *
+   * The sandbox cannot be swept while a hold is outstanding, and releasing it
+   * restarts the idle clock from when the work finished rather than when it
+   * started. The returned function is idempotent, so a `finally` that runs twice
+   * on an aborted stream cannot decrement another request's hold.
+   */
+  retain(sessionId: string): () => void {
+    this.acquire(sessionId);
+    const entry = this.entries.get(sessionId)!;
+    entry.leases += 1;
+    let released = false;
+
+    return () => {
+      if (released) return;
+      released = true;
+      entry.leases -= 1;
+      entry.lastUsedAt = this.now();
+    };
   }
 
   /** Tear down one session's sandbox. Safe to call for an unknown session. */
@@ -72,7 +110,7 @@ export class SandboxRegistry {
     if (this.idleTtlMs <= 0) return [];
     const cutoff = this.now() - this.idleTtlMs;
     const stale = [...this.entries.entries()]
-      .filter(([, entry]) => entry.lastUsedAt <= cutoff)
+      .filter(([, entry]) => entry.leases === 0 && entry.lastUsedAt <= cutoff)
       .map(([sessionId]) => sessionId);
 
     // Settled, not all: one container that refuses to die must not strand the
@@ -110,7 +148,13 @@ export class SandboxRegistry {
    */
   async destroyAll(): Promise<void> {
     this.stopSweeping();
-    const sessionIds = [...this.entries.keys()];
-    await Promise.allSettled(sessionIds.map((sessionId) => this.release(sessionId)));
+    // Close admission first, then drain. Snapshotting the map without closing
+    // leaves a window where an in-flight request creates a container that the
+    // teardown has already walked past, and the process exits owning it.
+    this.closed = true;
+    while (this.entries.size > 0) {
+      const sessionIds = [...this.entries.keys()];
+      await Promise.allSettled(sessionIds.map((sessionId) => this.release(sessionId)));
+    }
   }
 }

--- a/frontend/ee/agent/src/executors/registry.ts
+++ b/frontend/ee/agent/src/executors/registry.ts
@@ -1,0 +1,116 @@
+import type { Executor } from "./interface.js";
+
+/** Sandboxes idle for longer than this are torn down. 0 disables the sweep. */
+const DEFAULT_IDLE_TTL_MINUTES = 30;
+
+export function idleTtlMsFromEnv(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.SANDBOX_IDLE_TTL_MINUTES;
+  if (raw === undefined || raw.trim() === "") return DEFAULT_IDLE_TTL_MINUTES * 60_000;
+  const minutes = Number(raw);
+  if (!Number.isFinite(minutes) || minutes < 0) return DEFAULT_IDLE_TTL_MINUTES * 60_000;
+  return minutes * 60_000;
+}
+
+interface Entry {
+  executor: Executor;
+  lastUsedAt: number;
+}
+
+/**
+ * Owns the sandbox executors of live sessions and reclaims them when they go
+ * idle.
+ *
+ * Sessions were previously created and never deleted — the only two callers of
+ * `destroy()` were an HTTP route nothing invokes and the shutdown handler — so a
+ * long-running agent held every container it had ever created. An idle TTL gives
+ * a container a bounded lifetime even when nothing ever tells us its session is
+ * finished, mirroring Daytona's `autoStopInterval`.
+ */
+export class SandboxRegistry {
+  private readonly entries = new Map<string, Entry>();
+  private readonly create: (sessionId: string) => Executor;
+  private readonly idleTtlMs: number;
+  private readonly now: () => number;
+  private sweepTimer: NodeJS.Timeout | null = null;
+
+  constructor(options: {
+    create: (sessionId: string) => Executor;
+    idleTtlMs: number;
+    now?: () => number;
+  }) {
+    this.create = options.create;
+    this.idleTtlMs = options.idleTtlMs;
+    this.now = options.now ?? Date.now;
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** The session's executor, created on first use. Marks the session as active. */
+  acquire(sessionId: string): Executor {
+    const existing = this.entries.get(sessionId);
+    if (existing) {
+      existing.lastUsedAt = this.now();
+      return existing.executor;
+    }
+    const executor = this.create(sessionId);
+    this.entries.set(sessionId, { executor, lastUsedAt: this.now() });
+    return executor;
+  }
+
+  /** Tear down one session's sandbox. Safe to call for an unknown session. */
+  async release(sessionId: string): Promise<void> {
+    const entry = this.entries.get(sessionId);
+    if (!entry) return;
+    this.entries.delete(sessionId);
+    await entry.executor.destroy();
+  }
+
+  /** Tear down every sandbox idle for longer than the TTL. Returns their ids. */
+  async sweepIdle(): Promise<string[]> {
+    if (this.idleTtlMs <= 0) return [];
+    const cutoff = this.now() - this.idleTtlMs;
+    const stale = [...this.entries.entries()]
+      .filter(([, entry]) => entry.lastUsedAt <= cutoff)
+      .map(([sessionId]) => sessionId);
+
+    // Settled, not all: one container that refuses to die must not strand the
+    // rest for another TTL.
+    await Promise.allSettled(stale.map((sessionId) => this.release(sessionId)));
+    return stale;
+  }
+
+  /**
+   * Run the idle sweep on an interval. The timer is unref'd so it never holds
+   * the process open on its own.
+   */
+  startSweeping(intervalMs = 60_000): void {
+    if (this.sweepTimer || this.idleTtlMs <= 0) return;
+    this.sweepTimer = setInterval(() => {
+      void this.sweepIdle().then((swept) => {
+        if (swept.length > 0) {
+          console.log(`[Agent] Reclaimed ${swept.length} idle sandbox(es)`);
+        }
+      });
+    }, intervalMs);
+    this.sweepTimer.unref?.();
+  }
+
+  stopSweeping(): void {
+    if (!this.sweepTimer) return;
+    clearInterval(this.sweepTimer);
+    this.sweepTimer = null;
+  }
+
+  /**
+   * Tear down every sandbox, concurrently. Sequential teardown was itself a leak
+   * source: compose's default 10s stop grace period can expire partway through N
+   * `docker rm -f` calls, after which SIGKILL leaves the remainder running.
+   */
+  async destroyAll(): Promise<void> {
+    this.stopSweeping();
+    const sessionIds = [...this.entries.keys()];
+    await Promise.allSettled(sessionIds.map((sessionId) => this.release(sessionId)));
+  }
+}

--- a/frontend/ee/agent/src/index.ts
+++ b/frontend/ee/agent/src/index.ts
@@ -187,6 +187,9 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
   }
 
   return streamSSE(c, async (stream) => {
+    // Held for the whole turn: a tool loop can outlast the idle TTL, and without
+    // this the sweeper would tear the sandbox down mid-request.
+    const releaseSandbox = sessionExecutors.retain(sessionId);
     let assistantText = "";
     let loggedFirstUpdate = false;
 
@@ -300,7 +303,9 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
           resolve();
         },
       });
-    });
+      // .finally, not a trailing call: an aborted or failed turn must give the
+      // sandbox back too, or that session is never swept again.
+    }).finally(releaseSandbox);
   });
 });
 

--- a/frontend/ee/agent/src/index.ts
+++ b/frontend/ee/agent/src/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
@@ -12,17 +13,30 @@ import {
 } from "./session.js";
 import { getOrCreateAgent, runAgent, removeAgent, invalidateProviderCache } from "./agent.js";
 import { getSystemPrompt } from "./prompts/system.js";
-import { createExecutor } from "./executors/index.js";
+import {
+  createExecutor,
+  reclaimOrphanedSandboxes,
+  SandboxRegistry,
+  idleTtlMsFromEnv,
+} from "./executors/index.js";
 import { createTools } from "./tools/index.js";
-import type { Executor } from "./executors/interface.js";
 
 const app = new Hono();
 
 const AGENT_SERVICE_URL = process.env.AGENT_SERVICE_URL || "http://localhost:8100";
 const PORT = parseInt(new URL(AGENT_SERVICE_URL).port || "8100", 10);
 
-// Per-session executor cache (executor lifecycle tied to session)
-const sessionExecutors = new Map<string, Executor>();
+// Identifies this process to its sandbox containers. Startup reconciliation
+// removes every sandbox that does not carry it, so it must be fresh per process.
+const INSTANCE_ID = randomUUID();
+
+// Per-session executor cache. Sandboxes are also labelled with INSTANCE_ID so a
+// restart can reclaim them without any in-memory state, and the registry expires
+// them on an idle TTL so a session nobody deletes cannot hold one forever.
+const sessionExecutors = new SandboxRegistry({
+  create: (sessionId) => createExecutor({ sessionId, ownerId: INSTANCE_ID }),
+  idleTtlMs: idleTtlMsFromEnv(),
+});
 
 // Health check
 app.get("/health", (c) => {
@@ -93,11 +107,7 @@ app.delete("/api/v1/projects/:projectId/sessions/:sessionId", async (c) => {
   const userId = c.req.header("x-user-id") || "";
 
   // Destroy executor if one exists for this session
-  const executor = sessionExecutors.get(sessionId);
-  if (executor) {
-    await executor.destroy();
-    sessionExecutors.delete(sessionId);
-  }
+  await sessionExecutors.release(sessionId);
 
   removeAgent(sessionId);
   const result = await deleteSession(sessionId, userId);
@@ -135,12 +145,9 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
     traceSessionId: body.traceSessionId,
   });
 
-  // Get or create executor for this session (lazy — not initialized until tool use)
-  let executor = sessionExecutors.get(sessionId);
-  if (!executor) {
-    executor = createExecutor();
-    sessionExecutors.set(sessionId, executor);
-  }
+  // Get or create executor for this session (lazy — not initialized until tool
+  // use). This also marks the session as active for the idle sweep.
+  const executor = sessionExecutors.acquire(sessionId);
 
   // Use the session's workspaceId (authorized by getSession above) rather than
   // the raw header value, so tools can't be coerced into another workspace.
@@ -305,11 +312,10 @@ async function shutdown(signal: string): Promise<void> {
   isShuttingDown = true;
   console.log(`\n[Agent] Received ${signal}, shutting down...`);
   try {
-    // Destroy all active executors (sandbox containers)
-    for (const [id, executor] of sessionExecutors) {
-      await executor.destroy();
-      sessionExecutors.delete(id);
-    }
+    // Destroy all active executors (sandbox containers) concurrently — N
+    // sequential `docker rm -f` calls can outlast compose's stop grace period,
+    // and everything still alive when SIGKILL lands is leaked.
+    await sessionExecutors.destroyAll();
     await prisma.$disconnect();
     console.log("[Agent] Cleanup complete");
     process.exit(0);
@@ -336,6 +342,12 @@ async function main(): Promise<void> {
 
   // Sync standard model pricing from JSON → DB
   await syncStandardPrices();
+
+  // Reclaim sandboxes left behind by an earlier instance before taking traffic,
+  // then expire the ones this instance stops using. Between them these replace
+  // `make reset` as the only sweeper in the repo.
+  await reclaimOrphanedSandboxes(INSTANCE_ID);
+  sessionExecutors.startSweeping();
 
   serve({ fetch: app.fetch, port: PORT }, (info) => {
     console.log(`[Agent] Listening on http://localhost:${info.port}`);


### PR DESCRIPTION
## What

Sandbox ownership lived only in a module-level `Map` inside the agent process, so `traceroot-sandbox-*` containers accumulated on the Docker host with nothing able to reach them again. This gives a sandbox a durable identity, reclaims orphans at startup, expires idle ones, and makes shutdown fast enough to finish.

### 1. Durable identity (`executors/docker.ts`)

Every container is created with `traceroot.sandbox=1`, `traceroot.session=<sessionId>`, `traceroot.owner=<instance uuid>`. Ownership no longer depends on the creating process still being alive.

### 2. Reconciliation at startup (`reclaimOrphanedSandboxes`)

Before the service listens, it lists sandboxes and force-removes every one that does not carry the current instance id, in a single batched `docker rm -f`. Matching is by **name prefix**, not by label, so containers created before this change are reclaimed too. A missing Docker socket (Daytona deployments, CI) logs a warning and returns — startup never depends on it.

### 3. Idle TTL (`executors/registry.ts`)

`SandboxRegistry` owns the per-session executors and tears down any sandbox unused for `SANDBOX_IDLE_TTL_MINUTES` (default 30, `0` disables), swept once a minute on an unref'd timer. This is the piece that matters in practice: RCA and digest sessions are created and never deleted, and the only route that called `destroy()` is not invoked by anything in the repo — so without a TTL a healthy long-running agent still grows without bound. The sandbox is deliberately kept for the life of an *active* session rather than destroyed per run, since the cloned repo and workspace state are reused across turns.

### 4. Shutdown that finishes (`destroyAll`)

Teardown is now `Promise.allSettled` instead of sequential: N sequential `docker rm -f` calls can outlast compose's 10s default grace period, after which SIGKILL leaks whatever is left. The agent service also gets `stop_grace_period: 60s` in `docker-compose.prod.yml`.

### 5. Fits the current agent service

Rebased onto the `run-stream.ts` / hot-reload / deleted-session-fence changes on `main`:

- the registry wraps every executor it creates in `fenceExecutorToSession`, so a deleted session still cannot bring a sandbox back
- the `DELETE` route tears down through `release()`, which untracks before `destroy()` exactly as the old Map code did
- the turn's hold wraps `runAgentStream` with `.finally`
- `rememberExecutors` now takes the registry, and a `vite-node` reload calls `destroyAll()`, which also stops the previous execution's idle sweep timer

An earlier version of this PR switched the dev script to `tsx watch`; `main` now handles same-process reloads in `hot-reload.ts`, so that change is dropped.

## Tests

`src/executors/__tests__/registry.test.ts` (new): per-session reuse, idle sweep, renewed use resetting the clock, TTL disabled, `destroyAll` completing despite a rejecting teardown, and concurrency of teardown (peak in-flight == N, which fails on the old sequential loop).

`src/executors/__tests__/docker.test.ts`: the three labels are set on `docker run`; orphans are removed and the current instance's sandboxes spared; unlabelled legacy containers are reclaimed; removal is one batched call; a dead Docker socket resolves empty instead of throwing.

## Validation

- Full agent suite in `frontend/ee/agent`: 762 of 763 pass. The one failure is `evals/__tests__/client.test.ts` expecting `/` in a path, which fails the same way on `main` on Windows.
- `hot-reload.test.ts` drives the handoff with a real `SandboxRegistry`, plus a case where teardown rejects and the reload still proceeds.
- `tsc --noEmit` reports no errors in the touched files; `prettier` clean.

I do not have a Docker daemon on this machine, so the `docker` CLI interactions are covered by stubs rather than a live run: the tests assert the exact argv (`--label` triple on `docker run`, one batched `docker rm -f`), the owner-vs-orphan partition, the legacy-unlabelled case, and the dead-socket path. A live confirmation on the reporter's setup — leaked containers gone after one agent restart — would be worth having before merge.

No UI change, so no screenshots.

Closes #2101
