### PR TITLE
chore(docker): move images to node:24-alpine and golang:1.27-alpine

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -1,5 +1,5 @@
 # docker/Dockerfile.agent
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN apk add --no-cache openssl && \
     corepack enable && corepack prepare pnpm@10 --activate
 
@@ -44,7 +44,7 @@ RUN cd packages/core && \
 RUN cd packages/tools && pnpm build
 RUN cd ee/agent && pnpm build
 
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 
 RUN apk add --no-cache openssl docker-cli

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -1,5 +1,5 @@
 # docker/Dockerfile.agent
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 RUN apk add --no-cache openssl && \
     corepack enable && corepack prepare pnpm@10 --activate
 
@@ -44,7 +44,7 @@ RUN cd packages/core && \
 RUN cd packages/tools && pnpm build
 RUN cd ee/agent && pnpm build
 
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 RUN apk add --no-cache openssl docker-cli

--- a/docker/Dockerfile.billing
+++ b/docker/Dockerfile.billing
@@ -1,5 +1,5 @@
 # docker/Dockerfile.billing
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN apk add --no-cache openssl && \
     corepack enable && corepack prepare pnpm@10 --activate
 
@@ -45,7 +45,7 @@ RUN cd packages/slack && \
     node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{types:'./dist/index.d.ts',import:'./dist/index.js'}}; fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
 RUN cd worker && pnpm build
 
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 
 RUN apk add --no-cache openssl && \

--- a/docker/Dockerfile.billing
+++ b/docker/Dockerfile.billing
@@ -1,5 +1,5 @@
 # docker/Dockerfile.billing
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 RUN apk add --no-cache openssl && \
     corepack enable && corepack prepare pnpm@10 --activate
 
@@ -45,7 +45,7 @@ RUN cd packages/slack && \
     node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{types:'./dist/index.d.ts',import:'./dist/index.js'}}; fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
 RUN cd worker && pnpm build
 
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 RUN apk add --no-cache openssl && \

--- a/docker/Dockerfile.detector
+++ b/docker/Dockerfile.detector
@@ -1,5 +1,5 @@
 # docker/Dockerfile.detector
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN apk add --no-cache openssl && \
     corepack enable && corepack prepare pnpm@10 --activate
 
@@ -45,7 +45,7 @@ RUN cd packages/slack && \
     node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{types:'./dist/index.d.ts',import:'./dist/index.js'}}; fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
 RUN cd worker && pnpm build
 
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 
 RUN apk add --no-cache openssl && \

--- a/docker/Dockerfile.detector
+++ b/docker/Dockerfile.detector
@@ -1,5 +1,5 @@
 # docker/Dockerfile.detector
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 RUN apk add --no-cache openssl && \
     corepack enable && corepack prepare pnpm@10 --activate
 
@@ -45,7 +45,7 @@ RUN cd packages/slack && \
     node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{types:'./dist/index.d.ts',import:'./dist/index.js'}}; fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
 RUN cd worker && pnpm build
 
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 RUN apk add --no-cache openssl && \

--- a/docker/Dockerfile.migrate-clickhouse
+++ b/docker/Dockerfile.migrate-clickhouse
@@ -1,6 +1,6 @@
 # docker/Dockerfile.migrate-clickhouse
 # Lightweight image for running goose ClickHouse migrations.
-FROM golang:1.23-alpine AS build
+FROM golang:1.27-alpine AS build
 RUN go install github.com/pressly/goose/v3/cmd/goose@v3.24.1
 
 FROM alpine:3.24

--- a/docker/Dockerfile.migrate-postgres
+++ b/docker/Dockerfile.migrate-postgres
@@ -1,7 +1,7 @@
 # docker/Dockerfile.migrate-postgres
 # Prisma migration image — reuses the migrate stage from Dockerfile.web.
 # Build with: docker build --platform linux/amd64 -f docker/Dockerfile.migrate-postgres .
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 RUN apk add --no-cache openssl && \
     corepack enable && corepack prepare pnpm@10 --activate
 

--- a/docker/Dockerfile.migrate-postgres
+++ b/docker/Dockerfile.migrate-postgres
@@ -1,7 +1,7 @@
 # docker/Dockerfile.migrate-postgres
 # Prisma migration image — reuses the migrate stage from Dockerfile.web.
 # Build with: docker build --platform linux/amd64 -f docker/Dockerfile.migrate-postgres .
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN apk add --no-cache openssl && \
     corepack enable && corepack prepare pnpm@10 --activate
 

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,5 +1,5 @@
 # docker/Dockerfile.web
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 RUN apk add --no-cache openssl && \
     corepack enable && corepack prepare pnpm@10 --activate
 
@@ -81,7 +81,7 @@ COPY frontend/packages/core/prisma ./packages/core/prisma
 ENTRYPOINT ["./packages/core/node_modules/.bin/prisma", "migrate", "deploy", "--schema", "packages/core/prisma/schema.prisma"]
 
 # --- Runner stage ---
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 RUN apk add --no-cache openssl && \

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,5 +1,5 @@
 # docker/Dockerfile.web
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN apk add --no-cache openssl && \
     corepack enable && corepack prepare pnpm@10 --activate
 
@@ -81,7 +81,7 @@ COPY frontend/packages/core/prisma ./packages/core/prisma
 ENTRYPOINT ["./packages/core/node_modules/.bin/prisma", "migrate", "deploy", "--schema", "packages/core/prisma/schema.prisma"]
 
 # --- Runner stage ---
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 
 RUN apk add --no-cache openssl && \

--- a/frontend/packages/tools/package.json
+++ b/frontend/packages/tools/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.3"
+    "node": ">=24"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Base image and CI runtime update.

- Node Dockerfiles: `node:20-alpine` → `node:24-alpine` (current Active LTS; Next.js 16 supports it).
- `Dockerfile.migrate-clickhouse`: `golang:1.23-alpine` → `golang:1.27-alpine`. Built locally, goose runs.
- CI (`lint`, `build-test`, `test`): `node-version: "24"` so tests run on the shipped runtime.
- `frontend/packages/tools` engines field aligned to `>=24`.

This also fixes a real mismatch: the lockfile already contains `@earendil-works/pi-ai@0.80.3`, whose `engines.node` is `>=22.19.0`, which Node 20 in CI and in the images did not satisfy.

Python images unchanged.
