### PR TITLE
docs(cli): document detector and finding commands

### DIFF
--- a/docs/cli/get-started.mdx
+++ b/docs/cli/get-started.mdx
@@ -3,7 +3,7 @@ title: Get Started
 description: Bring TraceRoot to your terminal
 ---
 
-The TraceRoot CLI wraps the TraceRoot API so you can work with your project directly from the terminal — list, inspect, and export traces, then pipe the JSON into whatever comes next. It is built for AI coding agents and power users who prefer the command line.
+The TraceRoot CLI wraps the TraceRoot API so you can work with your project directly from the terminal — list, inspect, and export traces, and pull the findings your detectors raised — then pipe the JSON into whatever comes next. It is built for AI coding agents and power users who prefer the command line.
 
 Full source and reference live in the [`traceroot-cli`](https://github.com/traceroot-ai/traceroot-cli) repo.
 
@@ -47,6 +47,39 @@ traceroot traces get <trace-id>
 traceroot traces export <trace-id> --output ./my-trace
 ```
 
+## Work with detectors and findings
+
+Detectors watch incoming traces for hallucinations, tool and logic failures, safety violations, and intent drift. The CLI reads both your detectors and the findings they raise, so you can triage from the terminal.
+
+```bash
+# List your project's detectors — the DETECTOR ID column is what --detector takes
+traceroot detectors list
+
+# List recent findings across every detector
+traceroot findings list --since 24h
+
+# Narrow to the findings raised by one detector
+traceroot findings list --detector <detector-id> --since 7d
+
+# Open one finding: per-detector results and its free-text root cause analysis
+traceroot findings get <finding-id>          # or --trace <trace-id>
+```
+
+Pipe findings into `jq` or an agent with `--json`:
+
+```bash
+traceroot detectors list --json | jq '.data[].detector_id'
+traceroot findings list --detector <detector-id> --since 7d --json | jq '.data[].finding_id'
+```
+
+## Time filters
+
+Every list command takes the same time range flags:
+
+- `--since <duration>` — a relative window, e.g. `30m`, `6h`, `7d`, `2w`.
+- `--from` / `--to` — absolute bounds in ISO 8601, e.g. `2026-06-23T14:00:00Z`.
+- Quote timestamps that contain a space, e.g. `--from "2026-06-23 14:00:00"`.
+
 ## Command reference
 
 Add `--json` to any command for machine-readable output, or run `traceroot <command> --help` for the full flag list.
@@ -55,9 +88,12 @@ Add `--json` to any command for machine-readable output, or run `traceroot <comm
 | :-- | :-- |
 | `login` | Validate an API key and save credentials. |
 | `status` | Show the identity your credentials resolve to — workspace, project, host, and key hint. |
-| `traces list` | List traces for your project, newest first. Flag: `--limit <n>`. |
+| `traces list` | List traces for your project, newest first. Flags: `--limit <n>`, `--since <duration>`, `--from <timestamp>`, `--to <timestamp>`. |
 | `traces get <id>` | Show one trace: header, span tree, duration, and I/O preview. `--json` emits the full trace. |
 | `traces export <id>` | Write `trace.json`, `spans.json`, `git_context.json`, and a `manifest.json` index to a directory. Flags: `--output <dir>`, `--force`. |
+| `detectors list` | List your project's detectors, newest first. The `DETECTOR ID` column is what you pass to `findings list --detector`. Flags: `--limit <n>`, `--since <duration>`, `--from <timestamp>`, `--to <timestamp>`. |
+| `findings list` | List detector findings for your project, newest first. Flags: `--limit <n>`, `--since <duration>`, `--from <timestamp>`, `--to <timestamp>`, `--detector <id>`, `--trace <id>`. |
+| `findings get [id]` | Show one finding: per-detector results and its free-text root cause analysis. Look it up by finding id, or with `--trace <id>`. |
 
 ## What's next
 

--- a/docs/detectors/get-started.mdx
+++ b/docs/detectors/get-started.mdx
@@ -37,7 +37,7 @@ The pipeline that runs on every trace:
 
 ## View findings
 
-Open the detector to see its findings table. Each row links back to the trace that produced it; clicking the trace opens the trace viewer with a red **Alert** badge in the header.
+Open the detector to see its findings table. Each row links back to the trace that produced it; clicking the trace opens the trace viewer with a red **Alert** badge in the header.You can also read findings from the terminal with the [TraceRoot CLI](/cli/get-started).
 
 <Frame>
   <img src="/images/detector_findings_v1.png" alt="Detector findings table with the detail panel open" />


### PR DESCRIPTION
Closes #1445

The CLI shipped detector access (`detectors list`, `findings list`, `findings get`)
and time-range flags on every list command, but `docs/cli/get-started.mdx` still
covered only `login`, `status`, and `traces` — leaving the page reading as
traces-only.

Changes:
- Widen the intro from traces-only to traces + detector findings.
- Add a "Work with detectors and findings" section with runnable examples,
  including the `--json | jq` pipeline for piping findings into an agent.
- Add `detectors list`, `findings list`, and `findings get` to the command
  reference table; add `--since`/`--from`/`--to` to the `traces list` row.
- Add a shared "Time filters" note covering `--since` durations (`30m`, `6h`,
  `7d`, `2w`), ISO 8601 for `--from`/`--to`, and quoting timestamps with spaces.
- Cross-link from the detectors get-started page.

Source of truth for the flags is the `traceroot-cli` README, which already
documents the shipped surface accurately.

Not validated by running the CLI — this is a documentation-only change;
commands and flags were transcribed from the `traceroot-cli` README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the CLI docs to cover detector and finding commands that shipped but weren't documented, and adds time-range flags to list commands.

- Adds `detectors list`, `findings list`, and `findings get` to the command reference, plus `--since`/`--from`/`--to` on `traces list`.
- Adds a "Work with detectors and findings" section with runnable examples, including the `--json | jq` pipeline.
- Adds a shared "Time filters" note covering `--since` durations, ISO 8601 timestamps, and quoting timestamps with spaces.
- Widens the intro from traces-only to traces and detector findings.
- Cross-links from the detectors get-started page.
- Documentation-only; commands and flags are transcribed from the `traceroot-cli` README and were not validated by running the CLI.

Closes #1445.

<sup>Written for commit ba0ef7f422c632c8f8f46ffb1205546667bba640. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

