### PR TITLE
fix(api): hold agent reads to the user's plan retention

### DIFF
--- a/backend/rest/routers/deps.py
+++ b/backend/rest/routers/deps.py
@@ -48,9 +48,12 @@ async def get_project_access(
     Auth modes:
     - x-user-id: User's unique ID (from session) — normal user-initiated requests.
     - X-Internal-Secret: Shared secret — for trusted server-to-server calls
-      (e.g. the agent service running a system-initiated RCA session that has no
-      associated user). Bypasses the Next.js per-user access check; the agent
-      service is itself trusted to scope access correctly.
+      (the agent service, the workers). Trusted traffic is never rate limited.
+      What it may see depends on who it acts for: with an x-user-id (a chat
+      session the user drives) the user's membership and plan are resolved
+      exactly as for a direct request, so retention gating follows the plan;
+      without one (a system-initiated RCA session) there is no user to resolve
+      and the caller gets enterprise-equivalent access.
 
     Raises 401 if neither auth mode succeeds, 403 if no access, 404 if project
     not found.
@@ -59,22 +62,28 @@ async def get_project_access(
     # (defense-in-depth against any stale ContextVar value).
     clear_request_rate_limit_exempt()
 
-    # System bypass: agent service / worker calling on behalf of the system.
+    # Trusted internal traffic (agent service, workers): constant-time secret check.
     # Constant-time compare to avoid leaking the secret via response timing.
     if (
         x_internal_secret
         and settings.internal_api_secret
         and hmac.compare_digest(x_internal_secret, settings.internal_api_secret)
     ):
-        # Trusted internal traffic is not rate limited (system-controlled volume)
-        # and exempt from retention gating (enterprise-equivalent access).
+        # Trusted internal traffic is not rate limited (system-controlled volume).
         mark_request_rate_limit_exempt()
-        return ProjectAccessInfo(
-            project_id=project_id,
-            user_id=x_user_id or "system",
-            role=MemberRole.ADMIN,
-            billing_plan="enterprise",
-        )
+        if not x_user_id:
+            # A system session has no user whose plan could bound the read:
+            # enterprise-equivalent access, as the RCA pipeline has always had.
+            return ProjectAccessInfo(
+                project_id=project_id,
+                user_id="system",
+                role=MemberRole.ADMIN,
+                billing_plan="enterprise",
+            )
+        # Acting for a user: the trusted caller may skip the rate limiter, but
+        # not the user's plan — an agent read must not reach past the retention
+        # the same user is held to on the page.
+        return await _resolve_user_access(project_id, x_user_id)
 
     if not x_user_id:
         raise HTTPException(
@@ -82,12 +91,31 @@ async def get_project_access(
             detail="Missing x-user-id header",
         )
 
+    return await _resolve_user_access(project_id, x_user_id)
+
+
+async def _resolve_user_access(project_id: str, user_id: str) -> ProjectAccessInfo:
+    """Resolve a user's membership, workspace and plan for a project via the Next.js internal API.
+
+    Args:
+        project_id: The project the request targets.
+        user_id: The user the request acts for.
+
+    Returns:
+        The access record, with the workspace and plan the rate limiter and
+        retention gate key on.
+
+    Raises:
+        HTTPException: 401 when the auth service rejects the call, 403/404 when
+            the user has no access or the project is unknown, 503 when the auth
+            service is unreachable or answers without a usable workspace.
+    """
     # Validate access via Next.js internal API
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(
                 f"{settings.traceroot_ui_url}/api/internal/validate-project-access",
-                json={"userId": x_user_id, "projectId": project_id},
+                json={"userId": user_id, "projectId": project_id},
                 headers={"X-Internal-Secret": settings.internal_api_secret},
             )
     except httpx.RequestError as e:
@@ -133,7 +161,7 @@ async def get_project_access(
 
     return ProjectAccessInfo(
         project_id=project_id,
-        user_id=x_user_id,
+        user_id=user_id,
         role=data.get("role", MemberRole.VIEWER),
         workspace_id=workspace_id,
         billing_plan=data.get("billingPlan", "free"),

--- a/tests/rest/test_auth_deps.py
+++ b/tests/rest/test_auth_deps.py
@@ -27,7 +27,7 @@ from rest.routers.public.deps import (
     authenticate_user_token,
 )
 from rest.routers.public.traces import AuthResult, authenticate_api_key
-from shared.config import normalize_plan
+from shared.config import normalize_plan, settings
 
 BASE_URL = "http://localhost:3000"
 
@@ -301,6 +301,87 @@ class TestAuthenticateApiKey:
             await authenticate_api_key("Bearer test-key")
         assert exc_info.value.status_code == 503
         assert exc_info.value.detail == "Authentication service error"
+
+
+# ── get_project_access: trusted internal traffic ────────────────────────
+
+
+class TestGetProjectAccessInternal:
+    """The agent service and workers call with the shared secret. Traffic they
+    send on behalf of a user must see that user's plan, not enterprise access;
+    only a system session with no user keeps the enterprise-equivalent view."""
+
+    @pytest.fixture(autouse=True)
+    def _secret(self, monkeypatch):
+        monkeypatch.setattr(settings, "internal_api_secret", "internal-test-secret")
+
+    @respx.mock
+    async def test_user_initiated_request_resolves_the_users_plan(self):
+        route = respx.post(f"{BASE_URL}/api/internal/validate-project-access").mock(
+            return_value=Response(
+                200,
+                json={
+                    "hasAccess": True,
+                    "role": "MEMBER",
+                    "workspaceId": "ws-456",
+                    "billingPlan": "free",
+                },
+            )
+        )
+        result = await get_project_access(
+            "proj-123", "user-456", x_internal_secret="internal-test-secret"
+        )
+        assert route.called
+        assert result.billing_plan == "free"
+        assert result.role == "MEMBER"
+        assert result.workspace_id == "ws-456"
+        assert result.user_id == "user-456"
+        # Still trusted traffic: not rate limited.
+        assert is_request_rate_limit_exempt()
+
+    @respx.mock
+    async def test_system_session_without_a_user_keeps_enterprise_access(self):
+        route = respx.post(f"{BASE_URL}/api/internal/validate-project-access").mock(
+            return_value=Response(200, json={"hasAccess": True})
+        )
+        result = await get_project_access(
+            "proj-123", None, x_internal_secret="internal-test-secret"
+        )
+        assert not route.called
+        assert result.user_id == "system"
+        assert result.billing_plan == "enterprise"
+        assert is_request_rate_limit_exempt()
+
+    @respx.mock
+    async def test_user_initiated_request_is_refused_when_the_user_has_no_access(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-project-access").mock(
+            return_value=Response(200, json={"hasAccess": False, "error": "No access"})
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await get_project_access(
+                "proj-123", "user-456", x_internal_secret="internal-test-secret"
+            )
+        assert exc_info.value.status_code == 403
+
+    @respx.mock
+    async def test_wrong_secret_with_a_user_is_plain_user_auth_and_not_exempt(self):
+        # A wrong secret is not "internal": the user path runs, and the request
+        # is rate limited like any other.
+        route = respx.post(f"{BASE_URL}/api/internal/validate-project-access").mock(
+            return_value=Response(
+                200,
+                json={
+                    "hasAccess": True,
+                    "role": "MEMBER",
+                    "workspaceId": "ws-456",
+                    "billingPlan": "free",
+                },
+            )
+        )
+        result = await get_project_access("proj-123", "user-456", x_internal_secret="wrong")
+        assert route.called
+        assert result.billing_plan == "free"
+        assert is_request_rate_limit_exempt() is False
 
 
 # ── get_project_access ──────────────────────────────────────────────────


### PR DESCRIPTION
Requests carrying the internal service secret were treated as enterprise access regardless of who they acted for, so the in-app agent's dashboard, widget, trace and session reads for a user on a free plan reached the whole ClickHouse history while that user's own page was clamped to fifteen days.

## What changed

- Internal-secret traffic that names a user (`x-user-id`, the chat user) now resolves that user's membership, workspace and plan through the same `validate-project-access` path as a direct request, so every retention clamp keyed on `billing_plan` applies. It stays exempt from the rate limiter.
- A system session with no user (the RCA pipeline) keeps the enterprise-equivalent access it has always had.
- The shared resolution is one helper; the direct-user path is unchanged.

## Operational note

Each agent tool call now costs one validate round-trip to Next.js, the same as any direct page request. A Next outage therefore 503s agent reads for chat sessions, which already reach the agent only through Next's proxy routes. RCA sessions are unaffected.

## Verification

- New tests: user-bound internal traffic resolves the user's plan and stays rate-limit exempt; a user without access is refused; a system session keeps enterprise access without a validate call; a wrong secret is plain user auth and not exempt.
- Backend suite: 1162 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JddAMkfJ7P4HbtVZpkkTj9


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent reads bypassing plan retention for free-plan users. Internal-secret requests that include a user ID now resolve that user's plan through `validate-project-access`, so retention limits apply; system sessions with no user keep enterprise-equivalent access.

- Each agent tool call now adds one validate round-trip to Next.js; an outage 503s agent reads for chat sessions, but not RCA sessions.

<sup>Written for commit 23bc536c5215f92e28a8d917bca2858214496bc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

