### PR TITLE
fix(billing): meter detector scans that completed, not every attempt

### DIFF
--- a/backend/rest/routers/internal/usage.py
+++ b/backend/rest/routers/internal/usage.py
@@ -130,10 +130,19 @@ async def get_usage_details(
     traces = int(traces_result.result_rows[0][0]) if traces_result.result_rows else 0
     spans = int(spans_result.result_rows[0][0]) if spans_result.result_rows else 0
 
-    # Detector runs: count every scan attempt recorded by the detector worker
+    # Detector runs: count the scans the worker actually completed
     # (BYOK + system source both count toward Free-plan hard cap).
     # uniqExact on run_id dedups pre-merge duplicates in the ReplacingMergeTree —
     # same pattern as the traces / spans queries above.
+    #
+    # status is filtered because detector_runs records a row per attempt, and a
+    # failed attempt is not a scan: a missing provider key or a spans-download
+    # error writes a run that never reached a model. Left uncounted, a run of
+    # those burns a Free workspace's 100-scan cap without any inference, and on
+    # paid plans it inflates the scansRun denominator that apportions hosted-LLM
+    # overage. Filtering rows rather than the merged state is safe here: a retry
+    # reuses the deterministic run_id, so an attempt that failed and then
+    # succeeded contributes one completed row and uniqExact counts it once.
     detector_runs_result = ch.query(
         """
         SELECT uniqExact(run_id) as total
@@ -141,6 +150,7 @@ async def get_usage_details(
         WHERE project_id IN {project_ids:Array(String)}
           AND timestamp >= {start:String}
           AND timestamp < {end:String}
+          AND status = 'completed'
         """,
         parameters={
             "project_ids": project_id_list,

--- a/backend/rest/routers/internal/usage.py
+++ b/backend/rest/routers/internal/usage.py
@@ -1,5 +1,6 @@
 """Usage metering reads for billing."""
 
+import os
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, Query
@@ -10,6 +11,17 @@ from rest.routers.internal.auth import verify_internal_secret
 from rest.sql_utils import to_utc_naive
 
 router = APIRouter()
+
+# When the worker began distinguishing a detector run that reached a model from
+# one that did not. A 'failed' row older than this predates that distinction and
+# could be either, so it is counted as it was before the distinction existed
+# rather than dropped, which would restate a period already part-billed.
+#
+# Transitional. Once no billing window reaches back this far, both this and the
+# 'failed' arm of the detector_runs predicate can go. Override it with
+# DETECTOR_STATUS_CUTOVER if the worker rolls out at a different time from this
+# service.
+DETECTOR_STATUS_CUTOVER = os.getenv("DETECTOR_STATUS_CUTOVER", "2026-09-12 00:00:00")
 
 
 class UsageTotalResponse(BaseModel):
@@ -148,6 +160,14 @@ async def get_usage_details(
     # repeating it. The worker distinguishes the two when it writes the row:
     # 'failed' never reached a model, 'failed_after_inference' did.
     #
+    # Rows written before the worker learned that spelling cannot be told apart,
+    # so they are counted the way they were before this filter existed. That
+    # keeps the change from retroactively reducing a period already part-billed,
+    # and it expires on its own once no queried window reaches back this far.
+    # Backfilling instead is not available: aIMessage records the inference but
+    # carries no run or trace id to join back on, and deriving the count from
+    # those rows would double-count a retry that detector_runs dedups by run_id.
+    #
     # Filtering rows rather than the merged state is safe here: a retry reuses
     # the deterministic run_id, so an attempt that failed and then succeeded
     # contributes one counted row and uniqExact counts it once.
@@ -158,12 +178,16 @@ async def get_usage_details(
         WHERE project_id IN {project_ids:Array(String)}
           AND timestamp >= {start:String}
           AND timestamp < {end:String}
-          AND status IN ('completed', 'failed_after_inference')
+          AND (
+            status IN ('completed', 'failed_after_inference')
+            OR (status = 'failed' AND timestamp < {status_cutover:String})
+          )
         """,
         parameters={
             "project_ids": project_id_list,
             "start": start_str,
             "end": end_str,
+            "status_cutover": DETECTOR_STATUS_CUTOVER,
         },
     )
     detector_runs = (

--- a/backend/rest/routers/internal/usage.py
+++ b/backend/rest/routers/internal/usage.py
@@ -135,14 +135,22 @@ async def get_usage_details(
     # uniqExact on run_id dedups pre-merge duplicates in the ReplacingMergeTree —
     # same pattern as the traces / spans queries above.
     #
-    # status is filtered because detector_runs records a row per attempt, and a
-    # failed attempt is not a scan: a missing provider key or a spans-download
-    # error writes a run that never reached a model. Left uncounted, a run of
-    # those burns a Free workspace's 100-scan cap without any inference, and on
-    # paid plans it inflates the scansRun denominator that apportions hosted-LLM
-    # overage. Filtering rows rather than the merged state is safe here: a retry
-    # reuses the deterministic run_id, so an attempt that failed and then
-    # succeeded contributes one completed row and uniqExact counts it once.
+    # status is filtered because detector_runs records a row per attempt, and an
+    # attempt that never reached a model is not a scan: a missing provider key or
+    # a spans-download error writes such a run. Left uncounted, a run of those
+    # burns a Free workspace's 100-scan cap without any inference, and on paid
+    # plans it inflates the scansRun denominator that apportions hosted-LLM
+    # overage.
+    #
+    # Failure alone is the wrong test, though. An eval that fails after the model
+    # answered has spent its tokens, and their cost is metered, so it is a scan
+    # and must be counted or the cap and the overage split can both be evaded by
+    # repeating it. The worker distinguishes the two when it writes the row:
+    # 'failed' never reached a model, 'failed_after_inference' did.
+    #
+    # Filtering rows rather than the merged state is safe here: a retry reuses
+    # the deterministic run_id, so an attempt that failed and then succeeded
+    # contributes one counted row and uniqExact counts it once.
     detector_runs_result = ch.query(
         """
         SELECT uniqExact(run_id) as total
@@ -150,7 +158,7 @@ async def get_usage_details(
         WHERE project_id IN {project_ids:Array(String)}
           AND timestamp >= {start:String}
           AND timestamp < {end:String}
-          AND status = 'completed'
+          AND status IN ('completed', 'failed_after_inference')
         """,
         parameters={
             "project_ids": project_id_list,

--- a/frontend/worker/src/detection/clickhouse-writer.ts
+++ b/frontend/worker/src/detection/clickhouse-writer.ts
@@ -23,13 +23,22 @@ async function internalPost(path: string, body: unknown): Promise<void> {
   }
 }
 
+/**
+ * Terminal state of a detector run, as stored in ClickHouse.
+ *
+ * The distinction that matters for metering is whether a model was reached, not
+ * whether the run succeeded: 'failed' never reached one, so nothing was spent,
+ * while 'failed_after_inference' did and its tokens are billed like any scan.
+ */
+export type DetectorRunStatus = "completed" | "failed" | "failed_after_inference";
+
 export async function writeDetectorRun(params: {
   runId: string;
   detectorId: string;
   projectId: string;
   traceId: string;
   findingId: string | null;
-  status: "completed" | "failed";
+  status: DetectorRunStatus;
   // True when the worker emitted a self-trace for this run — set
   // optimistically at emit time, before ingestion is guaranteed; gates the
   // runs-tab link to the run's own trace. Omitted (false) when no emit

--- a/frontend/worker/src/processors/__tests__/detector-run-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-run-processor.test.ts
@@ -429,6 +429,48 @@ describe("processTrace — self-trace emission", () => {
     );
   });
 
+  it("marks an eval that failed after the model answered as a scan", async () => {
+    // The tokens were spent and their cost is metered, so the run has to keep
+    // counting towards scansRun. Recording it as a plain failure would leave a
+    // repeatable way to spend hosted inference without moving the meter.
+    mockRunDetection.mockResolvedValue({
+      ...CLEAN_RESULT,
+      error: "LLM did not call submit_result after retry",
+    });
+
+    await processTrace("t1", "p1", ["d1"]);
+
+    expect(mockWriteRun).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "failed_after_inference" }),
+    );
+  });
+
+  it("marks an eval that never reached the model as a plain failure", async () => {
+    // No API key, an unknown model, a BYOK detector with no provider: errorResult
+    // returns with its inference fields left at zero, and nothing was spent.
+    mockRunDetection.mockResolvedValue({
+      ...CLEAN_RESULT,
+      error: 'No API key configured for provider "anthropic"',
+      inferenceCost: 0,
+      inferenceInputTokens: 0,
+      inferenceOutputTokens: 0,
+      inferenceModel: null,
+      inferenceProvider: null,
+    });
+
+    await processTrace("t1", "p1", ["d1"]);
+
+    expect(mockWriteRun).toHaveBeenCalledWith(expect.objectContaining({ status: "failed" }));
+  });
+
+  it("still records a clean eval as completed", async () => {
+    mockRunDetection.mockResolvedValue(CLEAN_RESULT);
+
+    await processTrace("t1", "p1", ["d1"]);
+
+    expect(mockWriteRun).toHaveBeenCalledWith(expect.objectContaining({ status: "completed" }));
+  });
+
   it("carries selfTraced onto the triggered run write", async () => {
     mockRunDetection.mockResolvedValue({ ...CLEAN_RESULT, identified: true, summary: "found" });
 

--- a/frontend/worker/src/processors/detector-run-processor.ts
+++ b/frontend/worker/src/processors/detector-run-processor.ts
@@ -150,6 +150,19 @@ export interface ScanUsage {
   inferenceProvider: string | null;
 }
 
+/**
+ * Whether the run actually reached a model.
+ *
+ * A detector that fails before the call — no API key, an unknown model, a BYOK
+ * detector with no provider — returns an error result with its inference fields
+ * left at zero. One that fails after the call returns the tokens it spent.
+ */
+function consumedInference(usage: ScanUsage): boolean {
+  return (
+    usage.inferenceInputTokens > 0 || usage.inferenceOutputTokens > 0 || usage.inferenceCost > 0
+  );
+}
+
 async function detectorInferenceCost(usage: ScanUsage): Promise<number> {
   if (
     usage.inferenceCost > 0 ||
@@ -293,14 +306,24 @@ async function runSingleDetector(params: {
         `[Detector] Eval failed for detector ${detector.name} (${detector.id}) on trace ${traceId}: ${result.error}`,
       );
     }
-    // Not triggered — write run immediately (no finding_id)
+    // Not triggered — write run immediately (no finding_id).
+    //
+    // An eval that failed after the model answered is still a scan: the tokens
+    // were spent and their cost is metered. Only a run that never reached a
+    // model is not one. errorResult carries the inference it accumulated, so
+    // the two are told apart by that rather than by the failure itself, and the
+    // status keeps them distinguishable for anything counting scans.
     await writeDetectorRun({
       runId,
       detectorId: detector.id,
       projectId,
       traceId,
       findingId: null,
-      status: result.error ? "failed" : "completed",
+      status: !result.error
+        ? "completed"
+        : consumedInference(usage)
+          ? "failed_after_inference"
+          : "failed",
       selfTraced,
     }).catch((err) => console.error("[Detector] Failed to write run:", err));
     return { triggered: null, usage };

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -1097,8 +1097,8 @@ class TestUsageBillsEveryStoredRow:
         # paid for the inference, so the BYOK/system split must stay invisible here.
         assert "source" not in runs_sql
 
-    def test_detector_runs_are_metered_only_when_the_scan_completed(self, client, mock_ch, secret):
-        """A failed attempt is not a scan.
+    def test_detector_runs_are_metered_only_when_a_model_was_reached(self, client, mock_ch, secret):
+        """An attempt that never reached a model is not a scan.
 
         detector_runs holds a row per attempt, and the worker writes status='failed'
         for runs that never reached a model — a missing provider key, or a
@@ -1118,11 +1118,40 @@ class TestUsageBillsEveryStoredRow:
         )
         assert resp.status_code == 200
         runs_sql = mock_ch.query.call_args_list[2].args[0]
-        assert "status = 'completed'" in runs_sql
+        assert "'completed'" in runs_sql
+        assert "'failed_after_inference'" in runs_sql
         # The traces / spans meters are storage, not inference — a status predicate
         # there would silently stop billing stored rows.
         assert "status" not in mock_ch.query.call_args_list[0].args[0]
         assert "status" not in mock_ch.query.call_args_list[1].args[0]
+
+    def test_a_run_that_failed_after_inference_is_still_metered(self, client, mock_ch, secret):
+        """Failure alone is the wrong test for whether a scan happened.
+
+        The worker writes 'failed' only when no model was reached; an eval that
+        failed after the model answered is written as 'failed_after_inference',
+        because the tokens were spent and their cost is metered. Excluding those
+        would leave a repeatable way to spend hosted inference without moving
+        scansRun, which both evades the Free plan cap and shrinks the denominator
+        that apportions paid overage.
+        """
+        mock_ch.query.side_effect = [
+            _make_query_result([(3,)], ["total"]),
+            _make_query_result([(9,)], ["total"]),
+            _make_query_result([(2,)], ["total"]),
+        ]
+        resp = client.get(
+            "/api/v1/internal/usage/details",
+            params=self.PARAMS,
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        runs_sql = mock_ch.query.call_args_list[2].args[0]
+        assert "'failed_after_inference'" in runs_sql
+        # The bare 'failed' rows are the ones that must stay out. Asserting the
+        # predicate shape rather than its text keeps this honest if the SQL is
+        # reformatted: 'failed' appears inside 'failed_after_inference'.
+        assert "status IN ('completed', 'failed_after_inference')" in runs_sql
 
     def test_usage_total_counts_rows_from_every_source(self, client, mock_ch, secret):
         mock_ch.query.side_effect = [_make_query_result([(12,)], ["total"])]

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -1093,8 +1093,36 @@ class TestUsageBillsEveryStoredRow:
         # would silently stop billing self-traces again.
         assert "source" not in traces_sql
         assert "source" not in spans_sql
-        # detector_runs was never filtered — it is the per-evaluation result record.
+        # detector_runs is filtered on status, never on source: a scan counts whoever
+        # paid for the inference, so the BYOK/system split must stay invisible here.
         assert "source" not in runs_sql
+
+    def test_detector_runs_are_metered_only_when_the_scan_completed(self, client, mock_ch, secret):
+        """A failed attempt is not a scan.
+
+        detector_runs holds a row per attempt, and the worker writes status='failed'
+        for runs that never reached a model — a missing provider key, or a
+        spans-download error. Counting those bills inference that never happened:
+        a run of key failures exhausts a Free workspace's 100-scan cap, and on paid
+        plans it inflates the scansRun denominator that apportions hosted-LLM overage.
+        """
+        mock_ch.query.side_effect = [
+            _make_query_result([(3,)], ["total"]),
+            _make_query_result([(9,)], ["total"]),
+            _make_query_result([(2,)], ["total"]),
+        ]
+        resp = client.get(
+            "/api/v1/internal/usage/details",
+            params=self.PARAMS,
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        runs_sql = mock_ch.query.call_args_list[2].args[0]
+        assert "status = 'completed'" in runs_sql
+        # The traces / spans meters are storage, not inference — a status predicate
+        # there would silently stop billing stored rows.
+        assert "status" not in mock_ch.query.call_args_list[0].args[0]
+        assert "status" not in mock_ch.query.call_args_list[1].args[0]
 
     def test_usage_total_counts_rows_from_every_source(self, client, mock_ch, secret):
         mock_ch.query.side_effect = [_make_query_result([(12,)], ["total"])]

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -1148,10 +1148,40 @@ class TestUsageBillsEveryStoredRow:
         assert resp.status_code == 200
         runs_sql = mock_ch.query.call_args_list[2].args[0]
         assert "'failed_after_inference'" in runs_sql
-        # The bare 'failed' rows are the ones that must stay out. Asserting the
-        # predicate shape rather than its text keeps this honest if the SQL is
-        # reformatted: 'failed' appears inside 'failed_after_inference'.
-        assert "status IN ('completed', 'failed_after_inference')" in runs_sql
+        # Bare 'failed' rows written after the cutover must stay out. Note that
+        # 'failed' also appears inside 'failed_after_inference', so the arm has
+        # to be matched by its shape rather than by the word alone.
+        assert "status = 'failed' AND timestamp < {status_cutover:String}" in runs_sql
+        assert mock_ch.query.call_args_list[2].kwargs["parameters"]["status_cutover"]
+
+    def test_runs_predating_the_distinction_are_counted_as_they_were(self, client, mock_ch, secret):
+        """A 'failed' row older than the cutover could be either kind of failure.
+
+        The worker only began writing 'failed_after_inference' at this release, so
+        rows written before it conflate a run that reached a model with one that
+        did not. Dropping them all would restate a billing period already part
+        charged, and would hand back exactly the gap this branch is closing, so
+        they keep counting the way they did before the filter existed.
+
+        Backfilling is not an option: aIMessage records the inference but carries
+        no run or trace id to join back on, and counting those rows instead would
+        double-count a retry that detector_runs dedups by run_id.
+        """
+        mock_ch.query.side_effect = [
+            _make_query_result([(3,)], ["total"]),
+            _make_query_result([(9,)], ["total"]),
+            _make_query_result([(2,)], ["total"]),
+        ]
+        resp = client.get(
+            "/api/v1/internal/usage/details",
+            params=self.PARAMS,
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        call = mock_ch.query.call_args_list[2]
+        assert "status = 'failed' AND timestamp < {status_cutover:String}" in call.args[0]
+        # Passed as a parameter, not interpolated, like every other bound value here.
+        assert "status_cutover" in call.kwargs["parameters"]
 
     def test_usage_total_counts_rows_from_every_source(self, client, mock_ch, secret):
         mock_ch.query.side_effect = [_make_query_result([(12,)], ["total"])]


### PR DESCRIPTION
Closes #2033.

## The fix

`/api/v1/internal/usage/details` counted every `detector_runs` row. The table records one row per attempt, so runs that never reached a model were metered as scans. `status = 'completed'` is now part of the predicate.

That count feeds `detector.scansRun`, which enforces the Free plan's 100-scan hard cap and apportions hosted-LLM overage on paid plans. A stretch of failures from a missing provider key can therefore exhaust a workspace's cap without a single model call.

## Why filtering rows is safe here

`detector_runs` is a `ReplacingMergeTree` keyed on `(project_id, detector_id, run_id)`, so filtering rows before the merge is not automatically the same as filtering the merged state. It is equivalent in this case because the worker derives `run_id` deterministically from `sha256(project:trace:detector)`. An attempt that failed and was then retried successfully contributes one `completed` row, and `uniqExact(run_id)` counts it once. Retries only follow a failure, so the reverse ordering does not arise.

I kept the row-level predicate rather than reaching for `argMax(status, timestamp)` for that reason: same answer, and it stays consistent with the `uniqExact` pattern the traces and spans meters already use.

## Test

`test_detector_runs_are_metered_only_when_the_scan_completed` in `TestUsageBillsEveryStoredRow` asserts the predicate reaches `runs_sql`, and asserts it is **absent** from the traces and spans queries. Those two meter storage rather than inference, so a status filter there would silently stop billing stored rows.

The existing guard that no `source` token appears in `runs_sql` still holds. I reworded its comment, since the reason is now that a scan counts whoever paid for the inference, not that the query is unfiltered.

Fails against the current query, verified by reverting it. 1159 tests pass in `tests/rest`; ruff clean.

## One thing the issue does not cover

There is a second class of `status='failed'` run that this predicate now also excludes, and unlike the first class it **did** consume inference.

`frontend/worker/src/processors/detector-run-processor.ts:303` writes `status: result.error ? "failed" : "completed"` on a run where the model call already succeeded and the evaluation then failed. That path returns a populated `usage`, and `detector-run-processor.ts:419-446` writes an `aIMessage` row with `kind="detector"` and a real cost for exactly those runs.

So after this change:

- cost for such a run is still billed, through `aIMessage`
- the run no longer counts in `scansRun`

`detectorBillableCost = cost × overageScans / scansRun` reads both numbers, so those runs now sit in the numerator's cost but not the denominator's count.

I left it alone deliberately. The two classes are indistinguishable in `detector_runs` as it stands, since both write the same `status` string, and separating them means either a third status value or keying `scansRun` off `aIMessage` instead. Both are larger calls than this issue asked for, and both change what a "scan" means for billing.

The direction of the residual gap is also the safe one: it under-counts rather than over-counts, and it applies to eval errors after a successful model call, which are far rarer than the key-failure runs this fixes. Happy to open a follow-up if you want it closed properly, and happy to fold either approach into this PR if you'd rather have it in one place.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes detector scan metering so only runs that reached a model count toward the Free plan's 100-scan cap; eval failures after a model call still count as scans, and rows predating the fix keep counting as they did before.

- The `detector_runs` query counts `completed` and `failed_after_inference`; runs that never reached a model (`failed`) stay uncounted.
- `failed` rows written before the worker learned to distinguish the two statuses are counted as before via a cutover timestamp, so already-billed periods are not restated.
- The worker writes `failed_after_inference` when the model answered but the eval failed, keeping those runs in the scan count while their cost is still billed through `aIMessage`.

<sup>Written for commit 0e828b47c75925083ea117123a75b89b8aaa17ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

