### PR TITLE
docs(alerts): add metric alerts guide

### DIFF
--- a/docs/alerts/introduction.mdx
+++ b/docs/alerts/introduction.mdx
@@ -1,0 +1,84 @@
+---
+title: Alerts
+description: Monitor trace metrics and notify your team in Slack
+---
+
+Metric alerts watch your project's spans over a recent time window. Each rule summarizes a measure, compares the result with a threshold, and posts changes to your workspace's Slack channel.
+
+Metric alerts are separate from [detector alerts](/detectors/alerts). Detectors use an LLM-as-a-judge to find problems in individual traces, while metric alerts evaluate numeric conditions such as latency, cost, token usage, or span count.
+
+## Before you create an alert
+
+You need:
+
+- A project that is sending traces to TraceRoot.
+- A Slack workspace and destination channel connected under **Workspace settings > Integrations**. Slack integration is available on all current plans. Ask a workspace admin to connect or change the channel if you can't manage workspace settings.
+
+## Create an alert
+
+Open a project in [TraceRoot Cloud](https://app.traceroot.ai), select **Alerts** from the left navigation, then select **New Alert**.
+
+### Choose the metric
+
+Under **Metric**, choose a measure and aggregation. Available measures cover:
+
+- Span and distinct trace counts.
+- Latency and cost.
+- Input, output, and total token usage.
+- Token throughput.
+- Distinct users and sessions.
+
+The aggregation menu only offers operations that the selected measure supports. The **Live preview** charts the current rule so you can check the metric before saving it.
+
+Use **Add filter** to limit the spans included in the rule. Alerts support filters for model, environment, status, span kind, span name, root spans, and metadata. Metadata filters also require a key. The form previews and saves only complete, supported filter combinations.
+
+Distinct users and distinct sessions can't be combined with filters. Remove the filters or choose a different measure before creating the alert.
+
+### Set the condition
+
+Under **Conditions**:
+
+1. Choose a comparison operator and enter the threshold.
+2. Choose a lookback window from 1 minute to 2 hours.
+3. Choose how often to repeat a notification while the rule remains in breach.
+
+**Off (alert only on transitions)** posts when the metric enters the alert state and when it recovers. **Re-alert at a regular interval** also repeats the breach notification at the interval you enter.
+
+### Name and save the alert
+
+Under **Notifications**, enter the name that should appear in Slack. Confirm that the workspace is connected to Slack and has a destination channel, then select **Create Alert**.
+
+New alerts are active immediately. TraceRoot evaluates active rules once per minute, so the first result should appear within a minute.
+
+## Read alert states
+
+The Alerts table shows the rule's latest state:
+
+- **OK** — the latest measured value is within the threshold.
+- **Alert** — the latest measured value breaches the threshold.
+- **No Data** — the latest window returned no value, or the rule is waiting for a fresh result after it was created, after you changed an evaluation setting, or after you resumed it.
+- **Failing** — the last evaluation failed. Open the badge for details and check the rule's measure and filters if failures continue.
+- **Paused** — evaluation and notifications are stopped until you resume the rule.
+
+For rules created in the current form, an empty window doesn't send a notification or resolve an outstanding breach. If a breach was already announced, it remains outstanding until data returns and the rule can evaluate again.
+
+## Use Slack notifications
+
+Slack messages show the rule name, state, measured value, threshold, window, and filters. A breach notification includes:
+
+- **View alert**, which opens the rule.
+- **View traces**, which opens the evaluated time window in the trace list.
+
+The trace list carries supported rule filters where it can, but the list is trace-based while the alert evaluates spans. The linked results can therefore be broader than the exact spans that triggered the rule. Check the filter text in the Slack message for the complete rule conditions.
+
+Recovery messages include **View alert** but don't include **View traces**, because the metric is back within its threshold.
+
+## Manage alerts
+
+Use the actions menu on an alert to:
+
+- **Pause** or **Resume** evaluation and notifications.
+- **Edit** the metric, condition, filters, name, or renotify setting.
+- **Delete** the rule permanently. Deleting stops evaluation and notifications immediately and removes the recorded state.
+
+You can also search alerts by name from the Alerts page.

--- a/docs/detectors/alerts.mdx
+++ b/docs/detectors/alerts.mdx
@@ -1,9 +1,11 @@
 ---
-title: Alerts
+title: Detector alerts
 description: Send detector findings to email and Slack
 ---
 
-An alert fires once the two-step pipeline completes: the LLM-as-a-judge flags a trace, the TraceRoot AI agent finishes its root cause analysis, and the combined result lands in your configured channels. Email is supported by default; Slack is available on Pro plans and above.
+This page covers notifications for detector findings. To watch a metric over a window and compare it with a threshold, see [metric alerts](/alerts/introduction).
+
+A detector alert fires once the two-step pipeline completes: the LLM-as-a-judge flags a trace, the TraceRoot AI agent finishes its root cause analysis, and the combined result lands in your configured channels. Email is supported by default, and Slack is available on all current plans.
 
 ## Email
 
@@ -13,13 +15,15 @@ Each finding produces one email containing:
 - A direct link to the trace in TraceRoot Cloud.
 - The full root cause analysis written by the TraceRoot AI agent (root cause, code location, recent changes, recommendation).
 
-
 ## Slack
 
-Slack delivery is available on **Pro plans** and above. The integration is workspace-level — one Slack workspace per TraceRoot workspace, with a single destination channel.
+Slack integration is available on all current plans. The integration is workspace-level — one Slack workspace per TraceRoot workspace, with a single destination channel.
 
 <Frame>
-  <img src="/images/detector_slack_v1.png" alt="Detector alert posted to a Slack channel" />
+  <img
+    src="/images/detector_slack_v1.png"
+    alt="Detector alert posted to a Slack channel"
+  />
 </Frame>
 
 ### Connect Slack
@@ -27,8 +31,6 @@ Slack delivery is available on **Pro plans** and above. The integration is works
 1. Open **Settings** then **Integrations** as a workspace admin.
 2. Click **Connect** and complete the OAuth flow in your Slack workspace.
 3. Pick the channel TraceRoot should post alerts to.
-
-If your plan doesn't include Slack, the connect button takes you to the upgrade page instead of starting the OAuth flow.
 
 ### What Slack alerts contain
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -97,6 +97,12 @@
             ]
           },
           {
+            "group": "Alerts",
+            "pages": [
+              "alerts/introduction"
+            ]
+          },
+          {
             "group": "AI Agents",
             "pages": [
               "ai-agent/overview",


### PR DESCRIPTION
Fixes #2005

## Summary

- add a user guide for metric alert rules
- distinguish metric alerts from detector finding notifications
- add the Alerts guide to the documentation navigation
- align the detector Slack availability text with the current plan configuration

## Type of Change

- [x] docs - Documentation only changes

## Details

The guide covers the shipped metric rule flow: measures and filters, thresholds and lookback windows, alert states, repeat notifications, Slack links, and rule management.

It also documents the current trace-link granularity instead of implying span-level filtering that the trace list cannot express. The detector alert page now links to this guide and describes finding notifications separately.

## Validation

- Mintlify build validation passed
- Prettier passed for both changed MDX files
- JSON navigation, frontmatter, and internal-link checks passed

## Screenshots / Recordings

Not applicable; this PR changes documentation only.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I have updated documentation where necessary
- [x] Tests and screenshots are not applicable to this documentation-only change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metric alerts guide covering rule creation and management, and updates the detector alerts page to clarify the difference between metric alerts and detector finding notifications. Fixes #2005.

**Details**
- Documents the metric rule flow: measures, filters, thresholds, lookback windows, alert states, repeat notifications, Slack links, and rule management.
- Notes that metric alerts evaluate numeric span conditions, while detector alerts use LLM-as-a-judge on individual traces.
- Adds the Alerts guide to the documentation navigation.
- Updates the detector Slack availability text to say all current plans instead of Pro and above.

<sup>Written for commit 1700fdb6a39a4c49b66363fbba10c679bc6875c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

