### PR TITLE
fix(slack)-disclose omitted alert filters in trace links

### DIFF
--- a/frontend/packages/slack/src/__tests__/alert-blocks.test.ts
+++ b/frontend/packages/slack/src/__tests__/alert-blocks.test.ts
@@ -272,7 +272,8 @@ describe("buildAlertBlocks", () => {
     // the fallback carries the clause too, for clients that render no blocks
     expect(filtered.text).toContain("Where `span_kind = LLM` and");
 
-    const url = links.match(/<([^|]+)\|View traces>/)![1];
+    expect(links).toContain("View traces (some filters not applied)");
+    const url = links.match(/<([^|]+)\|View traces \(some filters not applied\)>/)![1];
     const filtersParam = new URL(url).searchParams.get("filters");
     expect(JSON.parse(filtersParam!)).toEqual([
       { field: "span_kind", op: "in", value: ["LLM"] },

--- a/frontend/packages/slack/src/alert-blocks.ts
+++ b/frontend/packages/slack/src/alert-blocks.ts
@@ -4,6 +4,7 @@ import {
   ALERT_THRESHOLD_OPERATOR_PHRASES,
   alertFiltersToTracePredicates,
   describeAlertFilter,
+  isCompleteAlertFilter,
   type AlertFilter,
   type AlertSeverity,
   type AlertThresholdOperator,
@@ -157,11 +158,16 @@ export function buildAlertBlocks(params: AlertBlockParams): AlertSlackMessage {
   // A recovery is within threshold and NO_DATA is empty: a traces link lands on nothing.
   // "Traces", not "spans": the list shows traces containing a matching span.
   if (severity === "ALERT") {
+    const predicates = alertFiltersToTracePredicates(filters);
+    const completeFilters = filters.filter(isCompleteAlertFilter);
+    const hasUnsupportedFilters = predicates.length < completeFilters.length;
+
+    const label = hasUnsupportedFilters ? "View traces (some filters not applied)" : "View traces";
+
     links.push(
-      `<${alertTracesUrl(appBaseUrl, projectId, windowStart, windowEnd, filters)}|View traces>`,
+      `<${alertTracesUrl(appBaseUrl, projectId, windowStart, windowEnd, filters)}|${label}>`,
     );
   }
-
   const footer = `${formatWindowRange(windowStart, windowEnd)} · ${previousSeverity} to ${severity}`;
 
   const blocks = [


### PR DESCRIPTION
## What

Disclose when an alert's "View traces" link cannot carry all of the rule's filters.

## Why

Some alert filters cannot be represented by the trace list. Previously, those filters were silently omitted from the link, which could make the linked trace results look broader than the alert condition.

The link now shows "View traces (some filters not applied)" when applicable.

## Validation

- `pnpm --dir frontend --filter @traceroot/slack test`
- `pnpm --dir frontend --filter @traceroot/slack build`
- `git diff --check`
- `pre-commit run --files frontend/packages/slack/src/alert-blocks.ts frontend/packages/slack/src/__tests__/alert-blocks.test.ts`

Closes #2144

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Slack "View traces" link so it discloses when some alert filters can't be represented in the trace list. Previously those filters were silently dropped, making the linked results look broader than the alert condition; the link now reads "View traces (some filters not applied)" in that case. Closes #2144.

<sup>Written for commit d6a4ba6382d9eb22804aea73daf3340be5c8cdbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

