### PR TITLE
fix(slack): keep sub-unit alert thresholds and readings legible

### DIFF
--- a/frontend/packages/slack/src/__tests__/alert-blocks.test.ts
+++ b/frontend/packages/slack/src/__tests__/alert-blocks.test.ts
@@ -67,6 +67,36 @@ describe("buildAlertBlocks", () => {
     expect(counted).not.toContain("12ms");
   });
 
+  it("keeps sub-unit thresholds and readings legible instead of rounding them to 0", () => {
+    // cost is dollars: one gpt-4o-mini span is ~4.5e-5, a whole window ~1e-3.
+    // Two-decimal rounding turned both the threshold and the reading into "0".
+    const cost = {
+      ...alertBase,
+      measure: "cost",
+      aggregation: "sum",
+      threshold: 0.0005,
+      value: 0.001125,
+    };
+    expect(sectionTexts(buildAlertBlocks(cost))[0]).toContain(
+      "`sum(cost)` was 0.00113, above the 0.0005 threshold, over the last 30m.",
+    );
+    const tiny = {
+      ...cost,
+      severity: "OK" as const,
+      previousSeverity: "ALERT" as const,
+      value: 4.5e-5,
+    };
+    expect(sectionTexts(buildAlertBlocks(tiny))[0]).toContain(
+      "`sum(cost)` recovered to 0.000045, back within the 0.0005 threshold, over the last 30m.",
+    );
+    // a fraction of a millisecond is still two decimals once it is at or above 1
+    expect(sectionTexts(buildAlertBlocks({ ...alertBase, value: 1.256 }))[0]).toContain(
+      "was 1.26ms",
+    );
+    // and sub-unit readings on other measures use the same significant-digit rule
+    expect(sectionTexts(buildAlertBlocks({ ...alertBase, value: 0.5 }))[0]).toContain("was 0.5ms");
+  });
+
   it("names the row-count pseudo-measure once when aggregation and measure coincide", () => {
     const [outcome] = sectionTexts(
       buildAlertBlocks({

--- a/frontend/packages/slack/src/alert-blocks.ts
+++ b/frontend/packages/slack/src/alert-blocks.ts
@@ -70,9 +70,20 @@ export function alertSpansUrl(
   return `${appBaseUrl}/projects/${encodeURIComponent(projectId)}/traces?${range}`;
 }
 
+// Cost is priced in dollars and a single LLM span lands in the 1e-5..1e-3
+// range, so two decimals would print every cost threshold and reading as 0
+// ("back within the 0 threshold"). Below 1 the message keeps three significant
+// digits instead; Intl never falls back to exponent notation, so 4.5e-5 reads
+// as 0.000045. At or above 1 two decimals stay the rule (1834.57ms).
+const SMALL_NUMBER_FORMAT = new Intl.NumberFormat("en-US", {
+  maximumSignificantDigits: 3,
+  useGrouping: false,
+});
+
 function formatNumber(value: number): string {
   if (!Number.isFinite(value)) return String(value);
   if (Number.isInteger(value)) return String(value);
+  if (Math.abs(value) < 1) return SMALL_NUMBER_FORMAT.format(value);
   return String(Math.round(value * 100) / 100);
 }
 


### PR DESCRIPTION
Fixes #2141. Stacked on #1891 (`feat/alerts-slack-blocks-pr`), which owns `alert-blocks.ts`.

## What

`formatNumber` rounded every non-integer to two decimals, so a cost rule on `sum(cost) > 0.0005` paged

> `sum(cost)` recovered to 0, back within the **0** threshold

and read `0.001125` as `0`. Cost is priced in dollars and one LLM span is ~1e-5, so this hit the `cost` measure's main use case.

Below 1 the message now keeps three significant digits via `Intl.NumberFormat` (`maximumSignificantDigits: 3`, no grouping), which never falls back to exponent notation, so `4.5e-5` reads as `0.000045`. At or above 1 the existing two-decimal rule is unchanged (`1834.57ms`, `1.26ms`); integers are untouched.

## Test

New case in `alert-blocks.test.ts`: a cost breach reads `was 0.00113, above the 0.0005 threshold`, its recovery reads `recovered to 0.000045`, and `1.256` / `0.5` on latency render as `1.26ms` / `0.5ms`. `pnpm test` in `packages/slack`: 29 passed. `tsc` and prettier clean.

Observed on staging (`sha-193be53`) during the alerts e2e run on 2026-09-07; rule R05 in the report.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01TqhoTSb7LF5vuaah8GYHKq