### PR TITLE
fix(agent): bound the Daytona init commands so a slow mirror cannot hold a turn open

### DIFF
--- a/frontend/ee/agent/src/executors/__tests__/daytona.test.ts
+++ b/frontend/ee/agent/src/executors/__tests__/daytona.test.ts
@@ -22,17 +22,25 @@ const mockDaytona = {
 
 vi.mock("@daytonaio/sdk", () => {
   // Declared inside the factory: vi.mock is hoisted above top-level bindings.
-  class DaytonaTimeoutError extends Error {}
+  class DaytonaError extends Error {
+    statusCode?: number;
+    constructor(message: string, statusCode?: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  }
+  class DaytonaTimeoutError extends DaytonaError {}
   return {
     // A function (not an arrow) so vitest 4 can construct it with `new`.
     Daytona: vi.fn(function Daytona() {
       return mockDaytona;
     }),
+    DaytonaError,
     DaytonaTimeoutError,
   };
 });
 
-import { DaytonaTimeoutError } from "@daytonaio/sdk";
+import { DaytonaError, DaytonaTimeoutError } from "@daytonaio/sdk";
 import { DaytonaExecutor } from "../daytona.js";
 
 describe("DaytonaExecutor", () => {
@@ -99,7 +107,9 @@ describe("DaytonaExecutor", () => {
     it("finishes init when the tool install times out", async () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       mockSandbox.process.executeCommand.mockImplementation(async (cmd: string) => {
-        if (cmd.includes("apt-get")) throw new Error("Command timed out after 300 seconds");
+        // The toolbox answered: a server-side per-command deadline.
+        if (cmd.includes("apt-get"))
+          throw new DaytonaError("Command timed out after 300 seconds", 408);
         return { exitCode: 0, result: "" };
       });
 
@@ -121,6 +131,22 @@ describe("DaytonaExecutor", () => {
 
       await expect(executor.init()).resolves.toBeUndefined();
       expect(executor.isReady()).toBe(true);
+      warn.mockRestore();
+    });
+
+    it("rethrows a transport failure even when its message mentions a timeout", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      // No HTTP status: the request never reached the toolbox.
+      const failure = new DaytonaError("connect ETIMEDOUT 10.0.0.5:2280");
+      mockSandbox.process.executeCommand.mockImplementation(async (cmd: string) => {
+        if (cmd.includes("apt-get")) throw failure;
+        return { exitCode: 0, result: "" };
+      });
+
+      await expect(executor.init()).rejects.toBe(failure);
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("Tool install did not finish within"),
+      );
       warn.mockRestore();
     });
 

--- a/frontend/ee/agent/src/executors/__tests__/daytona.test.ts
+++ b/frontend/ee/agent/src/executors/__tests__/daytona.test.ts
@@ -20,13 +20,19 @@ const mockDaytona = {
   create: vi.fn().mockResolvedValue(mockSandbox),
 };
 
-vi.mock("@daytonaio/sdk", () => ({
-  // A function (not an arrow) so vitest 4 can construct it with `new`.
-  Daytona: vi.fn(function Daytona() {
-    return mockDaytona;
-  }),
-}));
+vi.mock("@daytonaio/sdk", () => {
+  // Declared inside the factory: vi.mock is hoisted above top-level bindings.
+  class DaytonaTimeoutError extends Error {}
+  return {
+    // A function (not an arrow) so vitest 4 can construct it with `new`.
+    Daytona: vi.fn(function Daytona() {
+      return mockDaytona;
+    }),
+    DaytonaTimeoutError,
+  };
+});
 
+import { DaytonaTimeoutError } from "@daytonaio/sdk";
 import { DaytonaExecutor } from "../daytona.js";
 
 describe("DaytonaExecutor", () => {
@@ -102,6 +108,33 @@ describe("DaytonaExecutor", () => {
       expect(executor.isReady()).toBe(true);
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining("Tool install did not finish within 300s"),
+      );
+      warn.mockRestore();
+    });
+
+    it("also treats the SDK's own DaytonaTimeoutError as a timeout", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockSandbox.process.executeCommand.mockImplementation(async (cmd: string) => {
+        if (cmd.includes("apt-get")) throw new DaytonaTimeoutError("deadline exceeded");
+        return { exitCode: 0, result: "" };
+      });
+
+      await expect(executor.init()).resolves.toBeUndefined();
+      expect(executor.isReady()).toBe(true);
+      warn.mockRestore();
+    });
+
+    it("rethrows a non-timeout install failure instead of reporting a ready sandbox", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const failure = new Error("Sandbox not found");
+      mockSandbox.process.executeCommand.mockImplementation(async (cmd: string) => {
+        if (cmd.includes("apt-get")) throw failure;
+        return { exitCode: 0, result: "" };
+      });
+
+      await expect(executor.init()).rejects.toBe(failure);
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("Tool install did not finish within"),
       );
       warn.mockRestore();
     });

--- a/frontend/ee/agent/src/executors/__tests__/daytona.test.ts
+++ b/frontend/ee/agent/src/executors/__tests__/daytona.test.ts
@@ -74,6 +74,39 @@ describe("DaytonaExecutor", () => {
     });
   });
 
+  describe("init() timeouts (#2167)", () => {
+    it("bounds the workspace setup and the tool install", async () => {
+      await executor.init();
+
+      const calls = mockSandbox.process.executeCommand.mock.calls as [
+        string,
+        unknown,
+        unknown,
+        number,
+      ][];
+      const mkdir = calls.find(([cmd]) => cmd.includes("mkdir -p /workspace"));
+      const apt = calls.find(([cmd]) => cmd.includes("apt-get"));
+      expect(mkdir?.[3]).toBe(30);
+      expect(apt?.[3]).toBe(300);
+    });
+
+    it("finishes init when the tool install times out", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockSandbox.process.executeCommand.mockImplementation(async (cmd: string) => {
+        if (cmd.includes("apt-get")) throw new Error("Command timed out after 300 seconds");
+        return { exitCode: 0, result: "" };
+      });
+
+      await expect(executor.init()).resolves.toBeUndefined();
+
+      expect(executor.isReady()).toBe(true);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Tool install did not finish within 300s"),
+      );
+      warn.mockRestore();
+    });
+  });
+
   describe("exec()", () => {
     it("maps Daytona response to ExecResult", async () => {
       await executor.init();

--- a/frontend/ee/agent/src/executors/daytona.ts
+++ b/frontend/ee/agent/src/executors/daytona.ts
@@ -1,4 +1,4 @@
-import { Daytona, DaytonaTimeoutError } from "@daytonaio/sdk";
+import { Daytona, DaytonaError, DaytonaTimeoutError } from "@daytonaio/sdk";
 import type { Sandbox } from "@daytonaio/sdk";
 import type { Executor, ExecResult, ExecOptions } from "./interface.js";
 
@@ -14,13 +14,20 @@ const TOOL_INSTALL_TIMEOUT_SECONDS = 300;
 
 /**
  * Whether an executeCommand rejection is the per-command deadline expiring.
- * The SDK raises DaytonaTimeoutError for deadlines it enforces itself; a
- * `timeout` exceeded inside the toolbox comes back as a generic DaytonaError
- * whose message names the timeout. Anything else is a real failure.
+ * The SDK raises DaytonaTimeoutError for deadlines it enforces itself. A
+ * `timeout` exceeded inside the toolbox is answered by the server, so the SDK
+ * wraps it as a DaytonaError that carries the HTTP status and a message naming
+ * the timeout. A transport failure (sandbox gone, toolbox unreachable, socket
+ * timeout) never carries a status, so it stays fatal even when its message
+ * mentions a timeout.
  */
 function isCommandTimeout(error: unknown): boolean {
   if (error instanceof DaytonaTimeoutError) return true;
-  return error instanceof Error && /timed out|timeout/i.test(error.message);
+  return (
+    error instanceof DaytonaError &&
+    typeof error.statusCode === "number" &&
+    /timed out|timeout/i.test(error.message)
+  );
 }
 
 export class DaytonaExecutor implements Executor {

--- a/frontend/ee/agent/src/executors/daytona.ts
+++ b/frontend/ee/agent/src/executors/daytona.ts
@@ -1,4 +1,4 @@
-import { Daytona } from "@daytonaio/sdk";
+import { Daytona, DaytonaTimeoutError } from "@daytonaio/sdk";
 import type { Sandbox } from "@daytonaio/sdk";
 import type { Executor, ExecResult, ExecOptions } from "./interface.js";
 
@@ -11,6 +11,17 @@ const WORKSPACE_SETUP_TIMEOUT_SECONDS = 30;
  * ends (#2167). Slow-but-working mirrors have been seen at ~3 minutes.
  */
 const TOOL_INSTALL_TIMEOUT_SECONDS = 300;
+
+/**
+ * Whether an executeCommand rejection is the per-command deadline expiring.
+ * The SDK raises DaytonaTimeoutError for deadlines it enforces itself; a
+ * `timeout` exceeded inside the toolbox comes back as a generic DaytonaError
+ * whose message names the timeout. Anything else is a real failure.
+ */
+function isCommandTimeout(error: unknown): boolean {
+  if (error instanceof DaytonaTimeoutError) return true;
+  return error instanceof Error && /timed out|timeout/i.test(error.message);
+}
 
 export class DaytonaExecutor implements Executor {
   private daytona: Daytona | null = null;
@@ -55,6 +66,7 @@ export class DaytonaExecutor implements Executor {
     // boot on this image, so its in-process TLS can't be fixed by a later apt.
     // The install is best effort (note the `|| true`); a stalled mirror must
     // bound the turn, not hold it open, so a timeout is logged and init goes on.
+    // Any other rejection (sandbox gone, toolbox unreachable) is still fatal.
     try {
       await this.sandbox.process.executeCommand(
         "apt-get update -qq && apt-get install -y -qq ca-certificates git jq curl > /dev/null 2>&1 || true",
@@ -63,6 +75,7 @@ export class DaytonaExecutor implements Executor {
         TOOL_INSTALL_TIMEOUT_SECONDS,
       );
     } catch (error) {
+      if (!isCommandTimeout(error)) throw error;
       const message = error instanceof Error ? error.message : String(error);
       console.warn(
         `[DaytonaExecutor] Tool install did not finish within ${TOOL_INSTALL_TIMEOUT_SECONDS}s, continuing without it: ${message}`,

--- a/frontend/ee/agent/src/executors/daytona.ts
+++ b/frontend/ee/agent/src/executors/daytona.ts
@@ -2,6 +2,16 @@ import { Daytona } from "@daytonaio/sdk";
 import type { Sandbox } from "@daytonaio/sdk";
 import type { Executor, ExecResult, ExecOptions } from "./interface.js";
 
+/** Seconds allowed for the workspace mkdir in init(); it is local to the sandbox. */
+const WORKSPACE_SETUP_TIMEOUT_SECONDS = 30;
+/**
+ * Seconds allowed for the runtime apt-get install in init(). The step depends
+ * on the Ubuntu mirrors reachable from the sandbox; when they stall, an
+ * unbounded executeCommand never returns and the chat turn above it never
+ * ends (#2167). Slow-but-working mirrors have been seen at ~3 minutes.
+ */
+const TOOL_INSTALL_TIMEOUT_SECONDS = 300;
+
 export class DaytonaExecutor implements Executor {
   private daytona: Daytona | null = null;
   private sandbox: Sandbox | null = null;
@@ -33,6 +43,9 @@ export class DaytonaExecutor implements Executor {
     this.workDir = "/workspace";
     await this.sandbox.process.executeCommand(
       "mkdir -p /workspace/repos /workspace/traces /workspace/notes",
+      undefined,
+      undefined,
+      WORKSPACE_SETUP_TIMEOUT_SECONDS,
     );
 
     // Install required tools. ca-certificates is essential: cloneRepo uses the
@@ -40,9 +53,21 @@ export class DaytonaExecutor implements Executor {
     // certs must be present before any HTTPS clone. We intentionally do NOT rely
     // on Daytona's native go-git here — its daemon caches an empty cert pool at
     // boot on this image, so its in-process TLS can't be fixed by a later apt.
-    await this.sandbox.process.executeCommand(
-      "apt-get update -qq && apt-get install -y -qq ca-certificates git jq curl > /dev/null 2>&1 || true",
-    );
+    // The install is best effort (note the `|| true`); a stalled mirror must
+    // bound the turn, not hold it open, so a timeout is logged and init goes on.
+    try {
+      await this.sandbox.process.executeCommand(
+        "apt-get update -qq && apt-get install -y -qq ca-certificates git jq curl > /dev/null 2>&1 || true",
+        undefined,
+        undefined,
+        TOOL_INSTALL_TIMEOUT_SECONDS,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `[DaytonaExecutor] Tool install did not finish within ${TOOL_INSTALL_TIMEOUT_SECONDS}s, continuing without it: ${message}`,
+      );
+    }
 
     console.log(`[DaytonaExecutor] Sandbox ready, workDir: ${this.workDir}`);
   }


### PR DESCRIPTION
Fixes #2167

## Summary

`DaytonaExecutor.init()` ran the workspace `mkdir` and the runtime `apt-get update && apt-get install …` through `sandbox.process.executeCommand` without a timeout. When the package mirrors reachable from the sandbox stall, that call never returns, the tool call never ends, and the chat turn above it stays open with no `Sandbox ready` and no `tool_execution_end`, as in the staging trace in the issue.

## Type of Change

- [x] fix - A bug fix

## Details

`frontend/ee/agent/src/executors/daytona.ts`

- The mkdir gets a 30 s bound; it is local to the sandbox and only fails if the sandbox itself is broken, so it still throws.
- The tool install gets a 300 s bound (a slow but working mirror has been seen at about 3 minutes). The command is already best effort (`|| true` on the exit code), so a timeout is now handled the same way: it is logged with the bound and the reason, and `init()` completes. Later steps that need `git` or `curl` fail with their own error instead of the whole turn hanging.
- `exec()` is unchanged; it already forwards the caller's timeout.

`frontend/ee/agent/src/executors/__tests__/daytona.test.ts`

- asserts both init commands receive their bounds (`30`, `300`);
- makes the apt-get call reject with a timeout error and asserts `init()` still resolves, the executor is ready, and the warning names the bound.

`vitest run src/executors/__tests__/daytona.test.ts` in `frontend/ee/agent`: 24 passed (2 new). eslint and prettier are clean on both files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2167. Daytona initialization previously ran workspace setup and tool installation without timeouts, so a stalled package mirror could hold a chat turn open; it now bounds them to 30s and 300s. A tool-install timeout is logged and `init()` continues, while other failures still propagate.

**Bug Fixes**
- Recognizes the SDK’s `DaytonaTimeoutError` and toolbox timeout responses, but not transport errors with timeout-like messages.
- A workspace setup timeout remains fatal because it indicates a broken sandbox.
- Later operations report their own errors if a timed-out install leaves `git` or `curl` unavailable.
- Tests cover both timeout bounds, continued initialization, and propagation of non-timeout failures.

<sup>Written for commit 0d65c83703793df3c9215e4b9ba6a448fd2e6298. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

