### PR TITLE
fix(api): trace live stream 500s when ClickHouse returns a timezone-aware timestamp (live.py naive/aware subtraction)

### DIFF
--- a/backend/rest/routers/live.py
+++ b/backend/rest/routers/live.py
@@ -16,6 +16,7 @@ from starlette.responses import StreamingResponse
 from rest.retention import enforce_retention_by_time
 from rest.routers.deps import ProjectAccess
 from rest.services.trace_reader import get_trace_reader_service
+from rest.sql_utils import to_utc_naive
 from shared.config import settings
 
 logger = logging.getLogger(__name__)
@@ -118,6 +119,16 @@ async def live_trace_stream(
             root_end_time, last_ingest_time = await asyncio.to_thread(
                 _completion_state_in_clickhouse, project_id, trace_id
             )
+            # ClickHouse's DateTime64 columns here carry no explicit timezone,
+            # and the driver does not consistently return naive datetimes for
+            # them — normalize both to naive UTC before any comparison or
+            # arithmetic. Do this before max(), not just before the
+            # subtraction below: max() itself raises on a naive/aware pair
+            # just as the subtraction does on a naive-vs-aware pair.
+            if root_end_time is not None:
+                root_end_time = to_utc_naive(root_end_time)
+            if last_ingest_time is not None:
+                last_ingest_time = to_utc_naive(last_ingest_time)
 
             completion_deadline = None
             if root_end_time is not None:
@@ -126,8 +137,7 @@ async def live_trace_stream(
                 # holding the SSE connection and Redis subscription for the
                 # full window, while a trace whose descendants are still
                 # arriving (root ended early) keeps its late-span protection.
-                # ClickHouse stores naive UTC timestamps; clamp age at 0
-                # against clock skew.
+                # Clamp age at 0 against clock skew.
                 anchor = max(root_end_time, last_ingest_time or root_end_time)
                 now_utc = datetime.now(UTC).replace(tzinfo=None)
                 age = max(0.0, (now_utc - anchor).total_seconds())

--- a/tests/rest/test_live_router.py
+++ b/tests/rest/test_live_router.py
@@ -13,7 +13,7 @@ Key invariants under test:
 
 import asyncio
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -53,6 +53,21 @@ class MockPubSub:
 def _utcnow_naive() -> datetime:
     """ClickHouse returns naive UTC datetimes; mirror that in test values."""
     return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _aware(dt: datetime) -> datetime:
+    """Re-tag a naive-UTC value as timezone-aware UTC — same instant, the
+    driver-variance shape the fix must tolerate."""
+    return dt.replace(tzinfo=UTC)
+
+
+def _aware_offset(dt: datetime, *, hours: float) -> datetime:
+    """Re-express a naive-UTC instant as aware at a non-UTC offset — same
+    real instant, different tzinfo and different wall-clock digits. Used to
+    prove the fix does a real conversion (`.astimezone(UTC)`), not a blind
+    `.replace(tzinfo=None)` strip: a blind strip would keep this offset's
+    local digits and misread them as UTC, shifting the instant by `hours`."""
+    return dt.replace(tzinfo=UTC).astimezone(timezone(timedelta(hours=hours)))
 
 
 def redis_message(payload: dict) -> dict:
@@ -568,3 +583,188 @@ class TestRetentionGate:
             assert "event: trace_complete" in events
         finally:
             app.dependency_overrides.clear()
+
+
+class TestTimezoneAwareTimestamps:
+    """ClickHouse's DateTime64 columns here carry no explicit timezone, and
+    the driver does not consistently return naive datetimes for them.
+    These mirror TestQuietWindowAnchoring's scenarios with aware and mixed
+    naive/aware inputs, proving identical behavior — not just absence of a
+    crash — regardless of which of the two values (or both) came back aware.
+    """
+
+    def test_regression_both_aware_does_not_500(self, client):
+        """The exact shape of the reported incident: both timestamps aware.
+        This is the crash-reproduction case — status 200, not 500."""
+        pubsub = MockPubSub([])
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        now_aware = _aware(_utcnow_naive())
+        with (
+            patch("rest.routers.live.TRACE_COMPLETE_QUIET_SECONDS", 0.1),
+            patch(
+                "rest.routers.live._completion_state_in_clickhouse",
+                return_value=(now_aware, now_aware),
+            ),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            resp = client.get(ENDPOINT)
+
+        assert resp.status_code == 200
+        assert parse_sse_events(resp.text) == ["event: trace_complete"]
+
+    def test_both_aware_old_completed_trace_closes_immediately(self, client):
+        """Mirrors TestQuietWindowAnchoring.test_old_completed_trace_closes_immediately
+        with both timestamps aware instead of naive — same behavior expected."""
+        pubsub = MockPubSub([])
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        stale_root_end = _aware(_utcnow_naive() - timedelta(hours=1))
+        with (
+            patch("rest.routers.live.TRACE_COMPLETE_QUIET_SECONDS", 30),
+            patch(
+                "rest.routers.live._completion_state_in_clickhouse",
+                return_value=(stale_root_end, stale_root_end),
+            ),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            resp = client.get(ENDPOINT)
+
+        events = parse_sse_events(resp.text)
+        assert events == ["event: trace_complete"]
+        assert pubsub.get_message_calls == 0
+
+    def test_mixed_root_aware_last_ingest_naive_does_not_crash(self, client):
+        """root_end_time aware, last_ingest_time naive — the mixed pair that
+        crashes at max() rather than at the subtraction. Root ended long ago
+        (aware); spans are still actively arriving (naive, recent) — the
+        window must anchor to the recent activity, same as the all-naive
+        equivalent in test_old_root_with_recent_activity_keeps_quiet_window."""
+        late_batch = redis_message(
+            {"type": "spans", "spans": [{"span_id": "late", "trace_id": TRACE_ID}]}
+        )
+        pubsub = MockPubSub([late_batch])
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        stale_root_end = _aware(_utcnow_naive() - timedelta(minutes=5))
+        with (
+            patch("rest.routers.live.TRACE_COMPLETE_QUIET_SECONDS", 0.2),
+            patch(
+                "rest.routers.live._completion_state_in_clickhouse",
+                return_value=(stale_root_end, _utcnow_naive()),
+            ),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            resp = client.get(ENDPOINT)
+
+        events = parse_sse_events(resp.text)
+        assert events == ["event: spans", "event: trace_complete"]
+
+    def test_mixed_root_naive_last_ingest_aware_does_not_crash(self, client):
+        """The reverse mixed pair: root_end_time naive, last_ingest_time
+        aware. Same expected behavior as the previous test — the fix must
+        not assume which of the two columns is the one that comes back
+        aware, since they are independently typed."""
+        late_batch = redis_message(
+            {"type": "spans", "spans": [{"span_id": "late", "trace_id": TRACE_ID}]}
+        )
+        pubsub = MockPubSub([late_batch])
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        stale_root_end = _utcnow_naive() - timedelta(minutes=5)
+        with (
+            patch("rest.routers.live.TRACE_COMPLETE_QUIET_SECONDS", 0.2),
+            patch(
+                "rest.routers.live._completion_state_in_clickhouse",
+                return_value=(stale_root_end, _aware(_utcnow_naive())),
+            ),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            resp = client.get(ENDPOINT)
+
+        events = parse_sse_events(resp.text)
+        assert events == ["event: spans", "event: trace_complete"]
+
+    def test_both_aware_recently_completed_trace_still_gets_quiet_window(self, client):
+        """Mirrors TestQuietWindowAnchoring.test_recently_completed_trace_still_gets_quiet_window
+        with both timestamps aware — a root that ended a moment ago still
+        keeps the remaining quiet window for late descendant spans."""
+        late_batch = redis_message(
+            {"type": "spans", "spans": [{"span_id": "late", "trace_id": TRACE_ID}]}
+        )
+        pubsub = MockPubSub([late_batch])
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        now_aware = _aware(_utcnow_naive())
+        with (
+            patch("rest.routers.live.TRACE_COMPLETE_QUIET_SECONDS", 0.2),
+            patch(
+                "rest.routers.live._completion_state_in_clickhouse",
+                return_value=(now_aware, now_aware),
+            ),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            resp = client.get(ENDPOINT)
+
+        events = parse_sse_events(resp.text)
+        assert events == ["event: spans", "event: trace_complete"]
+
+    def test_aware_non_utc_offset_is_converted_not_blindly_stripped(self, client):
+        """A blind `.replace(tzinfo=None)` strip (instead of a real
+        `.astimezone(UTC)` conversion) would misread this +05:30-offset
+        timestamp's local digits as UTC, shifting the represented instant
+        5.5 hours into the future — making a trace that actually completed
+        an hour ago look like it hasn't gone stale yet, so the stream would
+        NOT close immediately and would instead poll for messages.
+        Correctly converted, this is the same instant as the existing
+        test_old_completed_trace_closes_immediately case: closes at once."""
+        pubsub = MockPubSub([])
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        stale_root_end = _aware_offset(_utcnow_naive() - timedelta(hours=1), hours=5.5)
+        with (
+            patch("rest.routers.live.TRACE_COMPLETE_QUIET_SECONDS", 30),
+            patch(
+                "rest.routers.live._completion_state_in_clickhouse",
+                return_value=(stale_root_end, stale_root_end),
+            ),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            resp = client.get(ENDPOINT)
+
+        events = parse_sse_events(resp.text)
+        assert events == ["event: trace_complete"]
+        # Correctly stale by 1 hour -> deadline already expired on arrival,
+        # closed without a single poll. A blind strip would have placed the
+        # (misread) instant in the future, leaving age clamped to 0 and the
+        # full quiet window still open -- this would poll at least once.
+        assert pubsub.get_message_calls == 0
+
+    def test_root_aware_none_last_ingest_falls_back_correctly(self, client):
+        """root_end_time aware, last_ingest_time is None: the `last_ingest_time
+        or root_end_time` fallback must use the already-normalized
+        root_end_time, not the raw aware value."""
+        pubsub = MockPubSub([])
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        stale_root_end = _aware(_utcnow_naive() - timedelta(hours=1))
+        with (
+            patch("rest.routers.live.TRACE_COMPLETE_QUIET_SECONDS", 30),
+            patch(
+                "rest.routers.live._completion_state_in_clickhouse",
+                return_value=(stale_root_end, None),
+            ),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            resp = client.get(ENDPOINT)
+
+        events = parse_sse_events(resp.text)
+        assert events == ["event: trace_complete"]
+        assert pubsub.get_message_calls == 0


### PR DESCRIPTION
Fixes #2166

## Summary

`GET /api/v1/projects/{project_id}/traces/{trace_id}/live` returns a 500 for a trace whose ClickHouse-returned completion timestamps come back timezone-aware instead of the assumed-always-naive.

 `event_generator()` in `backend/rest/routers/live.py` computes `anchor = max(root_end_time, last_ingest_time or root_end_time)` from `_completion_state_in_clickhouse()` (`maxIf(span_end_time, ...)`, `max(ch_update_time)`), then does `now_utc - anchor`. Neither `spans.span_end_time` nor `spans.ch_update_time` declares an explicit timezone in the schema, and the ClickHouse driver does not consistently return naive datetimes for such columns — so for at least one trace, one (or both) of these values came back timezone-aware, and the subtraction raised `TypeError: can't subtract offset-naive and offset-aware datetimes` inside the SSE generator after the client had already subscribed.

  ## Fix

Normalize both `root_end_time` and `last_ingest_time` to naive UTC via the existing `to_utc_naive()` helper (`rest/sql_utils.py` — already used for this exact class of problem in `rest/retention.py`) immediately after unpacking them, **before** the `max()` call — not just before the subtraction. `max()` itself raises a comparable `TypeError` on a mixed naive/aware pair, which is a second, previously-unobserved crash site sharing the same root cause.

`to_utc_naive()` does a real conversion (`.astimezone(UTC)`), not a blind `.replace(tzinfo=None)` strip, so it's correct regardless of which timezone the driver happens to attach.

  ## Test plan

`tests/rest/test_live_router.py` — 7 new tests (`TestTimezoneAwareTimestamps`), mirroring the existing `TestQuietWindowAnchoring` scenarios but with timezone-aware and mixed naive/aware inputs, proving identical *behavior*, not just absence of a crash:

  - Regression: both timestamps aware → 200, not 500 (the exact reported incident)
  - Both-aware versions of all 3 existing quiet-window-anchoring scenarios
  - Both mixed pairs (root aware / last-ingest naive, and the reverse) — these hit the `max()` crash site specifically
  - A non-UTC-offset aware timestamp, proving `to_utc_naive()` does a real conversion rather than a blind tzinfo strip (a blind strip would misread the offset's local digits as UTC, shifting the represented instant and silently producing the wrong quiet-window timing)
  - `root_end_time` aware + `last_ingest_time` is `None`, proving the `last_ingest_time or root_end_time` fallback uses the already-normalized value

 **Verification**: reverted just the source fix (kept the tests), reran — all 7 new tests failed, and notably the two mixed-pair tests failed with a *different* exception (`can't compare offset-naive and offset-aware datetimes`, from `max()`) than the others (`can't subtract...`), confirming the mixed-pair case is a real second crash site. Restored the fix — all 25 tests in the file pass, full `tests/rest/` suite (1289 tests) passes clean.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary



🤖 Description prepared with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2166: the trace live stream endpoint now returns 200 instead of 500 when ClickHouse returns timezone-aware completion timestamps. Previously, a naive/aware datetime mismatch raised `TypeError` inside the SSE generator, both in `max()` and in the subsequent subtraction.

**Bug Fixes**
- Normalizes `root_end_time` and `last_ingest_time` to naive UTC via `to_utc_naive()` before the `max()` call, which is a second crash site sharing the same root cause.
- Adds 7 regression tests covering both-aware, mixed naive/aware, non-UTC offset, and the `None` fallback case.

<sup>Written for commit ab7dde4dd8fbfaf61c3fd90da373934cc2e08fd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/2169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

