### PR TITLE
fix(api): make list_users end_before an exclusive upper bound

### DIFF
--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -1384,7 +1384,7 @@ class TraceReaderService:
             params["start_after"] = to_utc_naive(start_after)
 
         if end_before:
-            conditions.append("t.trace_start_time <= {end_before:DateTime64(3)}")
+            conditions.append("t.trace_start_time < {end_before:DateTime64(3)}")
             params["end_before"] = to_utc_naive(end_before)
 
         if not include_evaluations:


### PR DESCRIPTION
Closes #1366

## What
In `backend/rest/services/trace_reader.py`, `list_users` built its `end_before` filter as a **closed** upper bound (`<=`), while `list_traces`, `list_sessions`, `get_session`, and `_distinct_values` all use `<` (exclusive). This made the users tab include one extra boundary trace per page, so totals disagreed across tabs sharing the same `end_before` filter.

## Change
Changed the single `<=` in `list_users` to `<`. After this, all 5
`end_before:DateTime64` predicates in the file use `<`.

## Validation
I verified the change by static inspection of `trace_reader.py` (all `end_before` predicates now consistent) and confirmed the diff is scoped to this one predicate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `list_users` API so `end_before` is an exclusive upper bound, matching the other trace list endpoints and preventing an extra boundary trace per page. Closes #1366.

<sup>Written for commit 6b3654d31fb50749cb31d8a03a7861a251b2d459. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

