### PR TITLE
Harden the tools publish workflow

### DIFF
--- a/.github/workflows/publish-tools.yml
+++ b/.github/workflows/publish-tools.yml
@@ -43,7 +43,11 @@ jobs:
             tools-v*) ;;
             *) echo "::error::tag must start with tools-v, got '$TAG'"; exit 1 ;;
           esac
-          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+          IS_DRAFT=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
+          if [ "$IS_DRAFT" != "false" ]; then
+            echo "::error::$TAG is not a published release"
+            exit 1
+          fi
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish-tools.yml
+++ b/.github/workflows/publish-tools.yml
@@ -16,6 +16,9 @@ on:
         description: "Existing release tag to publish, e.g. tools-v0.2.0"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     # Product releases (vX.Y.Z) must not publish this package.
@@ -27,11 +30,30 @@ jobs:
       contents: read
       id-token: write   # npm trusted publishing
     steps:
+      # actions/checkout resolves a bare ref as refs/heads/<ref> before
+      # refs/tags/<ref>, so a branch named tools-v9.9.9 would shadow the tag.
+      # Require an actual release, then check out its tag explicitly.
+      - name: Verify the tag is a published release
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          case "$TAG" in
+            tools-v*) ;;
+            *) echo "::error::tag must start with tools-v, got '$TAG'"; exit 1 ;;
+          esac
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: refs/tags/${{ github.event.release.tag_name || inputs.tag }}
 
+      # Pin the pnpm version: this repo has no root package.json for
+      # action-setup to infer from. Matches build-test.yml.
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Three fixes from the review on #2154. Two are real bugs in what I merged.

**The pnpm setup would have failed on the first run.** `pnpm/action-setup@v4` infers its version from a root `package.json`, and this repo has none — `build-test.yml` pins `version: 10` for exactly that reason and I dropped it. Caught by cubic.

**A branch could shadow the release tag.** `actions/checkout` resolves a bare ref as `refs/heads/<ref>` before `refs/tags/<ref>`, so a branch named `tools-v9.9.9` would win over a tag of the same name, and `workflow_dispatch` would publish that branch head. Now the workflow requires the tag to name a real published release and checks out `refs/tags/` explicitly. Caught by trident and cubic.

Worth being precise about severity: **anyone with repo write can already publish arbitrary code** by creating a release, since `release: published` is the trigger. So this narrows a path rather than closing a boundary — the boundary is write access. What it removes is publishing from a *moving branch head* rather than a fixed commit, which is a real difference.

**Top-level `contents: read`** so permissions are least-privilege by default rather than inherited (Checkov).

The same checkout pattern is live in `traceroot-cli`'s `publish.yml` — fixing that separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden the tools publish workflow so it no longer accepts a bare ref that could resolve to a same-named branch; it now requires a published (non-draft) `tools-v*` release and checks out `refs/tags/` explicitly. It also pins `pnpm/action-setup@v4` to pnpm 10 to avoid setup failure in this repository and sets the workflow's default `contents` permission to read-only.

<sup>Written for commit 343718c63bb6bbaf57ebb63fbf34a79340047471. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

