### PR TITLE
fix(pricing): price the six unpriced codex SKUs

### DIFF
--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -811,6 +811,78 @@
     }
   },
   {
+    "id": "tr-gpt-5-3-codex-spark",
+    "modelName": "gpt-5.3-codex-spark",
+    "matchPattern": "(?i)^(openai\\/)?(gpt-5\\.3-codex-spark)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.00000175,
+      "output": 0.000014,
+      "cacheRead": 0.000000175,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-gpt-5-2-codex",
+    "modelName": "gpt-5.2-codex",
+    "matchPattern": "(?i)^(openai\\/)?(gpt-5\\.2-codex)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.00000175,
+      "output": 0.000014,
+      "cacheRead": 0.000000175,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-gpt-5-1-codex-max",
+    "modelName": "gpt-5.1-codex-max",
+    "matchPattern": "(?i)^(openai\\/)?(gpt-5\\.1-codex-max)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.00000125,
+      "output": 0.00001,
+      "cacheRead": 0.000000125,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-gpt-5-1-codex-mini",
+    "modelName": "gpt-5.1-codex-mini",
+    "matchPattern": "(?i)^(openai\\/)?(gpt-5\\.1-codex-mini)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.00000025,
+      "output": 0.000002,
+      "cacheRead": 0.000000025,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-gpt-5-1-codex",
+    "modelName": "gpt-5.1-codex",
+    "matchPattern": "(?i)^(openai\\/)?(gpt-5\\.1-codex)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.00000125,
+      "output": 0.00001,
+      "cacheRead": 0.000000125,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-gpt-5-codex",
+    "modelName": "gpt-5-codex",
+    "matchPattern": "(?i)^(openai\\/)?(gpt-5-codex)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.00000125,
+      "output": 0.00001,
+      "cacheRead": 0.000000125,
+      "cacheWrite": null
+    }
+  },
+  {
     "id": "tr-gemini-3-5-flash",
     "modelName": "gemini-3.5-flash",
     "matchPattern": "(?i)^(google\\/|models\\/)?gemini-3\\.5-flash(-[\\d-]+)?$",

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -185,6 +185,38 @@ KIMI_MODEL_CASES = [
     ("kimi-k3-20260716", "kimi-k3"),
 ]
 
+# Every codex SKU the OpenAI provider table ships, with the sibling forms that make
+# the entries easy to get wrong: the -max / -mini / -spark suffixes are not dated
+# revisions, so a pattern ending in (-[\d-]+)? does not reach them and each needs
+# its own entry.
+CODEX_MODEL_CASES = [
+    ("gpt-5.3-codex", "gpt-5.3-codex"),
+    ("openai/gpt-5.3-codex", "gpt-5.3-codex"),
+    ("gpt-5.3-codex-spark", "gpt-5.3-codex-spark"),
+    ("openai/gpt-5.3-codex-spark", "gpt-5.3-codex-spark"),
+    ("gpt-5.2-codex", "gpt-5.2-codex"),
+    ("gpt-5.1-codex", "gpt-5.1-codex"),
+    ("gpt-5.1-codex-max", "gpt-5.1-codex-max"),
+    ("gpt-5.1-codex-mini", "gpt-5.1-codex-mini"),
+    ("openai/gpt-5.1-codex-mini", "gpt-5.1-codex-mini"),
+    ("gpt-5-codex", "gpt-5-codex"),
+    ("openai/gpt-5-codex", "gpt-5-codex"),
+    # Dated revisions still fold into the base SKU.
+    ("gpt-5.1-codex-2026-01-20", "gpt-5.1-codex"),
+    ("gpt-5-codex-2025-09-15", "gpt-5-codex"),
+]
+
+# Per-1M-token rates from the OpenAI provider table, as USD per token.
+CODEX_PUBLISHED_RATES = [
+    ("gpt-5-codex", 1.25e-06, 1e-05, 1.25e-07),
+    ("gpt-5.1-codex", 1.25e-06, 1e-05, 1.25e-07),
+    ("gpt-5.1-codex-max", 1.25e-06, 1e-05, 1.25e-07),
+    ("gpt-5.1-codex-mini", 2.5e-07, 2e-06, 2.5e-08),
+    ("gpt-5.2-codex", 1.75e-06, 1.4e-05, 1.75e-07),
+    ("gpt-5.3-codex", 1.75e-06, 1.4e-05, 1.75e-07),
+    ("gpt-5.3-codex-spark", 1.75e-06, 1.4e-05, 1.75e-07),
+]
+
 
 @patch("worker.tokens.pricing._load_cache", _mock_load_cache)
 class TestGetModelPrice:
@@ -301,6 +333,69 @@ class TestGpt56LunaPublishedPrices:
         entry = next(e for e in real_cache if e["model_name"] == "gpt-5.6-luna")
         assert entry["prices"]["input"] == pytest.approx(2e-7)  # $0.20 / 1M tokens
         assert entry["prices"]["output"] == pytest.approx(1.2e-6)  # $1.20 / 1M tokens
+
+
+class TestCodexModelIds:
+    """Codex SKUs price like any other model rather than reading $0 (#1545).
+
+    Only gpt-5.3-codex was catalogued, so six of the seven shipped SKUs matched no
+    pattern: get_model_price returned None, cost was stored as null, and the span
+    rendered with no cost at all — which reads as a broken dashboard rather than a
+    missing catalogue row.
+    """
+
+    @pytest.mark.parametrize("model_id,expected_name", CODEX_MODEL_CASES)
+    def test_matches_expected_model(self, real_cache, model_id, expected_name):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            price = get_model_price(model_id)
+
+        assert price is not None, f"{model_id} should match a pricing entry but returned None"
+        assert price[MATCHED_MODEL_NAME] == expected_name, (
+            f"{model_id} matched a different entry than {expected_name}"
+        )
+
+    @pytest.mark.parametrize("model_id,expected_name", CODEX_MODEL_CASES)
+    def test_matches_exactly_one_entry(self, real_cache, model_id, expected_name):
+        """The SKU names nest — gpt-5.1-codex is a prefix of gpt-5.1-codex-max — so a
+        pattern that forgets its anchor prices two models at once and the winner
+        depends on catalogue order."""
+        matching = [
+            e["model_name"]
+            for e in real_cache
+            if re.search(e["match_pattern"], model_id, re.IGNORECASE)
+        ]
+        assert matching == [expected_name], (
+            f"{model_id} must match exactly the {expected_name} pattern, got {matching}"
+        )
+
+    @pytest.mark.parametrize(
+        "model_name,input_rate,output_rate,cache_read_rate", CODEX_PUBLISHED_RATES
+    )
+    def test_rates_match_the_published_figures(
+        self, real_cache, model_name, input_rate, output_rate, cache_read_rate
+    ):
+        """Absolute rates, not ratios: sibling SKUs share a rate card, so a row copied
+        from the wrong sibling stays internally consistent and passes a ratio check."""
+        entry = next(e for e in real_cache if e["model_name"] == model_name)
+        assert entry["prices"]["input"] == pytest.approx(input_rate)
+        assert entry["prices"]["output"] == pytest.approx(output_rate)
+        assert entry["prices"]["cacheRead"] == pytest.approx(cache_read_rate)
+
+    def test_mini_is_not_priced_like_the_rest_of_the_family(self, real_cache):
+        """gpt-5.1-codex-mini bills at a fifth of gpt-5.1-codex. Copying the family
+        rate card onto it would overcharge every mini span by 5x."""
+        mini = next(e for e in real_cache if e["model_name"] == "gpt-5.1-codex-mini")
+        full = next(e for e in real_cache if e["model_name"] == "gpt-5.1-codex")
+        assert mini["prices"]["input"] == pytest.approx(full["prices"]["input"] / 5)
+        assert mini["prices"]["output"] == pytest.approx(full["prices"]["output"] / 5)
+
+    def test_reported_model_calculates_a_cost(self, real_cache):
+        """The id from the issue, end to end."""
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            result = calculate_cost("gpt-5.1-codex-mini", "Hello world", "Hi there")
+
+        assert result["cost"] is not None
+        assert result["cost"] > 0
 
 
 class TestGeminiModelIds:


### PR DESCRIPTION
Closes #1545.

## What was wrong

`gpt-5.3-codex` was the only codex SKU in `standard-model-prices.json`. Every other one matched no entry, so `get_model_price` returned `None`, `cost_from_buckets` returned `None`, and the span stored `cost: null`. On the dashboard that renders as no cost at all, which reads as a broken cost column rather than a missing catalogue row.

Checked against the OpenAI provider table that ships in `@earendil-works/pi-ai`, the same source the issue cites:

| SKU | Priced before | Priced now |
|---|---|---|
| `gpt-5-codex` | no | yes |
| `gpt-5.1-codex` | no | yes |
| `gpt-5.1-codex-max` | no | yes |
| `gpt-5.1-codex-mini` | no | yes |
| `gpt-5.2-codex` | no | yes |
| `gpt-5.3-codex` | yes | unchanged |
| `gpt-5.3-codex-spark` | no | yes |

## Why the suffixes each need their own entry

The catalogue convention ends a pattern with `(-[\d-]+)?$`, which absorbs a dated revision such as `gpt-5.1-codex-2026-01-20`. It does not reach `-max`, `-mini` or `-spark`, since those are not digits. That is why the existing `gpt-5.3-codex` pattern never caught its own `-spark` sibling, and it is why each SKU gets a row rather than one widened pattern.

Widening the pattern instead would be actively wrong: `gpt-5.1-codex-mini` bills at a fifth of `gpt-5.1-codex`, so folding the family into one entry would overcharge every mini span by 5x.

## Rates

Taken from the provider table rather than inferred from siblings, as USD per token:

| SKU | input | output | cacheRead |
|---|---|---|---|
| `gpt-5-codex` | 1.25e-6 | 1e-5 | 1.25e-7 |
| `gpt-5.1-codex` | 1.25e-6 | 1e-5 | 1.25e-7 |
| `gpt-5.1-codex-max` | 1.25e-6 | 1e-5 | 1.25e-7 |
| `gpt-5.1-codex-mini` | 2.5e-7 | 2e-6 | 2.5e-8 |
| `gpt-5.2-codex` | 1.75e-6 | 1.4e-5 | 1.75e-7 |
| `gpt-5.3-codex-spark` | 1.75e-6 | 1.4e-5 | 1.75e-7 |

The already-present `gpt-5.3-codex` row matches that table exactly, which is a useful check that it is the right source. `cacheWrite` is `null` throughout, matching every other OpenAI entry.

## Tests

`TestCodexModelIds` in `tests/worker/tokens/test_pricing.py`, built on the existing `real_cache` fixture so it reads the shipped catalogue rather than a mock:

- every SKU resolves, bare and `openai/`-prefixed, and dated revisions still fold into the base SKU
- each id matches **exactly one** entry. The names nest, `gpt-5.1-codex` is a prefix of `gpt-5.1-codex-max`, so a pattern that lost its anchor would price two models at once and the winner would depend on catalogue order
- absolute published rates, not ratios. Sibling SKUs share a rate card, so a row copied from the wrong sibling stays internally consistent and would pass a ratio check
- `gpt-5.1-codex-mini` is a fifth of `gpt-5.1-codex`, guarding the 5x overcharge above
- the exact id from the issue, `gpt-5.1-codex-mini`, priced end to end through `calculate_cost`

30 of the 35 new cases fail against the catalogue as it stands today, verified by reverting the JSON and re-running. 277 tests pass in the pricing module; prettier and ruff clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1545 by adding price entries for the six unpriced Codex SKUs. Previously only `gpt-5.3-codex` was catalogued, so the other six SKUs matched no pattern, `get_model_price` returned `None`, and spans recorded `cost: null`, which rendered as a broken cost column on the dashboard.

- Each SKU gets its own entry because the pattern ending `(-[\d-]+)?$` only absorbs dated revisions, not `-max`, `-mini`, or `-spark` suffixes; widening the pattern would overcharge `gpt-5.1-codex-mini` by 5x.
- Rates come from the OpenAI provider table in `@earendil-works/pi-ai`, and the existing `gpt-5.3-codex` row matches that table exactly.
- Adds `TestCodexModelIds` covering SKU resolution, exact one-entry matches, absolute published rates, and the mini-to-family 5x ratio.

<sup>Written for commit 926b52c06acbfea7c6b5b64730162b629a2e8dd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

