### PR TITLE
feat(web): add GET /api/health for load balancer and kubelet probes

### DIFF
--- a/frontend/ui/src/app/api/health/route.test.ts
+++ b/frontend/ui/src/app/api/health/route.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+describe("GET /api/health", () => {
+  it("answers 200 with a small JSON body and no caching", async () => {
+    const res = GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    await expect(res.json()).resolves.toEqual({ status: "ok" });
+  });
+});

--- a/frontend/ui/src/app/api/health/route.ts
+++ b/frontend/ui/src/app/api/health/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+// GET /api/health
+//
+// Liveness endpoint for the load balancer and kubelet probes. Deliberately
+// touches nothing (no database, no auth): it answers "the web process is up
+// and serving", not "every dependency is healthy". A dependency check here
+// would take the whole web tier out of rotation when, say, Postgres blips,
+// which is the opposite of what a liveness probe is for.
+//
+// Exempt from the session middleware in proxy.ts; without that, the probe
+// gets a 307 to /auth/sign-in, which the ALB counts as unhealthy.
+export function GET() {
+  return NextResponse.json({ status: "ok" }, { headers: { "Cache-Control": "no-store" } });
+}

--- a/frontend/ui/src/proxy.test.ts
+++ b/frontend/ui/src/proxy.test.ts
@@ -29,6 +29,11 @@ describe("middleware matcher exemptions", () => {
     expect(isProtected("/api/health")).toBe(false);
   });
 
+  it("exempts only the exact health path, not neighbours", () => {
+    expect(isProtected("/api/healthcheck")).toBe(true);
+    expect(isProtected("/api/health/deep")).toBe(true);
+  });
+
   it("still protects app pages and session-authed API routes", () => {
     expect(isProtected("/projects/p1/datasets")).toBe(true);
     expect(isProtected("/api/projects/p1/datasets")).toBe(true);

--- a/frontend/ui/src/proxy.test.ts
+++ b/frontend/ui/src/proxy.test.ts
@@ -26,6 +26,7 @@ describe("middleware matcher exemptions", () => {
     expect(isProtected("/api/auth/callback")).toBe(false);
     expect(isProtected("/api/internal/validate-api-key")).toBe(false);
     expect(isProtected("/api/billing/webhook")).toBe(false);
+    expect(isProtected("/api/health")).toBe(false);
   });
 
   it("still protects app pages and session-authed API routes", () => {

--- a/frontend/ui/src/proxy.ts
+++ b/frontend/ui/src/proxy.ts
@@ -38,9 +38,10 @@ export const config = {
     // - api/internal (internal API for Python backend, uses X-Internal-Secret)
     // - api/cli (CLI token exchange, authenticates by bearer session token, no cookie)
     // - api/billing/webhook (Stripe webhook, uses signature verification)
+    // - api/health (load balancer / kubelet liveness probe; a 307 here reads as unhealthy)
     // - auth/* (sign-in, sign-up pages)
     // - _next (Next.js internals)
     // - static files
-    "/((?!api/auth|api/public|api/internal|api/cli|api/billing/webhook|api/github/token|api/github/callback|api/github/install-callback|auth/|_next/static|_next/image|images/|favicon.ico).*)",
+    "/((?!api/auth|api/public|api/internal|api/cli|api/billing/webhook|api/health|api/github/token|api/github/callback|api/github/install-callback|auth/|_next/static|_next/image|images/|favicon.ico).*)",
   ],
 };

--- a/frontend/ui/src/proxy.ts
+++ b/frontend/ui/src/proxy.ts
@@ -38,10 +38,10 @@ export const config = {
     // - api/internal (internal API for Python backend, uses X-Internal-Secret)
     // - api/cli (CLI token exchange, authenticates by bearer session token, no cookie)
     // - api/billing/webhook (Stripe webhook, uses signature verification)
-    // - api/health (load balancer / kubelet liveness probe; a 307 here reads as unhealthy)
+    // - api/health, exact (load balancer / kubelet liveness probe; a 307 here reads as unhealthy)
     // - auth/* (sign-in, sign-up pages)
     // - _next (Next.js internals)
     // - static files
-    "/((?!api/auth|api/public|api/internal|api/cli|api/billing/webhook|api/health|api/github/token|api/github/callback|api/github/install-callback|auth/|_next/static|_next/image|images/|favicon.ico).*)",
+    "/((?!api/auth|api/public|api/internal|api/cli|api/billing/webhook|api/health$|api/github/token|api/github/callback|api/github/install-callback|auth/|_next/static|_next/image|images/|favicon.ico).*)",
   ],
 };


### PR DESCRIPTION
Adds `GET /api/health`, a dependency-free liveness endpoint returning `200 {"status":"ok"}` with `Cache-Control: no-store`, and exempts it from the session middleware matcher so an unauthenticated probe gets 200 instead of a 307 to sign-in.

The Helm chart's kubelet probes already point at `/api/health`; until now they only passed because kubelet accepts a 3xx. The ALB target-group health check does not, so every web target showed unhealthy. The chart change that sets the ALB health check path follows in traceroot-k8s.

Tests: route test and a matcher exemption case in `proxy.test.ts`.