### PR TITLE
fix(ui): drive detectors and datasets pagination from local state (#2130)

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
@@ -3,7 +3,29 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, cleanup, screen, fireEvent } from "@testing-library/react";
 import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 
-const mocks = vi.hoisted(() => ({ push: vi.fn(), useDetectorList: vi.fn() }));
+const initialPageState = {
+  page: 0,
+  limit: 50,
+  dateFilter: { id: "7d" },
+  customStartDate: null,
+  customEndDate: null,
+  keyword: "",
+};
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  useDetectorList: vi.fn(),
+  goToPage: vi.fn(),
+  updateLimit: vi.fn(),
+  listPageState: {
+    page: 0,
+    limit: 50,
+    dateFilter: { id: "7d" },
+    customStartDate: null,
+    customEndDate: null,
+    keyword: "",
+  },
+}));
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ projectId: "proj-1" }),
@@ -13,13 +35,13 @@ vi.mock("next/navigation", () => ({
 // Controlled list state so the test asserts the exact range carried into the URL.
 vi.mock("@/lib/hooks/use-list-page-state", () => ({
   useListPageState: () => ({
-    state: { dateFilter: { id: "7d" }, customStartDate: null, customEndDate: null, keyword: "" },
-    queryOptions: { page: 1, limit: 50 },
+    state: mocks.listPageState,
+    queryOptions: { page: mocks.listPageState.page, limit: mocks.listPageState.limit },
     updateDateFilter: vi.fn(),
     updateCustomRange: vi.fn(),
     updateKeyword: vi.fn(),
-    updateLimit: vi.fn(),
-    goToPage: vi.fn(),
+    updateLimit: mocks.updateLimit,
+    goToPage: mocks.goToPage,
   }),
 }));
 
@@ -108,7 +130,6 @@ vi.mock("@/lib/hooks/use-retention", () => ({
 vi.mock("@/ee/features/billing/PricingDialog", () => ({ PricingDialog: () => null }));
 vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
 vi.mock("@/components/search-filter-bar", () => ({ SearchFilterBar: () => null }));
-vi.mock("@/components/list-pagination", () => ({ ListPagination: () => null }));
 vi.mock("@/features/detectors/components/delete-detector-dialog", () => ({
   DeleteDetectorDialog: () => null,
 }));
@@ -121,6 +142,9 @@ mocks.useDetectorList.mockReturnValue(defaultDetectorList);
 afterEach(() => {
   cleanup();
   mocks.push.mockClear();
+  mocks.goToPage.mockReset();
+  mocks.updateLimit.mockReset();
+  mocks.listPageState = { ...initialPageState };
   mocks.useDetectorList.mockReset();
   mocks.useDetectorList.mockReturnValue(defaultDetectorList);
 });
@@ -189,5 +213,32 @@ describe("DetectorsPage", () => {
 
     const heading = screen.getByText("No detectors yet");
     expect(heading.parentElement?.querySelector("svg")).toBeTruthy();
+  });
+
+  it("requests two distinct successive pages when Next is clicked twice before response settles", () => {
+    mocks.useDetectorList.mockReturnValue({
+      data: {
+        data: defaultDetectorList.data.data,
+        meta: { page: 0, limit: 10, total: 100 },
+      },
+      isLoading: false,
+      error: null,
+    });
+    mocks.listPageState = { ...initialPageState, page: 0, limit: 10 };
+
+    const { rerender } = render(<DetectorsPage />);
+
+    mocks.goToPage.mockImplementation((newPage: number) => {
+      mocks.listPageState = { ...mocks.listPageState, page: newPage };
+      rerender(<DetectorsPage />);
+    });
+
+    const nextButton = screen.getByRole("button", { name: "Next page" });
+    fireEvent.click(nextButton);
+    fireEvent.click(nextButton);
+
+    expect(mocks.goToPage).toHaveBeenCalledTimes(2);
+    expect(mocks.goToPage).toHaveBeenNthCalledWith(1, 1);
+    expect(mocks.goToPage).toHaveBeenNthCalledWith(2, 2);
   });
 });

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -324,8 +324,8 @@ export default function DetectorsPage() {
 
         {meta && (
           <ListPagination
-            page={meta.page}
-            limit={meta.limit}
+            page={state.page}
+            limit={state.limit}
             total={meta.total}
             onPageChange={goToPage}
             onLimitChange={updateLimit}

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -166,8 +166,8 @@ export function DatasetsView({ projectId }: { projectId: string }) {
 
       {meta && meta.total > 0 && (
         <ListPagination
-          page={meta.page}
-          limit={meta.limit}
+          page={page}
+          limit={limit}
           total={meta.total}
           onPageChange={goToPage}
           onLimitChange={setLimit}


### PR DESCRIPTION
### Summary
Drives the pagination control in `detectors/page.tsx` and `datasets-view.tsx` from local page state rather than the server's echoed page number. This ensures fast successive clicks on "Next" / "Prev" advance multiple pages properly rather than stalling and swallowing clicks while a request is in flight.

Closes #2130

### Changes
- `frontend/ui/src/app/projects/[projectId]/detectors/page.tsx`: Pass `state.page` and `state.limit` to `<ListPagination />` instead of `meta.page` and `meta.limit`.
- `frontend/ui/src/features/evaluations/views/datasets-view.tsx`: Pass `page` and `limit` from `useUrlPagination` to `<ListPagination />`.
- `frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx`: Added test verifying that two Next clicks issued before the response settles request two distinct successive pages.
- Verified all 6 `ListPagination` consumers agree on using local page state.

### Verification
- `npm test -- detectors/page.test.tsx` (8 passed)
- `npm test -- datasets` (106 passed)
- ESLint passed with 0 errors.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes detectors and datasets pagination so rapid clicks on Next/Prev no longer stall or swallow requests. Pagination now reads from local page state instead of the server's echoed page number, allowing successive clicks to advance multiple pages while a request is in flight. Closes #2130.

<sup>Written for commit 43faa3168fb8fb6493cc1b02fd97414793b2e45a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

