### PR TITLE
Publish @traceroot-ai/tools from CI

### DIFF
--- a/.github/workflows/announce-release-discord.yml
+++ b/.github/workflows/announce-release-discord.yml
@@ -35,6 +35,11 @@ concurrency:
 
 jobs:
   announce:
+    # tools-v* tags publish @traceroot-ai/tools, which is a package bump rather
+    # than a product release. Announcing those would misrepresent them.
+    if: >-
+      !startsWith(github.event.release.tag_name, 'tools-v') &&
+      !startsWith(inputs.tag, 'tools-v')
     runs-on: ubuntu-latest
     steps:
       - name: Post release notes to Discord

--- a/.github/workflows/publish-tools.yml
+++ b/.github/workflows/publish-tools.yml
@@ -1,0 +1,76 @@
+name: Publish @traceroot-ai/tools
+
+# The tool registry is generated from the public OpenAPI schema and consumed by
+# traceroot-cli as a published dependency, so it needs its own release cadence
+# separate from the product releases this repo already tags as vX.Y.Z.
+#
+# Trigger with a tools-v prefixed tag, e.g. tools-v0.2.0:
+#   gh release create tools-v0.2.0 --generate-notes
+on:
+  release:
+    types: [published]
+  # Re-run a publish after a workflow fix without recreating the release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish, e.g. tools-v0.2.0"
+        required: true
+
+jobs:
+  publish:
+    # Product releases (vX.Y.Z) must not publish this package.
+    if: >-
+      startsWith(github.event.release.tag_name, 'tools-v') ||
+      startsWith(inputs.tag, 'tools-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # npm trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      # Trusted publishing needs npm >= 11.5.1. Pinned to the 11 line rather
+      # than @latest: npm 12 requires Node ^22.22.2 and broke a publish here
+      # the day it shipped.
+      - name: Update npm
+        run: npm install -g npm@11
+
+      - name: Install dependencies
+        run: cd frontend && pnpm install --frozen-lockfile
+
+      - name: Verify release tag matches package version
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          PKG_VERSION=$(node -p "require('./frontend/packages/tools/package.json').version")
+          TAG_VERSION="${TAG#tools-v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::tag ($TAG_VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "version $PKG_VERSION matches tag $TAG"
+
+      - name: Build
+        run: cd frontend/packages/tools && pnpm build
+
+      - name: Test
+        run: cd frontend/packages/tools && pnpm test
+
+      # No token: npm verifies over OIDC that this run came from this repo and
+      # workflow. Published with npm rather than pnpm because pnpm's publish
+      # does not perform the OIDC exchange; safe because this package declares
+      # no dependencies at all.
+      - name: Publish
+        run: npm publish --provenance --access public
+        working-directory: frontend/packages/tools


### PR DESCRIPTION
`@traceroot-ai/tools` is generated from the public OpenAPI schema and `traceroot-cli` depends on it as a published package (`"@traceroot-ai/tools": "0.1.0"`) — but **nothing published it**. It has been going to npm by hand.

That leaves a manual step in the middle of an otherwise automated chain: regenerate the registry → hand-publish → bump the CLI dependency → release the CLI through CI. It is also the last place a personal npm credential is still used.

**Publishes over OIDC** via npm trusted publishing, matching `traceroot-cli`, `traceroot-ts` and `traceroot-pi-extension`. No token stored.

**Uses a `tools-v` tag prefix** so package releases stay separate from the `vX.Y.Z` product releases this repo already tags, and the job is gated on that prefix so a product release can never publish the package:

```
gh release create tools-v0.2.0 --generate-notes
```

Also gates the Discord announcement off `tools-v` tags — without that, a package bump would be announced as a product release.

⚠️ **Before merging:** configure the trusted publisher on npmjs.com for `@traceroot-ai/tools` → `traceroot-ai/traceroot`, workflow `publish-tools.yml`, environment blank, and tick **Allow `npm publish`**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes `@traceroot-ai/tools` from CI using npm trusted publishing over OIDC, replacing the manual hand-publish step and removing the last use of a personal npm credential. The new `publish-tools.yml` workflow runs on `tools-v*` release tags, and the Discord announcement now skips those tags so package bumps aren't announced as product releases.

**Migration**
- Before merging, configure the trusted publisher on npmjs.com for `@traceroot-ai/tools` → `traceroot-ai/traceroot`, workflow `publish-tools.yml`, environment blank, with "Allow npm publish" enabled.

<sup>Written for commit 894470c18ca98ba561af3c6c7db029bc79e55d8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

